### PR TITLE
Aba WhatsApp na landing + convite de cadastro p/ número sem conta (inclui Agentes Fase A)

### DIFF
--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -366,6 +366,57 @@ def _is_greeting(text: str) -> bool:
     return normalized in {"oi", "ola", "olá", "hello", "hi", "hey", "bom dia", "boa tarde", "boa noite"}
 
 
+# Tentativa de vincular por código ("link 123456" / "vincular 123456"). Espelha
+# os padrões do intent_classifier (account.link / account.vincular). Um número
+# SEM conta usa exatamente esse fluxo pra se vincular, então não pode ser barrado
+# pelo aviso de "crie sua conta". Usa o MESMO _normalize do classificador (que
+# troca pontuação por espaço) — senão "link: 123456" ou "link 123456." casariam
+# como vínculo lá no handle_incoming mas seriam barrados aqui, engolindo o código.
+_LINK_CODE_RE = re.compile(r"^(?:link|vincular)\s+\d{6}$")
+
+
+def _is_link_code_attempt(text: str) -> bool:
+    from core.intent_classifier import _normalize
+    return bool(_LINK_CODE_RE.match(_normalize(text or "")))
+
+
+def _signup_url() -> str:
+    from core.dashboard_links import get_dashboard_base_url
+    base = get_dashboard_base_url()
+    if not base.startswith("https://"):
+        base = "https://pigbankai.com"
+    return f"{base}/cadastro"
+
+
+def _send_no_account_notice(reply_to: str, auto_link_result: dict[str, Any], user_id: int | None = None) -> None:
+    """Número de WhatsApp sem NENHUMA conta vinculada por telefone. Sem esse
+    aviso, um comando ("gastei 50") cairia numa conta fantasma invisível (paywall
+    off / plans-v2 on) ou na mensagem de assinatura que assume conta existente
+    (paywall on) — os dois confundem quem ainda não tem cadastro. Então avisamos
+    e paramos aqui. Mandamos em TODA mensagem (nunca some em silêncio); o dedup
+    é só do log, pra não inflar o system_event_logs."""
+    _send_reply(
+        reply_to,
+        (
+            "🐷 Oi! Ainda não tenho uma conta ligada a este número de WhatsApp.\n\n"
+            "Pra eu começar a cuidar do seu dinheiro:\n"
+            f"1️⃣ Crie sua conta grátis: {_signup_url()}\n"
+            "   (use *este mesmo número* de WhatsApp)\n"
+            "2️⃣ Volte aqui e me manda um *oi* — eu vinculo na hora ✅\n\n"
+            "Já tem conta? Gere um código de vínculo no site e me manda: *link 123456*"
+        ),
+    )
+    if not _autolink_warning_already_sent(reply_to, "no_match_notice"):
+        log_system_event_sync(
+            "info",
+            "whatsapp_autolink_greeting_warning_sent",
+            "Convite de cadastro enviado a número de WhatsApp sem conta.",
+            source="wa_runtime",
+            user_id=user_id,
+            details={"wa_id": reply_to, "status": "no_match_notice"},
+        )
+
+
 def _build_autolink_warning_message(status: str, auto_link_result: dict[str, Any]) -> str | None:
     if status == "no_match":
         return (
@@ -491,8 +542,14 @@ def process_message(message: InboundMessage) -> None:
                             ),
                         )
                     return
+        elif auto_link_result["status"] == "no_match":
+            # Número sem conta alguma. Convida pro cadastro/vínculo e para aqui —
+            # EXCETO quando a própria mensagem é o código de vínculo, que precisa
+            # seguir pro handle_incoming pra ser consumido.
+            if not _is_link_code_attempt(message.text or ""):
+                _send_no_account_notice(reply_to, auto_link_result, user_id=uid)
+                return
         elif auto_link_result["status"] in {
-            "no_match",
             "multiple_accounts",
             "wa_linked_other_account",
             "account_has_other_whatsapp",

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -132,6 +132,18 @@ def _base_html(title: str, content: str) -> str:
 </html>"""
 
 
+def send_agent_report_email(to: str, user_id: int, subject: str, content_html: str) -> bool:
+    """E-mail proativo dos Agentes do Piggy (ex.: manchete mensal do Repórter).
+
+    Usa o template do Piggy com unsubscribe — canal grátis dos agentes.
+    """
+    try:
+        unsub = make_unsub_url(user_id, to)
+    except RuntimeError:
+        unsub = ""
+    return send_email(to, subject, _piggy_html(subject, content_html, unsub))
+
+
 def send_verification_email(to: str, code: str) -> bool:
     """Envia o código de verificação de 6 dígitos para confirmar o e-mail no cadastro."""
     content = f"""

--- a/core/services/piggy_agents.py
+++ b/core/services/piggy_agents.py
@@ -1,0 +1,404 @@
+"""Agentes do Piggy — detectores e runner (Fase A: Xerife, Repórter, Carteiro).
+
+Arquitetura (espelha recurring_charger.py):
+  - detectores são funções SÍNCRONAS `run_<kind>_once(today)` chamadas do
+    loop async via asyncio.to_thread;
+  - idempotência vem do banco: agent_events tem UNIQUE(agent_id, dedupe_key),
+    então rodar um detector N vezes no mesmo dia não duplica alerta;
+  - o loop roda de hora em hora; cada detector decide sozinho se tem algo
+    a fazer naquele tick (ex.: Repórter só age nos primeiros dias do mês).
+
+Gatilhos:
+  1. cron horário (run_agents_loop, registrado no lifespan);
+  2. pós-sync Open Finance (run_agents_for_user, chamado de pluggy_sync) —
+     roda só o Xerife, só pro usuário sincado.
+
+Canais na Fase A: feed do dashboard (sempre) + e-mail do Repórter (manchete
+mensal, canal principal dele). WhatsApp fica pra quando os templates Meta
+forem aprovados — mesmo padrão dormente do lembrete de boletos.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date, timedelta
+from typing import Any
+
+from db.connection import get_conn
+
+# ── Config ───────────────────────────────────────────────────────────────────
+
+# Desliga o subsistema inteiro sem deploy (mesmo espírito de RUN_BACKGROUND_TASKS).
+AGENTS_ENABLED = os.getenv("AGENTS_ENABLED", "1") != "0"
+AGENTS_INTERVAL_SEC = int(os.getenv("AGENTS_INTERVAL_SEC", str(60 * 60)))
+
+# Xerife: defaults dos thresholds (config do agente pode sobrescrever).
+XERIFE_MULTIPLIER = 2.5     # gasto único > N× a média da categoria
+XERIFE_MIN_VALOR = 50.0     # ignora anomalia abaixo disso (ruído)
+XERIFE_MIN_SAMPLES = 5      # mínimo de lançamentos no histórico da categoria
+
+MESES_PT = [
+    "", "janeiro", "fevereiro", "março", "abril", "maio", "junho",
+    "julho", "agosto", "setembro", "outubro", "novembro", "dezembro",
+]
+
+
+def _fmt_brl(v: float) -> str:
+    s = f"{v:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+    return f"R$ {s}"
+
+
+# ── Xerife: anomalia de gasto + limite de categoria ──────────────────────────
+
+def _xerife_detect_for_user(agent: dict[str, Any], today: date) -> int:
+    """Detecta pro usuário do agente; retorna quantos eventos novos gravou."""
+    from db import record_agent_event
+
+    cfg = agent.get("config") or {}
+    mult = float(cfg.get("multiplicador") or XERIFE_MULTIPLIER)
+    minimo = float(cfg.get("minimo") or XERIFE_MIN_VALOR)
+    user_id = agent["user_id"]
+    fired = 0
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            # Anomalia: lançamento das últimas 24h muito acima da média (90d)
+            # da própria categoria. Histórico exclui as últimas 24h pra o
+            # próprio gasto anômalo não puxar a média.
+            cur.execute(
+                """
+                with hist as (
+                  select lower(categoria) as cat, avg(valor) as media, count(*) as n
+                  from launches
+                  where user_id = %s
+                    and tipo in ('despesa', 'saida')
+                    and is_internal_movement = false
+                    and categoria is not null
+                    and criado_em >= now() - interval '90 days'
+                    and criado_em <  now() - interval '24 hours'
+                  group by 1
+                )
+                select l.id, l.valor, l.categoria, coalesce(l.alvo, l.nota, '') as descricao,
+                       h.media
+                from launches l
+                join hist h on lower(l.categoria) = h.cat
+                where l.user_id = %s
+                  and l.tipo in ('despesa', 'saida')
+                  and l.is_internal_movement = false
+                  and l.criado_em >= now() - interval '24 hours'
+                  and h.n >= %s
+                  and l.valor >= %s
+                  and l.valor > %s * h.media
+                """,
+                (user_id, user_id, XERIFE_MIN_SAMPLES, minimo, mult),
+            )
+            anomalias = cur.fetchall() or []
+
+            # Limite mensal por categoria (config: {"limites": {"delivery": 200}}).
+            limites: dict[str, Any] = cfg.get("limites") or {}
+            estouros: list[dict[str, Any]] = []
+            if limites:
+                cur.execute(
+                    """
+                    select lower(categoria) as cat, sum(valor) as total
+                    from launches
+                    where user_id = %s
+                      and tipo in ('despesa', 'saida')
+                      and is_internal_movement = false
+                      and categoria is not null
+                      and criado_em >= date_trunc('month', now())
+                    group by 1
+                    """,
+                    (user_id,),
+                )
+                gastos = {r["cat"]: float(r["total"]) for r in (cur.fetchall() or [])}
+                for cat, limite in limites.items():
+                    try:
+                        limite_f = float(limite)
+                    except (TypeError, ValueError):
+                        continue
+                    total = gastos.get(cat.lower(), 0.0)
+                    if limite_f > 0 and total > limite_f:
+                        estouros.append({"cat": cat.lower(), "total": total, "limite": limite_f})
+
+    for a in anomalias:
+        media = float(a["media"])
+        valor = float(a["valor"])
+        ok = record_agent_event(
+            agent["agent_id"], user_id, "xerife",
+            dedupe_key=f"anomalia:{a['id']}",
+            payload={
+                "tipo": "anomalia",
+                "launch_id": a["id"],
+                "categoria": a["categoria"],
+                "descricao": (a["descricao"] or "")[:120],
+                "valor": valor,
+                "media": round(media, 2),
+                "titulo": f"Gasto fora do padrão em {a['categoria']}",
+                "mensagem": (
+                    f"{_fmt_brl(valor)} em {a['categoria']}"
+                    f"{' (' + a['descricao'] + ')' if a['descricao'] else ''} — "
+                    f"seu normal na categoria é {_fmt_brl(media)}. Tá tudo certo?"
+                ),
+            },
+        )
+        fired += 1 if ok else 0
+
+    ym = today.strftime("%Y-%m")
+    for e in estouros:
+        ok = record_agent_event(
+            agent["agent_id"], user_id, "xerife",
+            dedupe_key=f"limite:{e['cat']}:{ym}",
+            payload={
+                "tipo": "limite",
+                "categoria": e["cat"],
+                "total": round(e["total"], 2),
+                "limite": e["limite"],
+                "titulo": f"Limite de {e['cat']} estourado",
+                "mensagem": (
+                    f"Você combinou {_fmt_brl(e['limite'])}/mês em {e['cat']} "
+                    f"e já foi {_fmt_brl(e['total'])}. Seguro a onda com você?"
+                ),
+            },
+            valor_impacto=None,
+        )
+        fired += 1 if ok else 0
+    return fired
+
+
+def run_xerife_once(today: date | None = None, user_id: int | None = None) -> dict:
+    """Roda o Xerife pra todos os agentes ativos (ou só um usuário)."""
+    from db import list_users_with_active_agents
+
+    today = today or date.today()
+    agents = list_users_with_active_agents("xerife")
+    if user_id is not None:
+        agents = [a for a in agents if a["user_id"] == user_id]
+    fired = 0
+    for agent in agents:
+        try:
+            fired += _xerife_detect_for_user(agent, today)
+        except Exception as exc:
+            print(f"[agents] xerife user={agent['user_id']}: {exc}", file=sys.stderr)
+    return {"ok": True, "agents": len(agents), "fired": fired}
+
+
+# ── Repórter: a manchete do mês ──────────────────────────────────────────────
+
+def _month_stats(cur, user_id: int, first: date, nxt: date) -> dict[str, float]:
+    cur.execute(
+        """
+        select
+          coalesce(sum(valor) filter (where tipo = 'receita'), 0)                 as entrou,
+          coalesce(sum(valor) filter (where tipo in ('despesa', 'saida')), 0)     as saiu,
+          coalesce(sum(valor) filter (where tipo = 'deposito_caixinha'), 0)
+            - coalesce(sum(valor) filter (where tipo = 'saque_caixinha'), 0)      as aportes
+        from launches
+        where user_id = %s
+          and is_internal_movement = false
+          and criado_em >= %s and criado_em < %s
+        """,
+        (user_id, first, nxt),
+    )
+    row = cur.fetchone() or {}
+    entrou = float(row.get("entrou") or 0)
+    saiu = float(row.get("saiu") or 0)
+    aportes = float(row.get("aportes") or 0)
+    # Regra de domínio: "sobrou" = receitas − despesas − aportes (≠ saldo).
+    return {"entrou": entrou, "saiu": saiu, "aportes": aportes,
+            "sobrou": entrou - saiu - aportes}
+
+
+def _reporter_run_for_user(agent: dict[str, Any], today: date) -> bool:
+    from db import record_agent_event, get_user_email
+
+    user_id = agent["user_id"]
+    first_this = today.replace(day=1)
+    last_month_end = first_this - timedelta(days=1)
+    first_prev = last_month_end.replace(day=1)
+    first_prev2 = (first_prev - timedelta(days=1)).replace(day=1)
+    ym = first_prev.strftime("%Y-%m")
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            stats = _month_stats(cur, user_id, first_prev, first_this)
+            prev = _month_stats(cur, user_id, first_prev2, first_prev)
+
+    if stats["entrou"] == 0 and stats["saiu"] == 0:
+        return False  # mês sem movimento não rende manchete
+
+    delta_pct = None
+    if prev["sobrou"] != 0:
+        delta_pct = round((stats["sobrou"] - prev["sobrou"]) / abs(prev["sobrou"]) * 100)
+
+    mes_nome = MESES_PT[first_prev.month]
+    titulo = f"A manchete de {mes_nome}"
+    resumo = (
+        f"Entrou {_fmt_brl(stats['entrou'])}, saiu {_fmt_brl(stats['saiu'])} — "
+        f"sobrou {_fmt_brl(stats['sobrou'])}"
+        + (f" ({'+' if delta_pct >= 0 else ''}{delta_pct}% vs mês anterior)."
+           if delta_pct is not None else ".")
+    )
+
+    inserted = record_agent_event(
+        agent["agent_id"], user_id, "reporter",
+        dedupe_key=f"manchete:{ym}",
+        payload={
+            "tipo": "manchete", "ym": ym, "mes": mes_nome,
+            "titulo": titulo, "mensagem": resumo,
+            "entrou": round(stats["entrou"], 2), "saiu": round(stats["saiu"], 2),
+            "aportes": round(stats["aportes"], 2), "sobrou": round(stats["sobrou"], 2),
+            "delta_pct": delta_pct,
+        },
+        channel="email",
+    )
+    if not inserted:
+        return False  # manchete do mês já publicada
+
+    # E-mail é o canal principal do Repórter. Falha de e-mail não desfaz o
+    # evento do feed — o dashboard sempre registra.
+    try:
+        email = get_user_email(user_id)
+        if email:
+            from core.services.email_service import send_agent_report_email
+            corpo = (
+                f"<p>🎤 Direto da redação, a manchete de <strong>{mes_nome}</strong>:</p>"
+                f"<div class=\"box\"><p style=\"margin:0\">"
+                f"<strong>Entrou:</strong> {_fmt_brl(stats['entrou'])}<br/>"
+                f"<strong>Saiu:</strong> {_fmt_brl(stats['saiu'])}<br/>"
+                f"<strong>Aportes nas caixinhas:</strong> {_fmt_brl(stats['aportes'])}<br/>"
+                f"<strong>Sobrou:</strong> {_fmt_brl(stats['sobrou'])}"
+                + (f" ({'+' if delta_pct >= 0 else ''}{delta_pct}% vs mês anterior)"
+                   if delta_pct is not None else "")
+                + "</p></div>"
+                f"<p>O detalhe completo tá no seu dashboard. Quer que eu abra a conta "
+                f"de alguma categoria? É só perguntar no WhatsApp. 🐷</p>"
+                f"<p class=\"sig\">— Repórter, o porquinho de plantão</p>"
+            )
+            send_agent_report_email(email, user_id, f"🎤 {titulo} — PigBank", corpo)
+    except Exception as exc:
+        print(f"[agents] reporter email user={user_id}: {exc}", file=sys.stderr)
+    return True
+
+
+def run_reporter_once(today: date | None = None) -> dict:
+    """Publica a manchete do mês fechado (só age nos primeiros 3 dias do mês)."""
+    from db import list_users_with_active_agents
+
+    today = today or date.today()
+    if today.day > 3:
+        return {"ok": True, "skipped": "fora da janela de fechamento"}
+    agents = list_users_with_active_agents("reporter")
+    sent = 0
+    for agent in agents:
+        try:
+            sent += 1 if _reporter_run_for_user(agent, today) else 0
+        except Exception as exc:
+            print(f"[agents] reporter user={agent['user_id']}: {exc}", file=sys.stderr)
+    return {"ok": True, "agents": len(agents), "published": sent}
+
+
+# ── Carteiro: boletos chegando (D-3 e D-0) ───────────────────────────────────
+
+def run_carteiro_once(today: date | None = None) -> dict:
+    """Registra no feed as contas pendentes vencendo em 3 dias e no dia.
+
+    Não toca em reminder_last_sent_on — essa coluna pertence ao lembrete
+    WhatsApp (dormente, wa_app._bill_reminder_tick). Dedupe própria via
+    agent_events.
+    """
+    from db import list_users_with_active_agents, record_agent_event
+
+    today = today or date.today()
+    agents = list_users_with_active_agents("carteiro")
+    fired = 0
+    for agent in agents:
+        user_id = agent["user_id"]
+        try:
+            with get_conn() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        select b.id, b.due_date, b.amount,
+                               coalesce(b.name, r.name, 'Conta') as nome,
+                               (b.due_date - %s) as dias
+                        from bill_instances b
+                        left join recurring_expenses r on r.id = b.recurring_id
+                        where b.user_id = %s
+                          and b.status = 'pending'
+                          and (b.due_date - %s) in (3, 0)
+                        """,
+                        (today, user_id, today),
+                    )
+                    bills = cur.fetchall() or []
+            for b in bills:
+                dias = int(b["dias"])
+                quando = "vence HOJE" if dias == 0 else f"vence em {dias} dias"
+                ok = record_agent_event(
+                    agent["agent_id"], user_id, "carteiro",
+                    dedupe_key=f"bill:{b['id']}:{dias}",
+                    payload={
+                        "tipo": "boleto",
+                        "bill_id": b["id"],
+                        "nome": b["nome"],
+                        "valor": float(b["amount"]),
+                        "vencimento": b["due_date"].isoformat(),
+                        "titulo": f"{b['nome']} {quando}",
+                        "mensagem": (
+                            f"📬 {b['nome']} ({_fmt_brl(float(b['amount']))}) {quando} "
+                            f"({b['due_date'].strftime('%d/%m')})."
+                        ),
+                    },
+                )
+                fired += 1 if ok else 0
+        except Exception as exc:
+            print(f"[agents] carteiro user={user_id}: {exc}", file=sys.stderr)
+    return {"ok": True, "agents": len(agents), "fired": fired}
+
+
+# ── Orquestração ─────────────────────────────────────────────────────────────
+
+def run_all_agents_once(today: date | None = None) -> dict:
+    today = today or date.today()
+    return {
+        "xerife": run_xerife_once(today),
+        "reporter": run_reporter_once(today),
+        "carteiro": run_carteiro_once(today),
+    }
+
+
+def run_agents_for_user(user_id: int, trigger: str = "of_sync") -> dict:
+    """Hook pós-sync do Open Finance: roda só o Xerife, só pro usuário sincado.
+
+    Fail-soft por contrato — quem chama (pluggy_sync) não pode quebrar por
+    causa de agente.
+    """
+    if not AGENTS_ENABLED:
+        return {"ok": True, "disabled": True}
+    try:
+        return run_xerife_once(user_id=user_id)
+    except Exception as exc:
+        print(f"[agents] run_for_user({user_id}, {trigger}): {exc}", file=sys.stderr)
+        return {"ok": False, "error": str(exc)}
+
+
+async def run_agents_loop() -> None:
+    """Loop perpétuo (asyncio task no lifespan). Tick horário."""
+    import asyncio
+
+    if not AGENTS_ENABLED:
+        print("[agents] AGENTS_ENABLED=0 — loop não iniciado")
+        return
+    await asyncio.sleep(5)
+    while True:
+        try:
+            result = await asyncio.to_thread(run_all_agents_once)
+            total = sum(
+                int(v.get("fired") or v.get("published") or 0)
+                for v in result.values() if isinstance(v, dict)
+            )
+            if total:
+                print(f"[agents] tick: {total} disparo(s) — {result}")
+        except Exception as exc:
+            print(f"[agents] tick falhou: {exc}", file=sys.stderr)
+        await asyncio.sleep(AGENTS_INTERVAL_SEC)

--- a/core/services/piggy_agents.py
+++ b/core/services/piggy_agents.py
@@ -189,13 +189,19 @@ def _month_stats(cur, user_id: int, first: date, nxt: date) -> dict[str, float]:
     cur.execute(
         """
         select
-          coalesce(sum(valor) filter (where tipo = 'receita'), 0)                 as entrou,
-          coalesce(sum(valor) filter (where tipo in ('despesa', 'saida')), 0)     as saiu,
+          coalesce(sum(valor) filter (where tipo = 'receita'
+                                        and is_internal_movement = false), 0)      as entrou,
+          coalesce(sum(valor) filter (where tipo in ('despesa', 'saida')
+                                        and is_internal_movement = false), 0)      as saiu,
+          -- aportes vêm de deposito/saque_caixinha, que db/pockets.py grava SEMPRE
+          -- como is_internal_movement=true. Por isso o guard de movimento interno
+          -- fica NOS filtros de entrou/saiu (pra não contar transferência como
+          -- receita/despesa), e NÃO no where global — senão aportes zeraria e
+          -- "sobrou" (receitas−despesas−aportes) sairia inflado.
           coalesce(sum(valor) filter (where tipo = 'deposito_caixinha'), 0)
             - coalesce(sum(valor) filter (where tipo = 'saque_caixinha'), 0)      as aportes
         from launches
         where user_id = %s
-          and is_internal_movement = false
           and criado_em >= %s and criado_em < %s
         """,
         (user_id, first, nxt),
@@ -210,7 +216,7 @@ def _month_stats(cur, user_id: int, first: date, nxt: date) -> dict[str, float]:
 
 
 def _reporter_run_for_user(agent: dict[str, Any], today: date) -> bool:
-    from db import record_agent_event, get_user_email
+    from db import record_agent_event, get_user_email, get_auth_user
 
     user_id = agent["user_id"]
     first_this = today.replace(day=1)
@@ -256,9 +262,14 @@ def _reporter_run_for_user(agent: dict[str, Any], today: date) -> bool:
         return False  # manchete do mês já publicada
 
     # E-mail é o canal principal do Repórter. Falha de e-mail não desfaz o
-    # evento do feed — o dashboard sempre registra.
+    # evento do feed — o dashboard sempre registra. Mas respeita quem se
+    # descadastrou dos e-mails de engajamento (engagement_opt_out, setado no
+    # /unsubscribe e no comando "parar emails"): a manchete continua no feed,
+    # só o envio proativo é suprimido.
     try:
-        email = get_user_email(user_id)
+        auth = get_auth_user(user_id)
+        opted_out = bool(auth and auth.get("engagement_opt_out"))
+        email = None if opted_out else get_user_email(user_id)
         if email:
             from core.services.email_service import send_agent_report_email
             corpo = (

--- a/core/services/pluggy_sync.py
+++ b/core/services/pluggy_sync.py
@@ -141,6 +141,16 @@ def sync_pluggy_item(provider_item_id: str) -> dict:
     # Propaga correções da Pluggy (transactions/updated) pros já importados (não deixa stale).
     updated = sync_imported_open_finance_updates(connection["user_id"], connection["id"])
 
+    # Agentes do Piggy — gatilho pós-sync: Xerife roda só sobre o delta deste
+    # usuário. IMPORTANTE: depois da reconciliação/import acima (merge-silencioso
+    # primeiro, senão duplicata manual+OF viraria falso positivo). Fail-soft.
+    if imported.get("inserted") or (imported_credit or {}).get("inserted"):
+        try:
+            from core.services.piggy_agents import run_agents_for_user
+            run_agents_for_user(connection["user_id"], trigger="of_sync")
+        except Exception as exc:  # nunca derruba o sync por causa de agente
+            print(f"[pluggy_sync] agents hook: {exc}")
+
     return {
         "ok": True,
         "item_id": provider_item_id,

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -213,6 +213,21 @@ from .open_finance import (
     update_pluggy_open_finance_item_status,
 )
 
+# ── Agentes do Piggy ──────────────────────────────────────────────────────────
+from .agents import (
+    AGENT_KINDS,
+    list_agents,
+    get_agent,
+    count_active_agents,
+    activate_agent,
+    pause_agent,
+    record_agent_event,
+    list_agent_events,
+    mark_agent_events_seen,
+    agents_summary,
+    list_users_with_active_agents,
+)
+
 # ── Relatórios, Auth, Dashboard, Engajamento ──────────────────────────────────
 from .reports import (
     set_daily_report_enabled,
@@ -460,4 +475,8 @@ __all__ = [
     "compute_behavioral_patterns",
     # insights (Sprint 7)
     "compute_active_insights",
+    # agentes do Piggy
+    "AGENT_KINDS", "list_agents", "get_agent", "count_active_agents",
+    "activate_agent", "pause_agent", "record_agent_event", "list_agent_events",
+    "mark_agent_events_seen", "agents_summary", "list_users_with_active_agents",
 ]

--- a/db/agents.py
+++ b/db/agents.py
@@ -1,0 +1,207 @@
+"""Agentes do Piggy — acesso a dados (agents + agent_events).
+
+Todas as funções são síncronas (chamar com asyncio.to_thread nos routers,
+como o resto do pacote db).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .connection import get_conn
+
+# Kinds fixos da Fase A. O catálogo de exibição (nome, descrição, arte)
+# vive no frontend/router; aqui só o que o banco precisa validar.
+AGENT_KINDS = ("xerife", "reporter", "carteiro")
+
+
+def list_agents(user_id: int) -> list[dict[str, Any]]:
+    """Agentes do usuário + contadores (disparos 30d, R$ salvos 365d)."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select a.id, a.kind, a.config, a.status, a.created_at,
+                       coalesce(e.fired_30d, 0)  as fired_30d,
+                       coalesce(e.saved_365d, 0) as saved_365d
+                from agents a
+                left join (
+                  select agent_id,
+                         count(*) filter (where fired_at >= now() - interval '30 days')  as fired_30d,
+                         coalesce(sum(valor_impacto) filter (
+                           where fired_at >= now() - interval '365 days'), 0)            as saved_365d
+                  from agent_events
+                  group by agent_id
+                ) e on e.agent_id = a.id
+                where a.user_id = %s
+                order by a.created_at
+                """,
+                (user_id,),
+            )
+            return list(cur.fetchall() or [])
+
+
+def get_agent(user_id: int, kind: str) -> dict[str, Any] | None:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select id, kind, config, status, created_at from agents"
+                " where user_id=%s and kind=%s",
+                (user_id, kind),
+            )
+            return cur.fetchone()
+
+
+def count_active_agents(user_id: int) -> int:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select count(*) as n from agents where user_id=%s and status='active'",
+                (user_id,),
+            )
+            row = cur.fetchone()
+            return int(row["n"]) if row else 0
+
+
+def activate_agent(user_id: int, kind: str, config: dict | None = None) -> dict[str, Any]:
+    """Cria (ou reativa) o agente. Upsert idempotente por (user_id, kind)."""
+    if kind not in AGENT_KINDS:
+        raise ValueError(f"kind inválido: {kind}")
+    cfg = json.dumps(config or {})
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into agents (user_id, kind, config, status)
+                values (%s, %s, %s::jsonb, 'active')
+                on conflict (user_id, kind) do update
+                  set status = 'active',
+                      config = case when excluded.config <> '{}'::jsonb
+                                    then excluded.config else agents.config end
+                returning id, kind, config, status, created_at
+                """,
+                (user_id, kind, cfg),
+            )
+            row = cur.fetchone()
+        conn.commit()
+    return row
+
+
+def pause_agent(user_id: int, kind: str) -> bool:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update agents set status='paused' where user_id=%s and kind=%s",
+                (user_id, kind),
+            )
+            changed = cur.rowcount > 0
+        conn.commit()
+    return changed
+
+
+def record_agent_event(
+    agent_id: int,
+    user_id: int,
+    kind: str,
+    dedupe_key: str,
+    payload: dict | None = None,
+    channel: str = "dashboard",
+    valor_impacto: float | None = None,
+) -> bool:
+    """Registra um disparo. Retorna False se a dedupe_key já existia."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into agent_events
+                  (agent_id, user_id, kind, dedupe_key, payload, channel, valor_impacto)
+                values (%s, %s, %s, %s, %s::jsonb, %s, %s)
+                on conflict (agent_id, dedupe_key) do nothing
+                """,
+                (agent_id, user_id, kind, dedupe_key,
+                 json.dumps(payload or {}), channel, valor_impacto),
+            )
+            inserted = cur.rowcount > 0
+        conn.commit()
+    return inserted
+
+
+def list_agent_events(user_id: int, limit: int = 20) -> list[dict[str, Any]]:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select id, kind, fired_at, payload, channel, valor_impacto, seen_at
+                from agent_events
+                where user_id=%s
+                order by fired_at desc
+                limit %s
+                """,
+                (user_id, limit),
+            )
+            return list(cur.fetchall() or [])
+
+
+def mark_agent_events_seen(user_id: int) -> int:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update agent_events set seen_at=now() where user_id=%s and seen_at is null",
+                (user_id,),
+            )
+            n = cur.rowcount
+        conn.commit()
+    return n
+
+
+def agents_summary(user_id: int) -> dict[str, Any]:
+    """Contadores do topo da página: ativos, pausados, disparos do mês, salvos no ano."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select
+                  count(*) filter (where status='active') as ativos,
+                  count(*) filter (where status='paused') as pausados
+                from agents where user_id=%s
+                """,
+                (user_id,),
+            )
+            a = cur.fetchone() or {}
+            cur.execute(
+                """
+                select
+                  count(*) filter (where fired_at >= date_trunc('month', now())) as disparos_mes,
+                  coalesce(sum(valor_impacto) filter (
+                    where fired_at >= now() - interval '365 days'), 0)           as salvos_ano,
+                  count(*) filter (where seen_at is null)                        as nao_lidos
+                from agent_events where user_id=%s
+                """,
+                (user_id,),
+            )
+            e = cur.fetchone() or {}
+    return {
+        "ativos": int(a.get("ativos") or 0),
+        "pausados": int(a.get("pausados") or 0),
+        "disparos_mes": int(e.get("disparos_mes") or 0),
+        "salvos_ano": float(e.get("salvos_ano") or 0),
+        "nao_lidos": int(e.get("nao_lidos") or 0),
+    }
+
+
+def list_users_with_active_agents(kind: str | None = None) -> list[dict[str, Any]]:
+    """(user_id, agent_id, kind, config) de todos os agentes ativos — insumo do runner."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            if kind:
+                cur.execute(
+                    "select id as agent_id, user_id, kind, config from agents"
+                    " where status='active' and kind=%s order by user_id",
+                    (kind,),
+                )
+            else:
+                cur.execute(
+                    "select id as agent_id, user_id, kind, config from agents"
+                    " where status='active' order by user_id",
+                )
+            return list(cur.fetchall() or [])

--- a/db/agents.py
+++ b/db/agents.py
@@ -63,13 +63,35 @@ def count_active_agents(user_id: int) -> int:
             return int(row["n"]) if row else 0
 
 
-def activate_agent(user_id: int, kind: str, config: dict | None = None) -> dict[str, Any]:
-    """Cria (ou reativa) o agente. Upsert idempotente por (user_id, kind)."""
+def activate_agent(
+    user_id: int, kind: str, config: dict | None = None, allow_multiple: bool = True
+) -> dict[str, Any] | None:
+    """Cria (ou reativa) o agente. Upsert idempotente por (user_id, kind).
+
+    Com `allow_multiple=False` (plano sem direito a vários agentes), a checagem
+    de limite e a ativação acontecem na MESMA transação, serializadas por um
+    advisory lock por usuário — senão duas ativações concorrentes de kinds
+    diferentes leem count=0 e ambas ativam, furando o teto do Free (TOCTOU).
+    Retorna None quando o limite bloqueia (o usuário já tem outro agente ativo).
+    Reativar o MESMO kind nunca conta como novo agente (kind <> %s no count).
+    """
     if kind not in AGENT_KINDS:
         raise ValueError(f"kind inválido: {kind}")
     cfg = json.dumps(config or {})
     with get_conn() as conn:
         with conn.cursor() as cur:
+            if not allow_multiple:
+                # Lock por usuário (liberado no fim da transação). hashtext→int4,
+                # promovido a bigint pela assinatura de 1 arg da função.
+                cur.execute("select pg_advisory_xact_lock(hashtext(%s))", (f"agent_activate:{user_id}",))
+                cur.execute(
+                    "select count(*) as n from agents"
+                    " where user_id=%s and status='active' and kind <> %s",
+                    (user_id, kind),
+                )
+                if int((cur.fetchone() or {}).get("n") or 0) >= 1:
+                    conn.rollback()
+                    return None
             cur.execute(
                 """
                 insert into agents (user_id, kind, config, status)

--- a/db/schema.py
+++ b/db/schema.py
@@ -1536,6 +1536,61 @@ def init_db():
         create index if not exists idx_affiliate_commissions_affiliate
           on affiliate_commissions (affiliate_id, status, available_at)
         """,
+
+        # ── Planos v2 (escada Grátis/Essencial/Plus/Pro) ─────────────────────
+        # Trial de 30 dias sem cartão. plan_trials é keyed por phone_hash e
+        # NÃO tem FK pra users de propósito: sobrevive à deleção da conta —
+        # recriar conta com o mesmo número herda o started_at original (trial
+        # já queimado). Regra: 30 dias únicos por telefone, na vida.
+        """alter table auth_accounts add column if not exists trial_started_at timestamptz""",
+        """
+        create table if not exists plan_trials (
+          phone_hash text primary key,
+          user_id bigint,
+          started_at timestamptz not null default now()
+        )
+        """,
+
+        # ── Agentes do Piggy (prateleira de jobs proativos) ──────────────────
+        # Um agente por kind por usuário (custom multiplica no futuro via
+        # config, não via linhas). status: 'active' | 'paused'.
+        """
+        create table if not exists agents (
+          id bigserial primary key,
+          user_id bigint not null references users(id) on delete cascade,
+          kind text not null,
+          config jsonb not null default '{}'::jsonb,
+          status text not null default 'active',
+          created_at timestamptz not null default now(),
+          unique (user_id, kind)
+        )
+        """,
+        """
+        create index if not exists idx_agents_user_status
+          on agents (user_id, status)
+        """,
+        # Cada disparo de agente. dedupe_key torna o runner idempotente
+        # (rodar o detector N vezes no dia não duplica alerta). valor_impacto
+        # alimenta o placar "R$ salvos"; seen_at = lido/não lido no feed.
+        """
+        create table if not exists agent_events (
+          id bigserial primary key,
+          agent_id bigint not null references agents(id) on delete cascade,
+          user_id bigint not null references users(id) on delete cascade,
+          kind text not null,
+          fired_at timestamptz not null default now(),
+          dedupe_key text not null,
+          payload jsonb not null default '{}'::jsonb,
+          channel text not null default 'dashboard',
+          valor_impacto numeric,
+          seen_at timestamptz,
+          unique (agent_id, dedupe_key)
+        )
+        """,
+        """
+        create index if not exists idx_agent_events_user_time
+          on agent_events (user_id, fired_at desc)
+        """,
     ]
 
     # autocommit: cada DDL roda em sua propria transacao e libera locks

--- a/frontend/blog-article.html
+++ b/frontend/blog-article.html
@@ -27,6 +27,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/comandos.html
+++ b/frontend/comandos.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/como-funciona.html
+++ b/frontend/como-funciona.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona" class="active">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -2075,3 +2075,67 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
                    animation:pig-bob 2.2s var(--ease) infinite; }
 @keyframes pig-bob { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-7px)} }
 @media (prefers-reduced-motion: reduce) { .loading-sticker { animation:none; } }
+
+/* ═══ Agentes do Piggy ═══════════════════════════════════════════════════ */
+.ag-sub { color: var(--text-2); font-size: 14px; margin: -6px 0 18px; max-width: 60ch; }
+.ag-counters { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; font-size: 13px; color: var(--text-2); }
+.ag-counter { display: inline-flex; align-items: center; gap: 6px; }
+.ag-counter b { color: var(--text); font-variant-numeric: tabular-nums; }
+.ag-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.ag-dot-on { background: var(--neon); }
+.ag-dot-off { background: var(--text-3); }
+.ag-dot-fire { background: var(--purple); }
+.ag-money { color: var(--neon); font-weight: 700; }
+
+.ag-shelf { display: grid; grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); gap: 14px; }
+.ag-card {
+  background: var(--glass-bg); border: 1px solid var(--glass-border);
+  border-radius: var(--radius); padding: 14px;
+  display: flex; flex-direction: column; gap: 9px;
+  transition: transform .15s var(--ease), border-color .15s var(--ease);
+}
+.ag-card:hover { transform: translateY(-3px); border-color: rgba(255, 45, 142, .35); }
+.ag-card-soon { opacity: .62; }
+.ag-card h3 { margin: 0; font-size: 16px; }
+.ag-desc { margin: 0; font-size: 12.5px; color: var(--text-2); line-height: 1.45; min-height: 36px; }
+.ag-chips { display: flex; gap: 6px; flex-wrap: wrap; }
+.ag-chip { font-size: 10.5px; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--glass-border); color: var(--text-2); }
+.ag-chip-fire { border-color: rgba(255, 201, 77, .4); color: #FFC94D; }
+.ag-chip-money { border-color: rgba(198, 241, 26, .4); color: var(--neon); }
+
+.ag-avatar {
+  border-radius: 14px; aspect-ratio: 1.35; overflow: hidden;
+  display: flex; align-items: flex-end; justify-content: center;
+}
+.ag-avatar svg { width: 72%; height: auto; display: block; }
+.ag-bg-xerife   { background: radial-gradient(circle at 30% 25%, #5A2140, #1E0C18); }
+.ag-bg-reporter { background: radial-gradient(circle at 70% 30%, #23404F, #0D1418); }
+.ag-bg-carteiro { background: radial-gradient(circle at 35% 70%, #4F3A16, #171006); }
+.ag-bg-detetive { background: radial-gradient(circle at 60% 25%, #33254F, #100C1B); }
+.ag-bg-cofre    { background: radial-gradient(circle at 30% 60%, #1E4A33, #08130D); }
+.ag-bg-barao    { background: radial-gradient(circle at 60% 40%, #4A3B12, #14100A); }
+.ag-bg-aviador  { background: radial-gradient(circle at 40% 30%, #16394F, #0A1218); }
+
+.ag-btn {
+  margin-top: auto; width: 100%; text-align: center; cursor: pointer;
+  font-size: 13px; font-weight: 700; border-radius: 11px; padding: 9px 0;
+  border: 1px solid transparent; font-family: inherit;
+}
+.ag-btn-on { background: var(--purple); color: #fff; }
+.ag-btn-on:hover { filter: brightness(1.08); }
+.ag-btn-active { background: transparent; border-color: var(--neon); color: var(--neon); }
+.ag-btn-soon { background: var(--glass-bg); color: var(--text-3); cursor: default; }
+
+.ag-feed-title { margin: 26px 0 12px; }
+.ag-feed { display: flex; flex-direction: column; gap: 10px; max-width: 760px; }
+.ag-event {
+  display: flex; gap: 12px; align-items: flex-start;
+  background: var(--glass-bg); border: 1px solid var(--glass-border);
+  border-radius: 14px; padding: 12px 14px;
+}
+.ag-event-new { border-color: rgba(255, 45, 142, .45); }
+.ag-event-face { width: 40px; height: 40px; border-radius: 10px; flex: none; overflow: hidden; display: flex; align-items: flex-end; justify-content: center; }
+.ag-event-face svg { width: 86%; height: auto; }
+.ag-event-body { min-width: 0; }
+.ag-event-msg { margin: 0; font-size: 13.5px; line-height: 1.45; }
+.ag-event-when { margin: 3px 0 0; font-size: 11.5px; color: var(--text-3); }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -47,6 +47,9 @@
   <button class="sidenav-item" type="button" data-nav="history" onclick="navigateTo('history')">
     <span class="sn-icon">🕒</span><span class="sn-label">Histórico</span>
   </button>
+  <button class="sidenav-item" type="button" data-nav="agentes" onclick="navigateTo('agentes')">
+    <span class="sn-icon">🐷</span><span class="sn-label">Agentes</span><span class="sn-tag new">novo</span>
+  </button>
 
   <div class="sidenav-section">Planejamento</div>
   <button class="sidenav-item" type="button" data-nav="fixed" onclick="navigateTo('fixed')">
@@ -516,6 +519,103 @@
     <div id="affiliate-stats" class="stats-row"></div>
 
     <div id="affiliate-body" class="mock-grid cols-2"></div>
+  </div>
+
+  <div id="agentes-view" class="dash-view">
+    <!-- Porquinhos: symbols SVG reutilizados nos cards e no feed -->
+    <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+      <defs>
+        <g id="pig-base">
+          <path d="M30 46 Q22 20 48 31 Q37 38 35 52 Z" fill="#E87FAC"/>
+          <path d="M90 46 Q98 20 72 31 Q83 38 85 52 Z" fill="#E87FAC"/>
+          <path d="M33 43 Q29 28 45 34 Q38 39 37 48 Z" fill="#C95A8B"/>
+          <path d="M87 43 Q91 28 75 34 Q82 39 83 48 Z" fill="#C95A8B"/>
+          <circle cx="60" cy="70" r="36" fill="#F48FB8"/>
+          <circle cx="39" cy="79" r="5.5" fill="#F7B1CC" opacity=".8"/>
+          <circle cx="81" cy="79" r="5.5" fill="#F7B1CC" opacity=".8"/>
+          <ellipse cx="60" cy="82" rx="17" ry="12" fill="#E86FA4"/>
+          <ellipse cx="54" cy="82" rx="2.6" ry="4.2" fill="#8A2F5C"/>
+          <ellipse cx="66" cy="82" rx="2.6" ry="4.2" fill="#8A2F5C"/>
+          <circle cx="46" cy="63" r="4" fill="#2A1118"/>
+          <circle cx="74" cy="63" r="4" fill="#2A1118"/>
+          <circle cx="47.4" cy="61.6" r="1.3" fill="#fff"/>
+          <circle cx="75.4" cy="61.6" r="1.3" fill="#fff"/>
+        </g>
+        <symbol id="ag-pig-xerife" viewBox="0 14 120 106">
+          <use href="#pig-base"/>
+          <path d="M40 55 Q46 51 52 54" stroke="#6B2346" stroke-width="3" fill="none" stroke-linecap="round"/>
+          <path d="M80 55 Q74 51 68 54" stroke="#6B2346" stroke-width="3" fill="none" stroke-linecap="round"/>
+          <ellipse cx="60" cy="38" rx="32" ry="8" fill="#7A4A22"/>
+          <path d="M44 37 Q43 16 60 16 Q77 16 76 37 Z" fill="#8F5A2B"/>
+          <rect x="44" y="31" width="32" height="6" fill="#5A3418"/>
+          <path d="M60 20 L61.8 24 L66 24.3 L62.8 27 L63.9 31 L60 28.7 L56.1 31 L57.2 27 L54 24.3 L58.2 24 Z" fill="#F2C230"/>
+        </symbol>
+        <symbol id="ag-pig-reporter" viewBox="0 10 120 110">
+          <use href="#pig-base"/>
+          <path d="M34 40 Q34 18 60 18 Q86 18 86 40 Z" fill="#3E5068"/>
+          <ellipse cx="60" cy="40" rx="26" ry="5" fill="#2C3A4B"/>
+          <circle cx="60" cy="17.5" r="2.6" fill="#2C3A4B"/>
+          <g transform="rotate(8 76 26)">
+            <rect x="67" y="18" width="18" height="12.5" rx="1.5" fill="#F5EEF1" stroke="#C9B3BD"/>
+            <text x="76" y="27" text-anchor="middle" font-size="5.4" font-weight="800" fill="#2A1118">PRESS</text>
+          </g>
+          <rect x="86" y="94" width="8" height="20" rx="4" fill="#3A2C34" transform="rotate(-24 90 104)"/>
+          <circle cx="92" cy="89" r="8.5" fill="#55677E" stroke="#2C3A4B" stroke-width="2"/>
+          <path d="M86.5 86 L97.5 86 M85.5 89 L98.5 89 M86.5 92 L97.5 92" stroke="#2C3A4B" stroke-width="1.2"/>
+        </symbol>
+        <symbol id="ag-pig-carteiro" viewBox="0 18 120 102">
+          <use href="#pig-base"/>
+          <path d="M38 40 Q38 21 60 21 Q82 21 82 40 Z" fill="#2E4C9E"/>
+          <ellipse cx="60" cy="40" rx="27" ry="5.5" fill="#233C80"/>
+          <circle cx="60" cy="30" r="4" fill="#F2C230"/>
+          <rect x="76" y="88" width="30" height="21" rx="2.5" fill="#F5EEF1" stroke="#C9B3BD"/>
+          <path d="M76 90 L91 101 L106 90" stroke="#FF2D8E" stroke-width="2" fill="none"/>
+        </symbol>
+        <symbol id="ag-pig-detetive" viewBox="0 16 120 104">
+          <use href="#pig-base"/>
+          <path d="M40 54 Q46 50 52 53" stroke="#6B2346" stroke-width="3" fill="none" stroke-linecap="round"/>
+          <path d="M68 50 Q74 47 80 50" stroke="#6B2346" stroke-width="3" fill="none" stroke-linecap="round"/>
+          <path d="M36 40 Q36 19 60 19 Q84 19 84 40 Z" fill="#7A5A34"/>
+          <ellipse cx="60" cy="40" rx="25" ry="5" fill="#5F4426"/>
+          <circle cx="90" cy="88" r="12" fill="rgba(198,241,26,.14)" stroke="#C9A227" stroke-width="3.2"/>
+          <path d="M98.5 96.5 L109 107" stroke="#8A6E2B" stroke-width="5" stroke-linecap="round"/>
+        </symbol>
+        <symbol id="ag-pig-cofre" viewBox="0 6 120 114">
+          <use href="#pig-base"/>
+          <rect x="51" y="30" width="18" height="5.5" rx="2.75" fill="#2A1118"/>
+          <circle cx="60" cy="16" r="8" fill="#F2C230" stroke="#C99A1E" stroke-width="2"/>
+          <rect x="57.5" y="12.5" width="5" height="7" rx="1" fill="#C99A1E"/>
+        </symbol>
+        <symbol id="ag-pig-barao" viewBox="0 2 120 118">
+          <use href="#pig-base"/>
+          <rect x="43" y="6" width="34" height="28" rx="3" fill="#1B0F16"/>
+          <rect x="43" y="26" width="34" height="7" fill="#FF2D8E"/>
+          <ellipse cx="60" cy="34" rx="27" ry="6" fill="#14090F"/>
+          <circle cx="74" cy="63" r="9" fill="rgba(255,255,255,.06)" stroke="#C9A227" stroke-width="2.2"/>
+          <path d="M80 70 Q90 82 85 96" stroke="#C9A227" stroke-width="1.8" fill="none"/>
+          <path d="M44 92 Q52 86 60 91 M60 91 Q68 86 76 92" stroke="#3A2230" stroke-width="3.2" fill="none" stroke-linecap="round"/>
+        </symbol>
+        <symbol id="ag-pig-aviador" viewBox="0 12 120 108">
+          <use href="#pig-base"/>
+          <path d="M32 46 Q32 17 60 17 Q88 17 88 46 Q74 38 60 38 Q46 38 32 46 Z" fill="#6B4A2B"/>
+          <circle cx="47" cy="42" r="7.5" fill="#9FD8E8" stroke="#3A2A1B" stroke-width="2.6"/>
+          <circle cx="73" cy="42" r="7.5" fill="#9FD8E8" stroke="#3A2A1B" stroke-width="2.6"/>
+          <path d="M54.5 42 L65.5 42 M39.5 42 L32 44 M80.5 42 L88 44" stroke="#3A2A1B" stroke-width="2.6"/>
+          <path d="M38 101 Q60 111 82 101 L82 110 Q60 118 38 110 Z" fill="#D6453A"/>
+        </symbol>
+      </defs>
+    </svg>
+
+    <div class="mock-header">
+      <p class="section-title" style="margin:0">Agentes</p>
+      <div id="agentes-counters" class="ag-counters"></div>
+    </div>
+    <p class="ag-sub">Sua equipe de porquinhos trabalhando 24h nos seus dados — cada um vigia uma coisa e só fala quando vale a pena.</p>
+
+    <div id="agentes-shelf" class="ag-shelf"></div>
+
+    <p class="section-title ag-feed-title">Últimos disparos</p>
+    <div id="agentes-feed" class="ag-feed"></div>
   </div>
 
   <div id="categories-view" class="dash-view">

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -383,7 +383,7 @@ function taxProfileForAsset(assetType) {
 // Mapa view-id → elemento. Inclui as novas seções acessíveis pelo sidebar.
 const DASH_VIEWS = [
   "overview", "analytics", "history", "fixed", "budgets", "goals",
-  "categories", "installments", "cards", "investments", "affiliate"
+  "categories", "installments", "cards", "investments", "affiliate", "agentes"
 ];
 
 function setMainView(view) {
@@ -430,6 +430,7 @@ function navigateTo(view) {
   if (view === "fixed") setRecurringTab("overview");
   if (view === "goals") loadGoalsView();
   if (view === "affiliate") loadAffiliateView();
+  if (view === "agentes") loadAgentesView();
 }
 
 // ── Cartões (view dinâmica conectada ao backend) ──────────────────────
@@ -5453,6 +5454,7 @@ const UPGRADE_MESSAGES = {
   history_unlimited: "Histórico além de 30 dias é exclusivo do PigBank+.",
   changelog: "As notícias e resumos do mercado feitos pela Piggy são exclusivos do PigBank+. Assine pra desbloquear.",
   recurring_expenses: "A agenda de boletos e os gastos fixos são exclusivos do PigBank+. Cadastre suas contas a pagar e nunca mais perca um vencimento.",
+  agents: "No Free você ativa 1 agente. Com PigBank+ a equipe inteira de porquinhos trabalha pra você — Xerife, Repórter, Carteiro e os próximos que chegarem.",
   generic: "Essa feature é exclusiva pra quem assina o PigBank+."
 };
 
@@ -9143,4 +9145,139 @@ if ("serviceWorker" in navigator) {
       .then(r => console.log("[PWA] SW registered:", r.scope))
       .catch(e => console.warn("[PWA] SW failed:", e));
   });
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   AGENTES DO PIGGY — prateleira, ativação e feed de disparos
+   ═══════════════════════════════════════════════════════════════════════ */
+let _agentesCache = null;
+
+async function loadAgentesView(forceFresh = false) {
+  const shelf = document.getElementById("agentes-shelf");
+  const feedEl = document.getElementById("agentes-feed");
+  if (!shelf) return;
+
+  if (_agentesCache && !forceFresh) {
+    _renderAgentes(_agentesCache);
+  } else {
+    shelf.innerHTML = `<div class="empty" style="grid-column:1/-1;padding:26px">Chamando os porquinhos… 🐷</div>`;
+    if (feedEl) feedEl.innerHTML = "";
+  }
+
+  try {
+    const [shelfRes, feedRes] = await Promise.all([
+      fetch(`${API}/agents/${USER_ID}`, { credentials: "same-origin" }),
+      fetch(`${API}/agents/${USER_ID}/feed?limit=20`, { credentials: "same-origin" }),
+    ]);
+    const data = await readResponsePayload(shelfRes);
+    if (!shelfRes.ok) throw new Error(data.detail || "Não foi possível carregar os agentes.");
+    const feed = await readResponsePayload(feedRes);
+    data.events = feedRes.ok ? (feed.events || []) : [];
+    _agentesCache = data;
+    _renderAgentes(data);
+    // Marca o feed como lido (fire-and-forget; não bloqueia a view)
+    fetch(`${API}/agents/${USER_ID}/feed/seen`, {
+      method: "POST", credentials: "same-origin", headers: csrfHeaders(),
+    }).catch(() => {});
+  } catch (err) {
+    shelf.innerHTML = `<div class="empty" style="grid-column:1/-1;padding:30px;color:var(--red)">Erro: ${esc(String(err.message || err))}</div>`;
+  }
+}
+
+function _renderAgentes(data) {
+  const counters = document.getElementById("agentes-counters");
+  const shelf = document.getElementById("agentes-shelf");
+  const feedEl = document.getElementById("agentes-feed");
+  if (!shelf) return;
+
+  const s = data.summary || {};
+  if (counters) {
+    counters.innerHTML = `
+      <span class="ag-counter"><i class="ag-dot ag-dot-on"></i> Ativos <b>${s.ativos || 0}</b></span>
+      <span class="ag-counter"><i class="ag-dot ag-dot-off"></i> Pausados <b>${s.pausados || 0}</b></span>
+      <span class="ag-counter"><i class="ag-dot ag-dot-fire"></i> Disparos <b>${s.disparos_mes || 0}</b></span>
+      ${s.salvos_ano > 0 ? `<span class="ag-counter ag-money">💰 ${fmt(s.salvos_ano)} salvos</span>` : ""}
+    `;
+  }
+
+  shelf.innerHTML = (data.catalog || []).map(card => {
+    const active = card.status === "active";
+    const chips = [
+      `<span class="ag-chip">${esc(card.freq)}</span>`,
+      card.fired_30d > 0 ? `<span class="ag-chip ag-chip-fire">⚡ ${card.fired_30d}</span>` : "",
+      card.saved_365d > 0 ? `<span class="ag-chip ag-chip-money">💰 ${fmtShort(card.saved_365d)}</span>` : "",
+    ].filter(Boolean).join("");
+    const btn = !card.disponivel
+      ? `<button class="ag-btn ag-btn-soon" disabled>Em breve</button>`
+      : active
+        ? `<button class="ag-btn ag-btn-active" onclick="pauseAgent('${card.kind}')">✓ Ativo · Pausar</button>`
+        : `<button class="ag-btn ag-btn-on" onclick="activateAgent('${card.kind}')">Ativar</button>`;
+    return `
+      <div class="ag-card${!card.disponivel ? " ag-card-soon" : ""}">
+        <div class="ag-avatar ag-bg-${esc(card.kind)}">
+          <svg viewBox="0 6 120 114" aria-hidden="true"><use href="#ag-pig-${esc(card.kind)}"/></svg>
+        </div>
+        <h3>${esc(card.nome)}</h3>
+        <p class="ag-desc">${esc(card.desc)}</p>
+        <div class="ag-chips">${chips}</div>
+        ${btn}
+      </div>
+    `;
+  }).join("");
+
+  if (feedEl) {
+    const events = data.events || [];
+    feedEl.innerHTML = events.length === 0
+      ? `<div class="empty" style="padding:22px">Nenhum disparo ainda. Ative um agente e ele fala assim que tiver algo que vale a pena. 🐷</div>`
+      : events.map(ev => {
+          const p = ev.payload || {};
+          return `
+            <div class="ag-event${ev.seen_at ? "" : " ag-event-new"}">
+              <div class="ag-event-face ag-bg-${esc(ev.kind)}">
+                <svg viewBox="0 6 120 114" aria-hidden="true"><use href="#ag-pig-${esc(ev.kind)}"/></svg>
+              </div>
+              <div class="ag-event-body">
+                <p class="ag-event-msg">${esc(p.mensagem || p.titulo || "Disparo")}</p>
+                <p class="ag-event-when">${esc(_agentName(ev.kind))} · ${fmtDate(ev.fired_at)}${ev.channel === "email" ? " · 📧 no seu e-mail" : ""}</p>
+              </div>
+            </div>
+          `;
+        }).join("");
+  }
+}
+
+function _agentName(kind) {
+  const card = ((_agentesCache || {}).catalog || []).find(c => c.kind === kind);
+  return card ? card.nome : kind;
+}
+
+async function activateAgent(kind) {
+  try {
+    const res = await fetch(`${API}/agents/${USER_ID}/${kind}/activate`, {
+      method: "POST", credentials: "same-origin",
+      headers: csrfHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({}),
+    });
+    const data = await readResponsePayload(res);
+    if (res.status === 403 && (data.detail || {}).error === "pro_required") {
+      showUpgradeModal("agents");
+      return;
+    }
+    if (!res.ok) throw new Error((data.detail && data.detail.error) || data.detail || "Não deu pra ativar o agente.");
+    loadAgentesView(true);
+  } catch (err) {
+    alert(String(err.message || err));
+  }
+}
+
+async function pauseAgent(kind) {
+  try {
+    const res = await fetch(`${API}/agents/${USER_ID}/${kind}/pause`, {
+      method: "POST", credentials: "same-origin", headers: csrfHeaders(),
+    });
+    if (!res.ok) throw new Error("Não deu pra pausar o agente.");
+    loadAgentesView(true);
+  } catch (err) {
+    alert(String(err.message || err));
+  }
 }

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -85,6 +85,7 @@ from db import (
     delete_launch_and_rollback,
 )
 from frontend.routes.affiliates import router as affiliates_router
+from frontend.routes.agents import router as agents_router
 from frontend.routes.analytics import router as analytics_router
 from frontend.routes.cards import router as cards_router
 from frontend.routes.open_finance import router as open_finance_router
@@ -1408,6 +1409,14 @@ async def lifespan(app: FastAPI):
         except Exception as exc:
             print(f"[news_bot] erro: {exc}", file=sys.stderr)
 
+    async def _piggy_agents():
+        try:
+            await asyncio.sleep(1)
+            from core.services.piggy_agents import run_agents_loop  # noqa: PLC0415
+            await run_agents_loop()
+        except Exception as exc:
+            print(f"[agents] erro: {exc}", file=sys.stderr)
+
     async def _account_deletion_worker():
         while True:
             try:
@@ -1485,6 +1494,7 @@ async def lifespan(app: FastAPI):
                 asyncio.create_task(_recurring_charger(), name="recurring_charger"),
                 asyncio.create_task(_proactive_ai(), name="proactive_ai"),
                 asyncio.create_task(_news_bot(), name="news_bot"),
+                asyncio.create_task(_piggy_agents(), name="piggy_agents"),
             ]
         )
     else:
@@ -4311,6 +4321,10 @@ app.include_router(analytics_router)
 
 # ─── Programa de afiliados → frontend/routes/affiliates.py ───────────────────
 app.include_router(affiliates_router)
+
+
+# ─── Agentes do Piggy → frontend/routes/agents.py ────────────────────────────
+app.include_router(agents_router)
 
 
 @app.get("/debug/ai/{user_id}/payload")

--- a/frontend/funcionalidades.html
+++ b/frontend/funcionalidades.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades" class="active">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,7 @@
       <a href="#funcionalidades">Funcionalidades</a>
       <a href="#como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -27,6 +27,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos" class="active">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/routes/agents.py
+++ b/frontend/routes/agents.py
@@ -1,0 +1,155 @@
+"""Agentes do Piggy — API do dashboard (prateleira, ativação, feed).
+
+Gate de plano: Free ativa 1 agente; Plus/Pro (v2) ou Pro (v1) ativam todos.
+Espelha o padrão dos outros routers: shared.authorize_dashboard_access por
+atributo de módulo + db lazy + asyncio.to_thread.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from frontend.routes import shared
+
+router = APIRouter()
+
+# Catálogo da prateleira. "disponivel": False = card "Em breve" (aparece
+# desabilitado — gate visível, nunca escondido). A arte (SVG) vive no front.
+AGENT_CATALOG: list[dict] = [
+    {
+        "kind": "xerife", "nome": "Xerife", "emoji": "🤠",
+        "freq": "Diário · a cada sync",
+        "desc": "Alerta quando um gasto foge do seu padrão ou uma categoria estoura o limite",
+        "disponivel": True,
+    },
+    {
+        "kind": "reporter", "nome": "Repórter", "emoji": "🎤",
+        "freq": "Mensal",
+        "desc": "Traz a manchete do seu mês: o que entrou, o que saiu e quanto sobrou",
+        "disponivel": True,
+    },
+    {
+        "kind": "carteiro", "nome": "Carteiro", "emoji": "📬",
+        "freq": "Contínuo",
+        "desc": "Não deixa boleto vencer: avisa antes, direto no seu feed",
+        "disponivel": True,
+    },
+    {
+        "kind": "detetive", "nome": "Detetive", "emoji": "🔍",
+        "freq": "Semanal",
+        "desc": "Fareja cobranças repetidas que parecem assinatura esquecida",
+        "disponivel": False,
+    },
+    {
+        "kind": "cofre", "nome": "Cofre", "emoji": "🎯",
+        "freq": "Dia do salário",
+        "desc": "Acompanha suas caixinhas e sugere o aporte que adianta a meta",
+        "disponivel": False,
+    },
+    {
+        "kind": "barao", "nome": "Barão", "emoji": "🎩",
+        "freq": "Diário · Open Finance",
+        "desc": "Fareja dinheiro parado rendendo nada e acompanha seus investimentos",
+        "disponivel": False,
+    },
+    {
+        "kind": "aviador", "nome": "Aviador", "emoji": "✈️",
+        "freq": "Dados externos",
+        "desc": "Caça passagem em promoção pros destinos que você marcar",
+        "disponivel": False,
+    },
+]
+
+
+def _plan_allows_multiple(user_id: int) -> bool:
+    from core.services.plan_service import is_pro, plans_v2_enabled, require_min_tier
+    if plans_v2_enabled():
+        # Escada v2: agentes ilimitados são corte do Plus (ver _FEATURE_MIN_TIER_V2).
+        return require_min_tier(user_id, "plus")
+    return is_pro(user_id)
+
+
+class ActivateBody(BaseModel):
+    config: dict | None = None
+
+
+@router.get("/agents/{user_id}")
+async def agents_shelf_route(request: Request, user_id: int):
+    shared.authorize_dashboard_access(request, user_id)
+    from db import agents_summary, list_agents
+
+    mine, summary, multi = await asyncio.gather(
+        asyncio.to_thread(list_agents, user_id),
+        asyncio.to_thread(agents_summary, user_id),
+        asyncio.to_thread(_plan_allows_multiple, user_id),
+    )
+    by_kind = {a["kind"]: a for a in mine}
+    catalog = []
+    for card in AGENT_CATALOG:
+        mine_a = by_kind.get(card["kind"])
+        catalog.append({
+            **card,
+            "status": (mine_a or {}).get("status"),
+            "config": (mine_a or {}).get("config") or {},
+            "fired_30d": int((mine_a or {}).get("fired_30d") or 0),
+            "saved_365d": float((mine_a or {}).get("saved_365d") or 0),
+        })
+    return {"ok": True, "summary": summary, "catalog": catalog, "multi_allowed": multi}
+
+
+@router.post("/agents/{user_id}/{kind}/activate")
+async def agents_activate_route(request: Request, user_id: int, kind: str, body: ActivateBody | None = None):
+    shared.authorize_dashboard_access(request, user_id)
+    from db import AGENT_KINDS, activate_agent, count_active_agents, get_agent
+
+    if kind not in AGENT_KINDS:
+        available = {c["kind"] for c in AGENT_CATALOG if c["disponivel"]}
+        detail = "Esse agente ainda não está disponível." if kind in {c["kind"] for c in AGENT_CATALOG} - available \
+            else "Agente desconhecido."
+        raise HTTPException(status_code=400, detail=detail)
+
+    existing = await asyncio.to_thread(get_agent, user_id, kind)
+    already_active = bool(existing and existing["status"] == "active")
+    if not already_active:
+        active_count = await asyncio.to_thread(count_active_agents, user_id)
+        if active_count >= 1 and not await asyncio.to_thread(_plan_allows_multiple, user_id):
+            # Mesmo payload de 403 do resto do app → frontend abre o modal de upgrade.
+            raise HTTPException(status_code=403, detail={"error": "pro_required", "feature": "agents"})
+
+    config = (body.config if body else None) or {}
+    agent = await asyncio.to_thread(activate_agent, user_id, kind, config)
+    return {"ok": True, "agent": {
+        "kind": agent["kind"], "status": agent["status"], "config": agent["config"],
+    }}
+
+
+@router.post("/agents/{user_id}/{kind}/pause")
+async def agents_pause_route(request: Request, user_id: int, kind: str):
+    shared.authorize_dashboard_access(request, user_id)
+    from db import pause_agent
+
+    changed = await asyncio.to_thread(pause_agent, user_id, kind)
+    if not changed:
+        raise HTTPException(status_code=404, detail="Agente não encontrado.")
+    return {"ok": True}
+
+
+@router.get("/agents/{user_id}/feed")
+async def agents_feed_route(request: Request, user_id: int, limit: int = 20):
+    shared.authorize_dashboard_access(request, user_id)
+    from db import list_agent_events
+
+    limit = max(1, min(int(limit), 50))
+    events = await asyncio.to_thread(list_agent_events, user_id, limit)
+    return {"ok": True, "events": events}
+
+
+@router.post("/agents/{user_id}/feed/seen")
+async def agents_feed_seen_route(request: Request, user_id: int):
+    shared.authorize_dashboard_access(request, user_id)
+    from db import mark_agent_events_seen
+
+    n = await asyncio.to_thread(mark_agent_events_seen, user_id)
+    return {"ok": True, "marked": n}

--- a/frontend/routes/agents.py
+++ b/frontend/routes/agents.py
@@ -64,7 +64,16 @@ AGENT_CATALOG: list[dict] = [
 
 
 def _plan_allows_multiple(user_id: int) -> bool:
-    from core.services.plan_service import is_pro, plans_v2_enabled, require_min_tier
+    from core.services.plan_service import is_pro
+    # plans_v2_enabled/require_min_tier só existem quando a escada v2 está no
+    # código (feature ainda atrás de flag, não shipada aqui). Sem ela, o gate
+    # binário (is_pro) É o comportamento certo — e é exatamente o que
+    # require_min_tier faz com v2 off. Import defensivo pra a view não morrer
+    # com ImportError enquanto o plans-v2 não pousa.
+    try:
+        from core.services.plan_service import plans_v2_enabled, require_min_tier
+    except ImportError:
+        return is_pro(user_id)
     if plans_v2_enabled():
         # Escada v2: agentes ilimitados são corte do Plus (ver _FEATURE_MIN_TIER_V2).
         return require_min_tier(user_id, "plus")
@@ -102,7 +111,7 @@ async def agents_shelf_route(request: Request, user_id: int):
 @router.post("/agents/{user_id}/{kind}/activate")
 async def agents_activate_route(request: Request, user_id: int, kind: str, body: ActivateBody | None = None):
     shared.authorize_dashboard_access(request, user_id)
-    from db import AGENT_KINDS, activate_agent, count_active_agents, get_agent
+    from db import AGENT_KINDS, activate_agent, get_agent
 
     if kind not in AGENT_KINDS:
         available = {c["kind"] for c in AGENT_CATALOG if c["disponivel"]}
@@ -112,14 +121,16 @@ async def agents_activate_route(request: Request, user_id: int, kind: str, body:
 
     existing = await asyncio.to_thread(get_agent, user_id, kind)
     already_active = bool(existing and existing["status"] == "active")
-    if not already_active:
-        active_count = await asyncio.to_thread(count_active_agents, user_id)
-        if active_count >= 1 and not await asyncio.to_thread(_plan_allows_multiple, user_id):
-            # Mesmo payload de 403 do resto do app → frontend abre o modal de upgrade.
-            raise HTTPException(status_code=403, detail={"error": "pro_required", "feature": "agents"})
+    # Reativar o MESMO kind não adiciona agente → não passa pelo teto. Só uma
+    # ativação de kind novo precisa do direito a múltiplos. O teto é aplicado
+    # DENTRO de activate_agent (mesma transação) pra fechar o TOCTOU.
+    allow_multiple = already_active or await asyncio.to_thread(_plan_allows_multiple, user_id)
 
     config = (body.config if body else None) or {}
-    agent = await asyncio.to_thread(activate_agent, user_id, kind, config)
+    agent = await asyncio.to_thread(activate_agent, user_id, kind, config, allow_multiple)
+    if agent is None:
+        # Mesmo payload de 403 do resto do app → frontend abre o modal de upgrade.
+        raise HTTPException(status_code=403, detail={"error": "pro_required", "feature": "agents"})
     return {"ok": True, "agent": {
         "kind": agent["kind"], "status": agent["status"], "config": agent["config"],
     }}

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -11,7 +11,7 @@
  * once the network is restored.
  */
 
-const CACHE_NAME = "finance-dash-v4";
+const CACHE_NAME = "finance-dash-v5";
 
 // Resources to pre-cache on install
 const PRECACHE = [
@@ -33,6 +33,7 @@ const SKIP_CACHE = [
   "/data/",
   "/open-finance/",
   "/history/",
+  "/agents/",
   "/health",
   "/admin",
   "/admin/",

--- a/frontend/suporte.html
+++ b/frontend/suporte.html
@@ -28,6 +28,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
       
     </div>
     <div class="nav-right">

--- a/frontend/whatsapp.html
+++ b/frontend/whatsapp.html
@@ -21,6 +21,7 @@
       <a href="/funcionalidades">Funcionalidades</a>
       <a href="/como-funciona">Como funciona</a>
       <a href="/precos">Planos</a>
+      <a href="/whatsapp" class="active">WhatsApp</a>
       
     </div>
     <div class="nav-right">
@@ -41,6 +42,47 @@
         <a class="btn btn-primary btn-lg" href="/wa">💬 Abrir conversa com a Piggy</a>
         <a class="btn btn-outline btn-lg" href="/cadastro">Criar conta grátis</a>
       </div>
+    </section>
+
+    <!-- ─── Como conectar ─────────────────────────────────────────── -->
+    <section class="section" style="padding-bottom:44px">
+      <div class="section-head" style="margin-bottom:30px">
+        <div class="eyebrow">Como conectar</div>
+        <h2>Comece em <span class="grad">3 passos</span></h2>
+        <p>Leva menos de um minuto. O segredo é usar o <b>mesmo número</b> de WhatsApp no cadastro — é ele que liga a conversa à sua conta.</p>
+      </div>
+
+      <div class="steps" style="max-width:620px;margin:0 auto 30px">
+        <div class="step">
+          <div class="step-num">1</div>
+          <div>
+            <h3>Crie sua conta com o mesmo número</h3>
+            <p>No <a href="/cadastro" class="grad" style="text-decoration:none;font-weight:700">cadastro grátis</a>, informe o número de telefone do seu WhatsApp. É esse número que a Piggy reconhece.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num">2</div>
+          <div>
+            <h3>Abra a conversa com a Piggy</h3>
+            <p>Toque em <b>"Abrir conversa com a Piggy"</b> aqui embaixo. Ele abre o WhatsApp já no chat certo, com uma mensagem pronta pra enviar.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num">3</div>
+          <div>
+            <h3>Mande "oi" e pronto</h3>
+            <p>Na primeira mensagem a Piggy vincula seu número à sua conta automaticamente e libera todos os comandos. A partir daí é só falar: <i>"gastei 50 no mercado"</i>.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="hero-cta" style="justify-content:center">
+        <a class="btn btn-primary btn-lg" href="/wa">💬 Abrir conversa com a Piggy</a>
+      </div>
+
+      <p style="max-width:560px;margin:22px auto 0;text-align:center;color:var(--ink-2);font-size:.9rem;line-height:1.6;background:linear-gradient(180deg,rgba(198,241,26,.06),transparent);border:1px solid rgba(198,241,26,.2);border-radius:14px;padding:16px 20px">
+        💡 <b>Já falou com o bot antes de se cadastrar?</b> Sem problema. É só criar a conta com o <b>mesmo número</b> de WhatsApp que a gente junta tudo que você já registrou na sua conta.
+      </p>
     </section>
 
     <section style="padding-bottom:40px">

--- a/tests/test_piggy_agents.py
+++ b/tests/test_piggy_agents.py
@@ -1,0 +1,84 @@
+"""Regressões dos Agentes do Piggy (achados de review do PR #3).
+
+Cobrem os dois fixes testáveis sem Postgres:
+- F1: a view de Agentes não pode morrer com ImportError quando o plans-v2
+  (plans_v2_enabled/require_min_tier) não está no código.
+- F3: o Repórter não manda e-mail pra quem se descadastrou (engagement_opt_out).
+
+F2 (aportes no _month_stats) e F5 (limite atômico no activate_agent) dependem de
+DB real — verificados por inspeção/SQL, não aqui.
+"""
+
+
+# ── F1: _plan_allows_multiple sobrevive sem os helpers do plans-v2 ────────────
+
+def test_plan_allows_multiple_cai_pra_is_pro_sem_plans_v2(monkeypatch):
+    import core.services.plan_service as ps
+    from frontend.routes.agents import _plan_allows_multiple
+
+    # Simula o estado da branch pushada: só is_pro existe.
+    monkeypatch.delattr(ps, "plans_v2_enabled", raising=False)
+    monkeypatch.delattr(ps, "require_min_tier", raising=False)
+    monkeypatch.setattr(ps, "is_pro", lambda uid: True)
+    assert _plan_allows_multiple(123) is True
+
+    monkeypatch.setattr(ps, "is_pro", lambda uid: False)
+    assert _plan_allows_multiple(123) is False
+
+
+def test_plan_allows_multiple_usa_tier_quando_plans_v2_presente(monkeypatch):
+    import core.services.plan_service as ps
+    from frontend.routes.agents import _plan_allows_multiple
+
+    monkeypatch.setattr(ps, "plans_v2_enabled", lambda: True, raising=False)
+    monkeypatch.setattr(ps, "require_min_tier", lambda uid, tier: tier == "plus", raising=False)
+    monkeypatch.setattr(ps, "is_pro", lambda uid: False)  # não deve ser usado no ramo v2
+    assert _plan_allows_multiple(123) is True
+
+
+# ── F3: Repórter respeita engagement_opt_out ─────────────────────────────────
+
+class _FakeCM:
+    """Context manager mínimo pra get_conn()/conn.cursor() — o _month_stats
+    real é substituído, então o cursor nunca é usado de verdade."""
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def cursor(self):
+        return _FakeCM()
+
+
+def _arm_reporter(monkeypatch, *, opted_out: bool):
+    import core.services.piggy_agents as pa
+    import db
+    import core.services.email_service as es
+    from datetime import date
+
+    sent: list = []
+
+    monkeypatch.setattr(pa, "get_conn", lambda: _FakeCM())
+    monkeypatch.setattr(
+        pa, "_month_stats",
+        lambda cur, uid, a, b: {"entrou": 1000.0, "saiu": 500.0, "aportes": 100.0, "sobrou": 400.0},
+    )
+    monkeypatch.setattr(db, "record_agent_event", lambda *a, **k: True)  # manchete nova
+    monkeypatch.setattr(db, "get_auth_user", lambda uid: {"engagement_opt_out": opted_out})
+    monkeypatch.setattr(db, "get_user_email", lambda uid: "user@example.com")
+    monkeypatch.setattr(es, "send_agent_report_email", lambda *a, **k: sent.append(a))
+
+    agent = {"agent_id": 1, "user_id": 42, "kind": "reporter"}
+    pa._reporter_run_for_user(agent, date(2026, 8, 5))
+    return sent
+
+
+def test_reporter_nao_envia_email_para_quem_descadastrou(monkeypatch):
+    sent = _arm_reporter(monkeypatch, opted_out=True)
+    assert sent == []
+
+
+def test_reporter_envia_email_quando_nao_descadastrado(monkeypatch):
+    sent = _arm_reporter(monkeypatch, opted_out=False)
+    assert len(sent) == 1

--- a/tests/test_whatsapp_confirmations.py
+++ b/tests/test_whatsapp_confirmations.py
@@ -100,6 +100,109 @@ def test_autolink_com_comando_nao_interrompe_para_boas_vindas(monkeypatch):
     assert replies == [("5565992741873", "uid=222 text=saldo", 222)]
 
 
+def test_numero_sem_conta_comando_bloqueia_e_convida_cadastro(monkeypatch):
+    """Número sem conta que manda um COMANDO (não saudação, não código) recebe o
+    convite de cadastro e NÃO cai no fluxo principal — sem isso o dado iria pra
+    uma conta fantasma invisível (ou pra mensagem de paywall que assume conta)."""
+    replies = []
+
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime.get_or_create_canonical_user",
+        lambda provider, external_id: 111,
+    )
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime.attempt_whatsapp_phone_link",
+        lambda wa_id, current_user_id=None: {"status": "no_match", "wa_phone": wa_id},
+    )
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime.log_system_event_sync", lambda *a, **k: None)
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime._autolink_warning_already_sent", lambda *a, **k: True)
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime.send_typing_indicator", lambda *a, **k: None)
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime._seen_recent", lambda message_id: False)
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime._send_reply", lambda to, body: replies.append((to, body)))
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime.handle_incoming",
+        lambda msg: (_ for _ in ()).throw(AssertionError("não deveria chamar o fluxo principal")),
+    )
+
+    process_message(
+        InboundMessage(
+            wa_id="5511988887777",
+            text="gastei 50 no mercado",
+            timestamp="123",
+            attachments=[],
+            raw={"id": "wamid.no-account", "type": "text"},
+        )
+    )
+
+    assert len(replies) == 1
+    to, body = replies[0]
+    assert to == "5511988887777"
+    assert "não tenho uma conta" in body.lower()
+    assert "/cadastro" in body
+
+
+def test_numero_sem_conta_com_codigo_de_vinculo_passa_pro_handler(monkeypatch):
+    """"link 123456" de um número sem conta NÃO pode ser barrado — é justamente
+    como quem se cadastrou sem telefone vincula o WhatsApp. Deve seguir pro
+    handle_incoming pra o código ser consumido."""
+    replies = []
+    handled = []
+
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime.get_or_create_canonical_user",
+        lambda provider, external_id: 111,
+    )
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime.attempt_whatsapp_phone_link",
+        lambda wa_id, current_user_id=None: {"status": "no_match", "wa_phone": wa_id},
+    )
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime._send_no_account_notice",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("não deveria bloquear um código de vínculo")),
+    )
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime.log_system_event_sync", lambda *a, **k: None)
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime.send_typing_indicator", lambda *a, **k: None)
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime._seen_recent", lambda message_id: False)
+    monkeypatch.setattr(
+        "adapters.whatsapp.wa_runtime._send_reply_with_optional_buttons",
+        lambda to, body, user_id=None: replies.append((to, body, user_id)),
+    )
+
+    def fake_handle_incoming(msg):
+        handled.append(msg)
+        return [OutgoingMessage(text="✅ WhatsApp vinculado!")]
+
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime.handle_incoming", fake_handle_incoming)
+
+    process_message(
+        InboundMessage(
+            wa_id="5511988887777",
+            text="link 123456",
+            timestamp="123",
+            attachments=[],
+            raw={"id": "wamid.link-code", "type": "text"},
+        )
+    )
+
+    assert len(handled) == 1
+    assert handled[0].text == "link 123456"
+    assert replies == [("5511988887777", "✅ WhatsApp vinculado!", 111)]
+
+
+def test_is_link_code_attempt_espelha_normalizacao_do_classificador():
+    """Formas que o intent_classifier normaliza e roteia como vínculo têm que
+    passar pela exceção — pontuação e caixa não podem barrar o código."""
+    from adapters.whatsapp.wa_runtime import _is_link_code_attempt
+
+    for ok in ("link 123456", "vincular 123456", "link: 123456",
+               "link 123456.", "LINK 123456", "  vincular   123456  ", "Vincular: 123456"):
+        assert _is_link_code_attempt(ok) is True, ok
+
+    for no in ("gastei 50 no mercado", "link", "vincular", "link 12345",
+               "linkar 123456", "link 123456 agora", "oi"):
+        assert _is_link_code_attempt(no) is False, no
+
+
 def test_botao_parar_atualizacoes_desliga_updates_do_whatsapp(monkeypatch):
     replies = []
     updates = []


### PR DESCRIPTION
## O que entra neste PR

Branch `feat/agentes-piggy` → `main`. **3 commits:**

### 1. `dba20eb` — WhatsApp: número sem conta recebe convite de cadastro em qualquer mensagem
Antes, só a saudação ("oi") de um número sem conta disparava o aviso "crie sua conta". Um comando ("gastei 50") caía numa **conta fantasma invisível** (com plans-v2/paywall off) ou na mensagem de paywall que assume conta existente + magic-link pra conta vazia (paywall on).
Agora, status `no_match` de **qualquer** mensagem convida pro cadastro/vínculo e para o fluxo — **exceto** código de vínculo (`link 123456`/`vincular 123456`), que segue pro `handle_incoming` pra ser consumido. A exceção reusa o `_normalize` do `intent_classifier` (paridade com o roteador: aceita `link: 123456`, `link 123456.` etc.).
Testes: `tests/test_whatsapp_confirmations.py` (comando bloqueia+convida; código passa pro handler; paridade de normalização) — **11 passed**.

### 2. `877da6b` — Landing: aba WhatsApp no menu + guia de conexão em 3 passos
- Link "WhatsApp" no menu de topo de todas as páginas (antes só no rodapé).
- Página `/whatsapp`: seção "Como conectar" em 3 passos, priorizando cadastrar com o mesmo número + nota sobre o merge de dados pré-cadastro.
- CTA direto pro chat da Piggy (`/wa`).

### 3. `3f2844a` — Agentes do Piggy — Fase A (Xerife, Repórter, Carteiro)
Trabalho pré-existente da branch. Gated por tier (Free 1 agente, Plus+ todos). Já estava commitado antes deste trabalho.

## ⚠️ Antes de mergear
- Este PR **inclui a Fase A dos Agentes** — confirmar se está pronta pra prod.
- As alterações **não commitadas** de plans-v2 (local) **não** estão aqui.
- O fix do WhatsApp foi validado só por testes unitários (o webhook real do WhatsApp não roda no ambiente de dev).
