### PR TITLE
Add PWA support and improve native app integration

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -304,6 +304,20 @@ html.pb-app body.pb-page-app .user-menu-btn {
 }
 html.pb-app body.pb-page-app .user-menu-btn .user-menu-main { display: none !important; }
 
+/* Dropdown da conta: a regra mobile do dashboard.css (≤600px) posiciona com
+   left:0 e width:100% do pai — mas no app o botão da conta é um círculo de
+   44px, então o menu virava uma faixa de 44px colada na borda direita com o
+   texto quebrando letra a letra. Ancora à direita do botão, com largura
+   própria e sem a quebra agressiva de palavra do modo app. */
+html.pb-app .user-dropdown {
+  left: auto !important;
+  right: 0 !important;
+  width: min(300px, calc(100vw - 24px)) !important;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  overflow-wrap: normal;
+}
+
 /* Flutuantes (FAB do chat, toast) sobem acima da tab bar */
 html.pb-app #piggy-fab {
   bottom: calc(84px + env(safe-area-inset-bottom)) !important;
@@ -449,3 +463,12 @@ html.pb-app .modal,
 html.pb-app .sidenav {
   -webkit-overflow-scrolling: touch;
 }
+
+/* Menu ☰ aberto fica ACIMA da tab bar (700) e abaixo dos modais (800) —
+   sem isso a tab bar cobria os últimos itens do menu. Safe area no rodapé
+   pra rolar até o fim no iPhone. */
+html.pb-app .sidenav {
+  z-index: 760;
+  padding-bottom: calc(14px + env(safe-area-inset-bottom));
+}
+html.pb-app .sidenav-backdrop.open { z-index: 750; }

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -3,6 +3,7 @@
  *
  * Ativação (qualquer um):
  *   - user agent contém "PigBankApp" (WebView do app iOS/Capacitor)
+ *   - PWA instalada (display-mode: standalone / navigator.standalone no iOS)
  *   - ?pbapp=1 na URL (persiste em localStorage — preview no navegador)
  *   - localStorage.pbApp === "1"
  *   Desativação no preview: ?pbapp=0
@@ -17,11 +18,23 @@
 
   let stored = null;
   try { stored = localStorage.getItem("pbApp"); } catch (_) {}
-  const inApp = /PigBankApp/.test(navigator.userAgent) || stored === "1";
+  // PWA instalada roda o mesmo "modo app" do app iOS — atualizações do site
+  // chegam nas duas cascas sem passo extra.
+  const standalone =
+    (window.matchMedia && window.matchMedia("(display-mode: standalone)").matches) ||
+    window.navigator.standalone === true;
+  const inApp = /PigBankApp/.test(navigator.userAgent) || stored === "1" || standalone;
   if (!inApp) return;
 
   const root = document.documentElement;
   root.classList.add("pb-app");
+
+  // PWA aberta na landing (start_url antiga "/"): entra pelo mesmo caminho do
+  // app iOS — /login pula direto pro /home quando a sessão está viva.
+  if (standalone && location.pathname === "/") {
+    location.replace("/login");
+    return;
+  }
 
   // Página atual → classe no body (CSS escopa por página) + aba ativa
   const PAGES = {

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -253,13 +253,15 @@
 
   // Login Google no app: o botão dispara o fluxo nativo (ASWebAuthenticationSession
   // com Face ID/autofill) em vez de navegar o WebView pro Google. O nativo faz
-  // o OAuth e devolve, carregando /d/{code} aqui pra logar. Fallback: se a ponte
-  // nativa não existir (build antigo), deixa o link seguir o fluxo web normal.
+  // o OAuth e devolve, carregando /d/{code} aqui pra logar. A ponte é checada
+  // NO CLIQUE (não no load): no cold launch o nativo pode registrar o handler
+  // depois do DOMContentLoaded — checar cedo perdia o fluxo com Face ID.
+  // Fallback: sem ponte (build antigo), o link segue o fluxo web normal.
   function wireGoogleLogin() {
-    const bridge = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.pbAuth;
-    if (!bridge) return;
     document.querySelectorAll('a[href="/auth/google/start"], a[href^="/auth/google/start"]').forEach(a => {
       a.addEventListener("click", ev => {
+        const bridge = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.pbAuth;
+        if (!bridge) return;
         ev.preventDefault();
         bridge.postMessage("google");
       });

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,8 +16,8 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=17" />
-  <script src="/app-mode.js?v=17"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <script src="/app-mode.js?v=18"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -79,8 +79,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=17" />
-  <script src="/app-mode.js?v=17"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <script src="/app-mode.js?v=18"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -17,8 +17,8 @@
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=17" />
-  <script src="/app-mode.js?v=17"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <script src="/app-mode.js?v=18"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -380,8 +380,8 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=17" />
-  <script src="/app-mode.js?v=17"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <script src="/app-mode.js?v=18"></script>
 </head>
 <body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,13 @@
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=2" />
 <meta name="theme-color" content="#0c0c0d" />
 <meta property="og:type" content="website" />
+<script>
+/* PWA instalada (start_url antiga "/"): entra pelo app, não pela landing —
+   /login pula direto pro /home quando a sessão está viva. */
+if ((window.matchMedia && matchMedia("(display-mode: standalone)").matches) || navigator.standalone === true) {
+  location.replace("/login");
+}
+</script>
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/site.css?v=5" />
 <style>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,8 +15,8 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=17" />
-  <script src="/app-mode.js?v=17"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <script src="/app-mode.js?v=18"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,8 +1,9 @@
 {
   "name": "PigBank",
   "short_name": "PigBank",
-  "description": "Dashboard financeiro pessoal em tempo real",
-  "start_url": "/",
+  "description": "PigBank — seu assistente financeiro no WhatsApp e na web",
+  "start_url": "/login",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#111111",
   "theme_color": "#111111",
@@ -26,8 +27,13 @@
   "shortcuts": [
     {
       "name": "Abrir Dashboard",
-      "url": "/",
+      "url": "/app",
       "description": "Ver resumo financeiro"
+    },
+    {
+      "name": "Lançar gasto",
+      "url": "/app?lancar=1",
+      "description": "Registrar um lançamento"
     }
   ]
 }

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -1,5 +1,5 @@
 /**
- * Finance Dashboard – Service Worker
+ * PigBank – Service Worker
  *
  * Strategy:
  *   - HTML / auth: never cached
@@ -11,12 +11,13 @@
  * once the network is restored.
  */
 
-const CACHE_NAME = "finance-dash-v6";
+const CACHE_NAME = "pigbank-v7";
 
 // Resources to pre-cache on install
 const PRECACHE = [
   "/",
   "/manifest.json",
+  "/brand/icon-192.png",
   "https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js",
 ];
 
@@ -99,24 +100,25 @@ self.addEventListener("fetch", event => {
 self.addEventListener("push", event => {
   if (!event.data) return;
   let data;
-  try { data = event.data.json(); } catch { data = { title: "Finance", body: event.data.text() }; }
+  try { data = event.data.json(); } catch { data = { title: "PigBank", body: event.data.text() }; }
   event.waitUntil(
-    self.registration.showNotification(data.title || "Finance Dashboard", {
+    self.registration.showNotification(data.title || "PigBank", {
       body:  data.body  || "",
-      icon:  "/manifest.json",
-      badge: "/manifest.json",
-      tag:   data.tag   || "finance-alert",
-      data:  { url: "/" },
+      icon:  "/brand/icon-192.png",
+      badge: "/brand/icon-192.png",
+      tag:   data.tag   || "pigbank-alert",
+      data:  { url: "/app" },
     })
   );
 });
 
 self.addEventListener("notificationclick", event => {
   event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || "/app";
   event.waitUntil(
     clients.matchAll({ type: "window" }).then(wins => {
       if (wins.length) return wins[0].focus();
-      return clients.openWindow("/");
+      return clients.openWindow(url);
     })
   );
 });

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1092,8 +1092,8 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=17" />
-  <script src="/app-mode.js?v=17"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <script src="/app-mode.js?v=18"></script>
 </head>
 <body>
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -42,9 +42,14 @@ npx cap open ios     # abre no Xcode
 
 ## Pendências (fase 2)
 
+- [x] Face ID lock — implementado direto no `AppDelegate.swift` via
+      `LocalAuthentication` (sem plugin): pede Face ID/Touch ID/código no cold
+      launch e ao voltar do background após 60s; cobre o conteúdo no app
+      switcher. **Só chega ao aparelho com um build nativo novo**
+      (`npx cap sync ios` + Archive no Xcode → TestFlight) — deploy do site
+      não atualiza código Swift.
 - [ ] Push notifications: APNs key no Apple Developer → backend envia via
       `aioapns`/`httpx` + registro do token no login (plugin já no bundle).
-- [ ] Face ID lock (plugin biométrico + `NSFaceIDUsageDescription` já no plist).
 - [ ] Conta de review da Apple: user demo com plano Pro ativo (grant manual).
 - [ ] Ficha da App Store: screenshots, descrição, App Privacy (dados: e-mail,
       telefone, dados financeiros — vinculados à identidade; sem tracking).

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -48,6 +48,10 @@ npx cap open ios     # abre no Xcode
       switcher. **Só chega ao aparelho com um build nativo novo**
       (`npx cap sync ios` + Archive no Xcode → TestFlight) — deploy do site
       não atualiza código Swift.
+- [x] Login Google nativo (ASWebAuthenticationSession + scheme
+      `pigbankai://`) — Face ID/autofill do Safari no botão "Entrar com
+      Google". Também exige build nativo novo; num build antigo o botão cai
+      no fluxo web dentro do WebView, sem Face ID.
 - [ ] Push notifications: APNs key no Apple Developer → backend envia via
       `aioapns`/`httpx` + registro do token no login (plugin já no bundle).
 - [ ] Conta de review da Apple: user demo com plano Pro ativo (grant manual).

--- a/mobile/ios/App/App/AppDelegate.swift
+++ b/mobile/ios/App/App/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private let siteBase = "https://pigbankai.com"
     private var authSession: ASWebAuthenticationSession?
     private var authBridgeReady = false
+    private var authBridgeRetries = 0
     private weak var appWebView: WKWebView?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -82,9 +83,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // Registra o handler JS "pbAuth" uma vez, quando o WebView existe.
+    // No cold launch o WebView do Capacitor pode nascer DEPOIS do primeiro
+    // didBecomeActive — sem retry a ponte só era registrada quando o app
+    // voltava do background, e o botão Google caía no fluxo web (sem Face ID).
     private func setupAuthBridge() {
         if authBridgeReady { return }
-        guard let wk = findWebView() else { return }
+        guard let wk = findWebView() else {
+            if authBridgeRetries < 20 {
+                authBridgeRetries += 1
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                    self?.setupAuthBridge()
+                }
+            }
+            return
+        }
         wk.configuration.userContentController.add(self, name: "pbAuth")
         authBridgeReady = true
     }


### PR DESCRIPTION
## Summary
This PR adds Progressive Web App (PWA) support to PigBank, enabling the web app to run in standalone mode with feature parity to the native iOS app. It also improves the native authentication bridge and fixes several UI/UX issues in app mode.

## Key Changes

### PWA Support
- Detect PWA standalone mode via `display-mode: standalone` media query and `navigator.standalone` on iOS
- Redirect PWA installations from landing page (`/`) to `/login`, matching native app behavior
- Update `manifest.json` with new `start_url: "/login"` and `scope: "/"` for proper PWA scoping
- Add PWA icon precaching in service worker and update notification defaults to use PigBank branding
- Add early redirect in `index.html` to prevent PWA from loading the landing page

### Native App Improvements
- **Google Login Bridge**: Move bridge detection from page load to click time, allowing the native handler to register after `DOMContentLoaded` during cold launch (fixes Face ID flow)
- **Auth Bridge Retry Logic**: Add retry mechanism in `AppDelegate.swift` (up to 20 retries with 250ms delays) to handle cases where WebView initializes after the first `didBecomeActive` call

### UI/UX Fixes
- Fix user account dropdown positioning in app mode: anchor to right instead of left, with proper width and scrolling for mobile screens
- Fix sidenav z-index layering: position above tab bar (z-index 760) but below modals, with safe area padding for iPhone notches
- Add safe area bottom padding to sidenav for proper scrolling on devices with home indicators

### Branding & Versioning
- Update service worker cache name from `finance-dash-v6` to `pigbank-v7`
- Update service worker title references from "Finance Dashboard" to "PigBank"
- Update manifest shortcuts to point to `/app` instead of `/`
- Add new "Lançar gasto" (Quick expense) shortcut to manifest
- Bump `app-mode.js` and `app-mode.css` versions to v18 across all HTML files

### Documentation
- Update iOS README to mark Face ID lock and native Google login as completed
- Add implementation notes about build requirements for native features

## Implementation Details
- PWA detection uses the same conditions as native app detection, ensuring consistent behavior
- The early redirect in `index.html` prevents the landing page from loading in PWA standalone mode
- Native auth bridge now checks for the bridge on each click rather than once at load, accommodating Capacitor's async WebView initialization
- All PWA and app mode changes are backward compatible with existing native app installations

https://claude.ai/code/session_01W5vwBQ14dv7w4ecsAhpECi