### PR TITLE
Open Finance: escolha do banco no site + status e copy honestos

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2598,19 +2598,12 @@ async def auth_new_link_code(request: Request, user_id: int = Depends(_get_curre
 
 
 def _open_finance_ui_enabled(user_id: int, email: str | None) -> bool:
-    """Gate da UI de Open Finance. Liga se:
-    - OF_UI_ENABLED global ligado (lançamento pra todos), OU
-    - o e-mail está em OF_UI_BETA_EMAILS (allowlist beta, case-insensitive), OU
-    - o user_id está em OF_UI_BETA_USER_IDS.
-    Default: desligado (nada muda pros usuários).
+    """UI de Open Finance liberada pra todos (novo front hardcodado).
+
+    Antes era um gate por env (OF_UI_ENABLED / OF_UI_BETA_EMAILS /
+    OF_UI_BETA_USER_IDS); o rollout terminou e agora está sempre ligado.
     """
-    if (os.getenv("OF_UI_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on"):
-        return True
-    beta_emails = {e.strip().lower() for e in (os.getenv("OF_UI_BETA_EMAILS") or "").split(",") if e.strip()}
-    if email and str(email).strip().lower() in beta_emails:
-        return True
-    beta_ids = {i.strip() for i in (os.getenv("OF_UI_BETA_USER_IDS") or "").split(",") if i.strip()}
-    return str(user_id) in beta_ids
+    return True
 
 
 @app.get("/auth/me")
@@ -2629,13 +2622,16 @@ async def auth_me(user_id: int = Depends(_get_current_user)):
     mfa = await asyncio.to_thread(get_mfa_status, user_id)
     from core.services.plan_service import (
         has_app_access, paywall_enabled, plans_v2_enabled,
-        get_plan_tier, get_trial_status, history_earliest_date,
+        get_plan_tier, get_trial_status, history_earliest_date, get_user_limits,
     )
     of_ui_enabled = _open_finance_ui_enabled(user_id, user_dict.get("email"))
     from core.services.plan_service import agents_ui_enabled as _agents_ui_enabled
     agents_ui = _agents_ui_enabled(user_id, user_dict.get("email"))
     # Planos v2: tier efetivo da escada + estado do trial (30d via Stripe).
     plan_tier = await asyncio.to_thread(get_plan_tier, user_id)
+    # Teto de bancos do plano (0 = Free/sem OF, None = ilimitado). O front usa pra,
+    # no Free pós-trial, trocar "Conectar" por "Reative seu banco" sem abrir o widget.
+    of_banks_max = (await asyncio.to_thread(get_user_limits, user_id)).get("of_banks_max")
     trial = await asyncio.to_thread(get_trial_status, user_id, user_dict)
     earliest_history = await asyncio.to_thread(history_earliest_date, user_id)
     # Não devolve pro cliente os blobs cifrados (redundantes — já há o claro
@@ -2652,6 +2648,7 @@ async def auth_me(user_id: int = Depends(_get_current_user)):
         "paywall_enabled": paywall_enabled(),
         "plans_v2_enabled": plans_v2_enabled(),
         "plan_tier": plan_tier,
+        "of_banks_max": of_banks_max,
         "trial": {"active": trial["active"], "days_left": trial["days_left"]},
         "history_earliest_date": earliest_history.isoformat() if earliest_history else None,
         "of_ui_enabled": of_ui_enabled,

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2629,9 +2629,15 @@ async def auth_me(user_id: int = Depends(_get_current_user)):
     agents_ui = _agents_ui_enabled(user_id, user_dict.get("email"))
     # Planos v2: tier efetivo da escada + estado do trial (30d via Stripe).
     plan_tier = await asyncio.to_thread(get_plan_tier, user_id)
-    # Teto de bancos do plano (0 = Free/sem OF, None = ilimitado). O front usa pra,
-    # no Free pós-trial, trocar "Conectar" por "Reative seu banco" sem abrir o widget.
-    of_banks_max = (await asyncio.to_thread(get_user_limits, user_id)).get("of_banks_max")
+    # Teto de bancos do plano (0 = Free/sem OF, None = ilimitado/sem gate na UI). O
+    # front usa pra, no Free pós-trial, trocar "Conectar" por "Reative seu banco" sem
+    # abrir o widget. SÓ sob a escada v2: com v2 OFF (rollback de emergência) o limite
+    # é governado pelo _enforce_bank_limit legado (Free ainda conecta, gate dormente),
+    # então não expomos o teto de free-tier — senão o rollback desligaria o OF na UI.
+    of_banks_max = (
+        (await asyncio.to_thread(get_user_limits, user_id)).get("of_banks_max")
+        if plans_v2_enabled() else None
+    )
     trial = await asyncio.to_thread(get_trial_status, user_id, user_dict)
     earliest_history = await asyncio.to_thread(history_earliest_date, user_id)
     # Não devolve pro cliente os blobs cifrados (redundantes — já há o claro

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -27,7 +27,7 @@ from core.services.pluggy import (
     delete_pluggy_item,
     list_pluggy_connectors,
 )
-from core.services.plan_service import bank_list_ui_enabled, is_pro
+from core.services.plan_service import is_pro
 from core.services.pluggy_sync import (
     refresh_and_sync_pluggy_user,
     sync_pluggy_item,
@@ -189,13 +189,11 @@ _CONNECTABLE_TYPES = {"PERSONAL_BANK"}
 
 @router.get("/open-finance/{user_id}/connectors")
 async def open_finance_connectors_route(request: Request, user_id: int):
-    """Catálogo completo de bancos da Pluggy pro modal 'Ver todos os bancos'.
+    """Catálogo completo de bancos da Pluggy pro modal "Conectar banco".
 
-    Gateado no beta (bank_list_ui_enabled): fora do allowlist devolve 403 e o front
-    mantém a lista curta de sempre. Retorna dicts enxutos (id/name/type/color/inv)."""
+    Fluxo padrão: a escolha do banco acontece no site (modal com busca) e o widget da
+    Pluggy abre já no banco escolhido. Retorna dicts enxutos (id/name/type/color/inv)."""
     shared.authorize_dashboard_access(request, user_id)
-    if not await asyncio.to_thread(bank_list_ui_enabled, user_id):
-        raise HTTPException(status_code=403, detail="Recurso em beta.")
     try:
         raw = await asyncio.to_thread(
             list_pluggy_connectors, None, include_sandbox=PLUGGY_INCLUDE_SANDBOX

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1154,11 +1154,11 @@ a { color: inherit; text-decoration: none; }
     <aside class="sidebar">
       <div class="sidebar-section">Segurança e acesso</div>
 
-      <button class="sidebar-item" type="button" id="of-sidebar-item" disabled>
+      <button class="sidebar-item" type="button" id="of-sidebar-item" data-section="open-finance" onclick="showSettingsSection('open-finance')">
         <span class="sidebar-icon">🏦</span>
         <span>
-          <span class="sidebar-title">Open Finance <span class="badge-soon" id="of-sidebar-badge">em breve</span></span>
-          <span class="sidebar-sub" id="of-sidebar-sub">Integração em teste</span>
+          <span class="sidebar-title">Open Finance</span>
+          <span class="sidebar-sub" id="of-sidebar-sub">Conecte seus bancos</span>
         </span>
       </button>
 
@@ -1237,50 +1237,13 @@ a { color: inherit; text-decoration: none; }
               <div class="step"        id="step-3"></div>
             </div>
 
-            <!-- Bank list (curta — fallback fora do beta) -->
-            <div class="bank-list" id="bank-list-short">
-              <button class="bank-row active" type="button" data-bank="nubank" onclick="selectBank('nubank')">
-                <span class="bank-logo nubank">NU</span>
-                <span class="bank-info">
-                  <span class="bank-name">Nubank</span>
-                  <span class="bank-meta">Conta corrente, crédito e poupança</span>
-                </span>
-                <span class="bank-check">✓</span>
-              </button>
-
-              <button class="bank-row" type="button" data-bank="itau" onclick="selectBank('itau')">
-                <span class="bank-logo itau">IT</span>
-                <span class="bank-info">
-                  <span class="bank-name">Itaú</span>
-                  <span class="bank-meta">Conta corrente e investimentos</span>
-                </span>
-                <span class="bank-check"></span>
-              </button>
-
-              <button class="bank-row" type="button" data-bank="bradesco" onclick="selectBank('bradesco')">
-                <span class="bank-logo bradesco">BR</span>
-                <span class="bank-info">
-                  <span class="bank-name">Bradesco</span>
-                  <span class="bank-meta">Conta corrente e poupança</span>
-                </span>
-                <span class="bank-check"></span>
-              </button>
-            </div>
-
-            <!-- Lista completa (beta): abre o modal com busca -->
-            <div id="bankpick-open-wrap" style="display:none">
-              <button class="bankpick-open-btn" type="button" onclick="openBankPicker()">
-                <span aria-hidden="true">🔎</span> Ver todos os bancos
-              </button>
-            </div>
-
             <!-- Status message -->
             <div class="connect-status" id="connect-status">
               <div class="spinner"></div>
               <span id="connect-status-text">Simulando autorização...</span>
             </div>
 
-            <button class="btn-connect" type="button" onclick="connectOpenFinance()" id="connect-btn">
+            <button class="btn-connect" type="button" onclick="openBankPicker()" id="connect-btn">
               Conectar Open Finance
             </button>
 
@@ -1297,7 +1260,7 @@ a { color: inherit; text-decoration: none; }
           </div>
         </div>
 
-        <!-- Modal: Ver todos os bancos (beta) -->
+        <!-- Modal: lista de todos os bancos do Open Finance (escolha acontece no site) -->
         <div class="bankpick-overlay" id="bankpick-overlay" onclick="if(event.target===this)closeBankPicker()">
           <div class="bankpick-modal" role="dialog" aria-modal="true" aria-label="Conectar banco">
             <div class="bankpick-head">
@@ -1796,7 +1759,12 @@ window.addEventListener("storage", (event) => {
 });
 async function readApiError(resp) {
   const raw = await resp.text();
-  try { return JSON.parse(raw).detail || raw; } catch { return raw || "Erro inesperado"; }
+  try {
+    const detail = JSON.parse(raw).detail;
+    // detail pode ser string OU objeto estruturado {code, message, ...} (ex.: limite de banco por plano)
+    if (detail && typeof detail === "object") return detail.message || detail.code || raw;
+    return detail || raw;
+  } catch { return raw || "Erro inesperado"; }
 }
 
 function filenameFromDisposition(header, fallback) {
@@ -2408,27 +2376,34 @@ async function requestAccountDeletion() {
 }
 
 /* ── Bank select ─────────────────────────────── */
-let selectedBank = "nubank";
-const OPEN_FINANCE_CONNECTORS = {
-  nubank: 612,
-  itau: 601,
-  bradesco: 603,
-};
-// connectorId efetivo passado pro widget da Pluggy. Vem do mapa curto acima OU do
-// modal "Ver todos os bancos" (beta). null = não pré-seleciona (o widget lista tudo).
-let selectedConnectorId = OPEN_FINANCE_CONNECTORS[selectedBank];
-let BANK_LIST_UI_ENABLED = false;
+// A escolha do banco acontece dentro do widget da Pluggy. Não pré-selecionamos
+// nada aqui (null = o widget lista todos os bancos disponíveis).
+let selectedConnectorId = null;
 
-function selectBank(bank) {
-  selectedBank = bank;
-  selectedConnectorId = OPEN_FINANCE_CONNECTORS[bank] || null;
-  document.querySelectorAll("#bank-list-short .bank-row").forEach(r => {
-    const on = r.dataset.bank === bank;
-    r.classList.toggle("active", on);
-    const chk = r.querySelector(".bank-check");
-    if (chk) chk.textContent = on ? "✓" : "";
-  });
-  setStep(1);
+/* ── Estado do plano (Open Finance) ──────────── */
+// Teto de bancos do plano, vindo de /auth/me. 0 = Free/sem OF (pós-trial): o botão
+// vira CTA de upgrade e não abre o widget. null = ainda não carregou OU ilimitado.
+let OF_BANKS_MAX = null;
+let OF_HAS_CONNECTION = false; // há alguma conexão (mesmo pausada)? refina a copy do CTA
+
+// Reconfigura o botão "Conectar Open Finance" conforme o plano. No Free (limite 0),
+// não faz sentido abrir a Pluggy (o /pluggy-item recusaria com 402): troca por um
+// CTA de upgrade que leva pra /precos.
+function applyOfConnectButton() {
+  const btn = document.getElementById("connect-btn");
+  if (!btn) return;
+  if (OF_BANKS_MAX === 0) {
+    btn.textContent = OF_HAS_CONNECTION ? "Reative seu banco" : "Assine para conectar um banco";
+    btn.onclick = () => { window.location.href = "/precos"; };
+    btn.disabled = false;
+    btn.classList.add("btn-connect--upgrade");
+  } else {
+    btn.textContent = "Conectar Open Finance";
+    // A escolha do banco acontece no site: abre a modal com a lista de todos os
+    // bancos do Open Finance; ao confirmar, o widget da Pluggy abre já no banco escolhido.
+    btn.onclick = () => openBankPicker();
+    btn.classList.remove("btn-connect--upgrade");
+  }
 }
 
 /* ── Step bar ────────────────────────────────── */
@@ -2439,12 +2414,12 @@ function setStep(n) {
   }
 }
 
-/* ── Modal "Ver todos os bancos" (beta) ──────── */
+/* ── Modal "Conectar banco" (lista completa da Pluggy) ──────── */
 let _bankConnectors = null;   // cache da lista da Pluggy
 let _bankPickSelected = null; // {id, name}
 
 function _stripAccent(s) {
-  return (s||"").normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+  return (s||"").normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase();
 }
 function _bankInitials(name) {
   const small = new Set(["de","do","da","dos","das","e","-"]);
@@ -2458,7 +2433,9 @@ function _bankColor(hex) {
 }
 
 async function openBankPicker() {
-  if (!BANK_LIST_UI_ENABLED) return;
+  // Free (limite 0): não abre o picker — leva pro upgrade (defesa; applyOfConnectButton
+  // já roteia o botão pra /precos nesse caso).
+  if (OF_BANKS_MAX === 0) { window.location.href = "/precos"; return; }
   const ov = document.getElementById("bankpick-overlay");
   ov.classList.add("open");
   const q = document.getElementById("bankpick-search");
@@ -2489,7 +2466,7 @@ function renderBankPicker(filter) {
   const items = (_bankConnectors||[]).filter(b => _stripAccent(b.name).includes(f));
   const el = document.getElementById("bankpick-list");
   if (!items.length) {
-    el.innerHTML = `<div class="bankpick-empty">Nenhum banco encontrado para “${esc(filter)}”.</div>`;
+    el.innerHTML = `<div class="bankpick-empty">Nenhum banco encontrado para "${esc(filter)}".</div>`;
     return;
   }
   let html = "", letter = "";
@@ -2535,7 +2512,6 @@ function _syncBankPickFoot() {
 function confirmBankPicker() {
   if (!_bankPickSelected) return;
   selectedConnectorId = _bankPickSelected.id;
-  selectedBank = _stripAccent(_bankPickSelected.name).replace(/\s+/g,"-") || "custom";
   closeBankPicker();
   connectOpenFinance();
 }
@@ -2578,6 +2554,8 @@ function bInitials(name) {
 
 /* ── Render ──────────────────────────────────── */
 function renderConnections(list) {
+  OF_HAS_CONNECTION = Array.isArray(list) && list.length > 0;
+  applyOfConnectButton(); // refina a copy do CTA de upgrade (reative vs assine)
   const el = document.getElementById("connections-list");
   if (!list.length) {
     el.innerHTML = `<div class="empty-state"><div class="empty-icon">🔌</div><div class="empty-title">Nenhum banco conectado</div><div class="empty-sub">Escolha uma instituição ao lado para começar.</div></div>`;
@@ -2840,8 +2818,15 @@ async function openPluggyConnect() {
     language: "pt",
     theme: "dark",
     onSuccess: async (itemData) => {
-      await savePluggyItem(itemData);
-      showToast("Banco conectado com sucesso!", "ok");
+      try {
+        await savePluggyItem(itemData);
+        showToast("Banco conectado com sucesso!", "ok");
+      } catch (err) {
+        // Ex.: limite de bancos do plano (402 OF_BANK_LIMIT) — o banco foi autorizado na
+        // Pluggy mas o plano não comporta mais conexões. Mostra o porquê pro usuário.
+        showToast(String(err && err.message ? err.message : err) || "Não foi possível salvar a conexão.", "error");
+        setStep(1);
+      }
     },
     onError: (error) => {
       console.error("Pluggy Connect error", error);
@@ -2859,52 +2844,10 @@ async function openPluggyConnect() {
   else throw new Error("Widget da Pluggy carregou em um formato inesperado.");
 }
 
-async function connectMock() {
-  if (!USER_ID) { showToast("Sessão inválida — faça login novamente", "error"); return; }
-  const btn = document.getElementById("connect-btn");
-  const statusEl = document.getElementById("connect-status");
-  const statusText = document.getElementById("connect-status-text");
-  btn.disabled = true;
-  statusEl.classList.add("show");
-  setStep(2);
-
-  const msgs = [
-    "Iniciando autorização simulada...",
-    "Consultando a instituição...",
-    "Importando contas e transações...",
-  ];
-  for (const m of msgs) { statusText.textContent = m; await new Promise(r => setTimeout(r, 450)); }
-
-  try {
-    const resp = await fetch(`${API}/open-finance/${USER_ID}/mock-connect`, {
-      method: "POST",
-      credentials: "same-origin",
-      headers: authHeaders({ "Content-Type":"application/json" }),
-      body: JSON.stringify({ institution: selectedBank }),
-    });
-    if (!resp.ok) throw new Error(await readApiError(resp));
-    const data = await resp.json();
-    const c = data.connections  || [];
-    const a = data.accounts     || [];
-    const t = data.transactions || [];
-    updateStats(c, a, t);
-    renderConnections(c);
-    renderAccounts(a);
-    renderTransactions(t);
-    setStep(3);
-    statusEl.classList.remove("show");
-    showToast("Banco conectado com sucesso!", "ok");
-  } catch (err) {
-    setStep(1);
-    statusEl.classList.remove("show");
-    showToast(err.message || "Erro ao conectar", "error");
-  } finally {
-    btn.disabled = false;
-  }
-}
-
 async function connectOpenFinance() {
   if (!USER_ID) { showToast("Sessão inválida — faça login novamente", "error"); return; }
+  // Free (limite 0): não abre o widget — o /pluggy-item recusaria. Leva pro upgrade.
+  if (OF_BANKS_MAX === 0) { window.location.href = "/precos"; return; }
   const btn = document.getElementById("connect-btn");
   const statusEl = document.getElementById("connect-status");
   const statusText = document.getElementById("connect-status-text");
@@ -3152,15 +3095,6 @@ async function initSettings() {
     redirectHome();
     return;
   }
-  // Beta: modal "Ver todos os bancos" (lista completa da Pluggy). Fora do allowlist
-  // (bank_list_ui=false) mantém a lista curta de sempre.
-  if (session && session.bank_list_ui) {
-    BANK_LIST_UI_ENABLED = true;
-    const wrap = document.getElementById("bankpick-open-wrap");
-    const short = document.getElementById("bank-list-short");
-    if (wrap) wrap.style.display = "";
-    if (short) short.style.display = "none";
-  }
   // Paywall: sem assinatura ativa → vai pro paywall (settings é gated).
   let me = null;
   try {
@@ -3188,6 +3122,10 @@ async function initSettings() {
       if (sub) sub.textContent = "Conecte seus bancos";
     }
   }
+
+  // Open Finance: teto de bancos do plano. 0 = Free/sem OF → botão vira CTA de upgrade.
+  OF_BANKS_MAX = (me && me.of_banks_max !== undefined) ? me.of_banks_max : null;
+  applyOfConnectButton();
 
   document.getElementById("dashboard-link").href = "/app";
   const allowedViews = ["security", "notifications", "data", "legal"];

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1313,8 +1313,7 @@ a { color: inherit; text-decoration: none; }
       <div class="info-banner">
         <span class="info-banner-icon">💡</span>
         <span>
-          <strong>Como funciona o Open Finance?</strong> Na versão real, você autoriza o acesso dentro do próprio app do banco — a gente nunca vê sua senha e você pode revogar quando quiser.
-          <strong>Nesta versão de teste, todos os dados são simulados.</strong>
+          <strong>Como funciona o Open Finance?</strong> Você autoriza o acesso dentro do ambiente seguro do banco, via Pluggy — a gente nunca vê sua senha e você pode revogar o acesso quando quiser.
         </span>
       </div>
 
@@ -2551,6 +2550,16 @@ function bInitials(name) {
   if (n.includes("bradesco")) return "BR";
   return (name||"?").slice(0,2).toUpperCase();
 }
+// Status da conexão Open Finance → pill. Três estados:
+//  • Conectado    — sincronizando normal (ACTIVE/UPDATED)
+//  • Pendente     — a Pluggy ainda está verificando/buscando (UPDATING/CREATED/WAITING_USER_ACTION)
+//  • Não conectado — parado, precisa reconectar (PAUSED/LOGIN_ERROR/ERROR/OUTDATED/WAITING_USER_INPUT/desconhecido)
+function connStatusPill(status) {
+  const st = String(status || "").toUpperCase();
+  if (st === "ACTIVE" || st === "ATIVO" || st === "UPDATED") return { pc: "active",  pl: "Conectado" };
+  if (st === "UPDATING" || st === "CREATED" || st === "WAITING_USER_ACTION") return { pc: "pending", pl: "Pendente" };
+  return { pc: "error", pl: "Não conectado" };
+}
 
 /* ── Render ──────────────────────────────────── */
 function renderConnections(list) {
@@ -2564,9 +2573,7 @@ function renderConnections(list) {
   el.innerHTML = list.map(c => {
     const cls = bClass(c.institution_name);
     const ini = bInitials(c.institution_name);
-    const st  = (c.status||"ativo").toLowerCase();
-    const pc  = st==="ativo"||st==="active" ? "active" : "pending";
-    const pl  = pc==="active" ? "Ativo" : "Pendente";
+    const { pc, pl } = connStatusPill(c.status);
     return `<div class="connection-row">
       <div class="conn-logo ${cls}">${esc(ini)}</div>
       <div class="conn-info">


### PR DESCRIPTION
## O que muda

Fluxo de **Conectar Open Finance** na tela de Configurações.

### `960d343` — escolha do banco no site + libera UI e gate por plano
- Botão "Conectar Open Finance" abre a **modal com a lista completa de bancos** (busca); ao confirmar, o widget da Pluggy abre já no banco escolhido.
- UI de OF ligada pra todos (aposenta o gate `OF_UI_ENABLED`) e `/connectors` destravado (era allowlist beta).
- **Free (`of_banks_max` 0):** botão vira CTA de upgrade → `/precos`, sem abrir o widget; expõe `of_banks_max` no `/auth/me`.
- Mensagem de limite de bancos do plano aparece no retorno (try/catch no `onSuccess` + `readApiError` extrai `.message`).
- Remove a lista curta fake, o código morto do picker antigo e o `connectMock`.

### `bc5cbf6` — copy do banner e status das conexões
- Banner sem a frase de "dados simulados" (a integração Pluggy é real); mantém só a explicação de segurança.
- Pill de conexão com 3 estados: **Conectado** (ACTIVE/UPDATED), **Pendente** (UPDATING/CREATED/WAITING_USER_ACTION) e **Não conectado** (PAUSED/erros).

## Testes
- Sintaxe JS (`new Function`) e Python (`ast.parse`) validadas.
- Preview visual da modal e dos 3 pills com o CSS real.
