### PR TITLE
Saldo: usar consolidado (Carteira + bancos conectados) no bot, relatórios e chat IA

### DIFF
--- a/adapters/discord/cogs/accounts_cog.py
+++ b/adapters/discord/cogs/accounts_cog.py
@@ -40,8 +40,11 @@ class AccountsCog(commands.Cog):
         # ── Saldo conta ───────────────────────────────────────────────────────
         if t in ("saldo", "saldo conta", "saldo da conta", "conta", "saldo geral"):
             # Com banco conectado (Open Finance), o saldo real é o consolidado.
+            # Em beta: só o allowlist de teste vê o consolidado (plan_service).
+            from core.services.plan_service import consolidated_balance_enabled
+
             cb = get_consolidated_balance(uid)
-            if int(cb.get("of_bank_count") or 0) > 0:
+            if int(cb.get("of_bank_count") or 0) > 0 and consolidated_balance_enabled(uid):
                 await message.reply(
                     f"💰 **Saldo total:** {fmt_brl(float(cb['consolidated'] or 0))}\n"
                     f"  👛 Carteira: {fmt_brl(float(cb['manual'] or 0))}\n"
@@ -216,7 +219,13 @@ class AccountsCog(commands.Cog):
                 despesas_por_categoria[cat] = despesas_por_categoria.get(cat, 0.0) + valor
 
         saldo_periodo = total_rec - total_des
-        saldo_atual = float(get_consolidated_balance(uid)["consolidated"] or 0)
+        # Em beta: consolidado só pro allowlist de teste; fora dele, Carteira manual.
+        from core.services.plan_service import consolidated_balance_enabled
+
+        _cb = get_consolidated_balance(uid)
+        saldo_atual = float(
+            (_cb["consolidated"] if consolidated_balance_enabled(uid) else _cb["manual"]) or 0
+        )
 
         # ── Dashboard tab ──────────────────────────────────────────────────
         ws_dash.append(["Período", f"{start.strftime('%d/%m/%Y')} a {end.strftime('%d/%m/%Y')}"])

--- a/adapters/discord/cogs/accounts_cog.py
+++ b/adapters/discord/cogs/accounts_cog.py
@@ -19,7 +19,7 @@ from openpyxl.chart import PieChart, Reference
 from openpyxl.styles import Font, PatternFill, Alignment
 
 from db import (
-    get_balance,
+    get_consolidated_balance,
     list_launches,
     delete_launch_and_rollback,
     set_pending_action,
@@ -39,8 +39,16 @@ class AccountsCog(commands.Cog):
 
         # ── Saldo conta ───────────────────────────────────────────────────────
         if t in ("saldo", "saldo conta", "saldo da conta", "conta", "saldo geral"):
-            bal = get_balance(uid)
-            await message.reply(f"🏦 **Conta Corrente:** {fmt_brl(float(bal))}")
+            # Com banco conectado (Open Finance), o saldo real é o consolidado.
+            cb = get_consolidated_balance(uid)
+            if int(cb.get("of_bank_count") or 0) > 0:
+                await message.reply(
+                    f"💰 **Saldo total:** {fmt_brl(float(cb['consolidated'] or 0))}\n"
+                    f"  👛 Carteira: {fmt_brl(float(cb['manual'] or 0))}\n"
+                    f"  🏦 Bancos conectados: {fmt_brl(float(cb['open_finance_bank'] or 0))}"
+                )
+            else:
+                await message.reply(f"🏦 **Conta Corrente:** {fmt_brl(float(cb['manual'] or 0))}")
             return True
 
         # ── Desfazer último lançamento ────────────────────────────────────────
@@ -208,7 +216,7 @@ class AccountsCog(commands.Cog):
                 despesas_por_categoria[cat] = despesas_por_categoria.get(cat, 0.0) + valor
 
         saldo_periodo = total_rec - total_des
-        saldo_atual = get_balance(uid)
+        saldo_atual = float(get_consolidated_balance(uid)["consolidated"] or 0)
 
         # ── Dashboard tab ──────────────────────────────────────────────────
         ws_dash.append(["Período", f"{start.strftime('%d/%m/%Y')} a {end.strftime('%d/%m/%Y')}"])

--- a/core/handlers/balance.py
+++ b/core/handlers/balance.py
@@ -13,8 +13,12 @@ def check(user_id: int) -> str:
     # ── Saldo da conta ───────────────────────────────────────────────────
     # Com banco conectado (Open Finance), o saldo verdadeiro é o consolidado:
     # Carteira (manual) + saldos autoritativos das contas bancárias sincronizadas.
+    # Em beta (consolidated_balance_enabled): só as contas de teste veem o
+    # consolidado; fora do allowlist, a saída é a de sempre (Carteira manual).
+    from core.services.plan_service import consolidated_balance_enabled
+
     cb = db.get_consolidated_balance(user_id)
-    if int(cb.get("of_bank_count") or 0) > 0:
+    if int(cb.get("of_bank_count") or 0) > 0 and consolidated_balance_enabled(user_id):
         lines.append(f"💰 *Saldo total*: {fmt_brl(float(cb['consolidated'] or 0))}")
         lines.append(f"  👛 Carteira: {fmt_brl(float(cb['manual'] or 0))}")
         lines.append(f"  🏦 Bancos conectados: {fmt_brl(float(cb['open_finance_bank'] or 0))}")

--- a/core/handlers/balance.py
+++ b/core/handlers/balance.py
@@ -10,9 +10,16 @@ def check(user_id: int) -> str:
     today = today_tz()
     lines: list[str] = []
 
-    # ── Saldo da conta corrente ──────────────────────────────────────────
-    bal = float(db.get_balance(user_id) or 0)
-    lines.append(f"🏦 *Conta Corrente*: {fmt_brl(bal)}")
+    # ── Saldo da conta ───────────────────────────────────────────────────
+    # Com banco conectado (Open Finance), o saldo verdadeiro é o consolidado:
+    # Carteira (manual) + saldos autoritativos das contas bancárias sincronizadas.
+    cb = db.get_consolidated_balance(user_id)
+    if int(cb.get("of_bank_count") or 0) > 0:
+        lines.append(f"💰 *Saldo total*: {fmt_brl(float(cb['consolidated'] or 0))}")
+        lines.append(f"  👛 Carteira: {fmt_brl(float(cb['manual'] or 0))}")
+        lines.append(f"  🏦 Bancos conectados: {fmt_brl(float(cb['open_finance_bank'] or 0))}")
+    else:
+        lines.append(f"🏦 *Conta Corrente*: {fmt_brl(float(cb['manual'] or 0))}")
 
     # ── Gastos de hoje ───────────────────────────────────────────────────
     today_launches = db.get_launches_by_period(user_id, today, today)

--- a/core/reports/reports_daily.py
+++ b/core/reports/reports_daily.py
@@ -26,9 +26,16 @@ def _add_months(y: int, m: int, delta: int) -> tuple[int, int]:
 
 
 def _saldo_atual(user_id: int) -> float:
-    """Saldo verdadeiro do usuário: Carteira manual + bancos conectados (Open Finance)."""
+    """Saldo verdadeiro do usuário: Carteira manual + bancos conectados (Open Finance).
+
+    Em beta (consolidated_balance_enabled): fora do allowlist de teste, mantém o
+    comportamento antigo (só a Carteira manual)."""
+    from core.services.plan_service import consolidated_balance_enabled
+
     cb = get_consolidated_balance(user_id) or {}
-    return float(cb.get("consolidated") or 0)
+    if consolidated_balance_enabled(user_id):
+        return float(cb.get("consolidated") or 0)
+    return float(cb.get("manual") or 0)
 
 
 def _card_bill_due_date(period_end: date, closing_day: int, due_day: int) -> date:

--- a/core/reports/reports_daily.py
+++ b/core/reports/reports_daily.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from utils_date import now_tz, _tz
 from db import (
-    get_balance, get_launches_by_period, get_summary_by_period,
+    get_consolidated_balance, get_launches_by_period, get_summary_by_period,
     list_users_with_daily_report_enabled, list_identities_by_user,
     list_users_with_weekly_report_enabled, list_users_with_monthly_report_enabled,
     list_credit_card_due_reminders, mark_card_reminder_sent,
@@ -23,6 +23,12 @@ def _add_months(y: int, m: int, delta: int) -> tuple[int, int]:
     y2 = y + (m2 - 1) // 12
     m2 = (m2 - 1) % 12 + 1
     return y2, m2
+
+
+def _saldo_atual(user_id: int) -> float:
+    """Saldo verdadeiro do usuário: Carteira manual + bancos conectados (Open Finance)."""
+    cb = get_consolidated_balance(user_id) or {}
+    return float(cb.get("consolidated") or 0)
 
 
 def _card_bill_due_date(period_end: date, closing_day: int, due_day: int) -> date:
@@ -67,7 +73,7 @@ def build_due_bill_reminders(user_id: int, today: date | None = None) -> list[di
 
 
 def build_daily_report_summary(user_id: int) -> dict[str, str]:
-    saldo = float(get_balance(user_id) or 0)
+    saldo = _saldo_atual(user_id)
 
     now      = now_tz()
     ref_date = now.date() - timedelta(days=1)   # o report roda às 9h e se refere a ontem
@@ -106,7 +112,7 @@ def build_daily_report_text(user_id: int) -> str:
 # --- resumos por período (semanal / mensal) ---
 
 def _build_period_report_summary(user_id: int, start_date: date, end_date: date) -> dict[str, str]:
-    saldo = float(get_balance(user_id) or 0)
+    saldo = _saldo_atual(user_id)
 
     launches = get_launches_by_period(user_id, start_date, end_date) or []
     summary  = get_summary_by_period(user_id, start_date, end_date)

--- a/core/services/ai_chat/tools/balance.py
+++ b/core/services/ai_chat/tools/balance.py
@@ -16,7 +16,13 @@ from ._base import Tool
 def _get_balance(user_id: int, args: dict[str, Any]) -> dict[str, Any]:
     # Saldo verdadeiro: Carteira manual + saldos das contas bancárias conectadas
     # via Open Finance (autoritativos, atualizados pelo sync).
+    # Em beta (consolidated_balance_enabled): fora do allowlist de teste, devolve
+    # o formato antigo (só o saldo manual), sem citar bancos conectados.
+    from core.services.plan_service import consolidated_balance_enabled
+
     cb = db.get_consolidated_balance(user_id)
+    if not consolidated_balance_enabled(user_id):
+        return {"balance": float(cb["manual"] or 0)}
     return {
         "balance": float(cb["consolidated"] or 0),
         "wallet_balance": float(cb["manual"] or 0),

--- a/core/services/ai_chat/tools/balance.py
+++ b/core/services/ai_chat/tools/balance.py
@@ -14,8 +14,15 @@ from ._base import Tool
 
 
 def _get_balance(user_id: int, args: dict[str, Any]) -> dict[str, Any]:
-    balance = db.get_balance(user_id)
-    return {"balance": float(balance)}
+    # Saldo verdadeiro: Carteira manual + saldos das contas bancárias conectadas
+    # via Open Finance (autoritativos, atualizados pelo sync).
+    cb = db.get_consolidated_balance(user_id)
+    return {
+        "balance": float(cb["consolidated"] or 0),
+        "wallet_balance": float(cb["manual"] or 0),
+        "connected_banks_balance": float(cb["open_finance_bank"] or 0),
+        "connected_bank_accounts": int(cb.get("of_bank_count") or 0),
+    }
 
 
 TOOLS: list[Tool] = [
@@ -24,7 +31,7 @@ TOOLS: list[Tool] = [
             "type": "function",
             "function": {
                 "name": "get_balance",
-                "description": "Retorna o saldo atual da conta corrente do usuário no PigBank, em reais. Use sempre que ele perguntar 'qual meu saldo?', 'quanto tenho?', 'quanto sobrou?' ou variações.",
+                "description": "Retorna o saldo atual do usuário no PigBank, em reais. `balance` é o saldo total (Carteira manual + contas bancárias conectadas via Open Finance); `wallet_balance` é só a Carteira e `connected_banks_balance` é a soma dos bancos conectados (`connected_bank_accounts` = nº de contas conectadas, 0 = nenhum banco). Use sempre que ele perguntar 'qual meu saldo?', 'quanto tenho?', 'quanto sobrou?' ou variações.",
                 "parameters": {"type": "object", "properties": {}},
             },
         },

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -220,6 +220,39 @@ def bank_list_ui_enabled(user_id: int, email: str | None = None) -> bool:
     return str(user_id) in beta_ids
 
 
+# Allowlist padrão do beta do saldo consolidado (Carteira + bancos OF) no bot/
+# relatórios/chat IA. Mesma mecânica dos Agentes: primeiro só o teste, depois geral.
+_CONSOLIDATED_BETA_EMAILS_DEFAULT = {"lucaskuramoti06@gmail.com", "hiagojo2016@gmail.com"}
+
+
+def consolidated_balance_enabled(user_id: int, email: str | None = None) -> bool:
+    """Gate beta do saldo consolidado nas superfícies de leitura (WhatsApp /saldo,
+    resumos, chat IA, Discord). Liga se:
+    - OF_CONSOLIDATED_BALANCE_ENABLED global ligado (lançamento pra todos), OU
+    - o e-mail está em OF_CONSOLIDATED_BETA_EMAILS (default = e-mails de teste), OU
+    - o user_id está em OF_CONSOLIDATED_BETA_USER_IDS.
+    Default: SÓ as contas de teste veem o consolidado; o resto segue vendo a
+    Carteira manual como sempre. O dashboard web não passa por aqui (já somava
+    os bancos antes deste gate)."""
+    if (os.getenv("OF_CONSOLIDATED_BALANCE_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on"):
+        return True
+    raw = os.getenv("OF_CONSOLIDATED_BETA_EMAILS")
+    if raw is None:
+        beta_emails = _CONSOLIDATED_BETA_EMAILS_DEFAULT
+    else:
+        beta_emails = {e.strip().lower() for e in raw.split(",") if e.strip()}
+    if email is None:
+        try:
+            from db import get_user_email
+            email = get_user_email(user_id)
+        except Exception:
+            email = None
+    if email and str(email).strip().lower() in beta_emails:
+        return True
+    beta_ids = {i.strip() for i in (os.getenv("OF_CONSOLIDATED_BETA_USER_IDS") or "").split(",") if i.strip()}
+    return str(user_id) in beta_ids
+
+
 def has_app_access(user_id: int) -> bool:
     """True se o usuário pode entrar no app.
 

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -1549,7 +1549,8 @@ def get_consolidated_balance(user_id: int) -> dict:
     """Saldo consolidado = saldo manual + soma dos saldos das contas BANK conectadas.
 
     Cartão (type CREDIT) fica de fora (é dívida, não saldo disponível). Auto-atualiza
-    conforme o sync refresca os saldos autoritativos dos bancos.
+    conforme o sync refresca os saldos autoritativos dos bancos. `of_bank_count` é o
+    nº de contas BANK conectadas — 0 = sem banco, e o chamador pode mostrar só o manual.
     """
     ensure_user(user_id)
     with get_conn() as conn:
@@ -1563,7 +1564,7 @@ def get_consolidated_balance(user_id: int) -> dict:
             # mesmo saldo 2x. DISTINCT ON pega o saldo da conexão mais recente por conta.
             cur.execute(
                 """
-                select coalesce(sum(b), 0) as b from (
+                select coalesce(sum(b), 0) as b, count(*) as n from (
                     select distinct on (a.provider_account_id) a.balance as b
                     from open_finance_accounts a
                     join open_finance_connections c on c.id = a.connection_id
@@ -1573,11 +1574,14 @@ def get_consolidated_balance(user_id: int) -> dict:
                 """,
                 (user_id,),
             )
-            of_bank = cur.fetchone()["b"]
+            of_row = cur.fetchone()
+            of_bank = of_row["b"]
+            of_count = int(of_row["n"] or 0)
 
     return {
         "manual": manual,
         "open_finance_bank": of_bank,
+        "of_bank_count": of_count,
         "consolidated": (manual or Decimal("0")) + (of_bank or Decimal("0")),
     }
 

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -1565,16 +1565,21 @@ def get_consolidated_balance(user_id: int) -> dict:
             # Dedup por conta REAL (provider_account_id): reconectar o banco cria uma nova
             # connection_id com a MESMA conta (a unicidade é por conexão), o que somaria o
             # mesmo saldo 2x. DISTINCT ON pega o saldo da conexão mais recente por conta.
+            # PAUSED/DELETED mantêm o espelho local para histórico, mas não representam
+            # uma conexão atual e portanto não podem compor o saldo corrente.
             cur.execute(
                 """
                 select coalesce(sum(b), 0) as b, count(*) as n from (
-                    select distinct on (a.provider_account_id) a.balance as b
+                    select distinct on (a.provider_account_id)
+                        a.balance as b,
+                        upper(coalesce(c.status, '')) as connection_status
                     from open_finance_accounts a
                     join open_finance_connections c on c.id = a.connection_id
                     where c.user_id=%s and upper(a.type) = 'BANK'
                       and upper(coalesce(a.currency, 'BRL')) = 'BRL'
                     order by a.provider_account_id, c.id desc
                 ) uniq
+                where connection_status not in ('PAUSED', 'DELETED')
                 """,
                 (user_id,),
             )

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -1551,6 +1551,9 @@ def get_consolidated_balance(user_id: int) -> dict:
     Cartão (type CREDIT) fica de fora (é dívida, não saldo disponível). Auto-atualiza
     conforme o sync refresca os saldos autoritativos dos bancos. `of_bank_count` é o
     nº de contas BANK conectadas — 0 = sem banco, e o chamador pode mostrar só o manual.
+
+    Só contas em BRL entram na soma (e no count): o saldo manual é em reais e não há
+    conversão de câmbio — somar USD 100 como R$ 100 mentiria o total.
     """
     ensure_user(user_id)
     with get_conn() as conn:
@@ -1569,6 +1572,7 @@ def get_consolidated_balance(user_id: int) -> dict:
                     from open_finance_accounts a
                     join open_finance_connections c on c.id = a.connection_id
                     where c.user_id=%s and upper(a.type) = 'BANK'
+                      and upper(coalesce(a.currency, 'BRL')) = 'BRL'
                     order by a.provider_account_id, c.id desc
                 ) uniq
                 """,

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -629,15 +629,17 @@ async def get_financial_data(
     # DISTINCT ON (provider_account_id): reconectar cria nova conexão com a MESMA conta;
     # sem dedup, o saldo (e a contagem) somaria em dobro. Pega a conexão mais recente.
     # Só contas em BRL: não há conversão de câmbio — somar USD 100 como R$ 100 mente o total.
+    # PAUSED/DELETED continuam no banco só como histórico e ficam fora do saldo atual.
     of_bank_rows = await _q(
         "SELECT COALESCE(SUM(b), 0) AS b, COUNT(*) AS n FROM ("
-        "  SELECT DISTINCT ON (a.provider_account_id) a.balance AS b "
+        "  SELECT DISTINCT ON (a.provider_account_id) "
+        "    a.balance AS b, UPPER(COALESCE(c.status, '')) AS connection_status "
         "  FROM open_finance_accounts a "
         "  JOIN open_finance_connections c ON c.id = a.connection_id "
         "  WHERE c.user_id = %s AND UPPER(a.type) = 'BANK' "
         "    AND UPPER(COALESCE(a.currency, 'BRL')) = 'BRL' "
         "  ORDER BY a.provider_account_id, c.id DESC"
-        ") uniq",
+        ") uniq WHERE connection_status NOT IN ('PAUSED', 'DELETED')",
         (user_id,),
     )
     of_bank_balance = float(of_bank_rows[0]["b"]) if of_bank_rows else 0.0

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -628,12 +628,14 @@ async def get_financial_data(
     # o breakdown "Carteira + Bancos" e a ação de ajustar a Carteira.
     # DISTINCT ON (provider_account_id): reconectar cria nova conexão com a MESMA conta;
     # sem dedup, o saldo (e a contagem) somaria em dobro. Pega a conexão mais recente.
+    # Só contas em BRL: não há conversão de câmbio — somar USD 100 como R$ 100 mente o total.
     of_bank_rows = await _q(
         "SELECT COALESCE(SUM(b), 0) AS b, COUNT(*) AS n FROM ("
         "  SELECT DISTINCT ON (a.provider_account_id) a.balance AS b "
         "  FROM open_finance_accounts a "
         "  JOIN open_finance_connections c ON c.id = a.connection_id "
         "  WHERE c.user_id = %s AND UPPER(a.type) = 'BANK' "
+        "    AND UPPER(COALESCE(a.currency, 'BRL')) = 'BRL' "
         "  ORDER BY a.provider_account_id, c.id DESC"
         ") uniq",
         (user_id,),

--- a/tests/test_consolidated_balance.py
+++ b/tests/test_consolidated_balance.py
@@ -79,6 +79,35 @@ def test_reconectar_banco_nao_duplica_saldo(user_id):
     assert cb["open_finance_bank"] == Decimal("650.00")  # saldo da conexão mais recente
 
 
+def test_conta_em_moeda_estrangeira_fica_fora_da_soma(user_id):
+    """Sem conversão de câmbio, USD 100 não pode entrar como R$ 100 no total."""
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    connection = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": f"item-test-usd-{user_id}", "connector": {"id": 612, "name": "Nubank"}, "status": "UPDATED"},
+    )
+    db.save_open_finance_sync(
+        connection["id"],
+        [
+            {
+                "provider_account_id": f"acc-test-usd-{user_id}",
+                "name": "Nubank Global", "type": "BANK", "subtype": "CHECKING_ACCOUNT",
+                "currency": "USD", "balance": Decimal("100.00"), "raw": {}, "transactions": [],
+            },
+            {
+                "provider_account_id": f"acc-test-brl-{user_id}",
+                "name": "Nubank Conta", "type": "BANK", "subtype": "CHECKING_ACCOUNT",
+                "currency": "BRL", "balance": Decimal("300.00"), "raw": {}, "transactions": [],
+            },
+        ],
+    )
+
+    cb = db.get_consolidated_balance(user_id)
+    assert cb["of_bank_count"] == 1          # só a conta BRL conta
+    assert cb["open_finance_bank"] == Decimal("300.00")
+    assert cb["consolidated"] == Decimal("400.00")
+
+
 def test_handler_saldo_mostra_consolidado_com_banco(user_id):
     db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
     _connect_fake_bank(user_id, "4320.75")

--- a/tests/test_consolidated_balance.py
+++ b/tests/test_consolidated_balance.py
@@ -3,11 +3,22 @@
 Regressão do bug: conectar um banco não atualizava o saldo mostrado ao usuário —
 bot, relatórios e chat IA liam só accounts.balance (Carteira manual), ignorando os
 saldos autoritativos das contas BANK sincronizadas via Pluggy.
+
+Lançamento em fases: o consolidado fica atrás do gate consolidated_balance_enabled
+(default = só as contas de teste). Os testes de exibição ligam o gate global via
+OF_CONSOLIDATED_BALANCE_ENABLED; os de gate-off garantem a saída antiga.
 """
 from decimal import Decimal
 
+import pytest
+
 import db
 from core.handlers import balance as h_balance
+
+
+@pytest.fixture()
+def consolidated_on(monkeypatch):
+    monkeypatch.setenv("OF_CONSOLIDATED_BALANCE_ENABLED", "1")
 
 
 def _connect_fake_bank(user_id: int, balance: str = "4320.75") -> int:
@@ -108,7 +119,7 @@ def test_conta_em_moeda_estrangeira_fica_fora_da_soma(user_id):
     assert cb["consolidated"] == Decimal("400.00")
 
 
-def test_handler_saldo_mostra_consolidado_com_banco(user_id):
+def test_handler_saldo_mostra_consolidado_com_banco(user_id, consolidated_on):
     db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
     _connect_fake_bank(user_id, "4320.75")
 
@@ -126,7 +137,7 @@ def test_handler_saldo_sem_banco_mantem_conta_corrente(user_id):
     assert "R$ 100,00" in out
 
 
-def test_ai_chat_tool_get_balance_consolidado(user_id):
+def test_ai_chat_tool_get_balance_consolidado(user_id, consolidated_on):
     from core.services.ai_chat.tools.balance import _get_balance
 
     db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
@@ -137,3 +148,37 @@ def test_ai_chat_tool_get_balance_consolidado(user_id):
     assert res["wallet_balance"] == 100.0
     assert res["connected_banks_balance"] == 900.0
     assert res["connected_bank_accounts"] == 1
+
+
+# ── Gate beta desligado (fora do allowlist de teste): comportamento antigo ─────
+
+def test_gate_off_handler_mantem_carteira_mesmo_com_banco(user_id):
+    """Fora do beta, conectar banco NÃO muda o /saldo (segue Carteira manual)."""
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    _connect_fake_bank(user_id, "4320.75")
+
+    out = h_balance.check(user_id)
+    assert "Conta Corrente" in out
+    assert "R$ 100,00" in out
+    assert "Saldo total" not in out
+    assert "4.320,75" not in out
+
+
+def test_gate_off_ai_chat_tool_formato_antigo(user_id):
+    from core.services.ai_chat.tools.balance import _get_balance
+
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    _connect_fake_bank(user_id, "900.00")
+
+    res = _get_balance(user_id, {})
+    assert res == {"balance": 100.0}
+
+
+def test_gate_liga_por_email_de_teste(user_id, monkeypatch):
+    """O allowlist default são os e-mails de teste (hiago/lucas)."""
+    from core.services.plan_service import consolidated_balance_enabled
+
+    monkeypatch.delenv("OF_CONSOLIDATED_BALANCE_ENABLED", raising=False)
+    assert consolidated_balance_enabled(user_id, email="lucaskuramoti06@gmail.com")
+    assert consolidated_balance_enabled(user_id, email="hiagojo2016@gmail.com")
+    assert not consolidated_balance_enabled(user_id, email="outro@exemplo.com")

--- a/tests/test_consolidated_balance.py
+++ b/tests/test_consolidated_balance.py
@@ -1,0 +1,110 @@
+"""Saldo consolidado (Carteira + bancos Open Finance) nas superfícies de leitura.
+
+Regressão do bug: conectar um banco não atualizava o saldo mostrado ao usuário —
+bot, relatórios e chat IA liam só accounts.balance (Carteira manual), ignorando os
+saldos autoritativos das contas BANK sincronizadas via Pluggy.
+"""
+from decimal import Decimal
+
+import db
+from core.handlers import balance as h_balance
+
+
+def _connect_fake_bank(user_id: int, balance: str = "4320.75") -> int:
+    """Cria uma conexão Pluggy + 1 conta BANK sincronizada com o saldo dado."""
+    connection = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": f"item-test-{user_id}", "connector": {"id": 612, "name": "Nubank"}, "status": "UPDATED"},
+    )
+    db.save_open_finance_sync(
+        connection["id"],
+        [{
+            "provider_account_id": f"acc-test-{user_id}",
+            "name": "Nubank Conta",
+            "type": "BANK",
+            "subtype": "CHECKING_ACCOUNT",
+            "currency": "BRL",
+            "balance": Decimal(balance),
+            "raw": {},
+            "transactions": [],
+        }],
+    )
+    return connection["id"]
+
+
+def test_get_consolidated_balance_sem_banco(user_id):
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    cb = db.get_consolidated_balance(user_id)
+    assert cb["manual"] == Decimal("100")
+    assert cb["open_finance_bank"] == Decimal("0")
+    assert cb["of_bank_count"] == 0
+    assert cb["consolidated"] == Decimal("100")
+
+
+def test_get_consolidated_balance_soma_banco_conectado(user_id):
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    _connect_fake_bank(user_id, "4320.75")
+
+    cb = db.get_consolidated_balance(user_id)
+    assert cb["manual"] == Decimal("100")
+    assert cb["open_finance_bank"] == Decimal("4320.75")
+    assert cb["of_bank_count"] == 1
+    assert cb["consolidated"] == Decimal("4420.75")
+
+
+def test_reconectar_banco_nao_duplica_saldo(user_id):
+    """Reconectar cria outra connection com a MESMA conta — o saldo não pode dobrar."""
+    _connect_fake_bank(user_id, "500.00")
+    # segunda conexão (novo item) com a mesma conta real (mesmo provider_account_id)
+    connection = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": f"item-test-2-{user_id}", "connector": {"id": 612, "name": "Nubank"}, "status": "UPDATED"},
+    )
+    db.save_open_finance_sync(
+        connection["id"],
+        [{
+            "provider_account_id": f"acc-test-{user_id}",
+            "name": "Nubank Conta",
+            "type": "BANK",
+            "subtype": "CHECKING_ACCOUNT",
+            "currency": "BRL",
+            "balance": Decimal("650.00"),
+            "raw": {},
+            "transactions": [],
+        }],
+    )
+
+    cb = db.get_consolidated_balance(user_id)
+    assert cb["of_bank_count"] == 1
+    assert cb["open_finance_bank"] == Decimal("650.00")  # saldo da conexão mais recente
+
+
+def test_handler_saldo_mostra_consolidado_com_banco(user_id):
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    _connect_fake_bank(user_id, "4320.75")
+
+    out = h_balance.check(user_id)
+    assert "Saldo total" in out
+    assert "R$ 4.420,75" in out
+    assert "Carteira" in out and "R$ 100,00" in out
+    assert "Bancos conectados" in out and "R$ 4.320,75" in out
+
+
+def test_handler_saldo_sem_banco_mantem_conta_corrente(user_id):
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    out = h_balance.check(user_id)
+    assert "Conta Corrente" in out
+    assert "R$ 100,00" in out
+
+
+def test_ai_chat_tool_get_balance_consolidado(user_id):
+    from core.services.ai_chat.tools.balance import _get_balance
+
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    _connect_fake_bank(user_id, "900.00")
+
+    res = _get_balance(user_id, {})
+    assert res["balance"] == 1000.0
+    assert res["wallet_balance"] == 100.0
+    assert res["connected_banks_balance"] == 900.0
+    assert res["connected_bank_accounts"] == 1

--- a/tests/test_consolidated_balance.py
+++ b/tests/test_consolidated_balance.py
@@ -119,6 +119,60 @@ def test_conta_em_moeda_estrangeira_fica_fora_da_soma(user_id):
     assert cb["consolidated"] == Decimal("400.00")
 
 
+@pytest.mark.parametrize("terminal_status", ["PAUSED", "DELETED"])
+def test_conexao_terminal_nao_entra_no_saldo_atual(user_id, terminal_status):
+    db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
+    connection_id = _connect_fake_bank(user_id, "4320.75")
+
+    if terminal_status == "PAUSED":
+        db.pause_open_finance_connection(connection_id)
+    else:
+        updated = db.update_pluggy_open_finance_item_status(
+            f"item-test-{user_id}", terminal_status
+        )
+        assert updated == 1
+
+    cb = db.get_consolidated_balance(user_id)
+    assert cb["manual"] == Decimal("100")
+    assert cb["open_finance_bank"] == Decimal("0")
+    assert cb["of_bank_count"] == 0
+    assert cb["consolidated"] == Decimal("100")
+
+
+@pytest.mark.parametrize("terminal_status", ["PAUSED", "DELETED"])
+def test_conexao_terminal_mais_recente_nao_ressuscita_saldo_antigo(user_id, terminal_status):
+    _connect_fake_bank(user_id, "500.00")
+    connection = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": f"item-test-2-{user_id}", "connector": {"id": 612, "name": "Nubank"}, "status": "UPDATED"},
+    )
+    db.save_open_finance_sync(
+        connection["id"],
+        [{
+            "provider_account_id": f"acc-test-{user_id}",
+            "name": "Nubank Conta",
+            "type": "BANK",
+            "subtype": "CHECKING_ACCOUNT",
+            "currency": "BRL",
+            "balance": Decimal("650.00"),
+            "raw": {},
+            "transactions": [],
+        }],
+    )
+
+    if terminal_status == "PAUSED":
+        db.pause_open_finance_connection(connection["id"])
+    else:
+        updated = db.update_pluggy_open_finance_item_status(
+            f"item-test-2-{user_id}", terminal_status
+        )
+        assert updated == 1
+
+    cb = db.get_consolidated_balance(user_id)
+    assert cb["of_bank_count"] == 0
+    assert cb["open_finance_bank"] == Decimal("0")
+
+
 def test_handler_saldo_mostra_consolidado_com_banco(user_id, consolidated_on):
     db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
     _connect_fake_bank(user_id, "4320.75")

--- a/tests/test_reports_daily.py
+++ b/tests/test_reports_daily.py
@@ -4,7 +4,8 @@ from core.reports.reports_daily import build_daily_report_text
 
 
 def test_build_daily_report_text_usa_formato_compacto():
-    with patch("core.reports.reports_daily.get_balance", return_value=1000), \
+    with patch("core.reports.reports_daily.get_consolidated_balance",
+               return_value={"manual": 1000, "open_finance_bank": 0, "of_bank_count": 0, "consolidated": 1000}), \
          patch("core.reports.reports_daily.get_launches_by_period", return_value=[{"id": 1}, {"id": 2}]), \
          patch("core.reports.reports_daily.get_summary_by_period", return_value={"despesa": 42.90, "receita": 10.0}):
         msg = build_daily_report_text(123)

--- a/tests/test_reports_period.py
+++ b/tests/test_reports_period.py
@@ -13,8 +13,12 @@ from core.reports.reports_daily import (
 _TZ = ZoneInfo("America/Sao_Paulo")
 
 
+def _cb(value):
+    return {"manual": value, "open_finance_bank": 0, "of_bank_count": 0, "consolidated": value}
+
+
 def test_build_weekly_report_text():
-    with patch("core.reports.reports_daily.get_balance", return_value=1000), \
+    with patch("core.reports.reports_daily.get_consolidated_balance", return_value=_cb(1000)), \
          patch("core.reports.reports_daily.get_launches_by_period", return_value=[{"id": 1}, {"id": 2}, {"id": 3}]), \
          patch("core.reports.reports_daily.get_summary_by_period", return_value={"despesa": 150.0, "receita": 20.0}):
         msg = build_weekly_report_text(123)
@@ -27,7 +31,7 @@ def test_build_weekly_report_text():
 
 
 def test_build_monthly_report_text():
-    with patch("core.reports.reports_daily.get_balance", return_value=1000), \
+    with patch("core.reports.reports_daily.get_consolidated_balance", return_value=_cb(1000)), \
          patch("core.reports.reports_daily.get_launches_by_period", return_value=[{"id": 1}]), \
          patch("core.reports.reports_daily.get_summary_by_period", return_value={"despesa": 999.90, "receita": 500.0}):
         msg = build_monthly_report_text(123)
@@ -49,7 +53,7 @@ def test_weekly_closed_usa_semana_anterior():
         return {"despesa": 0.0, "receita": 0.0}
 
     with patch("core.reports.reports_daily.now_tz", return_value=fake_now), \
-         patch("core.reports.reports_daily.get_balance", return_value=0), \
+         patch("core.reports.reports_daily.get_consolidated_balance", return_value=_cb(0)), \
          patch("core.reports.reports_daily.get_launches_by_period", return_value=[]), \
          patch("core.reports.reports_daily.get_summary_by_period", side_effect=_fake_summary):
         s = build_weekly_report_summary(123, closed=True)
@@ -69,7 +73,7 @@ def test_monthly_closed_usa_mes_anterior():
         return {"despesa": 0.0, "receita": 0.0}
 
     with patch("core.reports.reports_daily.now_tz", return_value=fake_now), \
-         patch("core.reports.reports_daily.get_balance", return_value=0), \
+         patch("core.reports.reports_daily.get_consolidated_balance", return_value=_cb(0)), \
          patch("core.reports.reports_daily.get_launches_by_period", return_value=[]), \
          patch("core.reports.reports_daily.get_summary_by_period", side_effect=_fake_summary):
         s = build_monthly_report_summary(123, closed=True)


### PR DESCRIPTION
## Problema

Ao conectar um banco via Open Finance, o saldo mostrado ao usuário **não atualizava para o saldo verdadeiro da conta**. O sync da Pluggy funcionava (contas e saldos eram gravados nas tabelas OF), mas as superfícies de leitura mostravam só `accounts.balance` (a Carteira manual):

- `/saldo` no WhatsApp
- Resumos diário/semanal/mensal
- Tool `get_balance` do chat IA
- Discord (comando `saldo` e export de Excel)

`get_consolidated_balance` (Carteira + saldos autoritativos das contas BANK sincronizadas) existia desde a Fase 1 do Open Finance, mas nunca foi ligada a nenhuma dessas superfícies — só o dashboard web fazia a soma, com query própria.

## Correção

- **db**: `get_consolidated_balance` agora retorna também `of_bank_count` (nº de contas BANK conectadas, deduplicado por `provider_account_id` — reconectar o banco não duplica o saldo), pro chamador decidir se mostra o breakdown.
- **WhatsApp `/saldo` e Discord `saldo`**: com banco conectado mostram `💰 Saldo total` + breakdown `👛 Carteira` / `🏦 Bancos conectados`. **Sem banco conectado, a saída fica exatamente como era** ("Conta Corrente").
- **Relatórios diário/semanal/mensal**: "Saldo atual" passa a ser o consolidado.
- **Chat IA (`get_balance`)**: retorna `balance` consolidado + `wallet_balance`, `connected_banks_balance` e `connected_bank_accounts`, com a descrição da tool atualizada.
- **Export Excel (Discord)**: célula "Saldo Atual" usa o consolidado.

Fluxos que **movem** dinheiro (pagar fatura, investir, caixinhas) seguem usando só a Carteira, que é de onde o dinheiro realmente sai — sem mudança.

### Moeda (review)

Só contas em **BRL** entram na soma consolidada (e no `of_bank_count`) — sem conversão de câmbio, USD 100 entraria como R$ 100. Mesmo filtro aplicado na query equivalente do dashboard web (bug pré-existente).

### Lançamento em fases (gate beta)

O consolidado nas superfícies do bot fica atrás de `consolidated_balance_enabled` (mesma mecânica dos gates de Agentes/lista de bancos):

- **Default: só as contas de teste** — `lucaskuramoti06@gmail.com` e `hiagojo2016@gmail.com`.
- Ajustável sem deploy: `OF_CONSOLIDATED_BETA_EMAILS` / `OF_CONSOLIDATED_BETA_USER_IDS`.
- Abrir pra todos depois: `OF_CONSOLIDATED_BALANCE_ENABLED=1`.
- Fora do allowlist, tudo se comporta exatamente como antes (Carteira manual). O dashboard web fica fora do gate (já somava os bancos antes deste PR).

## Testes

- `tests/test_consolidated_balance.py`: consolidação com/sem banco, reconexão sem duplicar saldo, conta em moeda estrangeira fora da soma, handler do WhatsApp e tool da IA com gate ligado, comportamento antigo com gate desligado e allowlist por e-mail.
- Mocks de `tests/test_reports_daily.py` e `tests/test_reports_period.py` ajustados para `get_consolidated_balance`.
- Suíte completa rodada com Postgres local: **909 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zvMGrN5UFYNcJ1eW8e7U3