### PR TITLE
chore(sec): liga Dependabot + pip-audit no CI e corrige CVEs de pillo…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Dependências Python (requirements.txt na raiz do repo)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    # Agrupa updates de patch/minor num único PR pra reduzir ruído (dev solo).
+    # CVEs de segurança abrem PR próprio mesmo assim.
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Actions usadas nos workflows (.github/workflows)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: pip-audit
+      - name: pip-audit (informativo, nao bloqueia)
         run: |
           python -m pip install --upgrade pip pip-audit
-          pip-audit -r requirements.txt --strict
+          pip-audit -r requirements.txt || echo "::warning title=pip-audit::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,3 +51,23 @@ jobs:
       - name: Run tests
         run: |
           PYTHONPATH=. pytest -q
+
+  # Varredura de CVE nas dependências. Não-bloqueante: sinaliza sem travar
+  # o merge/deploy (uma CVE sem fix disponível não deve segurar a main).
+  # O Dependabot (.github/dependabot.yml) abre os PRs de correção.
+  audit:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: pip-audit
+        run: |
+          python -m pip install --upgrade pip pip-audit
+          pip-audit -r requirements.txt --strict

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ typing_extensions==4.15.0
 urllib3==2.6.3
 yarl==1.22.0
 ofxparse==0.21
-pypdf==6.14.2
+pypdf==6.15.0
 fastapi==0.115.6
 uvicorn[standard]==0.30.6
 websockets==16.0
@@ -63,4 +63,4 @@ resend==2.27.0
 pyotp==2.9.0
 qrcode==8.2
 reportlab==4.5.0
-pillow==12.2.0
+pillow==12.3.0


### PR DESCRIPTION
…w/pypdf

- .github/dependabot.yml: updates semanais de pip (agrupados) e github-actions
- tests.yml: job 'audit' com pip-audit (nao-bloqueante, continue-on-error)
- requirements.txt: pillow 12.2.0->12.3.0, pypdf 6.14.2->6.15.0 (PYSEC-2026)