### PR TITLE
feat(sec): job de retencao de auth_login_events (minimizacao LGPD)

### DIFF
--- a/core/services/login_events_retention.py
+++ b/core/services/login_events_retention.py
@@ -1,0 +1,78 @@
+"""
+core/services/login_events_retention.py — Retenção de auth_login_events.
+
+Apaga eventos de login mais antigos que N dias (minimização de dados / LGPD).
+É o mecanismo que cobre as tentativas ÓRFÃS (falha de login antes de a conta
+existir, sem user_id): a exclusão de conta apaga o que tem user_id, e este job
+apaga o resto por tempo — sem precisar buscar por e-mail.
+
+Loop diário, registrado no lifespan do app.
+
+Config (envs, opcionais):
+  - LOGIN_EVENTS_RETENTION_DAYS  (default '90')  — 0 desliga o job.
+  - LOGIN_EVENTS_RETENTION_INTERVAL_HOURS (default '24')
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _retention_days() -> int:
+    try:
+        return int(os.getenv("LOGIN_EVENTS_RETENTION_DAYS", "90"))
+    except (TypeError, ValueError):
+        return 90
+
+
+def _interval_hours() -> int:
+    try:
+        return int(os.getenv("LOGIN_EVENTS_RETENTION_INTERVAL_HOURS", "24"))
+    except (TypeError, ValueError):
+        return 24
+
+
+async def purge_old_login_events() -> int:
+    """Apaga auth_login_events com mais de N dias. Retorna quantas linhas caíram.
+
+    Com LOGIN_EVENTS_RETENTION_DAYS <= 0, é no-op (retorna 0)."""
+    days = _retention_days()
+    if days <= 0:
+        return 0
+    # Import tardio pra evitar ciclo de import no boot (admin_dashboard puxa muita
+    # coisa); mesmo padrão dos wrappers do lifespan.
+    from core.admin_dashboard import db_connect
+
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                delete from auth_login_events
+                where created_at < now() - (%s || ' days')::interval
+                """,
+                (str(days),),
+            )
+            deleted = cur.rowcount
+        await conn.commit()
+    return int(deleted or 0)
+
+
+async def run_login_events_retention_loop() -> None:
+    """Loop perpétuo (asyncio task no lifespan). Roda a purga 1x/dia."""
+    await asyncio.sleep(120)  # deixa o boot assentar antes do 1º tick
+    while True:
+        try:
+            n = await purge_old_login_events()
+            if n:
+                logger.info(
+                    "[login_retention] apagou %s login events > %s dias",
+                    n, _retention_days(),
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensivo
+            logger.warning("[login_retention] erro: %s", exc)
+        await asyncio.sleep(_interval_hours() * 3600)

--- a/core/services/login_events_retention.py
+++ b/core/services/login_events_retention.py
@@ -1,10 +1,12 @@
 """
 core/services/login_events_retention.py — Retenção de auth_login_events.
 
-Apaga eventos de login mais antigos que N dias (minimização de dados / LGPD).
+Apaga tentativas de login FALHAS mais antigas que N dias (minimização / LGPD).
 É o mecanismo que cobre as tentativas ÓRFÃS (falha de login antes de a conta
 existir, sem user_id): a exclusão de conta apaga o que tem user_id, e este job
-apaga o resto por tempo — sem precisar buscar por e-mail.
+apaga as falhas órfãs por tempo — sem precisar buscar por e-mail. Logins
+bem-sucedidos NÃO são apagados aqui (ancoram is_known_login_ip; já saem na
+exclusão de conta por user_id).
 
 Loop diário, registrado no lifespan do app.
 
@@ -36,7 +38,15 @@ def _interval_hours() -> int:
 
 
 async def purge_old_login_events() -> int:
-    """Apaga auth_login_events com mais de N dias. Retorna quantas linhas caíram.
+    """Apaga tentativas de login FALHAS com mais de N dias. Retorna quantas caíram.
+
+    Só falhas (`success = false`) de propósito:
+      - São exatamente as linhas órfãs (falha pré-conta, `user_id` nulo) que a
+        exclusão de conta não alcança — o alvo original desta retenção.
+      - Os logins BEM-SUCEDIDOS são preservados porque ancoram
+        `core.audit.is_known_login_ip` (senão um IP conhecido, mas sem login nos
+        últimos N dias, voltaria a disparar e-mail de "novo dispositivo").
+        Esses já são apagados por `user_id` na exclusão de conta.
 
     Com LOGIN_EVENTS_RETENTION_DAYS <= 0, é no-op (retorna 0)."""
     days = _retention_days()
@@ -51,7 +61,8 @@ async def purge_old_login_events() -> int:
             await cur.execute(
                 """
                 delete from auth_login_events
-                where created_at < now() - (%s || ' days')::interval
+                where success = false
+                  and created_at < now() - (%s || ' days')::interval
                 """,
                 (str(days),),
             )

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -1563,6 +1563,14 @@ async def lifespan(app: FastAPI):
         except Exception as exc:
             print(f"[agents] erro: {exc}", file=sys.stderr)
 
+    async def _login_events_retention():
+        try:
+            await asyncio.sleep(2)
+            from core.services.login_events_retention import run_login_events_retention_loop  # noqa: PLC0415
+            await run_login_events_retention_loop()
+        except Exception as exc:
+            print(f"[login_events_retention] erro: {exc}", file=sys.stderr)
+
     async def _account_deletion_worker():
         while True:
             try:
@@ -1666,6 +1674,7 @@ async def lifespan(app: FastAPI):
                 asyncio.create_task(_proactive_ai(), name="proactive_ai"),
                 asyncio.create_task(_news_bot(), name="news_bot"),
                 asyncio.create_task(_piggy_agents(), name="piggy_agents"),
+                asyncio.create_task(_login_events_retention(), name="login_events_retention"),
             ]
         )
     else:

--- a/tests/test_login_events_retention.py
+++ b/tests/test_login_events_retention.py
@@ -1,0 +1,64 @@
+"""Testes da retenção de auth_login_events.
+
+Integração leve (banco de teste). Garante que a purga apaga só FALHAS antigas
+e preserva logins bem-sucedidos (âncora do is_known_login_ip) e falhas recentes.
+"""
+import asyncio
+
+import pytest
+
+from core.services import login_events_retention as ret
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_tables():
+    from core.admin_dashboard import ensure_admin_tables
+    _run(ensure_admin_tables())
+
+
+async def _insert(ip, success, days_ago):
+    from core.admin_dashboard import db_connect
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "insert into auth_login_events (success, ip_address, created_at) "
+                "values (%s, %s, now() - (%s || ' days')::interval)",
+                (success, ip, str(days_ago)),
+            )
+        await conn.commit()
+
+
+async def _exists(ip, success):
+    from core.admin_dashboard import db_connect
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "select count(*) as n from auth_login_events "
+                "where ip_address = %s and success = %s",
+                (ip, success),
+            )
+            row = await cur.fetchone()
+    return (row["n"] if isinstance(row, dict) else row[0]) > 0
+
+
+def test_purga_so_falhas_antigas(monkeypatch):
+    monkeypatch.setenv("LOGIN_EVENTS_RETENTION_DAYS", "90")
+    ip = "198.51.100.10"
+    _run(_insert(ip, False, 120))   # falha antiga  → deve sumir
+    _run(_insert(ip, False, 5))     # falha recente → fica
+    _run(_insert(ip, True, 120))    # sucesso antigo (âncora IP) → fica
+
+    deleted = _run(ret.purge_old_login_events())
+
+    assert deleted == 1
+    assert _run(_exists(ip, False)) is True   # a falha recente sobrou
+    assert _run(_exists(ip, True)) is True    # o sucesso antigo foi preservado
+
+
+def test_desligado_e_noop(monkeypatch):
+    monkeypatch.setenv("LOGIN_EVENTS_RETENTION_DAYS", "0")
+    assert _run(ret.purge_old_login_events()) == 0


### PR DESCRIPTION
Apaga logs de login > N dias (LOGIN_EVENTS_RETENTION_DAYS, default 90; 0 desliga). Loop diario registrado no lifespan. Cobre as tentativas orfas (falha de login sem user_id) por tempo, sem lookup por email.

Habilita o proximo passo: parar de gravar email em claro em auth_login_events (fazer DEPOIS deste no ar + apos merge do alarme A09, pra nao conflitar em log_auth_login_event).