### PR TITLE
refactor(pii): para dual-write de delivered_to_email (data_export_tok…

### DIFF
--- a/db/privacy.py
+++ b/db/privacy.py
@@ -76,11 +76,11 @@ def create_data_export_token(
             """
             insert into data_export_tokens
               (token, user_id, expires_at, request_ip, request_user_agent,
-               delivered_to_email, delivered_to_email_enc)
-            values (%s, %s, %s, %s, %s, %s, %s)
+               delivered_to_email_enc)
+            values (%s, %s, %s, %s, %s, %s)
             """,
             (token, user_id, expires_at, request_ip, request_user_agent,
-             delivered_to_email, encrypt_pii_optional(delivered_to_email)),
+             encrypt_pii_optional(delivered_to_email)),
         )
         conn.commit()
 

--- a/scripts/pii_phase5_README.md
+++ b/scripts/pii_phase5_README.md
@@ -1,0 +1,48 @@
+# PII — Fase 5: remover as colunas em claro
+
+**Status:** preparado, **não executado**. O drop é irreversível e hoje está
+**bloqueado por código**, não só pelo seu aval.
+
+## Por que não é só "dropar as colunas"
+
+As colunas cifradas (`email_enc`, `phone_enc`, etc.) já convivem com as em
+claro (`email`, `phone_e164`, ...). Mas o código **ainda lê e escreve as em
+claro**. Exemplos confirmados em 2026-08-10:
+
+- **Escrita:** `core/admin_dashboard.py` (`log_auth_login_event` insere `email`
+  + `email_enc`), `db/google_auth.py` (`auth_accounts`, `auth_identities`,
+  `pending_google_signups`), `db/privacy.py` (`data_export_tokens`).
+- **Leitura (fallback):** `db/privacy.py:56/474` (`row.get("email")`),
+  `core/audit.py:264`, `core/admin_dashboard.py:328/333`.
+
+Se as colunas caírem agora, esses INSERTs quebram (referenciam coluna
+inexistente) e os fallbacks de leitura viram `NULL`. **Cadastro e login
+param.** Por isso a ordem importa.
+
+## Sequência segura (nesta ordem)
+
+1. **Backfill 100%.** Rode `migrate_pii_to_encrypted.py` até o fim e confirme
+   com `pii_phase5_precheck.sql` → todas as contagens `faltando = 0`.
+2. **Migração de código** (PR próprio, com testes):
+   - Parar de **escrever** as colunas em claro (tirar `email`/`phone_e164`/
+     `display_name`/`name_hint`/`delivered_to_email` dos INSERT/UPDATE).
+   - Trocar toda **leitura** em claro por decrypt do `_enc`
+     (`decrypt_pii(...)`), removendo os `row.get("email")` de fallback.
+   - `email_verification_codes` tem TTL curto — pode ser o primeiro a limpar.
+3. **Deploy** dessa migração e observar 1–2 dias (cadastro, login, export,
+   exclusão de conta, painel admin).
+4. **Backup** verificado (`pg_dump`) guardado fora do Railway.
+5. **Precheck de novo** → `faltando = 0`.
+6. **Drop**: descomentar `pii_phase5_drop_columns.sql`, rodar no DBeaver dentro
+   da transação, conferir o `\d`, e só então `COMMIT`.
+
+## Arquivos
+
+- `pii_phase5_precheck.sql` — go/no-go, somente leitura, seguro em prod.
+- `pii_phase5_drop_columns.sql` — o DROP, guardado (default `ROLLBACK`).
+
+## O que eu preciso de você
+
+O passo 2 (migração de código) é a parte grande e é onde eu preciso do seu
+"vai" pra abrir o PR. O drop em si (passo 6) você roda à mão, com o backup na
+mão — eu não executo operação irreversível em prod.

--- a/scripts/pii_phase5_README.md
+++ b/scripts/pii_phase5_README.md
@@ -19,27 +19,35 @@ Se as colunas caírem agora, esses INSERTs quebram (referenciam coluna
 inexistente) e os fallbacks de leitura viram `NULL`. **Cadastro e login
 param.** Por isso a ordem importa.
 
-## Sequência segura (nesta ordem)
+Isto é um **expand/contract**: primeiro afrouxa o schema, depois muda o código,
+por último remove as colunas. Pular o expand quebra o cadastro.
 
 1. **Backfill 100%.** Rode `migrate_pii_to_encrypted.py` até o fim e confirme
    com `pii_phase5_precheck.sql` → todas as contagens `faltando = 0`.
-2. **Migração de código** (PR próprio, com testes):
+2. **EXPAND: afrouxar `NOT NULL`** (rode `pii_phase5_expand_nullable.sql` **antes**
+   do passo 3). Hoje são `NOT NULL`: `auth_accounts.email`,
+   `pending_google_signups.email`, `email_verification_codes.email`. Se você
+   fizer o passo 3 (inserts sem a coluna em claro) com elas ainda `NOT NULL`,
+   **todo cadastro quebra com constraint violation** — as colunas só somem no
+   passo 6. `DROP NOT NULL` é reversível e não apaga dado.
+3. **Migração de código** (PR próprio, com testes):
    - Parar de **escrever** as colunas em claro (tirar `email`/`phone_e164`/
      `display_name`/`name_hint`/`delivered_to_email` dos INSERT/UPDATE).
    - Trocar toda **leitura** em claro por decrypt do `_enc`
      (`decrypt_pii(...)`), removendo os `row.get("email")` de fallback.
    - `email_verification_codes` tem TTL curto — pode ser o primeiro a limpar.
-3. **Deploy** dessa migração e observar 1–2 dias (cadastro, login, export,
+4. **Deploy** dessa migração e observar 1–2 dias (cadastro, login, export,
    exclusão de conta, painel admin).
-4. **Backup** verificado (`pg_dump`) guardado fora do Railway.
-5. **Precheck de novo** → `faltando = 0`.
-6. **Drop**: descomentar `pii_phase5_drop_columns.sql`, rodar no DBeaver dentro
-   da transação, conferir o `\d`, e só então `COMMIT`.
+5. **Backup** verificado (`pg_dump`) guardado fora do Railway.
+6. **Precheck de novo** → `faltando = 0`.
+7. **CONTRACT (drop)**: descomentar `pii_phase5_drop_columns.sql`, rodar no
+   DBeaver dentro da transação, conferir o `\d`, e só então `COMMIT`.
 
 ## Arquivos
 
 - `pii_phase5_precheck.sql` — go/no-go, somente leitura, seguro em prod.
-- `pii_phase5_drop_columns.sql` — o DROP, guardado (default `ROLLBACK`).
+- `pii_phase5_expand_nullable.sql` — EXPAND: `DROP NOT NULL` (passo 2, reversível).
+- `pii_phase5_drop_columns.sql` — CONTRACT: o DROP, guardado (default `ROLLBACK`).
 
 ## O que eu preciso de você
 

--- a/scripts/pii_phase5_drop_columns.sql
+++ b/scripts/pii_phase5_drop_columns.sql
@@ -1,0 +1,41 @@
+-- ============================================================================
+-- PII — Fase 5 · DROP das colunas em claro   ⚠️ IRREVERSÍVEL ⚠️
+-- ----------------------------------------------------------------------------
+-- NÃO RODE ANTES DE:
+--   1. pii_phase5_precheck.sql retornar faltando = 0 em TODAS as linhas.
+--   2. A migração de CÓDIGO estar concluída e no ar (ver pii_phase5_README.md):
+--      nenhum SELECT/INSERT/UPDATE pode mais tocar nas colunas em claro.
+--      Hoje AINDA tocam — rodar isto agora QUEBRA os inserts de login/cadastro.
+--   3. BACKUP verificado do banco (pg_dump) guardado fora do Railway.
+--
+-- Roda em transação: se algo destoar, dá ROLLBACK antes do COMMIT.
+-- Deixado comentado de propósito — descomente só quando 1-3 estiverem OK.
+-- ============================================================================
+
+BEGIN;
+
+-- -- auth_accounts
+-- ALTER TABLE auth_accounts            DROP COLUMN IF EXISTS email;
+-- ALTER TABLE auth_accounts            DROP COLUMN IF EXISTS phone_e164;
+-- ALTER TABLE auth_accounts            DROP COLUMN IF EXISTS display_name;
+--
+-- -- auth_identities
+-- ALTER TABLE auth_identities          DROP COLUMN IF EXISTS email;
+--
+-- -- auth_login_events
+-- ALTER TABLE auth_login_events        DROP COLUMN IF EXISTS email;
+--
+-- -- data_export_tokens
+-- ALTER TABLE data_export_tokens       DROP COLUMN IF EXISTS delivered_to_email;
+--
+-- -- pending_google_signups
+-- ALTER TABLE pending_google_signups   DROP COLUMN IF EXISTS email;
+-- ALTER TABLE pending_google_signups   DROP COLUMN IF EXISTS name_hint;
+--
+-- -- email_verification_codes
+-- ALTER TABLE email_verification_codes DROP COLUMN IF EXISTS email;
+-- ALTER TABLE email_verification_codes DROP COLUMN IF EXISTS phone_e164;
+
+-- Confira o \d das tabelas AQUI antes de confirmar.
+-- Se estiver tudo certo: COMMIT;  senão: ROLLBACK;
+ROLLBACK;  -- padrão seguro: não commita nada. Troque por COMMIT conscientemente.

--- a/scripts/pii_phase5_expand_nullable.sql
+++ b/scripts/pii_phase5_expand_nullable.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- PII — Fase 5 · EXPAND: afrouxar NOT NULL das colunas em claro
+-- ----------------------------------------------------------------------------
+-- Rode ANTES da migração de código que para de escrever as colunas em claro
+-- (passo 2 → passo 3 do pii_phase5_README.md). Sem isto, os INSERT sem a
+-- coluna em claro estouram NOT NULL enquanto a coluna ainda existe (o drop só
+-- vem depois, em pii_phase5_drop_columns.sql).
+--
+-- Reversível (não apaga dado): pra desfazer, `... SET NOT NULL` de novo — mas
+-- só depois de garantir que não há linhas com NULL nessas colunas.
+-- Seguro rodar em prod. Idempotente (DROP NOT NULL em coluna já nullable é no-op).
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE auth_accounts            ALTER COLUMN email DROP NOT NULL;
+ALTER TABLE pending_google_signups   ALTER COLUMN email DROP NOT NULL;
+ALTER TABLE email_verification_codes ALTER COLUMN email DROP NOT NULL;
+
+COMMIT;

--- a/scripts/pii_phase5_precheck.sql
+++ b/scripts/pii_phase5_precheck.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- PII — Fase 5 · PRECHECK (somente leitura, seguro rodar em prod)
+-- ----------------------------------------------------------------------------
+-- Objetivo: provar que TODA linha com PII em claro já tem o par cifrado (_enc)
+-- populado. Enquanto qualquer contagem abaixo for > 0, o DROP (ver
+-- pii_phase5_drop_columns.sql) PERDERIA DADO e NÃO PODE rodar.
+--
+-- Uso: rode no DBeaver (não no painel do Railway — ele engole erro).
+-- Go/no-go: todas as linhas devem retornar faltando = 0.
+-- ============================================================================
+
+-- auth_accounts: email / phone_e164 / display_name
+select 'auth_accounts.email'        as coluna, count(*) as faltando
+  from auth_accounts where email is not null and email_enc is null
+union all
+select 'auth_accounts.phone_e164',  count(*)
+  from auth_accounts where phone_e164 is not null and phone_enc is null
+union all
+select 'auth_accounts.display_name', count(*)
+  from auth_accounts where display_name is not null and display_name_enc is null
+
+-- auth_identities: email
+union all
+select 'auth_identities.email',     count(*)
+  from auth_identities where email is not null and email_enc is null
+
+-- auth_login_events: email (snapshot de auditoria)
+union all
+select 'auth_login_events.email',   count(*)
+  from auth_login_events where email is not null and email_enc is null
+
+-- data_export_tokens: delivered_to_email
+union all
+select 'data_export_tokens.delivered_to_email', count(*)
+  from data_export_tokens where delivered_to_email is not null and delivered_to_email_enc is null
+
+-- pending_google_signups: email / name_hint (linhas transitórias)
+union all
+select 'pending_google_signups.email', count(*)
+  from pending_google_signups where email is not null and email_enc is null
+union all
+select 'pending_google_signups.name_hint', count(*)
+  from pending_google_signups where name_hint is not null and name_hint_enc is null
+
+-- email_verification_codes: email / phone_e164 (linhas de TTL curto)
+union all
+select 'email_verification_codes.email', count(*)
+  from email_verification_codes where email is not null and email_enc is null
+union all
+select 'email_verification_codes.phone_e164', count(*)
+  from email_verification_codes where phone_e164 is not null and phone_enc is null
+
+order by faltando desc, coluna;


### PR DESCRIPTION
…ens)

Passo 1 (seguro/isolado) da remocao de dual-write de PII em claro. data_export_tokens.delivered_to_email: escreve so o _enc. Coluna e nullable, apagada por user_id (user_owned_tables), nunca lida por valor. Sem impacto em cadastro/login.

Inclui scripts de referencia da Fase 5 (drop futuro, guardado): scripts/pii_phase5_*.