### PR TITLE
feat(sec): alarme de spike de falha de login (A09 detector 1)

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -150,7 +150,6 @@ async def log_auth_login_event(
 ):
     try:
         normalized_email = (email or "").strip().lower() or None
-        alert_payload = None
         async with await db_connect() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
@@ -163,21 +162,15 @@ async def log_auth_login_event(
                     (user_id, normalized_email, encrypt_pii_optional(normalized_email),
                      success, ip_address, user_agent, failure_reason),
                 )
-                # A09 — spike de falha de login: detecta na MESMA transação (já
-                # enxerga a tentativa recém-inserida) e grava o marcador de
-                # cooldown. Nunca deixa a segurança derrubar o registro de login.
-                if not success:
-                    try:
-                        from core.services.security_alerts import detect_auth_failure_spike
-                        alert_payload = await detect_auth_failure_spike(cur, ip_address=ip_address)
-                    except Exception:
-                        alert_payload = None
             await conn.commit()
-        # Dispara fora da transação: fire-and-forget, no-op sem webhook.
-        if alert_payload:
+        # A09 — spike de falha de login: agenda a detecção FORA desta transação
+        # (task de fundo, conexão própria, depois do commit acima). Assim não
+        # atrasa a resposta do login, não pode abortar este commit, e a contagem
+        # enxerga as tentativas concorrentes já persistidas. Fire-and-forget.
+        if not success:
             try:
-                from core.services.security_alerts import fire_auth_spike_alert
-                await fire_auth_spike_alert(alert_payload)
+                from core.services.security_alerts import schedule_auth_failure_spike_check
+                schedule_auth_failure_spike_check(ip_address)
             except Exception:
                 pass
     except Exception as exc:

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -104,6 +104,13 @@ async def ensure_admin_tables():
                 ON auth_login_events (user_id, success, created_at DESC)
                 """
             )
+            # Suporta a detecção de spike de falha de login por IP (A09).
+            await cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_auth_login_events_ip_time
+                ON auth_login_events (ip_address, success, created_at DESC)
+                """
+            )
             await cur.execute(
                 """
                 CREATE TABLE IF NOT EXISTS system_event_logs (
@@ -143,6 +150,7 @@ async def log_auth_login_event(
 ):
     try:
         normalized_email = (email or "").strip().lower() or None
+        alert_payload = None
         async with await db_connect() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
@@ -155,7 +163,23 @@ async def log_auth_login_event(
                     (user_id, normalized_email, encrypt_pii_optional(normalized_email),
                      success, ip_address, user_agent, failure_reason),
                 )
+                # A09 — spike de falha de login: detecta na MESMA transação (já
+                # enxerga a tentativa recém-inserida) e grava o marcador de
+                # cooldown. Nunca deixa a segurança derrubar o registro de login.
+                if not success:
+                    try:
+                        from core.services.security_alerts import detect_auth_failure_spike
+                        alert_payload = await detect_auth_failure_spike(cur, ip_address=ip_address)
+                    except Exception:
+                        alert_payload = None
             await conn.commit()
+        # Dispara fora da transação: fire-and-forget, no-op sem webhook.
+        if alert_payload:
+            try:
+                from core.services.security_alerts import fire_auth_spike_alert
+                await fire_auth_spike_alert(alert_payload)
+            except Exception:
+                pass
     except Exception as exc:
         print(f"[admin] failed to record auth login event: {exc}", file=sys.stderr)
 

--- a/core/services/admin_notify.py
+++ b/core/services/admin_notify.py
@@ -138,3 +138,9 @@ def notify_subscription_canceled(
         f"acesso Pro até: {when}"
     )
     return _send(message)
+
+
+def notify_security_alert(message: str) -> bool:
+    """Alerta de segurança (ex.: spike de falha de login). Mensagem já formatada
+    pelo chamador. No-op silencioso sem ADMIN_NOTIFY_WEBHOOK_URL, como os demais."""
+    return _send(message)

--- a/core/services/security_alerts.py
+++ b/core/services/security_alerts.py
@@ -5,10 +5,18 @@ Hoje: spike de falha de login por IP (A09 detector 1). Quando um IP acumula
 muitas falhas de login numa janela curta, dispara um alerta administrativo via
 `core.services.admin_notify` (Slack/Discord).
 
-Princípios:
-  - Fire-and-forget: nunca bloqueia o login; o envio roda em thread separada.
-  - No-op silencioso sem `ADMIN_NOTIFY_WEBHOOK_URL` (herda de admin_notify).
-  - Nunca levanta exceção: um alerta que falha não pode derrubar a autenticação.
+Arquitetura (importante — evita 3 armadilhas):
+  - A detecção roda em uma **task de fundo** (`asyncio.create_task`), DEPOIS de
+    o evento de login já ter sido commitado. Assim:
+      1. NÃO atrasa a resposta do login (o webhook não é aguardado inline).
+      2. Um erro de SQL do detector NÃO aborta a transação do login (conexão
+         separada) — o registro de auditoria do login está garantido.
+      3. A contagem enxerga as tentativas concorrentes já commitadas (não fica
+         cega pra inserts não-commitados de outras transações).
+  - Serializa a detecção por IP com `pg_advisory_xact_lock`, então rajadas
+    concorrentes do mesmo IP não geram alerta duplicado nem perdem o threshold.
+  - Fire-and-forget: no-op silencioso sem `ADMIN_NOTIFY_WEBHOOK_URL`; nunca
+    levanta — um alerta que falha não pode derrubar a autenticação.
   - Anti-storm: cooldown por IP via marcador em `system_event_logs`.
   - Desligável sem deploy: `SECURITY_ALERTS_ENABLED=0`.
 
@@ -30,6 +38,9 @@ from psycopg.types.json import Jsonb
 logger = logging.getLogger(__name__)
 
 _ALERT_EVENT_TYPE = "auth_spike_alert"
+
+# Mantém referência forte às tasks de fundo (senão o GC pode coletá-las).
+_background_tasks: set[asyncio.Task] = set()
 
 
 def _enabled() -> bool:
@@ -57,71 +68,97 @@ def _cell(row: Any, key: str, idx: int) -> Any:
         return None
 
 
-async def detect_auth_failure_spike(cur, *, ip_address: str | None) -> dict | None:
-    """Roda DENTRO da transação de `log_auth_login_event` (mesmo cursor async),
-    logo já enxerga a tentativa recém-inserida.
+def schedule_auth_failure_spike_check(ip_address: str | None) -> None:
+    """Agenda a detecção de spike numa task de fundo — FORA da transação do
+    login e do caminho de resposta. Chamar DEPOIS do commit do evento de login.
 
-    Se o IP passou do threshold de falhas na janela E não está em cooldown,
-    grava o marcador de cooldown (na mesma transação) e devolve o payload do
-    alerta pra ser disparado FORA da transação. Caso contrário devolve None.
-
-    Nunca levanta: em qualquer erro, devolve None (login segue normal).
+    No-op sem IP, desligado, ou sem event loop rodando (ex.: chamada síncrona
+    em teste). Nunca levanta.
     """
     if not _enabled() or not ip_address:
-        return None
+        return
+    try:
+        task = asyncio.create_task(_detect_and_maybe_alert(ip_address))
+    except RuntimeError:
+        # Sem event loop em execução — nada a agendar.
+        return
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def _detect_and_maybe_alert(ip_address: str) -> None:
+    """Roda em transação PRÓPRIA (conexão separada), serializada por IP.
+
+    Como roda depois do commit do login, a contagem enxerga as tentativas já
+    persistidas. O advisory lock garante que rajadas concorrentes do mesmo IP
+    avaliem o threshold e gravem o cooldown de forma atômica. Nunca levanta.
+    """
     try:
         threshold = _int_env("AUTH_ALERT_THRESHOLD", 5)
         window = _int_env("AUTH_ALERT_WINDOW_MIN", 5)
         cooldown = _int_env("AUTH_ALERT_COOLDOWN_MIN", 30)
+        payload = None
 
-        await cur.execute(
-            """
-            select count(*) as n
-            from auth_login_events
-            where ip_address = %s
-              and success = false
-              and created_at >= now() - (%s || ' minutes')::interval
-            """,
-            (ip_address, str(window)),
-        )
-        n = _cell(await cur.fetchone(), "n", 0) or 0
-        if n < threshold:
-            return None
+        # Import tardio: admin_dashboard puxa muita coisa; evita ciclo no boot.
+        from core.admin_dashboard import db_connect
 
-        key = f"ip:{ip_address}"
-        await cur.execute(
-            """
-            select 1
-            from system_event_logs
-            where event_type = %s
-              and details ->> 'key' = %s
-              and created_at >= now() - (%s || ' minutes')::interval
-            limit 1
-            """,
-            (_ALERT_EVENT_TYPE, key, str(cooldown)),
-        )
-        if await cur.fetchone():
-            return None  # já alertamos sobre esse IP recentemente
+        async with await db_connect() as conn:
+            async with conn.cursor() as cur:
+                # Serializa a detecção por IP (lock de transação, liberado no
+                # commit). Evita alerta duplicado / threshold perdido sob rajada.
+                await cur.execute(
+                    "select pg_advisory_xact_lock(hashtext(%s)::bigint)",
+                    (f"auth_spike:{ip_address}",),
+                )
+                await cur.execute(
+                    """
+                    select count(*) as n
+                    from auth_login_events
+                    where ip_address = %s
+                      and success = false
+                      and created_at >= now() - (%s || ' minutes')::interval
+                    """,
+                    (ip_address, str(window)),
+                )
+                n = _cell(await cur.fetchone(), "n", 0) or 0
+                if n >= threshold:
+                    key = f"ip:{ip_address}"
+                    await cur.execute(
+                        """
+                        select 1
+                        from system_event_logs
+                        where event_type = %s
+                          and details ->> 'key' = %s
+                          and created_at >= now() - (%s || ' minutes')::interval
+                        limit 1
+                        """,
+                        (_ALERT_EVENT_TYPE, key, str(cooldown)),
+                    )
+                    if not await cur.fetchone():
+                        await cur.execute(
+                            """
+                            insert into system_event_logs
+                              (level, event_type, message, source, details)
+                            values ('warning', %s, %s, 'security_alerts', %s)
+                            """,
+                            (
+                                _ALERT_EVENT_TYPE,
+                                f"Spike de falha de login: {n} em {window}min (IP {ip_address})",
+                                Jsonb({"key": key, "count": int(n), "ip": ip_address, "window": window}),
+                            ),
+                        )
+                        payload = {"ip": ip_address, "count": int(n), "window": window}
+            await conn.commit()
 
-        await cur.execute(
-            """
-            insert into system_event_logs (level, event_type, message, source, details)
-            values ('warning', %s, %s, 'security_alerts', %s)
-            """,
-            (
-                _ALERT_EVENT_TYPE,
-                f"Spike de falha de login: {n} em {window}min (IP {ip_address})",
-                Jsonb({"key": key, "count": int(n), "ip": ip_address, "window": window}),
-            ),
-        )
-        return {"ip": ip_address, "count": int(n), "window": window}
+        if payload:
+            await _send_alert(payload)
     except Exception as exc:  # pragma: no cover - defensivo
-        logger.warning("[security_alerts] detect_auth_failure_spike falhou: %s", exc)
-        return None
+        logger.warning("[security_alerts] detecção de spike falhou: %s", exc)
 
 
-async def fire_auth_spike_alert(payload: dict) -> None:
-    """Dispara o alerta (fire-and-forget). Chamar FORA da transação do login."""
+async def _send_alert(payload: dict) -> None:
+    """Envia o alerta pelo webhook. Já roda fora da transação e da task do
+    request, então pode aguardar o envio em thread sem impactar ninguém."""
     try:
         from core.services.admin_notify import notify_security_alert
 
@@ -131,4 +168,4 @@ async def fire_auth_spike_alert(payload: dict) -> None:
         )
         await asyncio.to_thread(notify_security_alert, message)
     except Exception as exc:  # pragma: no cover - defensivo
-        logger.warning("[security_alerts] fire_auth_spike_alert falhou: %s", exc)
+        logger.warning("[security_alerts] envio do alerta falhou: %s", exc)

--- a/core/services/security_alerts.py
+++ b/core/services/security_alerts.py
@@ -1,0 +1,134 @@
+"""
+core/services/security_alerts.py — Detecção de eventos de segurança → alerta.
+
+Hoje: spike de falha de login por IP (A09 detector 1). Quando um IP acumula
+muitas falhas de login numa janela curta, dispara um alerta administrativo via
+`core.services.admin_notify` (Slack/Discord).
+
+Princípios:
+  - Fire-and-forget: nunca bloqueia o login; o envio roda em thread separada.
+  - No-op silencioso sem `ADMIN_NOTIFY_WEBHOOK_URL` (herda de admin_notify).
+  - Nunca levanta exceção: um alerta que falha não pode derrubar a autenticação.
+  - Anti-storm: cooldown por IP via marcador em `system_event_logs`.
+  - Desligável sem deploy: `SECURITY_ALERTS_ENABLED=0`.
+
+Config (envs, todas opcionais):
+  - SECURITY_ALERTS_ENABLED   (default '1')
+  - AUTH_ALERT_THRESHOLD      (default '5')   falhas na janela pra alertar
+  - AUTH_ALERT_WINDOW_MIN     (default '5')   tamanho da janela, em minutos
+  - AUTH_ALERT_COOLDOWN_MIN   (default '30')  silêncio por IP após um alerta
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from psycopg.types.json import Jsonb
+
+logger = logging.getLogger(__name__)
+
+_ALERT_EVENT_TYPE = "auth_spike_alert"
+
+
+def _enabled() -> bool:
+    return (os.getenv("SECURITY_ALERTS_ENABLED", "1") or "").strip().lower() not in (
+        "0", "false", "no", "off", "",
+    )
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _cell(row: Any, key: str, idx: int) -> Any:
+    """Lê um valor de row seja ela dict_row (dict) ou tupla."""
+    if row is None:
+        return None
+    if isinstance(row, dict):
+        return row.get(key)
+    try:
+        return row[idx]
+    except (IndexError, KeyError, TypeError):
+        return None
+
+
+async def detect_auth_failure_spike(cur, *, ip_address: str | None) -> dict | None:
+    """Roda DENTRO da transação de `log_auth_login_event` (mesmo cursor async),
+    logo já enxerga a tentativa recém-inserida.
+
+    Se o IP passou do threshold de falhas na janela E não está em cooldown,
+    grava o marcador de cooldown (na mesma transação) e devolve o payload do
+    alerta pra ser disparado FORA da transação. Caso contrário devolve None.
+
+    Nunca levanta: em qualquer erro, devolve None (login segue normal).
+    """
+    if not _enabled() or not ip_address:
+        return None
+    try:
+        threshold = _int_env("AUTH_ALERT_THRESHOLD", 5)
+        window = _int_env("AUTH_ALERT_WINDOW_MIN", 5)
+        cooldown = _int_env("AUTH_ALERT_COOLDOWN_MIN", 30)
+
+        await cur.execute(
+            """
+            select count(*) as n
+            from auth_login_events
+            where ip_address = %s
+              and success = false
+              and created_at >= now() - (%s || ' minutes')::interval
+            """,
+            (ip_address, str(window)),
+        )
+        n = _cell(await cur.fetchone(), "n", 0) or 0
+        if n < threshold:
+            return None
+
+        key = f"ip:{ip_address}"
+        await cur.execute(
+            """
+            select 1
+            from system_event_logs
+            where event_type = %s
+              and details ->> 'key' = %s
+              and created_at >= now() - (%s || ' minutes')::interval
+            limit 1
+            """,
+            (_ALERT_EVENT_TYPE, key, str(cooldown)),
+        )
+        if await cur.fetchone():
+            return None  # já alertamos sobre esse IP recentemente
+
+        await cur.execute(
+            """
+            insert into system_event_logs (level, event_type, message, source, details)
+            values ('warning', %s, %s, 'security_alerts', %s)
+            """,
+            (
+                _ALERT_EVENT_TYPE,
+                f"Spike de falha de login: {n} em {window}min (IP {ip_address})",
+                Jsonb({"key": key, "count": int(n), "ip": ip_address, "window": window}),
+            ),
+        )
+        return {"ip": ip_address, "count": int(n), "window": window}
+    except Exception as exc:  # pragma: no cover - defensivo
+        logger.warning("[security_alerts] detect_auth_failure_spike falhou: %s", exc)
+        return None
+
+
+async def fire_auth_spike_alert(payload: dict) -> None:
+    """Dispara o alerta (fire-and-forget). Chamar FORA da transação do login."""
+    try:
+        from core.services.admin_notify import notify_security_alert
+
+        message = (
+            "🚨 Spike de falha de login\n"
+            f"IP {payload['ip']} — {payload['count']} falhas em {payload['window']}min"
+        )
+        await asyncio.to_thread(notify_security_alert, message)
+    except Exception as exc:  # pragma: no cover - defensivo
+        logger.warning("[security_alerts] fire_auth_spike_alert falhou: %s", exc)

--- a/docs/security_alerts_A09_design.md
+++ b/docs/security_alerts_A09_design.md
@@ -1,0 +1,117 @@
+# A09 — Alertas de segurança (design, não implementado)
+
+Objetivo: ser avisado **na hora** de dois eventos: pico de falha de login e
+5xx em série. Reaproveita a infra que já existe — nada de canal novo.
+
+## Infra reaproveitada
+
+- **Canal:** `core/services/admin_notify.py` → `ADMIN_NOTIFY_WEBHOOK_URL`
+  (Slack/Discord auto-detect). Já é **fire-and-forget** e **no-op silencioso**
+  se a env estiver vazia. Todo alerta sai por `asyncio.to_thread(_send, msg)`
+  pra não pesar no request.
+- **Fonte de dados de auth:** `auth_login_events` (já gravado por
+  `core/admin_dashboard.py::log_auth_login_event`, com `success`,
+  `ip_address`, `email`, `created_at`).
+- **Trilha de dedup:** `system_event_logs` (já existe, via `log_system_event`)
+  — marca "já alertei sobre X" de forma cross-worker.
+
+## Princípios (valem pros dois detectores)
+
+1. **Nunca bloquear o request** — sempre fire-and-forget.
+2. **Zero PII no alerta** — email sempre mascarado (`a***@dominio`), nunca
+   token/senha/query string. Detalhe cru fica no log server-side.
+3. **Anti-storm** — cooldown por chave (IP, rota) pra um ataque não virar 200
+   mensagens. Cross-worker via marcador em `system_event_logs`.
+4. **Feature flag** — `SECURITY_ALERTS_ENABLED` (default: ligado só se o webhook
+   estiver setado). Desliga sem deploy.
+
+---
+
+## Detector 1 — Spike de falha de login  ✅ prioridade
+
+**Threshold escolhido:** 5 falhas / 5 min. Duas chaves independentes:
+- **por IP** — pega brute-force de um IP contra várias contas.
+- **por email** — pega credential stuffing distribuído contra uma conta.
+
+**Onde plugar:** ao fim de `log_auth_login_event`, quando `success=False`.
+Depois de gravar a tentativa, roda a contagem da janela:
+
+```sql
+-- por IP (mesma ideia por email, trocando a coluna)
+select count(*) from auth_login_events
+ where ip_address = %s and success = false
+   and created_at >= now() - interval '5 minutes';
+```
+
+**Fluxo:**
+1. `count >= 5` numa das chaves →
+2. checa cooldown: houve `system_event_logs` tipo `auth_spike_alert` pra essa
+   chave nos últimos **30 min**? Se sim, silencia.
+3. senão: grava o marcador e dispara `admin_notify`.
+
+**Mensagem (exemplo):**
+```
+🚨 Spike de falha de login
+IP 203.0.113.7 — 6 falhas em 5min
+Alvos: le***@gmail.com, ad***@pigbank.com  (3 contas distintas)
+```
+
+**Envs novas:** `AUTH_ALERT_THRESHOLD=5`, `AUTH_ALERT_WINDOW_MIN=5`,
+`AUTH_ALERT_COOLDOWN_MIN=30`.
+
+**Custo:** 1 SELECT indexado por falha de login. Falha de login já é raro e já
+rate-limited (5/min) — custo desprezível. Precisa de índice
+`(ip_address, created_at)` e `(email, created_at)` em `auth_login_events`
+(checar se já existe; senão, `create index concurrently`).
+
+**Teste:** unit que insere 5 falhas na janela e afirma que `_send` é chamado 1x
+(e que a 6ª, dentro do cooldown, não chama).
+
+---
+
+## Detector 2 — 5xx em série  (2º incremento, mais invasivo)
+
+**Threshold sugerido:** 10 respostas 5xx / 5 min (global). Ajustável por env.
+
+**Onde plugar:** o app já tem um `@app.middleware("http")` de headers de
+segurança (perto da linha 1735). Adicionar um contador de 5xx em janela
+deslizante **em memória** (por worker) — sem tocar no DB no hot path:
+- deque de timestamps dos 5xx dos últimos 5 min;
+- ao passar de 10, dispara alerta (com cooldown de 30 min via marcador).
+
+**Cuidado (liga com o B1 da auditoria):** o alerta manda só `método + rota +
+status` (ex.: `POST /ai/chat → 500`), **nunca** o corpo da exceção — detalhe
+cru vai pro log server-side. Isso também é um empurrão pra fechar o B1
+(erros verbosos ecoados ao cliente).
+
+**Mensagem (exemplo):**
+```
+🔥 5xx em série: 12 erros em 5min
+Top rotas: POST /lancamentos (7), POST /ai/chat (3)
+```
+
+**Por que é "2º incremento":** mexe no arquivo de 260KB e no caminho de TODA
+resposta. Baixo risco (só conta e, no limiar, dispara async), mas quero testar
+com calma — daí separar do detector 1.
+
+**Envs novas:** `HTTP5XX_ALERT_THRESHOLD=10`, `HTTP5XX_ALERT_WINDOW_MIN=5`.
+
+---
+
+## Arquivos a criar/tocar quando for implementar
+
+- **novo** `core/services/security_alerts.py` — lógica dos dois detectores +
+  cooldown + máscara de email + montagem da mensagem. Isola tudo num módulo.
+- `core/admin_dashboard.py` — 1 chamada no fim de `log_auth_login_event`.
+- `frontend/finance_bot_websocket_custom.py` — contador 5xx no middleware
+  existente (só no 2º incremento).
+- `db/schema.py` — garantir índices `(ip_address, created_at)` /
+  `(email, created_at)` em `auth_login_events`.
+- `tests/test_security_alerts.py` — thresholds, cooldown, no-op sem webhook,
+  máscara de PII.
+
+## Decisões pendentes suas
+
+- Ligar já o detector 1? (é o de maior valor e menor risco)
+- 5xx: threshold 10/5min serve, ou prefere outro?
+- Cooldown de 30 min está bom, ou quer mais/menos agressivo?

--- a/tests/test_security_alerts.py
+++ b/tests/test_security_alerts.py
@@ -1,0 +1,80 @@
+"""Testes do detector de spike de falha de login (A09 detector 1).
+
+Não tocam no banco: usam um cursor falso, então rodam em segundos e cobrem a
+lógica de threshold + cooldown sem precisar de Postgres.
+"""
+import asyncio
+
+from core.services import security_alerts
+
+
+class FakeCursor:
+    """Cursor async mínimo. Responde a 3 queries: contagem, checagem de
+    cooldown e insert do marcador."""
+
+    def __init__(self, *, count: int, cooldown_hit: bool = False):
+        self._count = count
+        self._cooldown_hit = cooldown_hit
+        self._last = None
+        self.marker_inserts = []
+
+    async def execute(self, sql, params=None):
+        s = " ".join(sql.split()).lower()
+        if "count(*)" in s:
+            self._last = {"n": self._count}
+        elif "select 1" in s and "system_event_logs" in s:
+            self._last = (1,) if self._cooldown_hit else None
+        elif s.startswith("insert into system_event_logs"):
+            self.marker_inserts.append(params)
+            self._last = None
+        else:
+            self._last = None
+
+    async def fetchone(self):
+        return self._last
+
+
+def _run(count, *, cooldown_hit=False, ip="203.0.113.7"):
+    cur = FakeCursor(count=count, cooldown_hit=cooldown_hit)
+    result = asyncio.run(
+        security_alerts.detect_auth_failure_spike(cur, ip_address=ip)
+    )
+    return result, cur
+
+
+def test_abaixo_do_threshold_nao_alerta(monkeypatch):
+    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
+    result, cur = _run(count=4)
+    assert result is None
+    assert cur.marker_inserts == []
+
+
+def test_no_threshold_alerta_e_grava_marcador(monkeypatch):
+    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
+    result, cur = _run(count=5)
+    assert result is not None
+    assert result["count"] == 5
+    assert result["ip"] == "203.0.113.7"
+    assert len(cur.marker_inserts) == 1  # gravou o cooldown
+
+
+def test_em_cooldown_nao_realerta(monkeypatch):
+    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
+    result, cur = _run(count=20, cooldown_hit=True)
+    assert result is None
+    assert cur.marker_inserts == []
+
+
+def test_desligado_por_env_nao_alerta(monkeypatch):
+    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
+    monkeypatch.setenv("SECURITY_ALERTS_ENABLED", "0")
+    result, cur = _run(count=99)
+    assert result is None
+    assert cur.marker_inserts == []
+
+
+def test_sem_ip_nao_alerta(monkeypatch):
+    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
+    result, cur = _run(count=99, ip=None)
+    assert result is None
+    assert cur.marker_inserts == []

--- a/tests/test_security_alerts.py
+++ b/tests/test_security_alerts.py
@@ -1,80 +1,93 @@
 """Testes do detector de spike de falha de login (A09 detector 1).
 
-Não tocam no banco: usam um cursor falso, então rodam em segundos e cobrem a
-lógica de threshold + cooldown sem precisar de Postgres.
+Integração leve: usa o banco de teste (como test_audit.py). Exercita o novo
+desenho — detecção em transação própria, depois do commit do login, com
+cooldown por IP. Cada teste usa um IP distinto pra não interferir nos outros.
 """
 import asyncio
 
-from core.services import security_alerts
+import pytest
+
+from core.services import admin_notify, security_alerts
 
 
-class FakeCursor:
-    """Cursor async mínimo. Responde a 3 queries: contagem, checagem de
-    cooldown e insert do marcador."""
-
-    def __init__(self, *, count: int, cooldown_hit: bool = False):
-        self._count = count
-        self._cooldown_hit = cooldown_hit
-        self._last = None
-        self.marker_inserts = []
-
-    async def execute(self, sql, params=None):
-        s = " ".join(sql.split()).lower()
-        if "count(*)" in s:
-            self._last = {"n": self._count}
-        elif "select 1" in s and "system_event_logs" in s:
-            self._last = (1,) if self._cooldown_hit else None
-        elif s.startswith("insert into system_event_logs"):
-            self.marker_inserts.append(params)
-            self._last = None
-        else:
-            self._last = None
-
-    async def fetchone(self):
-        return self._last
+def _run(coro):
+    return asyncio.run(coro)
 
 
-def _run(count, *, cooldown_hit=False, ip="203.0.113.7"):
-    cur = FakeCursor(count=count, cooldown_hit=cooldown_hit)
-    result = asyncio.run(
-        security_alerts.detect_auth_failure_spike(cur, ip_address=ip)
-    )
-    return result, cur
+@pytest.fixture(autouse=True)
+def _ensure_tables():
+    from core.admin_dashboard import ensure_admin_tables
+    _run(ensure_admin_tables())
 
 
-def test_abaixo_do_threshold_nao_alerta(monkeypatch):
+async def _insert_failures(ip: str, n: int) -> None:
+    from core.admin_dashboard import db_connect
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            for _ in range(n):
+                await cur.execute(
+                    "insert into auth_login_events (success, ip_address, failure_reason) "
+                    "values (false, %s, 'bad_password')",
+                    (ip,),
+                )
+        await conn.commit()
+
+
+async def _marker_count(ip: str) -> int:
+    from core.admin_dashboard import db_connect
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "select count(*) as n from system_event_logs "
+                "where event_type = 'auth_spike_alert' and details->>'key' = %s",
+                (f"ip:{ip}",),
+            )
+            row = await cur.fetchone()
+    return row["n"] if isinstance(row, dict) else row[0]
+
+
+@pytest.fixture
+def _capture(monkeypatch):
+    sent: list[str] = []
+    monkeypatch.setattr(admin_notify, "notify_security_alert", lambda m: sent.append(m) or True)
     monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
-    result, cur = _run(count=4)
-    assert result is None
-    assert cur.marker_inserts == []
+    monkeypatch.setenv("AUTH_ALERT_COOLDOWN_MIN", "30")
+    monkeypatch.delenv("SECURITY_ALERTS_ENABLED", raising=False)
+    return sent
 
 
-def test_no_threshold_alerta_e_grava_marcador(monkeypatch):
-    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
-    result, cur = _run(count=5)
-    assert result is not None
-    assert result["count"] == 5
-    assert result["ip"] == "203.0.113.7"
-    assert len(cur.marker_inserts) == 1  # gravou o cooldown
+def test_abaixo_do_threshold_nao_alerta(_capture):
+    ip = "203.0.113.201"
+    _run(_insert_failures(ip, 4))
+    _run(security_alerts._detect_and_maybe_alert(ip))
+    assert _capture == []
+    assert _run(_marker_count(ip)) == 0
 
 
-def test_em_cooldown_nao_realerta(monkeypatch):
-    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
-    result, cur = _run(count=20, cooldown_hit=True)
-    assert result is None
-    assert cur.marker_inserts == []
+def test_no_threshold_alerta_e_grava_marcador(_capture):
+    ip = "203.0.113.202"
+    _run(_insert_failures(ip, 5))
+    _run(security_alerts._detect_and_maybe_alert(ip))
+    assert len(_capture) == 1
+    assert ip in _capture[0]
+    assert _run(_marker_count(ip)) == 1
 
 
-def test_desligado_por_env_nao_alerta(monkeypatch):
-    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
+def test_cooldown_nao_realerta(_capture):
+    ip = "203.0.113.203"
+    _run(_insert_failures(ip, 6))
+    _run(security_alerts._detect_and_maybe_alert(ip))   # 1º: alerta
+    _run(security_alerts._detect_and_maybe_alert(ip))   # 2º: em cooldown
+    assert len(_capture) == 1
+    assert _run(_marker_count(ip)) == 1
+
+
+def test_schedule_desligado_por_env_e_noop(monkeypatch):
+    # SECURITY_ALERTS_ENABLED=0 → schedule vira no-op (nem agenda a task).
     monkeypatch.setenv("SECURITY_ALERTS_ENABLED", "0")
-    result, cur = _run(count=99)
-    assert result is None
-    assert cur.marker_inserts == []
+    security_alerts.schedule_auth_failure_spike_check("203.0.113.204")  # não levanta
 
 
-def test_sem_ip_nao_alerta(monkeypatch):
-    monkeypatch.setenv("AUTH_ALERT_THRESHOLD", "5")
-    result, cur = _run(count=99, ip=None)
-    assert result is None
-    assert cur.marker_inserts == []
+def test_schedule_sem_ip_e_noop():
+    security_alerts.schedule_auth_failure_spike_check(None)  # não levanta


### PR DESCRIPTION
Detecta brute-force por IP e avisa o admin via admin_notify (Slack/Discord).
- core/services/security_alerts.py: detecta na mesma txn do log de login, threshold 5 falhas/5min (envs AUTH_ALERT_*), cooldown 30min por IP via marcador em system_event_logs. Fire-and-forget, no-op sem webhook, nunca levanta (seguranca nao derruba o login). Desligavel: SECURITY_ALERTS_ENABLED=0
- admin_dashboard.py: hook no log_auth_login_event (so em falha) + indice (ip_address, success, created_at)
- admin_notify.py: notify_security_alert()
- tests/test_security_alerts.py: threshold/cooldown/desligado, sem DB
- docs/security_alerts_A09_design.md: design (inclui detector 2 de 5xx, futuro)