### PR TITLE
fix(credito): remove preposicao solta da nota da compra natural

### DIFF
--- a/core/handlers/credit.py
+++ b/core/handlers/credit.py
@@ -429,6 +429,9 @@ def _clean_credit_purchase_description(text: str, card_name: str | None) -> str:
             desc,
             flags=re.IGNORECASE,
         ).strip()
+    # Remove preposição/conector solto que sobra ao tirar "...no crédito"/cartão
+    # (ex.: "no crédito com minha namorada" → "com minha namorada" → "minha namorada").
+    desc = re.sub(r"^\s*(?:com|no|na|em)\b\s*", "", desc, flags=re.IGNORECASE).strip()
     desc = re.sub(r"\s+", " ", desc).strip(" -:;,.")
     return desc
 


### PR DESCRIPTION
'gastei 400 no credito com minha namorada' gerava nota 'com minha namorada'; agora vira 'minha namorada' (tira o conector com/no/na/em que sobra depois de remover 'no credito'/cartao). Corrige test_compra_natural_credito_usa_categoria_custom que estava VERMELHO na main ha algum tempo — era o que deixava a CI das 4 PRs vermelha. Suite: 939 passed.