### PR TITLE
fix: renda fixa do banco na aba de Investimentos + caixinha OF saldo 0 (Nubank)

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -229,6 +229,8 @@ from .open_finance import (
 from .rv import (
     list_rv_positions,
     rv_portfolio_summary,
+    list_of_fixed_income,
+    of_fixed_income_summary,
     pluggy_rv_kind,
     RV_KIND_LABELS,
 )
@@ -447,6 +449,7 @@ __all__ = [
     "save_open_finance_investments",
     "sync_open_finance_caixinhas",
     "list_rv_positions", "rv_portfolio_summary", "pluggy_rv_kind", "RV_KIND_LABELS",
+    "list_of_fixed_income", "of_fixed_income_summary",
     "list_caixinha_candidates", "bind_pocket_to_caixinha",
     "list_banqueiro_pockets", "banqueiro_pocket_pace", "update_pocket_of_last_seen",
     "delete_open_finance_transactions", "classify_open_finance_launch",

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -690,7 +690,9 @@ def sync_open_finance_caixinhas(connection_id: int, user_id: int) -> dict:
     created = linked = mirrored = 0
     with get_conn() as conn:
         with conn.cursor() as cur:
-            # 1. caixinhas OF desta conexão com cara de caixinha
+            # 1. caixinhas OF desta conexão com cara de caixinha E SALDO > 0.
+            # Saldo 0 = fundo/reserva vazia (ex.: Nubank "Reserva Planejada" que o
+            # Pluggy devolve zerado) — não vira caixinha fantasma.
             cur.execute(
                 """
                 select i.id as of_id, i.name, coalesce(i.balance, 0) as balance,
@@ -698,6 +700,7 @@ def sync_open_finance_caixinhas(connection_id: int, user_id: int) -> dict:
                 from open_finance_investments i
                 where i.connection_id = %s
                   and i.name ilike any (%s)
+                  and coalesce(i.balance, 0) > 0
                 """,
                 (connection_id, _CAIXINHA_NAME_PATTERNS),
             )
@@ -774,8 +777,25 @@ def sync_open_finance_caixinhas(connection_id: int, user_id: int) -> dict:
                 (user_id,),
             )
             mirrored = cur.rowcount
+
+            # 4. Auto-cura: remove caixinhas AUTO-CRIADAS (source='open_finance') cujo
+            # investimento do banco está zerado/sumiu — limpa as fantasmas já criadas
+            # (ex.: "Reserva Planejada" do Nubank que veio com saldo 0).
+            cur.execute(
+                """
+                delete from pockets p
+                 using open_finance_investments i
+                 where p.of_investment_id = i.id
+                   and p.user_id = %s
+                   and p.source = 'open_finance'
+                   and coalesce(i.balance, 0) <= 0
+                """,
+                (user_id,),
+            )
+            cleaned = cur.rowcount
         conn.commit()
-    return {"caixinhas_created": created, "caixinhas_linked": linked, "caixinhas_mirrored": mirrored}
+    return {"caixinhas_created": created, "caixinhas_linked": linked,
+            "caixinhas_mirrored": mirrored, "caixinhas_cleaned": cleaned}
 
 
 def get_open_finance_connection_by_item_id(provider_item_id: str, provider: str = "pluggy") -> dict | None:

--- a/db/rv.py
+++ b/db/rv.py
@@ -18,6 +18,7 @@ amount, balance}. `value` (preço unitário) pode vir null → fallback balance/
 """
 from __future__ import annotations
 
+import re
 from decimal import InvalidOperation
 
 from .connection import get_conn
@@ -133,3 +134,78 @@ def rv_portfolio_summary(user_id: int) -> dict:
         "pnl_pct": (pnl / invested) if invested > 0 else 0.0,
         "count": len(pos),
     }
+
+
+# ── Renda fixa do banco (Open Finance): CDB, Tesouro — NÃO vira caixinha ───────
+# Decisão 2026-08-11: o Nubank (e outros) manda os investimentos com nome jurídico
+# gigante e SEM apelido; não dá pra tratar como "caixinha". Então renda fixa do banco
+# aparece aqui, na aba de Investimentos, agregada e read-only.
+
+def _clean_of_name(name: str) -> str:
+    """Nome legível pro investimento do banco (Pluggy manda o nome jurídico completo)."""
+    n = (name or "").strip()
+    up = n.upper()
+    if up.startswith("CDB"):
+        parts = [p.strip() for p in n.split(" - ")]
+        if len(parts) > 1:
+            issuer = re.sub(r"\b(S\.?/?A\.?|SOCIEDADE.*|FINANCIAMENTO.*|LTDA.*)\b.*", "", parts[1], flags=re.I)
+            issuer = " ".join(w.capitalize() for w in issuer.split()[:3]).strip()
+            return f"CDB · {issuer}" if issuer else "CDB"
+        return "CDB"
+    if up.startswith("TESOURO"):
+        return n  # já limpo (ex.: "Tesouro IPCA+ 2032")
+    if len(n) > 40:  # fundo/previdência com nome jurídico longo
+        base = re.sub(r"\b(FUNDO DE INVESTIMENTO.*|RESPONSABILIDADE.*|LTDA.*|S\.?/?A\.?)\b.*", "", n, flags=re.I).strip()
+        base = (base or n[:38]).strip()
+        return (base[:38] + "…") if len(base) > 38 else base
+    return n
+
+
+def list_of_fixed_income(user_id: int) -> list[dict]:
+    """Renda fixa do banco (FIXED_INCOME: CDB/Tesouro) via Open Finance, agregada por
+    nome limpo, read-only. Exclui o que virou caixinha (of_investment_id vinculado) e
+    saldo <= 0. P&L = balance − amount."""
+    ensure_user(user_id)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select i.name, i.balance,
+                       nullif(i.raw->>'amount', '')::numeric as amount
+                from open_finance_investments i
+                join open_finance_connections c on c.id = i.connection_id
+                where c.user_id = %s
+                  and upper(coalesce(i.type, '')) = 'FIXED_INCOME'
+                  and coalesce(i.balance, 0) > 0
+                  and not exists (
+                    select 1 from pockets p
+                    where p.of_investment_id = i.id and p.user_id = %s
+                  )
+                """,
+                (user_id, user_id),
+            )
+            rows = [dict(r) for r in (cur.fetchall() or [])]
+
+    groups: dict[str, dict] = {}
+    for r in rows:
+        label = _clean_of_name(r.get("name"))
+        bal = _f(r.get("balance"))
+        inv = _f(r.get("amount"), bal)
+        g = groups.setdefault(label, {"name": label, "balance": 0.0, "invested": 0.0, "count": 0})
+        g["balance"] += bal
+        g["invested"] += inv
+        g["count"] += 1
+
+    out = []
+    for g in groups.values():
+        pnl = g["balance"] - g["invested"]
+        out.append({**g, "pnl": pnl, "pnl_pct": (pnl / g["invested"]) if g["invested"] > 0 else 0.0})
+    out.sort(key=lambda x: x["balance"], reverse=True)
+    return out
+
+
+def of_fixed_income_summary(user_id: int) -> dict:
+    items = list_of_fixed_income(user_id)
+    bal = sum(i["balance"] for i in items)
+    inv = sum(i["invested"] for i in items)
+    return {"balance": bal, "invested": inv, "pnl": bal - inv, "count": sum(i["count"] for i in items)}

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
-<link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
+<link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
 <link rel="manifest" href="/manifest.json" />
 <meta name="theme-color" content="#111111" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -738,6 +738,16 @@
         </div>
         <div id="rv-summary" class="rv-summary"></div>
         <div id="rv-list"></div>
+      </div>
+
+      <!-- 3c. Renda fixa via banco (CDB/Tesouro do Open Finance) — read-only, agregada -->
+      <div class="mock-card" id="of-rf-card" style="margin-bottom:14px;display:none">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:14px;flex-wrap:wrap;gap:10px">
+          <h3 style="margin:0">Renda fixa · via banco</h3>
+          <span style="font-size:.7rem;color:var(--text-3)">CDB e Tesouro · atualizado pelo seu banco</span>
+        </div>
+        <div id="of-rf-summary" class="rv-summary"></div>
+        <div id="of-rf-list"></div>
       </div>
 
       <!-- 4. Simulador líquido -->

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -6169,6 +6169,45 @@ function renderInvestmentsPanel(d) {
   }).join("") : `<div class="empty">Nenhum investimento cadastrado.</div>`;
 
   renderVariableIncomePanel(d);
+  renderOfFixedIncomePanel(d);
+}
+
+// Renda fixa do banco (CDB/Tesouro via Open Finance) — agregada, read-only.
+function renderOfFixedIncomePanel(d) {
+  const card = document.getElementById("of-rf-card");
+  if (!card) return;
+  const items = d.of_fixed_income || [];
+  const sum = d.of_fixed_income_summary || {};
+  if (!items.length) { card.style.display = "none"; return; }
+  card.style.display = "";
+
+  const elS = document.getElementById("of-rf-summary");
+  if (elS) elS.innerHTML = `
+    <div class="chips" style="margin-top:0;margin-bottom:6px">
+      <div class="chip"><div class="chip-lbl">Saldo</div><div class="chip-val b">${fmt(sum.balance || 0)}</div></div>
+      <div class="chip"><div class="chip-lbl">Investido</div><div class="chip-val">${fmt(sum.invested || 0)}</div></div>
+      <div class="chip"><div class="chip-lbl">Rendeu</div><div class="chip-val">${fmtPnl(sum.pnl || 0)}</div></div>
+    </div>`;
+
+  const elL = document.getElementById("of-rf-list");
+  if (!elL) return;
+  elL.innerHTML = items.map(i => {
+    const n = Number(i.count || 1);
+    const papeis = n > 1 ? `<span class="mini-tag">${n} papéis</span>` : "";
+    return `
+      <div class="invest-card rv-card-item">
+        <div class="invest-head">
+          <div style="min-width:0">
+            <div class="invest-name">${esc(i.name)} <span class="rv-badge">via banco</span></div>
+            <div class="invest-meta"><span class="mini-tag">Renda fixa</span>${papeis}</div>
+          </div>
+          <div style="text-align:right">
+            <div class="val b">${fmt(i.balance)}</div>
+            <div style="font-size:.8rem;margin-top:2px">${fmtPnl(i.pnl, i.pnl_pct)}</div>
+          </div>
+        </div>
+      </div>`;
+  }).join("");
 }
 
 // Renda variável (ações/FIIs) vinda do Open Finance — read-only, marcada a mercado.

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -67,6 +67,7 @@ from db import (
     accrue_all_pockets,
     accrue_all_investments,
     list_rv_positions,
+    list_of_fixed_income,
     create_investment_db,
     delete_investment,
     get_dashboard_market_rates,
@@ -293,30 +294,34 @@ async def _get_dashboard_current_state(user_id: int):
     now_mono = _startup_time.monotonic()
     cached = _dashboard_current_cache.get(int(user_id))
     if cached and now_mono - cached[0] < _DASHBOARD_CURRENT_CACHE_TTL_SECONDS:
-        return cached[1], cached[2], cached[3], cached[4]
+        return cached[1], cached[2], cached[3], cached[4], cached[5]
 
-    # rv_positions só LÊ open_finance_investments (não bate na rede) → cabe no gather
-    # sem estourar a latência do snapshot; a corretora é a fonte, o sync já atualizou.
-    current_pockets, current_investments, market_rates, rv_positions = await asyncio.gather(
+    # rv_positions e of_fixed_income só LÊEM open_finance_investments (não batem na
+    # rede) → cabem no gather sem estourar latência; a corretora é a fonte, o sync já
+    # atualizou. of_fixed_income = renda fixa do banco (CDB/Tesouro) agregada.
+    (current_pockets, current_investments, market_rates,
+     rv_positions, of_fixed_income) = await asyncio.gather(
         asyncio.to_thread(accrue_all_pockets, user_id),
         asyncio.to_thread(accrue_all_investments, user_id),
         asyncio.to_thread(get_dashboard_market_rates),
         asyncio.to_thread(list_rv_positions, user_id),
+        asyncio.to_thread(list_of_fixed_income, user_id),
     )
-    # Renda variável (ações/FIIs via OF) é feature paga (Essencial+). No Grátis o
-    # painel não recebe posições — a aba de investimentos já é gated, e assim o dado
-    # do banco nem trafega pra quem não tem o plano.
+    # RV + renda fixa via OF são features pagas (Essencial+). No Grátis não trafega o
+    # dado do banco — a aba de investimentos já é gated.
     from core.services.plan_service import require_min_tier
     if not require_min_tier(user_id, "essencial"):
         rv_positions = []
+        of_fixed_income = []
     _dashboard_current_cache[int(user_id)] = (
         _startup_time.monotonic(),
         current_pockets,
         current_investments,
         market_rates,
         rv_positions,
+        of_fixed_income,
     )
-    return current_pockets, current_investments, market_rates, rv_positions
+    return current_pockets, current_investments, market_rates, rv_positions, of_fixed_income
 
 
 def _dashboard_launch_filter_sql(filter_type: str | None, query: str | None) -> tuple[list[str], list]:
@@ -378,7 +383,7 @@ async def get_financial_data(
     page = max(int(page or 1), 1)
     limit = max(min(int(limit or 25), 100), 1)
     offset = (page - 1) * limit
-    current_pockets, current_investments, market_rates, current_rv_positions = await _get_dashboard_current_state(user_id)
+    current_pockets, current_investments, market_rates, current_rv_positions, current_of_fixed_income = await _get_dashboard_current_state(user_id)
     launch_filter_clauses, launch_filter_params = _dashboard_launch_filter_sql(filter_type, query)
     launch_filter_sql = "".join(f"\n                  AND ({clause})" for clause in launch_filter_clauses)
 
@@ -393,6 +398,7 @@ async def get_financial_data(
     pockets = current_pockets
     investments = current_investments  # do cache
     rv_positions = current_rv_positions  # renda variável (ações/FIIs via OF), do cache
+    of_fixed_income = current_of_fixed_income  # renda fixa do banco (CDB/Tesouro), agregada
     # Plano pago (Essencial+) tem OF ao vivo. No Grátis (pós-trial) as caixinhas do
     # banco congelam → o front troca "Sincronizada" por "reative seu banco" (upsell).
     from core.services.plan_service import require_min_tier as _require_min_tier
@@ -823,6 +829,12 @@ async def get_financial_data(
             "market_value": sum(p["market_value"] for p in rv_positions),
             "invested":     sum(p["invested"] for p in rv_positions),
             "pnl":          sum(p["pnl"] for p in rv_positions),
+        },
+        "of_fixed_income":    of_fixed_income,  # renda fixa do banco (CDB/Tesouro), agregada
+        "of_fixed_income_summary": {
+            "balance":  sum(i["balance"] for i in of_fixed_income),
+            "invested": sum(i["invested"] for i in of_fixed_income),
+            "pnl":      sum(i["pnl"] for i in of_fixed_income),
         },
         "market_rates":       market_rates,
         "recent_launches":    [dict(r) for r in launches],

--- a/tests/test_of_caixinha_autoimport.py
+++ b/tests/test_of_caixinha_autoimport.py
@@ -90,6 +90,35 @@ def test_dedup_binds_existing_manual_pocket(user_id):
     assert float(pk["Reserva"]["balance"]) == 777.0
 
 
+def test_zero_balance_caixinha_not_imported(user_id):
+    # Reserva/fundo com saldo 0 (ex.: Nubank "Reserva Planejada" vazia) não vira caixinha.
+    conn_id = _seed_connection(user_id)
+    _save(conn_id, [{"id": "cxz", "name": "Reserva Planejada", "type": "MUTUAL_FUND",
+                     "subtype": "INVESTMENT_FUND", "balance": 0.0}])
+    res = db.sync_open_finance_caixinhas(conn_id, user_id)
+    assert res["caixinhas_created"] == 0
+    assert "Reserva Planejada" not in _pockets(user_id)
+
+
+def test_phantom_zero_of_caixinha_is_cleaned(user_id):
+    # Fantasma já criada (saldo 0) é removida pela auto-cura no próximo sync.
+    conn_id = _seed_connection(user_id)
+    _save(conn_id, [{"id": "cxp", "name": "Reserva X", "type": "MUTUAL_FUND",
+                     "subtype": "INVESTMENT_FUND", "balance": 0.0}])
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select id from open_finance_investments where connection_id=%s and provider_investment_id='cxp'", (conn_id,))
+            of_id = cur.fetchone()["id"]
+            cur.execute(
+                "insert into pockets(user_id,name,balance,source,of_investment_id,interest_enabled) "
+                "values(%s,'Reserva X',0,'open_finance',%s,false)", (user_id, of_id))
+        conn.commit()
+    assert "Reserva X" in _pockets(user_id)          # existe antes
+    res = db.sync_open_finance_caixinhas(conn_id, user_id)
+    assert res["caixinhas_cleaned"] == 1
+    assert "Reserva X" not in _pockets(user_id)      # removida
+
+
 def test_of_pocket_is_readonly_for_deposit_and_withdraw(user_id):
     # Caixinha do banco (OF) não aceita aporte/resgate pelo Pig — read-only.
     conn_id = _seed_connection(user_id)

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -99,3 +99,25 @@ def test_zero_market_value_is_hidden(user_id):
 def test_no_of_data_returns_empty(user_id):
     assert db.list_rv_positions(user_id) == []
     assert db.rv_portfolio_summary(user_id)["count"] == 0
+
+
+# ── Renda fixa do banco (CDB/Tesouro) agregada — não vira caixinha ────────────
+def test_of_fixed_income_aggregated_and_clean(user_id):
+    NU = "CDB - NU FINANCEIRA S.A. - SOCIEDADE DE CREDITO, FINANCIAMENTO E INVESTIMENTO"
+    _seed(user_id, [
+        {"id": "cdb1", "name": NU, "type": "FIXED_INCOME", "subtype": "CDB", "balance": 1000.0, "amount": 950.0},
+        {"id": "cdb2", "name": NU, "type": "FIXED_INCOME", "subtype": "CDB", "balance": 2000.0, "amount": 1900.0},
+        {"id": "tes1", "name": "Tesouro IPCA+ 2032", "type": "FIXED_INCOME", "subtype": "TREASURY", "balance": 500.0, "amount": 480.0},
+        {"id": "cdb0", "name": NU, "type": "FIXED_INCOME", "subtype": "CDB", "balance": 0.0, "amount": 0.0},  # zero → fora
+        {"id": "eq1", "name": "PETR4", "code": "PETR4", "type": "EQUITY", "subtype": "STOCK", "balance": 900.0, "amount": 1000.0},  # RV, não RF
+    ])
+    items = db.list_of_fixed_income(user_id)
+    by = {i["name"]: i for i in items}
+    assert "CDB · Nu Financeira" in by            # nome jurídico → limpo
+    assert by["CDB · Nu Financeira"]["count"] == 2  # os 2 com saldo (o zero fora)
+    assert by["CDB · Nu Financeira"]["balance"] == pytest.approx(3000.0)
+    assert by["CDB · Nu Financeira"]["pnl"] == pytest.approx(150.0)  # 3000 - 2850
+    assert "Tesouro IPCA+ 2032" in by
+    assert "PETR4" not in by                       # equity não é renda fixa
+    summ = db.of_fixed_income_summary(user_id)
+    assert summ["balance"] == pytest.approx(3500.0)


### PR DESCRIPTION
Fix descoberto com dado real de prod (conta Nubank): o Pluggy expõe os investimentos do Nubank com **nome jurídico gigante** e **sem apelido**, e a "Reserva Planejada" (fundo) vem **zerada** — o que virava uma caixinha fantasma R$0.

## A — não auto-importar caixinha OF com saldo 0 (+ auto-cura)
- Auto-import pula `balance <= 0` → a "NU RESERVA PLANEJADA" vazia não vira mais caixinha.
- Auto-cura: remove as fantasmas `source='open_finance'` já criadas cujo investimento está zerado (limpa o que já foi pra prod).

## B — renda fixa do banco na aba de Investimentos (não como caixinha)
- Como Nubank não distingue caixinha de investimento nem dá apelido, os **CDB/Tesouro** do banco passam a aparecer em **"Renda fixa · via banco"** na aba de Investimentos — **agregados por nome limpo** (ex.: `CDB - NU FINANCEIRA S.A. - SOCIEDADE...` → `CDB · Nu Financeira`, "2 papéis"), read-only, com P&L (`balance − amount`).
- Exclui o que virou caixinha (`of_investment_id`) e saldo <= 0. Gate **Essencial+**.

## Validação
- Testes novos (agregação + nome limpo + skip zero + auto-cura) verdes; suíte relacionada sem regressão (48 passam).
- Verificado na conta demo: `CDB · Nu Financeira · 2 papéis · R$ 8.350,00 · ↑ R$ 350,00 (4,38%)` + Tesouro; a "Reserva Planejada" vazia não vira caixinha.

Diagnóstico completo do dado real do Nubank feito via `railway ssh` (read-only): todos os campos de valor vinham 0 nesse fundo, e nenhum campo tem apelido — só o nome jurídico.
