### PR TITLE
feat: liga saldo consolidado + agentes pra todas as contas (regra por plano intacta)

### DIFF
--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -180,14 +180,13 @@ def agents_beta_tester(user_id: int, email: str | None = None) -> bool:
 
 
 def agents_ui_enabled(user_id: int, email: str | None = None) -> bool:
-    """Gate beta da feature de Agentes (mesma mecânica do Open Finance). Liga se:
-    - AGENTS_UI_ENABLED global ligado (lançamento pra todos), OU
-    - o usuário é tester do beta (allowlist de e-mail/id — ver agents_beta_tester).
-    Default: SÓ os e-mails de teste veem/usam os agentes. Pra abrir geral, setar
-    AGENTS_UI_ENABLED=1 (aí este gate para de restringir e vale só o gate por tier)."""
-    if (os.getenv("AGENTS_UI_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on"):
-        return True
-    return agents_beta_tester(user_id, email)
+    """Gate da feature de Agentes. LANÇADO pra todos por padrão — quem decide
+    Free vs pago é o gate por tier (agent_kind_allowed/require_min_tier), não este.
+    AGENTS_UI_ENABLED=0 é o freio de emergência: volta pro modo beta (só os
+    testers da allowlist — ver agents_beta_tester)."""
+    if (os.getenv("AGENTS_UI_ENABLED") or "").strip().lower() in ("0", "false", "no", "off"):
+        return agents_beta_tester(user_id, email)
+    return True
 
 
 # Allowlist padrão do beta da lista completa de bancos (modal com busca). Mesma
@@ -226,16 +225,15 @@ _CONSOLIDATED_BETA_EMAILS_DEFAULT = {"lucaskuramoti06@gmail.com", "hiagojo2016@g
 
 
 def consolidated_balance_enabled(user_id: int, email: str | None = None) -> bool:
-    """Gate beta do saldo consolidado nas superfícies de leitura (WhatsApp /saldo,
-    resumos, chat IA, Discord). Liga se:
-    - OF_CONSOLIDATED_BALANCE_ENABLED global ligado (lançamento pra todos), OU
-    - o e-mail está em OF_CONSOLIDATED_BETA_EMAILS (default = e-mails de teste), OU
-    - o user_id está em OF_CONSOLIDATED_BETA_USER_IDS.
-    Default: SÓ as contas de teste veem o consolidado; o resto segue vendo a
-    Carteira manual como sempre. O dashboard web não passa por aqui (já somava
+    """Gate do saldo consolidado nas superfícies de leitura (WhatsApp /saldo,
+    resumos, chat IA, Discord). LANÇADO pra todos por padrão: quem tem banco OF
+    conectado vê Carteira + bancos somados, o resto segue só a Carteira manual.
+    OF_CONSOLIDATED_BALANCE_ENABLED=0 é o freio de emergência: volta pro beta
+    (só a allowlist de e-mail/id). O dashboard web não passa por aqui (já somava
     os bancos antes deste gate)."""
-    if (os.getenv("OF_CONSOLIDATED_BALANCE_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on"):
+    if (os.getenv("OF_CONSOLIDATED_BALANCE_ENABLED") or "").strip().lower() not in ("0", "false", "no", "off"):
         return True
+    # Freio puxado: volta pro comportamento de beta (só a allowlist).
     raw = os.getenv("OF_CONSOLIDATED_BETA_EMAILS")
     if raw is None:
         beta_emails = _CONSOLIDATED_BETA_EMAILS_DEFAULT

--- a/tests/test_consolidated_balance.py
+++ b/tests/test_consolidated_balance.py
@@ -206,8 +206,9 @@ def test_ai_chat_tool_get_balance_consolidado(user_id, consolidated_on):
 
 # ── Gate beta desligado (fora do allowlist de teste): comportamento antigo ─────
 
-def test_gate_off_handler_mantem_carteira_mesmo_com_banco(user_id):
-    """Fora do beta, conectar banco NÃO muda o /saldo (segue Carteira manual)."""
+def test_gate_off_handler_mantem_carteira_mesmo_com_banco(user_id, monkeypatch):
+    """Com o freio puxado (fora do beta), conectar banco NÃO muda o /saldo."""
+    monkeypatch.setenv("OF_CONSOLIDATED_BALANCE_ENABLED", "0")
     db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
     _connect_fake_bank(user_id, "4320.75")
 
@@ -218,7 +219,8 @@ def test_gate_off_handler_mantem_carteira_mesmo_com_banco(user_id):
     assert "4.320,75" not in out
 
 
-def test_gate_off_ai_chat_tool_formato_antigo(user_id):
+def test_gate_off_ai_chat_tool_formato_antigo(user_id, monkeypatch):
+    monkeypatch.setenv("OF_CONSOLIDATED_BALANCE_ENABLED", "0")
     from core.services.ai_chat.tools.balance import _get_balance
 
     db.add_launch_and_update_balance(user_id, "receita", 100, None, "seed")
@@ -228,11 +230,20 @@ def test_gate_off_ai_chat_tool_formato_antigo(user_id):
     assert res == {"balance": 100.0}
 
 
-def test_gate_liga_por_email_de_teste(user_id, monkeypatch):
-    """O allowlist default são os e-mails de teste (hiago/lucas)."""
+def test_gate_lancado_default_geral(user_id, monkeypatch):
+    """Lançado: sem env, TODO usuário passa no gate (o resto depende de ter banco)."""
     from core.services.plan_service import consolidated_balance_enabled
 
     monkeypatch.delenv("OF_CONSOLIDATED_BALANCE_ENABLED", raising=False)
+    assert consolidated_balance_enabled(user_id, email="lucaskuramoti06@gmail.com")
+    assert consolidated_balance_enabled(user_id, email="outro@exemplo.com")
+
+
+def test_gate_freio_volta_pro_allowlist(user_id, monkeypatch):
+    """OF_CONSOLIDATED_BALANCE_ENABLED=0 é o freio: volta pro beta (só allowlist)."""
+    from core.services.plan_service import consolidated_balance_enabled
+
+    monkeypatch.setenv("OF_CONSOLIDATED_BALANCE_ENABLED", "0")
     assert consolidated_balance_enabled(user_id, email="lucaskuramoti06@gmail.com")
     assert consolidated_balance_enabled(user_id, email="hiagojo2016@gmail.com")
     assert not consolidated_balance_enabled(user_id, email="outro@exemplo.com")

--- a/tests/test_piggy_agents.py
+++ b/tests/test_piggy_agents.py
@@ -81,16 +81,17 @@ def test_reporter_envia_email_quando_nao_descadastrado(monkeypatch):
     assert len(sent) == 1
 
 
-# ── Beta dos Agentes: allowlist por e-mail (lançamento em fases) ──────────────
+# ── Agentes: lançado geral, com freio de emergência pra voltar ao beta ────────
 
-def test_agents_ui_enabled_default_so_emails_de_teste(monkeypatch):
+def test_agents_ui_enabled_default_lancado_geral(monkeypatch):
+    # Lançado: sem env, TODO usuário vê os agentes. O limite Free vs pago mora
+    # no gate por tier (agent_kind_allowed), não aqui.
     import core.services.plan_service as ps
     monkeypatch.delenv("AGENTS_UI_ENABLED", raising=False)
     monkeypatch.delenv("AGENTS_BETA_EMAILS", raising=False)
     monkeypatch.delenv("AGENTS_BETA_USER_IDS", raising=False)
     assert ps.agents_ui_enabled(1, "lucaskuramoti06@gmail.com") is True
-    assert ps.agents_ui_enabled(1, "HIAGOJO2016@gmail.com") is True   # case-insensitive
-    assert ps.agents_ui_enabled(1, "estranho@example.com") is False
+    assert ps.agents_ui_enabled(1, "estranho@example.com") is True
 
 
 def test_agents_ui_enabled_flag_global_abre_geral(monkeypatch):
@@ -99,9 +100,21 @@ def test_agents_ui_enabled_flag_global_abre_geral(monkeypatch):
     assert ps.agents_ui_enabled(1, "qualquer@example.com") is True
 
 
-def test_agents_ui_enabled_env_sobrescreve_default(monkeypatch):
+def test_agents_ui_enabled_freio_volta_pro_beta(monkeypatch):
+    # AGENTS_UI_ENABLED=0 é o freio de emergência: volta pro modo beta,
+    # só a allowlist de e-mail/id passa.
     import core.services.plan_service as ps
-    monkeypatch.delenv("AGENTS_UI_ENABLED", raising=False)
+    monkeypatch.setenv("AGENTS_UI_ENABLED", "0")
+    monkeypatch.delenv("AGENTS_BETA_EMAILS", raising=False)
+    monkeypatch.delenv("AGENTS_BETA_USER_IDS", raising=False)
+    assert ps.agents_ui_enabled(1, "lucaskuramoti06@gmail.com") is True
+    assert ps.agents_ui_enabled(1, "HIAGOJO2016@gmail.com") is True   # case-insensitive
+    assert ps.agents_ui_enabled(1, "estranho@example.com") is False
+
+
+def test_agents_ui_enabled_freio_respeita_allowlist_custom(monkeypatch):
+    import core.services.plan_service as ps
+    monkeypatch.setenv("AGENTS_UI_ENABLED", "0")
     monkeypatch.setenv("AGENTS_BETA_EMAILS", "novo@example.com")
     assert ps.agents_ui_enabled(1, "novo@example.com") is True
     assert ps.agents_ui_enabled(1, "lucaskuramoti06@gmail.com") is False


### PR DESCRIPTION
## O que muda

Liga duas features que estavam em beta por allowlist de e-mail **pra todas as contas**, mantendo a regra Free vs pago.

- **`agents_ui_enabled`** — a prateleira de agentes deixa de ficar restrita à allowlist e fica visível pra todos. O gate por tier (`agent_kind_allowed`, escada 0/0/3/6) é ANDado em todos os runners e na rota de ativação, então **Free continua limitado e pago desbloqueia** — este gate só controla visibilidade.
- **`consolidated_balance_enabled`** — saldo consolidado (Carteira + bancos OF) passa a aparecer pra todos nas superfícies de leitura (WhatsApp `/saldo`, resumos, chat IA, Discord). Quem tem banco OF conectado vê somado; quem não tem segue só a Carteira manual.

## Freio de emergência

As envs invertem a semântica e viram desligamento — mesmo padrão do lançamento da escada de planos:
- `AGENTS_UI_ENABLED=0` → volta agentes pro beta (só allowlist)
- `OF_CONSOLIDATED_BALANCE_ENABLED=0` → volta saldo consolidado pro beta (só allowlist)

## Risco

Baixo. Nenhum limite de plano foi tocado; só a condição de visibilidade beta. Sintaxe validada.