### PR TITLE
Enforce escolha de plano no servidor (gate de página)

### DIFF
--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -363,6 +363,34 @@ def gate_pro_page(request: Request):
     return None
 
 
+def _resolve_page_user_id(request: Request) -> int | None:
+    """user_id de uma navegação de página autenticada, aceitando os DOIS cookies
+    que valem uma sessão logada: auth_token (JWT de 15min) E dashboard_token (12h).
+
+    Espelha o que /auth/validate + resolve_dashboard_user_id aceitam. Sem isto, o
+    gate acharia "deslogado" quando o access expira mas o dashboard_token ainda é
+    válido (estado normal — o front só renova o access DEPOIS que o HTML carrega),
+    servindo a página sem checar o gate. Devolve None quando nenhum cookie é uma
+    sessão válida (aí o próprio HTML manda pro login)."""
+    # 1. auth_token (JWT curto)
+    token = get_auth_token_from_request(request, None)
+    payload = decode_jwt(token) if token else None
+    if payload and payload.get("type") == "auth":
+        uid = int(payload["sub"])
+        jti = payload.get("jti")
+        if not jti:
+            return uid
+        session = get_active_session(jti)
+        if session and int(session.get("user_id") or 0) == uid:
+            return uid
+    # 2. dashboard_token (cookie de 12h) — mesma validação de sessão/jti das
+    #    rotas de dados. Levanta 401 quando inválido → tratamos como deslogado.
+    try:
+        return resolve_dashboard_user_id(request)
+    except HTTPException:
+        return None
+
+
 def gate_plan_selection(request: Request):
     """Gate de PÁGINA do cadastro: obriga a escolher um plano na /precos antes
     de servir o HTML do dashboard (home/app/settings). É o enforcement REAL —
@@ -381,18 +409,11 @@ def gate_plan_selection(request: Request):
     if _is_pigbank_app(request):
         return None
 
-    token = get_auth_token_from_request(request, None)
-    payload = decode_jwt(token) if token else None
-    # Deslogado / token inválido: deixa o HTML carregar e redirecionar pro login
+    user_id = _resolve_page_user_id(request)
+    # Deslogado / sessão inválida: deixa o HTML carregar e redirecionar pro login
     # (comportamento atual preservado — não força /precos em quem nem logou).
-    if not payload or payload.get("type") != "auth":
+    if user_id is None:
         return None
-    user_id = int(payload["sub"])
-    jti = payload.get("jti")
-    if jti:
-        session = get_active_session(jti)
-        if not session or int(session.get("user_id") or 0) != user_id:
-            return None
     try:
         if needs_plan_selection(user_id):
             return RedirectResponse(url="/precos?escolha=1", status_code=302)

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -10,6 +10,7 @@ chamam via atributo de módulo, ex: `shared.authorize_dashboard_access`).
 
 import asyncio
 import json
+import logging
 import os
 import pathlib
 from datetime import date, datetime, timezone
@@ -295,6 +296,13 @@ def resolve_dashboard_user_id(request: Request) -> int:
 _GATE_EXEMPT_PREFIXES = ("/billing", "/auth", "/conta")
 
 
+def _is_pigbank_app(request: Request) -> bool:
+    """True se a requisição vem do WebView do app iOS (UA anexa "PigBankApp").
+    Usado pra isentar o app dos gates que forçariam a /precos — diretriz 3.1.1
+    da App Store proíbe empurrar tela de compra; o app fica no acesso base."""
+    return "PigBankApp" in (request.headers.get("user-agent") or "")
+
+
 def _enforce_subscription_gate(request: Request, user_id: int) -> None:
     """Backstop server-side das rotas de dados do dashboard. Além do paywall
     (assinatura ativa/trial), fecha o gate de escolha de plano no cadastro: sem
@@ -306,7 +314,9 @@ def _enforce_subscription_gate(request: Request, user_id: int) -> None:
     if any(path.startswith(p) for p in _GATE_EXEMPT_PREFIXES):
         return
     from core.services.plan_service import has_app_access, needs_plan_selection
-    if needs_plan_selection(user_id):
+    # App iOS não passa pelo gate de escolha (não pode comprar/escolher via web);
+    # segue governado por has_app_access e pelos limites por-feature/tier.
+    if not _is_pigbank_app(request) and needs_plan_selection(user_id):
         raise HTTPException(status_code=402, detail={"error": "plan_selection_required"})
     if not has_app_access(user_id):
         raise HTTPException(status_code=402, detail={"error": "subscription_required"})
@@ -350,6 +360,46 @@ def gate_pro_page(request: Request):
             return login_redirect
     if not is_pro(user_id):
         return RedirectResponse(url="/precos", status_code=302)
+    return None
+
+
+def gate_plan_selection(request: Request):
+    """Gate de PÁGINA do cadastro: obriga a escolher um plano na /precos antes
+    de servir o HTML do dashboard (home/app/settings). É o enforcement REAL —
+    os redirects em JS são só UX e são burláveis (JS em cache, navegação direta,
+    página sem o script). Aqui o servidor decide antes de entregar a página.
+
+    Retorna None quando pode servir (deslogado — o próprio HTML manda pro login;
+    ou já escolheu plano). Devolve RedirectResponse pra /precos quando o usuário
+    está logado e ainda não escolheu. Nunca levanta — é navegação de browser."""
+    from fastapi.responses import RedirectResponse
+    from core.services.plan_service import needs_plan_selection
+
+    # App iOS (WebView anexa "PigBankApp" ao UA): não redireciona pra tela de
+    # planos/compra — diretriz 3.1.1 da App Store. Espelha o !window.PB_IN_APP
+    # do cliente. O acesso segue governado pelos gates por-feature/tier.
+    if _is_pigbank_app(request):
+        return None
+
+    token = get_auth_token_from_request(request, None)
+    payload = decode_jwt(token) if token else None
+    # Deslogado / token inválido: deixa o HTML carregar e redirecionar pro login
+    # (comportamento atual preservado — não força /precos em quem nem logou).
+    if not payload or payload.get("type") != "auth":
+        return None
+    user_id = int(payload["sub"])
+    jti = payload.get("jti")
+    if jti:
+        session = get_active_session(jti)
+        if not session or int(session.get("user_id") or 0) != user_id:
+            return None
+    try:
+        if needs_plan_selection(user_id):
+            return RedirectResponse(url="/precos?escolha=1", status_code=302)
+    except Exception:
+        # Nunca trava a navegação por erro no gate; o backstop de dados (402) e o
+        # redirect em JS seguem valendo como rede de segurança.
+        logging.getLogger(__name__).warning("gate_plan_selection falhou", exc_info=True)
     return None
 
 

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from frontend.routes.shared import (
     FRONTEND_DIR,
+    gate_plan_selection,
     gate_pro_page,
     html_file,
     inject_meta_pixel,
@@ -37,17 +38,28 @@ async def serve_landing():
 
 
 @router.get("/app")
-async def serve_dashboard():
+async def serve_dashboard(request: Request):
+    # Gate server-side: cadastro sem plano escolhido é mandado pra /precos antes
+    # de receber o HTML do app (não depende do redirect em JS, que é burlável).
+    gate = gate_plan_selection(request)
+    if gate is not None:
+        return gate
     return html_file(FRONTEND_DIR / "dashboard.html", pixel=False)
 
 
 @router.get("/home")
-async def serve_home():
+async def serve_home(request: Request):
+    gate = gate_plan_selection(request)
+    if gate is not None:
+        return gate
     return html_file(FRONTEND_DIR / "home.html")
 
 
 @router.get("/settings")
-async def serve_settings():
+async def serve_settings(request: Request):
+    gate = gate_plan_selection(request)
+    if gate is not None:
+        return gate
     return html_file(FRONTEND_DIR / "settings.html", pixel=False)
 
 

--- a/tests/test_gate_plan_selection.py
+++ b/tests/test_gate_plan_selection.py
@@ -8,6 +8,8 @@ Convenção de monkeypatch (ver docstring de shared): patchar
 `frontend.routes.shared.<nome>` e `core.services.plan_service.needs_plan_selection`.
 """
 
+import pytest
+from fastapi import HTTPException
 from fastapi.responses import RedirectResponse
 
 import core.services.plan_service as plan_service
@@ -15,16 +17,25 @@ import frontend.routes.shared as shared
 
 
 class _Req:
-    """Request falso: só o que gate_plan_selection toca."""
+    """Request falso: só o que gate_plan_selection/_resolve_page_user_id tocam."""
     def __init__(self, ua=""):
         self.headers = {"user-agent": ua}
+        self.cookies = {}
 
 
-def _patch(monkeypatch, *, token="tok", payload=None, needs=True, session=None):
+def _patch(monkeypatch, *, token="tok", payload=None, needs=True, session=None,
+           dashboard_uid=None):
     monkeypatch.setattr(shared, "get_auth_token_from_request", lambda req, creds: token)
     monkeypatch.setattr(shared, "decode_jwt", lambda t: payload)
     monkeypatch.setattr(shared, "get_active_session", lambda jti: session)
     monkeypatch.setattr(plan_service, "needs_plan_selection", lambda uid: needs)
+
+    # Fallback do dashboard_token (12h): resolve o user OU levanta 401.
+    def _fake_dash(req):
+        if dashboard_uid is None:
+            raise HTTPException(status_code=401, detail="x")
+        return dashboard_uid
+    monkeypatch.setattr(shared, "resolve_dashboard_user_id", _fake_dash)
 
 
 def test_cadastro_sem_plano_redireciona_pra_precos(monkeypatch):
@@ -40,8 +51,8 @@ def test_plano_escolhido_serve_a_pagina(monkeypatch):
 
 
 def test_deslogado_nao_forca_precos(monkeypatch):
-    # Sem token válido: deixa o HTML carregar (ele redireciona pro login).
-    _patch(monkeypatch, token=None, payload=None, needs=True)
+    # Sem token válido em nenhum cookie: deixa o HTML carregar (ele vai pro login).
+    _patch(monkeypatch, token=None, payload=None, needs=True, dashboard_uid=None)
     assert shared.gate_plan_selection(_Req()) is None
 
 
@@ -51,8 +62,18 @@ def test_app_ios_e_isento(monkeypatch):
     assert shared.gate_plan_selection(_Req(ua="Mozilla/5.0 PigBankApp/1.2")) is None
 
 
-def test_sessao_jti_invalida_nao_redireciona(monkeypatch):
-    # Token com jti mas sessão revogada: não força /precos (o HTML trata o login).
+def test_dashboard_token_vale_mesmo_com_access_expirado(monkeypatch):
+    # auth_token expirado (decode_jwt → None) mas dashboard_token (12h) válido:
+    # tem que resolver o user e AINDA aplicar o gate (bug pego pelo Codex).
+    _patch(monkeypatch, token=None, payload=None, needs=True, dashboard_uid=7)
+    out = shared.gate_plan_selection(_Req())
+    assert isinstance(out, RedirectResponse)
+    assert out.headers["location"] == "/precos?escolha=1"
+
+
+def test_jti_invalido_cai_no_dashboard_token(monkeypatch):
+    # auth_token com jti mas sessão revogada → tenta o dashboard_token; se ele
+    # também não vale, trata como deslogado (serve, sem forçar /precos).
     _patch(monkeypatch, payload={"type": "auth", "sub": "7", "jti": "x"},
-           needs=True, session=None)
+           needs=True, session=None, dashboard_uid=None)
     assert shared.gate_plan_selection(_Req()) is None

--- a/tests/test_gate_plan_selection.py
+++ b/tests/test_gate_plan_selection.py
@@ -1,0 +1,58 @@
+"""Gate server-side de escolha de plano (frontend/routes/shared.gate_plan_selection).
+
+Enforcement REAL do funil de cadastro: antes de servir o HTML do dashboard
+(home/app/settings), o servidor manda pra /precos quem ainda não escolheu um
+plano. Os redirects em JS são só UX; este gate é o que não dá pra burlar.
+
+Convenção de monkeypatch (ver docstring de shared): patchar
+`frontend.routes.shared.<nome>` e `core.services.plan_service.needs_plan_selection`.
+"""
+
+from fastapi.responses import RedirectResponse
+
+import core.services.plan_service as plan_service
+import frontend.routes.shared as shared
+
+
+class _Req:
+    """Request falso: só o que gate_plan_selection toca."""
+    def __init__(self, ua=""):
+        self.headers = {"user-agent": ua}
+
+
+def _patch(monkeypatch, *, token="tok", payload=None, needs=True, session=None):
+    monkeypatch.setattr(shared, "get_auth_token_from_request", lambda req, creds: token)
+    monkeypatch.setattr(shared, "decode_jwt", lambda t: payload)
+    monkeypatch.setattr(shared, "get_active_session", lambda jti: session)
+    monkeypatch.setattr(plan_service, "needs_plan_selection", lambda uid: needs)
+
+
+def test_cadastro_sem_plano_redireciona_pra_precos(monkeypatch):
+    _patch(monkeypatch, payload={"type": "auth", "sub": "7"}, needs=True)
+    out = shared.gate_plan_selection(_Req())
+    assert isinstance(out, RedirectResponse)
+    assert out.headers["location"] == "/precos?escolha=1"
+
+
+def test_plano_escolhido_serve_a_pagina(monkeypatch):
+    _patch(monkeypatch, payload={"type": "auth", "sub": "7"}, needs=False)
+    assert shared.gate_plan_selection(_Req()) is None
+
+
+def test_deslogado_nao_forca_precos(monkeypatch):
+    # Sem token válido: deixa o HTML carregar (ele redireciona pro login).
+    _patch(monkeypatch, token=None, payload=None, needs=True)
+    assert shared.gate_plan_selection(_Req()) is None
+
+
+def test_app_ios_e_isento(monkeypatch):
+    # UA do WebView do app: nunca redireciona pra tela de compra (3.1.1).
+    _patch(monkeypatch, payload={"type": "auth", "sub": "7"}, needs=True)
+    assert shared.gate_plan_selection(_Req(ua="Mozilla/5.0 PigBankApp/1.2")) is None
+
+
+def test_sessao_jti_invalida_nao_redireciona(monkeypatch):
+    # Token com jti mas sessão revogada: não força /precos (o HTML trata o login).
+    _patch(monkeypatch, payload={"type": "auth", "sub": "7", "jti": "x"},
+           needs=True, session=None)
+    assert shared.gate_plan_selection(_Req()) is None


### PR DESCRIPTION
## Contexto

Follow-up do #30. Um usuário reportou que, após o cadastro, caía na `/precos` normalmente — mas **sem selecionar plano nenhum**, ao abrir outra página, entrava direto no dashboard no plano Grátis. O gate não estava obrigando a escolha.

## Causa

O gate de escolha de plano dependia **só de JavaScript no cliente** (`home.html`, `dashboard.js`, `settings.html` liam `needs_plan_selection` via `/auth/me` e redirecionavam). Isso é burlável: JS/HTML em cache, navegação direta pra uma rota, ou uma página sem o script deixavam o cadastro entrar no dashboard sem escolher plano. Era uma trava de fachada, não real.

## Mudança

Enforcement **no servidor**, antes de entregar o HTML do dashboard:

- **`gate_plan_selection()`** novo em `frontend/routes/shared.py`: as rotas `/home`, `/app` e `/settings` redirecionam pra `/precos?escolha=1` quando o usuário está logado e ainda não escolheu plano (lê o JWT do cookie, valida a sessão por jti — mesmo padrão do `gate_pro_page`). Deslogado/token inválido → serve a página normalmente (o próprio HTML manda pro login; comportamento inalterado).
- **App iOS isento** (UA `PigBankApp`) tanto no gate de página quanto no backstop `402` das rotas de dados (`_enforce_subscription_gate`) — diretriz 3.1.1 da App Store proíbe empurrar tela de compra. Extraí o `_is_pigbank_app(request)` como helper compartilhado.
- O gate nunca levanta exceção: erro no meio dele só loga e deixa passar (o backstop 402 e o redirect em JS seguem como rede de segurança).

Com isso, o funil passa a ter enforcement de verdade: redirect em JS (UX) + backstop 402 nas APIs de dados + **gate de página server-side** (o que faltava).

## Testes

`tests/test_gate_plan_selection.py` cobre: cadastro sem plano → redirect pra `/precos`; plano escolhido → serve; deslogado → não força `/precos`; app iOS → isento; sessão jti inválida → não redireciona. Os GETs anônimos de `/home`/`/app`/`/settings` seguem retornando 200 (deslogado passa pelo gate).

## Notas de deploy

Depende do `init_db` do #30 já ter rodado em produção (cria a coluna `auth_accounts.plan_selected_at` e carimba as contas existentes). Sem colunas novas nesta PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012nxZ2yH8BZbASCjVXdrvks)_