### PR TITLE
Add CompleteRegistration, StartTrial and ViewContent tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,15 +28,20 @@ POLL_INTERVAL=30
 # ── Meta (Facebook) Pixel + Conversions API ─────────────────────────────────────
 # ID do Pixel do Meta Ads. Quando preenchido, o pixel é injetado no <head> das
 # páginas públicas (landing, /precos, /cadastro, /login, etc.) e dispara:
-#   • PageView       — em toda página pública
-#   • InitiateCheckout — ao clicar em "Assinar" em /precos
-#   • Purchase       — no retorno de pagamento aprovado (/home?upgrade=success)
+#   • PageView          — em toda página pública
+#   • ViewContent       — ao abrir a página de planos (/precos)
+#   • CompleteRegistration — quando a conta é criada (/cadastro)
+#   • InitiateCheckout  — ao clicar em "Assinar" em /precos
+#   • StartTrial        — no início do trial (retorno do checkout)
+#   • Purchase          — na compra imediata (checkout sem trial)
 # Deixe vazio em dev/staging para não carregar nenhum rastreio.
 META_PIXEL_ID=
 #
-# Token da Conversions API (server-side). Opcional, mas recomendado: o webhook
-# da Stripe dispara o Purchase server-a-servidor com o valor REAL da assinatura
-# e o mesmo event_id do pixel (o Meta deduplica → conta a compra uma vez só).
+# Token da Conversions API (server-side). Opcional, mas recomendado: o backend
+# dispara os eventos server-a-servidor com o mesmo event_id do pixel (o Meta
+# deduplica → conta a conversão uma vez só). Cobre CompleteRegistration,
+# StartTrial e o Purchase da cobrança REAL (fim do trial + renovações, via
+# invoice.paid da Stripe, com o valor efetivamente pago).
 # Mais preciso e imune a adblock/iOS. Gere em: Events Manager → seu Pixel →
 # Configurações → Conversions API → "Gerar token de acesso".
 # Requer META_PIXEL_ID setado. Vazio → só o rastreio client-side roda.

--- a/core/services/meta_capi.py
+++ b/core/services/meta_capi.py
@@ -1,22 +1,28 @@
 """
 core/services/meta_capi.py — Meta (Facebook) Conversions API (server-side).
 
-Complementa o pixel client-side: o webhook da Stripe dispara o `Purchase` daqui,
-com o valor REAL da assinatura e um `event_id` compartilhado com o pixel do
+Complementa o pixel client-side: o backend dispara os eventos de conversão
+daqui, com dados precisos e um `event_id` compartilhado com o pixel do
 navegador. O Meta deduplica eventos com mesmo (event_name, event_id) vindos do
-pixel e da CAPI — então a compra conta uma vez só, mesmo que os dois disparem.
+pixel e da CAPI — então a conversão conta uma vez só, mesmo que os dois disparem.
+
+Eventos enviados hoje (via `send_event`):
+  - CompleteRegistration — no /auth/verify-email e no signup via Google.
+  - StartTrial           — no checkout.session.completed com status=trialing.
+  - Purchase             — compra imediata (checkout sem trial) e a cobrança
+                           real de invoice.paid (fim do trial + renovações).
 
 Por que server-side além do pixel:
   - Valor preciso da compra (o pixel client-side manda só a moeda) → ROAS real.
   - Imune a adblock / iOS-ATT / restrição de cookie (o pixel perde ~10-30%).
-  - Dedup por event_id resolve o disparo duplicado do ?upgrade=success.
+  - Dedup por event_id resolve disparos duplicados.
 
 Configuração (ambas obrigatórias — se faltar qualquer uma, tudo vira no-op):
   - META_PIXEL_ID: mesmo ID usado no pixel client-side.
   - META_PIXEL_ACCESS_TOKEN: token da Conversions API (Events Manager →
     Configurações → Conversions API → Gerar token de acesso).
 
-Quem chama: webhook do Stripe (checkout.session.completed), sempre via
+Quem chama: webhook do Stripe e os endpoints de cadastro, sempre via
 asyncio.to_thread pra não pesar no request crítico. Falha silenciosa.
 """
 from __future__ import annotations
@@ -50,53 +56,72 @@ def capi_configured() -> bool:
     )
 
 
-def purchase_event_id(session_id: str) -> str:
-    """event_id determinístico da compra, derivado da sessão de checkout.
+# ── event_id builders — mantêm client e servidor em sincronia pro dedup ──────
+# O client-side usa EXATAMENTE o mesmo formato a partir do id que recebe, então
+# o Meta deduplica os pares pixel↔CAPI. Suffixos distintos (sessão vs fatura)
+# garantem que eventos diferentes nunca colidam.
 
-    O client-side (home.html) usa o MESMO formato a partir do `sid` que a
-    Stripe devolve no success_url — é isso que permite o dedup no Meta.
-    """
-    return f"purchase_{session_id}"
+def purchase_event_id(ref: str) -> str:
+    """Purchase — `ref` é a sessão de checkout (compra imediata, casa com o
+    pixel) ou o id da fatura (cobrança real pós-trial / renovação, só servidor)."""
+    return f"purchase_{ref}"
 
 
-def send_purchase_event(
+def trial_event_id(session_id: str) -> str:
+    """StartTrial — derivado da sessão de checkout; casa com o pixel na volta
+    do checkout (/home?upgrade=success&ev=trial)."""
+    return f"trial_{session_id}"
+
+
+def registration_event_id(user_id: int | str) -> str:
+    """CompleteRegistration — derivado do user_id recém-criado; casa com o
+    pixel disparado no /cadastro após a conta ser criada."""
+    return f"signup_{user_id}"
+
+
+def send_event(
     *,
-    session_id: str,
+    event_name: str,
+    event_id: str,
     event_time: int,
-    value: float,
+    value: float | None = None,
     currency: str = "BRL",
     email: str | None = None,
     event_source_url: str | None = None,
+    action_source: str = "website",
 ) -> bool:
-    """Envia um evento `Purchase` pro Meta via Conversions API.
+    """Envia um evento genérico pro Meta via Conversions API.
 
-    Retorna True se o Meta aceitou (2xx). No-op → False quando CAPI não está
-    configurado. Falha silenciosa (log + False) — nunca deve quebrar o webhook.
+    `value` é opcional (eventos como CompleteRegistration não têm valor
+    monetário). Retorna True se o Meta aceitou (2xx). No-op → False quando a
+    CAPI não está configurada. Falha silenciosa (log + False) — nunca deve
+    quebrar o fluxo que chamou.
     """
     pixel_id = (os.getenv(_PIXEL_ID_ENV) or "").strip()
     token = (os.getenv(_ACCESS_TOKEN_ENV) or "").strip()
     if not pixel_id or not token:
         return False
 
-    # user_data precisa de ao menos um identificador pro Meta casar a conversão.
+    # user_data precisa de ao menos um identificador pro Meta casar o evento.
     user_data: dict[str, list[str]] = {}
     if email:
         user_data["em"] = [_sha256(email)]
     if not user_data:
-        logger.warning("[meta_capi] Purchase sem identificador (email) — pulando envio.")
+        logger.warning("[meta_capi] %s sem identificador (email) — pulando envio.", event_name)
         return False
 
     event: dict = {
-        "event_name": "Purchase",
+        "event_name": event_name,
         "event_time": int(event_time),
-        "event_id": purchase_event_id(session_id),
-        "action_source": "website",
+        "event_id": event_id,
+        "action_source": action_source,
         "user_data": user_data,
-        "custom_data": {
-            "currency": (currency or "BRL").upper(),
-            "value": round(float(value or 0), 2),
-        },
     }
+    if value is not None:
+        event["custom_data"] = {
+            "currency": (currency or "BRL").upper(),
+            "value": round(float(value), 2),
+        }
     if event_source_url:
         event["event_source_url"] = event_source_url
 
@@ -111,10 +136,31 @@ def send_purchase_event(
         if 200 <= resp.status_code < 300:
             return True
         logger.warning(
-            "[meta_capi] Purchase rejeitado (%s): %s",
-            resp.status_code, resp.text[:300],
+            "[meta_capi] %s rejeitado (%s): %s",
+            event_name, resp.status_code, resp.text[:300],
         )
         return False
     except Exception as exc:
-        logger.warning("[meta_capi] falha ao enviar Purchase: %s", exc, exc_info=True)
+        logger.warning("[meta_capi] falha ao enviar %s: %s", event_name, exc, exc_info=True)
         return False
+
+
+def send_purchase_event(
+    *,
+    session_id: str,
+    event_time: int,
+    value: float,
+    currency: str = "BRL",
+    email: str | None = None,
+    event_source_url: str | None = None,
+) -> bool:
+    """Wrapper de compatibilidade — Purchase derivado da sessão de checkout."""
+    return send_event(
+        event_name="Purchase",
+        event_id=purchase_event_id(session_id),
+        event_time=event_time,
+        value=value,
+        currency=currency,
+        email=email,
+        event_source_url=event_source_url,
+    )

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -141,6 +141,9 @@
       var res=await fetch('/auth/verify-email',{method:'POST',credentials:'same-origin',headers:csrfHeaders({'Content-Type':'application/json'}),body:JSON.stringify({email:_email,code:code})});
       var d=await payload(res);
       if(!res.ok){err('verify-error',d.detail||'Código inválido.');return}
+      // Meta Ads: conta criada. eventID casa com o CompleteRegistration
+      // server-side (CAPI) pro Meta deduplicar.
+      if(window.fbq&&d.user_id){fbq('track','CompleteRegistration',{},{eventID:'signup_'+d.user_id});}
       goDash(d.dashboard_url);
     }catch(e){err('verify-error','Erro de conexão. Tente novamente.')}
     finally{b.disabled=false;b.textContent='Confirmar'}

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -33,7 +33,7 @@ from datetime import datetime, date, timedelta, timezone
 from zoneinfo import ZoneInfo
 from typing import Dict
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Depends, Query, Request, Response
+from fastapi import BackgroundTasks, FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Depends, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, RedirectResponse, HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -2348,7 +2348,7 @@ async def auth_register(request: Request, body: RegisterBody):
 
 @app.post("/auth/verify-email")
 @limiter.limit("10/minute")
-async def auth_verify_email(request: Request, response: Response, body: VerifyEmailBody):
+async def auth_verify_email(request: Request, response: Response, body: VerifyEmailBody, background_tasks: BackgroundTasks):
     """
     Confirma o código de verificação e cria a conta.
     Retorna JWT + link_code igual ao registro anterior.
@@ -2375,13 +2375,13 @@ async def auth_verify_email(request: Request, response: Response, body: VerifyEm
 
     await _apply_referral_attribution(request, response, int(user_id))
 
-    # Meta Conversions API — CompleteRegistration (conta criada). Fire-and-forget,
-    # nunca pode quebrar o cadastro. event_id signup_<uid> casa com o pixel do
-    # /cadastro pro Meta deduplicar.
+    # Meta Conversions API — CompleteRegistration (conta criada). Agendado como
+    # background task (roda DEPOIS da resposta) pra um Meta lento/fora nunca
+    # atrasar o cadastro. event_id signup_<uid> casa com o pixel do /cadastro.
     try:
         from core.services.meta_capi import capi_configured, registration_event_id, send_event
         if capi_configured():
-            await asyncio.to_thread(
+            background_tasks.add_task(
                 send_event,
                 event_name="CompleteRegistration",
                 event_id=registration_event_id(user_id),
@@ -3436,6 +3436,7 @@ async def auth_google_complete_signup(
     request: Request,
     response: Response,
     body: GoogleSignupCompleteBody,
+    background_tasks: BackgroundTasks,
 ):
     """Finaliza o cadastro Google: cria conta com nome + telefone."""
     from db import consume_pending_google_signup
@@ -3465,17 +3466,18 @@ async def auth_google_complete_signup(
     await _apply_referral_attribution(request, response, user_id)
 
     # Meta Conversions API — CompleteRegistration (conta criada via Google).
-    # Fire-and-forget; event_id signup_<uid> casa com o pixel pro dedup.
+    # Background task (roda após a resposta); event_id signup_<uid> casa com o
+    # pixel do /onboarding pro Meta deduplicar.
     try:
         from core.services.meta_capi import capi_configured, registration_event_id, send_event
         if capi_configured():
-            await asyncio.to_thread(
+            background_tasks.add_task(
                 send_event,
                 event_name="CompleteRegistration",
                 event_id=registration_event_id(user_id),
                 event_time=int(datetime.now(timezone.utc).timestamp()),
                 email=email,
-                event_source_url=f"{DASHBOARD_URL}/cadastro",
+                event_source_url=f"{DASHBOARD_URL}/onboarding",
             )
     except Exception as exc:
         print(f"[auth] meta capi registration (google) falhou user={user_id}: {exc}")

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2375,6 +2375,23 @@ async def auth_verify_email(request: Request, response: Response, body: VerifyEm
 
     await _apply_referral_attribution(request, response, int(user_id))
 
+    # Meta Conversions API — CompleteRegistration (conta criada). Fire-and-forget,
+    # nunca pode quebrar o cadastro. event_id signup_<uid> casa com o pixel do
+    # /cadastro pro Meta deduplicar.
+    try:
+        from core.services.meta_capi import capi_configured, registration_event_id, send_event
+        if capi_configured():
+            await asyncio.to_thread(
+                send_event,
+                event_name="CompleteRegistration",
+                event_id=registration_event_id(user_id),
+                event_time=int(datetime.now(timezone.utc).timestamp()),
+                email=body.email.strip().lower(),
+                event_source_url=f"{DASHBOARD_URL}/cadastro",
+            )
+    except Exception as exc:
+        print(f"[auth] meta capi registration falhou user={user_id}: {exc}")
+
     wa_link = _build_whatsapp_onboarding_link(user_id)
 
     return {
@@ -3447,6 +3464,22 @@ async def auth_google_complete_signup(
 
     await _apply_referral_attribution(request, response, user_id)
 
+    # Meta Conversions API — CompleteRegistration (conta criada via Google).
+    # Fire-and-forget; event_id signup_<uid> casa com o pixel pro dedup.
+    try:
+        from core.services.meta_capi import capi_configured, registration_event_id, send_event
+        if capi_configured():
+            await asyncio.to_thread(
+                send_event,
+                event_name="CompleteRegistration",
+                event_id=registration_event_id(user_id),
+                event_time=int(datetime.now(timezone.utc).timestamp()),
+                email=email,
+                event_source_url=f"{DASHBOARD_URL}/cadastro",
+            )
+    except Exception as exc:
+        print(f"[auth] meta capi registration (google) falhou user={user_id}: {exc}")
+
     await log_auth_login_event(
         email,
         True,
@@ -3666,7 +3699,10 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             mode="subscription",
             locale="pt-BR",
             allow_promotion_codes=True,
-            success_url=f"{DASHBOARD_URL}/home?upgrade=success&sid={{CHECKOUT_SESSION_ID}}",
+            success_url=(
+                f"{DASHBOARD_URL}/home?upgrade=success&sid={{CHECKOUT_SESSION_ID}}"
+                f"&ev={'trial' if trial_days > 0 else 'purchase'}"
+            ),
             cancel_url=f"{DASHBOARD_URL}/home?upgrade=cancelled",
             metadata=metadata,
             subscription_data=subscription_data,
@@ -4170,18 +4206,30 @@ async def billing_webhook(request: Request):
                 )
             except Exception as exc:
                 print(f"[billing] admin notify falhou user={user_id}: {exc}")
-            # Meta Conversions API — Purchase server-side (valor real + dedup
-            # com o pixel do navegador via event_id derivado da sessão).
+            # Meta Conversions API — conversão server-side, deduplicada com o
+            # pixel via event_id derivado da sessão. Trial → StartTrial; compra
+            # imediata (sem trial) → Purchase. A cobrança REAL pós-trial e as
+            # renovações viram Purchase lá no invoice.paid (não aqui).
             try:
-                from core.services.meta_capi import capi_configured, send_purchase_event
+                from core.services.meta_capi import (
+                    capi_configured,
+                    purchase_event_id,
+                    send_event,
+                    trial_event_id,
+                )
                 _sid = _g(session, "id")
                 if capi_configured() and _sid:
                     _value, _currency = _subscription_amount(sub)
                     _capi_email = await _user_email(user_id)
                     _evt_time = int(_g(event, "created") or _g(session, "created") or 0)
+                    if sub_status == "trialing":
+                        _ev_name, _ev_id = "StartTrial", trial_event_id(_sid)
+                    else:
+                        _ev_name, _ev_id = "Purchase", purchase_event_id(_sid)
                     await asyncio.to_thread(
-                        send_purchase_event,
-                        session_id=_sid,
+                        send_event,
+                        event_name=_ev_name,
+                        event_id=_ev_id,
                         event_time=_evt_time,
                         value=_value,
                         currency=_currency,
@@ -4189,7 +4237,7 @@ async def billing_webhook(request: Request):
                         event_source_url=f"{DASHBOARD_URL}/home",
                     )
             except Exception as exc:
-                print(f"[billing] meta capi purchase falhou user={user_id}: {exc}")
+                print(f"[billing] meta capi checkout ({sub_status}) falhou user={user_id}: {exc}")
         elif user_id:
             await log_system_event(
                 "info",
@@ -4253,6 +4301,32 @@ async def billing_webhook(request: Request):
                         )
                 except Exception as exc:
                     print(f"[affiliates] comissao falhou user={user_id}: {exc}")
+
+                # Meta Conversions API — Purchase da cobrança REAL (fim do trial
+                # e renovações), com o valor efetivamente pago. A primeira fatura
+                # da compra imediata (billing_reason=subscription_create) já virou
+                # Purchase no checkout.session.completed, então pulamos ela aqui
+                # pra não contar duas vezes. Server-only: o usuário não está no
+                # site nesse momento (nada a deduplicar com o pixel).
+                try:
+                    from core.services.meta_capi import capi_configured, purchase_event_id, send_event
+                    _billing_reason = _g(invoice, "billing_reason")
+                    _inv_id = _g(invoice, "id")
+                    if capi_configured() and _inv_id and _billing_reason != "subscription_create":
+                        _capi_email = await _user_email(user_id)
+                        _evt_time = int(_g(event, "created") or _g(invoice, "created") or 0)
+                        await asyncio.to_thread(
+                            send_event,
+                            event_name="Purchase",
+                            event_id=purchase_event_id(_inv_id),
+                            event_time=_evt_time,
+                            value=amount_brl,
+                            currency=(_g(invoice, "currency") or "brl").upper(),
+                            email=_capi_email,
+                            event_source_url=f"{DASHBOARD_URL}/home",
+                        )
+                except Exception as exc:
+                    print(f"[billing] meta capi invoice purchase falhou user={user_id}: {exc}")
 
     elif event["type"] == "customer.subscription.trial_will_end":
         # Stripe dispara ~3 dias antes do trial acabar. Email de aviso (item 38)

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1264,23 +1264,29 @@ function goExplorePro() {
 (function handleUpgradeReturn() {
   const params = new URLSearchParams(window.location.search);
   const status = params.get("upgrade");
-  const sid = params.get("sid");  // id da sessão Stripe → event_id do Purchase
+  const sid = params.get("sid");  // id da sessão Stripe → event_id do evento
+  const ev = params.get("ev");    // "trial" | "purchase" (definido pelo success_url)
   if (!status) return;
 
   // Limpa os query params da URL pra nao reaparecer em refresh.
   const cleanUrl = new URL(window.location.href);
   cleanUrl.searchParams.delete("upgrade");
   cleanUrl.searchParams.delete("sid");
+  cleanUrl.searchParams.delete("ev");
   window.history.replaceState({}, "", cleanUrl.toString());
 
   if (status === "success") {
-    // Conversão de compra pro Meta Ads — só dispara quando há `sid` (id real da
-    // sessão de checkout, que a Stripe injeta no success_url). Sem sid = alguém
-    // abriu /home?upgrade=success na mão → NÃO conta como compra. A fonte de
-    // verdade é o Purchase server-side (Conversions API), disparado do webhook
-    // verificado; este é só o sinal do navegador, deduplicado pelo mesmo eventID.
+    // Conversão pro Meta Ads — só dispara com `sid` (id real da sessão de
+    // checkout que a Stripe injeta no success_url). Sem sid = alguém abriu a URL
+    // na mão → não conta. `ev` diz se foi início de trial (StartTrial) ou compra
+    // imediata sem trial (Purchase). A fonte de verdade é o server-side (CAPI);
+    // este é só o sinal do navegador, deduplicado pelo mesmo eventID.
     if (window.fbq && sid) {
-      fbq("track", "Purchase", { currency: "BRL" }, { eventID: "purchase_" + sid });
+      if (ev === "trial") {
+        fbq("track", "StartTrial", { currency: "BRL" }, { eventID: "trial_" + sid });
+      } else {
+        fbq("track", "Purchase", { currency: "BRL" }, { eventID: "purchase_" + sid });
+      }
     }
     // Pequeno delay pra dar o "wow effect" depois da pagina carregar
     setTimeout(() => {

--- a/frontend/onboarding.html
+++ b/frontend/onboarding.html
@@ -113,6 +113,9 @@ document.getElementById("signup-form").addEventListener("submit", async function
     });
     const data = await res.json().catch(function(){ return {}; });
     if (!res.ok) { showError(data.detail || "Não foi possível criar sua conta."); submitBtn.disabled = false; submitBtn.textContent = "Criar minha conta"; return; }
+    // Meta Ads: conta criada via Google. eventID casa com o CompleteRegistration
+    // server-side (CAPI) pro Meta deduplicar.
+    if (window.fbq && data.user_id) { fbq("track", "CompleteRegistration", {}, { eventID: "signup_" + data.user_id }); }
     window.location.replace(data.dashboard_url || "/home");
   } catch (err) { showError("Erro de conexão. Tente novamente."); submitBtn.disabled = false; submitBtn.textContent = "Criar minha conta"; }
 });

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -510,6 +510,10 @@ async function startCheckout(interval, btn, plan) {
     btn.textContent = originalText;
   }
 }
+
+// Meta Ads: visualização da página de planos → público de remarketing
+// "olhou o preço mas não assinou".
+if (window.fbq) fbq("track", "ViewContent", { content_name: "precos", content_category: "plans" });
 </script>
   <script src="/nav-auth.js?v=7" defer></script>
 </body>

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -58,7 +58,10 @@ async def serve_reset_password():
 
 @router.get("/onboarding")
 async def serve_onboarding():
-    return html_file(FRONTEND_DIR / "onboarding.html", pixel=False)
+    # Página de conclusão do cadastro via Google → parte do funil de aquisição.
+    # Recebe o pixel pra o CompleteRegistration client-side (dedup com o CAPI e
+    # cobertura do modo pixel-only, sem token da Conversions API).
+    return html_file(FRONTEND_DIR / "onboarding.html")
 
 
 @router.get("/login")


### PR DESCRIPTION
## Resumo

Amplia o rastreio do Meta Ads pro **funil inteiro** (viu → cadastrou → trial → pagou), complementando o pixel + Conversions API já existentes (PR #31). Todos os eventos são **deduplicados** por `event_id` compartilhado entre navegador (pixel) e servidor (CAPI).

## Eventos novos

| Evento | Onde dispara | Pixel | CAPI | Dedup (`event_id`) |
|--------|--------------|:-----:|:----:|--------------------|
| **ViewContent** | Ao abrir `/precos` | ✅ | — | — |
| **CompleteRegistration** | Conta criada (`/auth/verify-email` + signup via Google) | ✅ | ✅ | `signup_<user_id>` |
| **StartTrial** | Início do trial (volta do checkout) | ✅ | ✅ | `trial_<session_id>` |
| **Purchase** (refinado) | Compra imediata na hora; cobrança real (fim do trial + renovações) no `invoice.paid` | ✅ | ✅ | `purchase_<session_id>` / `purchase_<invoice_id>` |

## Mudanças principais

- **`core/services/meta_capi.py`**: generaliza em `send_event(event_name, event_id, ...)` (valor opcional) e adiciona os builders `trial_event_id` e `registration_event_id`. `send_purchase_event` vira wrapper de compatibilidade.
- **`checkout.session.completed`**: trial → `StartTrial`; compra imediata (sem trial) → `Purchase`.
- **`invoice.paid`**: dispara `Purchase` com o valor **efetivamente pago** na cobrança real (fim do trial + renovações). A 1ª fatura da compra imediata (`billing_reason=subscription_create`) é pulada aqui pra não contar duas vezes.
- **`/auth/verify-email` e signup via Google**: `CompleteRegistration` server-side (fire-and-forget, nunca quebra o cadastro).
- **`success_url`**: ganha `&ev=trial|purchase` pra o client escolher o evento certo na volta.
- **`cadastro.html` / `home.html` / `precos.html`**: eventos client-side correspondentes.
- **`.env.example`**: documenta os novos eventos.

## Comportamento a destacar

- O `Purchase` deixou de disparar no **início do trial** (quando ainda não há cobrança) — agora só quando o dinheiro entra de fato. O início do trial vira `StartTrial`.
- Cada **renovação** mensal também dispara um `Purchase` (representa receita real). Contar só a primeira compra por cliente exigiria controle de estado adicional — fácil de adicionar depois se for a preferência.

## Testes

- Suíte completa executada com Postgres local: **917 passed**. As falhas restantes são exclusivamente `ModuleNotFound` de dependências ausentes no ambiente local (`ofxparse`, `discord`), sem relação com esta mudança.
- Billing + auth (exercitam os handlers alterados): **76 passed**.
- Unit tests dos helpers de `meta_capi` (event_id builders, no-op sem config, exigência de identificador).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLrV5UimiZ6nqFZryLDu9g)_