### PR TITLE
Banner de trial: sem barra lateral, ícones legíveis no claro, snooze 1d

### DIFF
--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -9,6 +9,7 @@
   --radius:        22px;
   --green:  #00F078; --neon:   #C6F11A; --red:    #FF2D2D; --blue:   #FF80B8;
   --purple: #FF2D8E; --yellow: #fbbf24;
+  --neon-ink: var(--neon);  /* lima legível: neon puro no escuro, escurece no claro (ver body.light) */
   --text:   rgba(255,255,255,0.92);
   --text-2: rgba(255,255,255,0.52);
   --text-3: rgba(255,255,255,0.28);
@@ -27,6 +28,7 @@ body.light {
   --text-2: #475569;
   --text-3: #94a3b8;
   --div:    rgba(15,23,42,0.08);
+  --neon-ink: #5E8000;  /* neon puro fica ilegível sobre fundo claro; olive-lima escuro mantém a identidade */
   --orb-opacity: .12;
 }
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -163,16 +163,15 @@
   <!-- Banner de trial (B1) — só pro Grátis sem trial ativo; escondido no app iOS.
        Revelado por maybeShowTrialBanner() em dashboard.js. -->
   <div id="trial-banner" style="display:none;position:relative;background:var(--glass-bg);border:1px solid var(--glass-border);border-radius:22px;padding:20px 22px;overflow:hidden;margin-bottom:18px">
-    <div style="position:absolute;top:0;left:0;bottom:0;width:4px;background:linear-gradient(#FF2D8E,#C6F11A)"></div>
     <div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap">
       <span style="flex-shrink:0;width:46px;height:46px;border-radius:14px;background:rgba(255,45,142,.16);color:#FF2D8E;display:inline-flex;align-items:center;justify-content:center;font-size:24px"><i class="ph ph-sparkle" aria-hidden="true"></i></span>
       <div style="flex:1;min-width:220px">
         <div style="color:var(--text);font-weight:600;font-size:1rem;line-height:1.3">Experimente o Plus por 30 dias grátis</div>
         <div style="color:var(--text-2);font-size:.82rem;line-height:1.45;margin-top:3px">Conecte seu banco, ative os agentes e veja seu dinheiro trabalhar. Cancele quando quiser.</div>
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:11px">
-          <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-bank" style="color:#C6F11A" aria-hidden="true"></i> Open Finance</span>
-          <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-robot" style="color:#C6F11A" aria-hidden="true"></i> Agentes do Piggy</span>
-          <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-clock-counter-clockwise" style="color:#C6F11A" aria-hidden="true"></i> Histórico ilimitado</span>
+          <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-bank" style="color:var(--neon-ink)" aria-hidden="true"></i> Open Finance</span>
+          <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-robot" style="color:var(--neon-ink)" aria-hidden="true"></i> Agentes do Piggy</span>
+          <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-clock-counter-clockwise" style="color:var(--neon-ink)" aria-hidden="true"></i> Histórico ilimitado</span>
         </div>
       </div>
       <div style="display:flex;flex-direction:column;align-items:stretch;gap:8px;flex-shrink:0">

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -5498,7 +5498,7 @@ const UPGRADE_MESSAGES = {
 // externa = rejeição Apple 3.1.1, a checagem é feita por quem chama). O "Agora
 // não" silencia por TRIAL_BANNER_SNOOZE_DAYS via localStorage.
 const TRIAL_BANNER_SNOOZE_KEY = "pb_trial_banner_snooze_until";
-const TRIAL_BANNER_SNOOZE_DAYS = 7;
+const TRIAL_BANNER_SNOOZE_DAYS = 1;
 
 function maybeShowTrialBanner() {
   const el = document.getElementById("trial-banner");


### PR DESCRIPTION
Ajustes no banner de trial (B1) da conta Grátis, exibido na Visão geral do dashboard.

## Mudanças
- **Remove a barra de gradiente** rosa→lima do lado esquerdo do banner.
- **Ícones das badges legíveis no tema claro**: novo token `--neon-ink` — lima (`#C6F11A`) no escuro, olive-lima escuro (`#5E8000`) no claro. Antes os ícones eram `#C6F11A` fixo, quase ilegíveis sobre o fundo claro.
- **Snooze do "Agora não" reduzido de 7 → 1 dia** (`TRIAL_BANNER_SNOOZE_DAYS`).

## Arquivos
- `frontend/dashboard.css` — token `--neon-ink` no `:root` e `body.light`
- `frontend/dashboard.html` — remove a barra; badges usam `var(--neon-ink)`
- `frontend/dashboard.js` — `TRIAL_BANNER_SNOOZE_DAYS = 1`

Sem mudança de comportamento fora do banner. O banner segue aparecendo só pra conta Grátis sem trial ativo e escondido no app iOS.