### PR TITLE
Optimize performance: lazy-load Sortable, cache menu state, parallelize auth

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=6"></script>
+<script defer src="/dashboard.js?v=7"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=7"></script>
+<script defer src="/dashboard.js?v=8"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -10,16 +10,24 @@
 <meta name="theme-color" content="#111111" />
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+<!-- Aquece a conexão com os CDNs de terceiros antes de baixar os scripts. -->
+<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+<!-- Bibliotecas de terceiros: só usadas depois que uma view abre (gráficos /
+     drag-and-drop). Com defer não bloqueiam o parse nem o primeiro paint; a
+     ordem do documento continua garantida, então executam antes do dashboard.js. -->
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/dashboard.css?v=2" />
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
-<script src="/static/auth-refresh.js"></script>
-<script src="/modals.js"></script>
+<!-- defer preserva a ordem: auth-refresh (patch do fetch) → modals → app-mode →
+     dashboard.js. Nenhum script inline depende deles durante o parse. -->
+<script defer src="/static/auth-refresh.js"></script>
+<script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=18" />
-  <script src="/app-mode.js?v=19"></script>
+  <script defer src="/app-mode.js?v=19"></script>
 </head>
 <body class="has-sidenav">
 
@@ -1530,7 +1538,7 @@
   </div>
 </div>
 
-<script src="/dashboard.js?v=4"></script>
+<script defer src="/dashboard.js?v=5"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 
@@ -1569,7 +1577,7 @@
   </div>
 </div>
 
-<script src="/dashboard-chat.js"></script>
+<script defer src="/dashboard-chat.js"></script>
 
 </body>
 </html>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -13,11 +13,11 @@
 <!-- Aquece a conexão com os CDNs de terceiros antes de baixar os scripts. -->
 <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-<!-- Bibliotecas de terceiros: só usadas depois que uma view abre (gráficos /
-     drag-and-drop). Com defer não bloqueiam o parse nem o primeiro paint; a
-     ordem do documento continua garantida, então executam antes do dashboard.js. -->
+<!-- Chart.js: usado pela view padrão (overview). defer tira do caminho
+     bloqueante do parse, mas ainda pré-carrega durante a ociosidade, ficando
+     pronto quando os dados chegam. Sortable NÃO entra aqui: é carregado sob
+     demanda (ensureSortable) só quando o usuário reordena cartões. -->
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/dashboard.css?v=2" />
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=5"></script>
+<script defer src="/dashboard.js?v=6"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -119,7 +119,12 @@ function applyUserMenuState(email, plan, displayName) {
    cabeçalho e aplicar os gates de UI na hora, sem esperar o round-trip do
    /auth/dashboard-profile. Saldos e transações NUNCA entram aqui — a política
    do app é não cachear dado financeiro no dispositivo (ver service-worker.js).
-   O valor é sobrescrito pelo perfil fresco ~1 RTT depois, e limpo no logout. */
+   O valor é sobrescrito pelo perfil fresco ~1 RTT depois.
+   O cache é ESCOPADO ao USER_ID validado: o paint otimista só acontece se o
+   registro pertencer ao usuário da sessão atual. Isso evita mostrar a
+   identidade de um usuário anterior quando outra conta loga no mesmo
+   navegador — inclusive se o logout foi feito por Settings/Home (cujos
+   handlers não conhecem esta chave) e mesmo que o fetch fresco falhe. */
 const _MENU_CACHE_KEY = "pigbank_menu_v1";
 function _readMenuCache() {
   try {
@@ -127,9 +132,9 @@ function _readMenuCache() {
     return raw ? JSON.parse(raw) : null;
   } catch { return null; }
 }
-function _writeMenuCache(email, plan, displayName) {
+function _writeMenuCache(userId, email, plan, displayName) {
   try {
-    localStorage.setItem(_MENU_CACHE_KEY, JSON.stringify({ email, plan, displayName }));
+    localStorage.setItem(_MENU_CACHE_KEY, JSON.stringify({ userId, email, plan, displayName }));
   } catch {}
 }
 function clearMenuCache() {
@@ -137,15 +142,22 @@ function clearMenuCache() {
 }
 
 async function loadUserMenuState() {
-  // Paint otimista: aplica o último chrome conhecido antes do fetch resolver.
+  // Paint otimista: aplica o último chrome conhecido ANTES do fetch resolver,
+  // mas só se o cache for do usuário já validado nesta sessão (USER_ID).
   const cached = _readMenuCache();
-  if (cached) applyUserMenuState(cached.email || "", cached.plan || "free", cached.displayName || "");
+  if (cached && USER_ID && String(cached.userId) === String(USER_ID)) {
+    applyUserMenuState(cached.email || "", cached.plan || "free", cached.displayName || "");
+  } else if (cached) {
+    // Cache de outro usuário (ou formato antigo sem userId): descarta pra não
+    // vazar identidade. Será reescrito com o perfil correto abaixo.
+    clearMenuCache();
+  }
   try {
     const res = await fetch(`${API}/auth/dashboard-profile`, { credentials: "same-origin" });
     if (!res.ok) return;
     const data = await readResponsePayload(res);
     applyUserMenuState(data.email || "", data.plan || "free", data.display_name || "");
-    _writeMenuCache(data.email || "", data.plan || "free", data.display_name || "");
+    _writeMenuCache(USER_ID, data.email || "", data.plan || "free", data.display_name || "");
   } catch {}
 }
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -114,12 +114,38 @@ function applyUserMenuState(email, plan, displayName) {
   applyProGates();
 }
 
+/* ─── Cache do chrome do header (instant paint no cold start) ─────────────
+   Guarda só dados NÃO-financeiros do menu (nome/email/plano) pra pintar o
+   cabeçalho e aplicar os gates de UI na hora, sem esperar o round-trip do
+   /auth/dashboard-profile. Saldos e transações NUNCA entram aqui — a política
+   do app é não cachear dado financeiro no dispositivo (ver service-worker.js).
+   O valor é sobrescrito pelo perfil fresco ~1 RTT depois, e limpo no logout. */
+const _MENU_CACHE_KEY = "pigbank_menu_v1";
+function _readMenuCache() {
+  try {
+    const raw = localStorage.getItem(_MENU_CACHE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch { return null; }
+}
+function _writeMenuCache(email, plan, displayName) {
+  try {
+    localStorage.setItem(_MENU_CACHE_KEY, JSON.stringify({ email, plan, displayName }));
+  } catch {}
+}
+function clearMenuCache() {
+  try { localStorage.removeItem(_MENU_CACHE_KEY); } catch {}
+}
+
 async function loadUserMenuState() {
+  // Paint otimista: aplica o último chrome conhecido antes do fetch resolver.
+  const cached = _readMenuCache();
+  if (cached) applyUserMenuState(cached.email || "", cached.plan || "free", cached.displayName || "");
   try {
     const res = await fetch(`${API}/auth/dashboard-profile`, { credentials: "same-origin" });
     if (!res.ok) return;
     const data = await readResponsePayload(res);
     applyUserMenuState(data.email || "", data.plan || "free", data.display_name || "");
+    _writeMenuCache(data.email || "", data.plan || "free", data.display_name || "");
   } catch {}
 }
 
@@ -247,6 +273,7 @@ async function logoutDashboard() {
       headers: csrfHeaders()
     });
   } catch {}
+  clearMenuCache();  // não deixa o chrome de um usuário vazar pro próximo login
   localStorage.setItem('finbot_logout_at', String(Date.now()));
   window.location.replace('/?logout=1');
 }

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9274,8 +9274,15 @@ function _showAccessError(title, msg) {
 (async () => {
   const view = params.get("view");
 
+  // /auth/validate e /auth/me são independentes (ambos por cookie — o /me não
+  // precisa do USER_ID). Disparamos os dois em paralelo pra cortar uma ida ao
+  // servidor do caminho crítico de abertura. O .catch no /me evita rejeição
+  // não tratada caso o validate falhe e a gente saia antes de consumi-lo.
+  const validatePromise = fetch(`${API}/auth/validate`, { credentials: "same-origin" });
+  const mePromise = fetch(`${API}/auth/me`, { credentials: "same-origin" }).catch(() => null);
+
   try {
-    const resp = await fetch(`${API}/auth/validate`, { credentials: "same-origin" });
+    const resp = await validatePromise;
     if (!resp.ok) { _showAccessError(); return; }
     const data = await resp.json();
     USER_ID = data.user_id;
@@ -9287,8 +9294,8 @@ function _showAccessError(title, msg) {
   // Paywall: sem assinatura ativa → manda pro paywall antes de carregar o app.
   // (As rotas de dados também devolvem 402 como reforço server-side.)
   try {
-    const meResp = await fetch(`${API}/auth/me`, { credentials: "same-origin" });
-    if (meResp.ok) {
+    const meResp = await mePromise;
+    if (meResp && meResp.ok) {
       const me = await meResp.json();
       historyEarliestDate = me?.history_earliest_date || null;
       updateMonthLabel();

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -42,6 +42,32 @@ let WS_URL  = "";
 let USER_EMAIL = "";
 let USER_PLAN = "";
 
+/* ─── Loader de scripts sob demanda ──────────────────────────────────────
+   Carrega uma lib de terceiros só quando ela é realmente necessária, em vez
+   de baixá-la em todo boot. Deduplica: várias chamadas para a mesma URL
+   compartilham a mesma Promise. */
+const _scriptLoaders = {};
+function _loadScriptOnce(src) {
+  if (_scriptLoaders[src]) return _scriptLoaders[src];
+  _scriptLoaders[src] = new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = src;
+    s.async = true;
+    s.onload = () => resolve();
+    s.onerror = () => { delete _scriptLoaders[src]; reject(new Error(`Falha ao carregar ${src}`)); };
+    document.head.appendChild(s);
+  });
+  return _scriptLoaders[src];
+}
+
+/* Sortable só é usado no drag-to-reorder dos cartões (ponteiro fino). Carrega
+   sob demanda pra tirar ~50KB de todo boot de quem nunca reordena cartão. */
+function ensureSortable() {
+  if (typeof window.Sortable !== "undefined") return Promise.resolve();
+  return _loadScriptOnce("https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js")
+    .catch(() => {});
+}
+
 function getCookie(name) {
   return document.cookie.split("; ").find(row => row.startsWith(`${name}=`))?.split("=")[1] || "";
 }
@@ -8132,11 +8158,14 @@ function _installWalletDrag(wallet) {
 
 /* Drag-to-reorder na view Cartões (#cards-grid). Cards são <details>, então
    `delay` evita conflito com click no <summary> (expandir/colapsar). */
-function setupCardsGridSort() {
-  if (typeof Sortable === "undefined") return;
+async function setupCardsGridSort() {
+  // Drag só faz sentido em ponteiro fino (mouse/trackpad). Checa antes de
+  // carregar a lib pra não baixar nada em touch.
   if (!window.matchMedia("(pointer: fine)").matches) return;
   const grid = document.getElementById("cards-grid");
   if (!grid) return;
+  await ensureSortable();
+  if (typeof Sortable === "undefined") return;   // load falhou → segue sem drag
   if (grid.__sortable) {
     try { grid.__sortable.destroy(); } catch (_) {}
   }

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -6,7 +6,11 @@
 <title>Configurações — PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <meta name="theme-color" content="#111111" />
-<script src="https://cdn.pluggy.ai/pluggy-connect/v2.7.0/pluggy-connect.js"></script>
+<!-- Widget da Pluggy: só é instanciado quando o usuário abre "conectar banco"
+     (openPluggyConnect). defer tira o download do caminho bloqueante do parse;
+     o factory (window.PluggyConnect) já estará pronto muito antes do clique. -->
+<link rel="preconnect" href="https://cdn.pluggy.ai" crossorigin />
+<script defer src="https://cdn.pluggy.ai/pluggy-connect/v2.7.0/pluggy-connect.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <style>


### PR DESCRIPTION
## Summary
This PR improves dashboard performance through three complementary optimizations: lazy-loading the Sortable library only when needed, caching non-financial user menu state for instant paint on cold starts, and parallelizing independent auth API calls to reduce critical path latency.

## Key Changes

- **Lazy-load Sortable.js**: Implemented `ensureSortable()` and `_loadScriptOnce()` to load the Sortable library on-demand only when users attempt to reorder cards AND have a fine pointer (mouse/trackpad). This eliminates ~50KB from the initial bundle for users who never reorder cards or use touch devices.

- **Menu state caching**: Added localStorage-based caching of non-financial user data (email, plan, displayName) to enable optimistic UI paint before the `/auth/dashboard-profile` API call completes. Cache is cleared on logout to prevent user data leakage between sessions.

- **Parallel auth requests**: Changed `/auth/validate` and `/auth/me` from sequential to parallel execution, removing one round-trip from the critical path. Both calls are independent (cookie-based) and can be dispatched simultaneously.

- **Script loading optimization**: Converted all dashboard scripts to use `defer` attribute and removed synchronous Sortable.js load from HTML. Added `preconnect` hints for third-party CDNs (Cloudflare, jsDelivr, Pluggy) to warm up connections before script downloads.

- **Conditional library loading**: Chart.js remains eagerly loaded (used by default overview) but deferred; Sortable is now fully lazy-loaded; Pluggy Connect widget deferred since it's only instantiated on user action.

## Implementation Details

- The `_scriptLoaders` cache deduplicates concurrent requests for the same script URL
- Menu cache only stores non-sensitive data; financial data is explicitly excluded per app policy (see service-worker.js)
- Pointer media query check prevents unnecessary Sortable download on touch devices
- Error handling in lazy-load gracefully degrades (drag-to-reorder simply unavailable if load fails)
- All script defer ordering preserved to maintain dependency chain: auth-refresh → modals → app-mode → dashboard.js

https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT