### PR TITLE
fix(open-finance): oculta caixinhas OF zeradas da tela de vínculo

### DIFF
--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -554,6 +554,11 @@ def list_caixinha_candidates(user_id: int) -> list[dict]:
                        and upper(coalesce(i.subtype,'')) = 'CDB')
                     or i.name ilike any (array['%%caixinha%%','%%cofrinho%%','%%reserva%%','%%objetivo%%'])
                   )
+                  -- Nubank devolve toda posição de CDB via OF, inclusive caixinhas já
+                  -- esvaziadas (saldo 0). Elas poluem a tela de vínculo sem servir pra
+                  -- nada, então só mostramos candidatos com saldo > 0 — exceto os que já
+                  -- estão vinculados a uma meta (mantidos pra permitir desvincular).
+                  and (coalesce(i.balance, 0) > 0 or p.id is not null)
                 order by i.balance desc nulls last
                 """,
                 (user_id, user_id),

--- a/tests/test_of_caixinha_autoimport.py
+++ b/tests/test_of_caixinha_autoimport.py
@@ -137,6 +137,51 @@ def test_of_pocket_is_readonly_for_deposit_and_withdraw(user_id):
         db.pocket_withdraw_to_account(user_id, "Caixinha Viagem", 100.0)
 
 
+def test_candidates_hide_unlinked_zero_balance(user_id):
+    # Nubank devolve toda posição de CDB via OF, inclusive caixinhas já esvaziadas
+    # (saldo 0). A tela de vínculo não deve listar essas — só as com saldo > 0.
+    conn_id = _seed_connection(user_id)
+    _save(conn_id, [
+        {"id": "cx-live", "name": "CDB - NU FINANCEIRA S.A.", "type": "FIXED_INCOME",
+         "subtype": "CDB", "balance": 500.0},
+        {"id": "cx-zero", "name": "CDB - NU FINANCEIRA S.A.", "type": "FIXED_INCOME",
+         "subtype": "CDB", "balance": 0.0},
+    ])
+    cands = db.list_caixinha_candidates(user_id)
+    ids = {c["of_investment_id"] for c in cands}
+    live = _of_id(conn_id, "cx-live")
+    zero = _of_id(conn_id, "cx-zero")
+    assert live in ids       # com saldo aparece
+    assert zero not in ids   # zerada e sem vínculo some da lista
+
+
+def test_candidates_keep_linked_zero_balance(user_id):
+    # Caixinha vinculada a uma meta permanece na lista mesmo zerada, pra
+    # permitir o desvínculo pela UI.
+    conn_id = _seed_connection(user_id)
+    _save(conn_id, [{"id": "cx-drained", "name": "Caixinha Viagem", "type": "FIXED_INCOME",
+                     "subtype": "CDB", "balance": 0.0}])
+    of_id = _of_id(conn_id, "cx-drained")
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "insert into pockets(user_id,name,balance,source,of_investment_id,interest_enabled) "
+                "values(%s,'Minha meta',0,'open_finance',%s,false)", (user_id, of_id))
+        conn.commit()
+    ids = {c["of_investment_id"] for c in db.list_caixinha_candidates(user_id)}
+    assert of_id in ids
+
+
+def _of_id(conn_id: int, provider_investment_id: str) -> int:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select id from open_finance_investments "
+                "where connection_id=%s and provider_investment_id=%s",
+                (conn_id, provider_investment_id))
+            return cur.fetchone()["id"]
+
+
 def test_accrual_does_not_touch_of_pocket_balance(user_id):
     conn_id = _seed_connection(user_id)
     _save(conn_id, [{"id": "cx4", "name": "Cofrinho férias", "type": "FIXED_INCOME",


### PR DESCRIPTION
## Problema

Na tela **Caixinhas & metas** (Configurações) apareciam dezenas de "caixinhas" — quase todas com **R$ 0,00 guardado** — muito mais do que o usuário realmente tem.

## Causa

No Nubank, cada caixinha é internamente um **CDB da NU FINANCEIRA S.A.** Via Open Finance (Pluggy), o banco devolve **todas** as posições de CDB que já existiram na conta, incluindo caixinhas já esvaziadas/fechadas, que retornam com saldo **R$ 0,00**.

A query `list_caixinha_candidates` (que alimenta a tela de vínculo) listava **todo** CDB independente do saldo, enquanto o auto-import de caixinhas (`sync_open_finance_caixinhas`) já filtrava corretamente por `balance > 0`. Ou seja, só a tela de vínculo estava poluída — as caixinhas de fato criadas no app já estavam corretas.

## Mudança

- `db/open_finance.py` — `list_caixinha_candidates` agora só retorna candidatos com **saldo > 0**, mantendo os que já estão **vinculados a uma meta** (mesmo zerados) para permitir o desvínculo pela UI. Alinha a tela de vínculo ao filtro que o auto-import já aplicava.
- `tests/test_of_caixinha_autoimport.py` — cobre dois casos: candidato zerado e sem vínculo some da lista; candidato zerado mas vinculado permanece.

## Notas de verificação

Não consegui rodar a suíte neste ambiente (falta `DATABASE_URL` e o build de `cryptography` está quebrado no sandbox). As mudanças passam por `py_compile`. Os testes novos seguem exatamente o padrão dos existentes em `test_of_caixinha_autoimport.py` e devem rodar no CI com Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzovQddeeCU98ztTuqHFTk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzovQddeeCU98ztTuqHFTk)_