### PR TITLE
Fix: data/hora, clique no lançamento, seletor de mês e flicker das análises

### DIFF
--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -839,8 +839,13 @@ header h1 { font-size:1.1rem; font-weight:650; letter-spacing:-.02em; }
 
 .month-nav { display:flex; align-items:center; }
 .mbtn { background:rgba(255,255,255,.07);border:1px solid var(--glass-border);color:var(--text-2);
-  width:30px;height:30px;border-radius:8px;cursor:pointer;font-size:.95rem;
-  display:flex;align-items:center;justify-content:center;transition:all .2s var(--ease); }
+  width:30px;height:30px;border-radius:8px;cursor:pointer;font-size:.95rem;flex-shrink:0;
+  display:flex;align-items:center;justify-content:center;
+  /* Transição só em cor/fundo (não em `all`): evita animar opacity no
+     enable/disable, que sob o header com backdrop-filter deixava "fantasma"
+     do botão no WebView do iOS. translateZ força camada própria e mata o ghost. */
+  transition:background .2s var(--ease), color .2s var(--ease);
+  transform:translateZ(0); -webkit-backface-visibility:hidden; backface-visibility:hidden; }
 .mbtn:hover:not(:disabled) { background:rgba(255,255,255,.14);color:var(--text); }
 .mbtn:disabled { opacity:.3;cursor:default; }
 #month-label { min-width:128px;text-align:center;font-size:.8rem;font-weight:600;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,7 +20,7 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
-<link rel="stylesheet" href="/dashboard.css?v=2" />
+<link rel="stylesheet" href="/dashboard.css?v=3" />
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
 <!-- defer preserva a ordem: auth-refresh (patch do fetch) → modals → app-mode →
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=8"></script>
+<script defer src="/dashboard.js?v=9"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=9"></script>
+<script defer src="/dashboard.js?v=10"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -309,9 +309,23 @@ const fmtShort = n => {
     : "R$" + Number(n).toLocaleString("pt-BR",{minimumFractionDigits:0,maximumFractionDigits:0});
 };
 
+// Fuso do app (o backend agrupa tudo em America/Sao_Paulo). Exibimos as datas
+// SEMPRE nesse fuso pra não depender do timezone do dispositivo — no WebView do
+// iOS ele costuma vir em UTC, o que fazia a hora aparecer ~3h adiantada.
+const APP_TZ = "America/Sao_Paulo";
 const fmtDate = iso => {
   if (!iso) return "—";
-  return new Date(iso).toLocaleString("pt-BR",{day:"2-digit",month:"2-digit",hour:"2-digit",minute:"2-digit"});
+  let s = String(iso);
+  // Se a string vier sem timezone (naive), a coluna é timestamptz em UTC:
+  // normaliza pra UTC antes de converter, senão o JS assume hora local.
+  const hasTz = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(s);
+  if (!hasTz) s = s.replace(" ", "T") + "Z";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleString("pt-BR", {
+    day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit",
+    timeZone: APP_TZ,
+  });
 };
 
 const esc = s => String(s ?? "").replace(/[&<>"']/g, c => ({
@@ -4571,7 +4585,9 @@ async function loadAnalyticsView(forceFresh = false, months = null) {
   if (_analyticsCache && _analyticsCache.months === _analyticsCurrentMonths && !forceFresh) {
     renderAnalyticsView(_analyticsCache);
     _fetchAnalyticsAll(_analyticsCurrentMonths).then(fresh => {
-      if (fresh) {
+      // Só re-renderiza se algo mudou de verdade — senão reconstruía os
+      // gráficos do Chart.js a cada visita, dando flicker de "recarregando".
+      if (fresh && JSON.stringify(fresh) !== JSON.stringify(_analyticsCache)) {
         _analyticsCache = fresh;
         renderAnalyticsView(fresh);
       }
@@ -6835,10 +6851,28 @@ function renderLaunchesPagination(totalItems, totalPages) {
   return html;
 }
 
+const LAUNCH_TYPE_LABELS = {
+  deposito_caixinha: "dep. caixinha",
+  saque_caixinha: "saque caixinha",
+  aporte_investimento: "aporte invest.",
+  resgate_investimento: "resgate invest.",
+  transferencia_interna: "transf. interna",
+  pagamento_fatura: "pgto. fatura",
+  ajuste_saldo: "ajuste saldo",
+  criar_caixinha: "criar caixinha",
+  create_investment: "criar invest.",
+  delete_pocket: "remover caixinha",
+  delete_investment: "remover invest.",
+  credito: "crédito",
+};
+// Guarda os lançamentos renderizados pra o clique na linha abrir o detalhe.
+let _renderedLaunches = [];
+
 function renderLaunches() {
   if (!lastData) return;
 
   const items = lastData.recent_launches || [];
+  _renderedLaunches = items;
 
   const card = document.getElementById("launches-card");
 
@@ -6856,23 +6890,10 @@ function renderLaunches() {
 
   launchesPage = meta.page || 1;
 
-	  const TYPE_LABELS = {
-    deposito_caixinha: "dep. caixinha",
-    saque_caixinha: "saque caixinha",
-    aporte_investimento: "aporte invest.",
-    resgate_investimento: "resgate invest.",
-    transferencia_interna: "transf. interna",
-    pagamento_fatura: "pgto. fatura",
-    ajuste_saldo: "ajuste saldo",
-    criar_caixinha: "criar caixinha",
-    create_investment: "criar invest.",
-    delete_pocket: "remover caixinha",
-	    delete_investment: "remover invest.",
-    credito: "crédito"
-	  };
+	  const TYPE_LABELS = LAUNCH_TYPE_LABELS;
 
 		  card.innerHTML =
-		    items.map(l => {
+		    items.map((l, idx) => {
       const isInternal = l.is_internal_movement;
       const valClass   = isInternal ? '' : (l.tipo==='receita'||l.tipo==='entrada' ? 'g' : 'r');
       const valStyle   = isInternal ? 'color:var(--text-2)' : '';
@@ -6885,7 +6906,7 @@ function renderLaunches() {
         ? `<button class="bgt-btn launch-delete-btn" onclick="event.stopPropagation();confirmDeleteLaunch(${l.id}, ${JSON.stringify(describeLaunch(l).replace(/<[^>]+>/g, '').trim()).replace(/"/g, '&quot;')}, ${l.valor}, ${l.tipo === 'credito' ? 'true' : 'false'}, ${l.installments_total || 'null'})" title="Apagar lançamento"><i class="ph ph-trash" aria-hidden="true"></i></button>`
         : '';
       return `
-      <div class="row" style="${isInternal?'opacity:.75':''}">
+      <div class="row" style="cursor:pointer;${isInternal?'opacity:.75':''}" onclick="openLaunchDetail(${idx})">
         <span class="lbl">
 	          <span class="tag ${l.tipo}">${typeLabel}</span>
 	          ${isInternal ? '<span class="tag interno">mov. interna</span>' : ''}
@@ -6901,6 +6922,21 @@ function renderLaunches() {
       </div>
     `}).join("")
     + renderLaunchesPagination(meta.total || items.length, meta.total_pages || 1);
+}
+
+// Clique numa linha da Visão Geral: abre o detalhe com a descrição COMPLETA
+// (que não cabe inteira no celular) + os campos principais. Reusa o modal
+// genérico (corpo com white-space:pre-wrap, então as quebras de linha valem).
+function openLaunchDetail(idx) {
+  const l = (_renderedLaunches || [])[idx];
+  if (!l) return;
+  const typeLabel = LAUNCH_TYPE_LABELS[l.tipo] || String(l.tipo || "").replaceAll("_", " ");
+  const desc = describeLaunch(l).replace(/<[^>]+>/g, "").trim() || "—";
+  const lines = [desc, "", `Valor: ${fmt(l.valor)}`, `Tipo: ${typeLabel}`];
+  if (l.categoria) lines.push(`Categoria: ${l.categoria}`);
+  if (l.is_internal_movement) lines.push("Movimentação interna");
+  lines.push(`Data: ${fmtDate(l.criado_em)}`);
+  alertModal(lines.join("\n"), { title: "Detalhe do lançamento", okText: "Fechar" });
 }
 
 /* ═══════════════════════════════════════════════════════════════════════

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -313,15 +313,54 @@ const fmtShort = n => {
 // SEMPRE nesse fuso pra não depender do timezone do dispositivo — no WebView do
 // iOS ele costuma vir em UTC, o que fazia a hora aparecer ~3h adiantada.
 const APP_TZ = "America/Sao_Paulo";
-const fmtDate = iso => {
-  if (!iso) return "—";
+
+// Normaliza uma string de data: se vier sem timezone (naive), a coluna é
+// timestamptz em UTC, então trata como UTC. Devolve um Date (instante) ou null.
+function _isoToDate(iso) {
+  if (!iso) return null;
   let s = String(iso);
-  // Se a string vier sem timezone (naive), a coluna é timestamptz em UTC:
-  // normaliza pra UTC antes de converter, senão o JS assume hora local.
   const hasTz = /(?:[zZ]|[+-]\d{2}:?\d{2})$/.test(s);
   if (!hasTz) s = s.replace(" ", "T") + "Z";
   const d = new Date(s);
-  if (isNaN(d.getTime())) return "—";
+  return isNaN(d.getTime()) ? null : d;
+}
+
+// Partes de parede (ano/mês/dia/hora/min) de um instante num dado fuso.
+function _wallPartsInTZ(date, tz) {
+  const dtf = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+  });
+  const p = {};
+  for (const part of dtf.formatToParts(date)) p[part.type] = part.value;
+  if (p.hour === "24") p.hour = "00"; // alguns engines usam 24 pra meia-noite
+  return p;
+}
+
+// Offset do fuso (em minutos) num instante: negativo p/ oeste de UTC (-180 = -03:00).
+function _tzOffsetMinutes(date, tz) {
+  const p = _wallPartsInTZ(date, tz);
+  const asUTC = Date.UTC(+p.year, +p.month - 1, +p.day, +p.hour, +p.minute, +p.second);
+  return Math.round((asUTC - date.getTime()) / 60000);
+}
+
+// "YYYY-MM-DDTHH:MM" interpretado como hora de PAREDE em APP_TZ -> instante ISO
+// (UTC). Ex.: 12:00 em São Paulo -> 15:00Z. Brasil não tem DST (desde 2019),
+// então o offset é estável.
+function appTzWallClockToISO(localStr) {
+  if (!localStr) return null;
+  const [datePart, timePart = "00:00"] = String(localStr).split("T");
+  const [y, mo, da] = datePart.split("-").map(Number);
+  const [h, mi] = timePart.split(":").map(Number);
+  if ([y, mo, da, h, mi].some(n => Number.isNaN(n))) return null;
+  const asUTC = Date.UTC(y, mo - 1, da, h, mi);
+  const offsetMin = _tzOffsetMinutes(new Date(asUTC), APP_TZ);
+  return new Date(asUTC - offsetMin * 60000).toISOString();
+}
+
+const fmtDate = iso => {
+  const d = _isoToDate(iso);
+  if (!d) return "—";
   return d.toLocaleString("pt-BR", {
     day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit",
     timeZone: APP_TZ,
@@ -7181,11 +7220,13 @@ let editingLaunchIsCredit = false;
 // ISO instant → "YYYY-MM-DDTHH:MM" no fuso local do navegador (formato do
 // input datetime-local). Espelha o que o fmtDate mostra na lista.
 function toLocalDatetimeInput(iso) {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return "";
-  const pad = n => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-       + `T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  // Renderiza o campo datetime-local na hora de PAREDE de APP_TZ (não do
+  // device), pra bater com o que fmtDate exibe. Sem isso, no WebView UTC do
+  // iOS o campo mostrava 3h a mais que o resumo.
+  const d = _isoToDate(iso);
+  if (!d) return "";
+  const p = _wallPartsInTZ(d, APP_TZ);
+  return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}`;
 }
 
 function openEditLaunchModal(launchId) {
@@ -7263,9 +7304,11 @@ async function submitEditLaunch() {
   if (!editingLaunchIsCredit) {
     const dataVal = document.getElementById("edit-launch-data").value;
     if (dataVal) {
-      const d = new Date(dataVal);
-      if (isNaN(d.getTime())) { showEditLaunchError("Data inválida."); return; }
-      criadoEmISO = d.toISOString();
+      // O input é hora de parede em APP_TZ (mesmo fuso do display/edição).
+      // Converte pro instante UTC correto — não usa new Date(dataVal), que
+      // interpretaria no fuso do device (UTC no WebView iOS) e deslocaria 3h.
+      criadoEmISO = appTzWallClockToISO(dataVal);
+      if (!criadoEmISO) { showEditLaunchError("Data inválida."); return; }
     }
   }
 


### PR DESCRIPTION
## Resumo
Correções de UX no dashboard a partir do teste no app iOS (feedback direto do usuário).

## Mudanças

- **Data/hora do lançamento (`fmtDate`)** — passa a exibir sempre em `America/Sao_Paulo` e trata timestamps sem timezone como UTC. No WebView do iOS o fuso do device costuma vir em UTC, o que mostrava a hora ~3h adiantada; agora bate com o agrupamento por dia do backend (que já usa esse fuso).

- **Clique no lançamento (Visão Geral)** — clicar numa linha abre um modal com a **descrição completa** (que não cabe inteira no celular) + valor, tipo, categoria e data. Reusa o modal genérico (corpo com `white-space:pre-wrap`). Botões de editar/apagar seguem com `stopPropagation`. Labels de tipo movidos para escopo de módulo (`LAUNCH_TYPE_LABELS`).

- **Seletor de mês (setas duplicadas)** — os `.mbtn` deixam de animar `all` (só cor/fundo) e ganham camada própria (`translateZ`). Isso mata o "fantasma" de repaint que, sob o header com `backdrop-filter`, duplicava a seta intermitentemente no WebView do iOS.

- **Análises (flicker ao trocar de tela)** — a revalidação stale-while-revalidate só re-renderiza se os dados mudaram, evitando reconstruir os gráficos do Chart.js a cada visita (sensação de "recarregando").

## Notas
- O seletor de mês (#3) é um artefato de repaint **intermitente** que não é reproduzível fora do device — a correção é o endurecimento clássico para iOS; precisa de re-teste no app.
- A lentidão inicial da Visão Geral é latência do backend (WebSocket), não re-fetch no frontend — fora do escopo destas mudanças.

## Cache busting
`dashboard.js` v8→v9, `dashboard.css` v2→v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT)_