### PR TITLE
Modal de detalhe do lançamento + paint instantâneo da Visão Geral

### DIFF
--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -1565,7 +1565,8 @@ body.light .ov-period-tabs { background:rgba(0,0,0,.04); }
 /* Modal de detalhe do lançamento: altura mínima + espaçamento generoso pra
    não parecer "espremido" quando há pouca informação. O botão fica ancorado
    embaixo (margin-top:auto) dando ar de limpeza. */
-.modal.launch-detail { width:min(420px,92vw);min-height:320px;display:flex;flex-direction:column; }
+.modal.launch-detail { width:min(420px,92vw);min-height:min(320px,86vh);max-height:86vh;
+  overflow:auto;display:flex;flex-direction:column; }
 .modal.launch-detail h3 { margin-bottom:14px; }
 .ld-desc { font-size:1rem;line-height:1.5;font-weight:600;color:var(--text);
   background:rgba(255,255,255,.04);border:1px solid var(--glass-border);

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -1561,6 +1561,22 @@ body.light .ov-period-tabs { background:rgba(0,0,0,.04); }
   border-radius:20px;padding:28px;width:min(360px,90vw);
   box-shadow:0 24px 60px rgba(0,0,0,.6);animation:fadeIn .25s var(--ease); }
 .modal.wide { width:min(760px,92vw);max-height:86vh;overflow:auto; }
+
+/* Modal de detalhe do lançamento: altura mínima + espaçamento generoso pra
+   não parecer "espremido" quando há pouca informação. O botão fica ancorado
+   embaixo (margin-top:auto) dando ar de limpeza. */
+.modal.launch-detail { width:min(420px,92vw);min-height:320px;display:flex;flex-direction:column; }
+.modal.launch-detail h3 { margin-bottom:14px; }
+.ld-desc { font-size:1rem;line-height:1.5;font-weight:600;color:var(--text);
+  background:rgba(255,255,255,.04);border:1px solid var(--glass-border);
+  border-radius:14px;padding:18px 16px;margin-bottom:6px;word-break:break-word; }
+.ld-meta { display:flex;flex-direction:column; }
+.ld-row { display:flex;justify-content:space-between;align-items:baseline;gap:16px;
+  padding:13px 2px;border-top:1px solid var(--div);font-size:.9rem; }
+.ld-row:first-child { border-top:none; }
+.ld-k { color:var(--text-3);flex-shrink:0; }
+.ld-v { color:var(--text);font-weight:600;text-align:right;word-break:break-word; }
+.modal.launch-detail .modal-acts { margin-top:auto;padding-top:22px; }
 .modal h3 { font-size:1rem;font-weight:650;margin-bottom:5px; }
 .modal .msub { font-size:.78rem;color:var(--text-2);margin-bottom:18px; }
 .modal-inp { width:100%;background:rgba(255,255,255,.07);border:1px solid var(--glass-border);

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,7 +20,7 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
-<link rel="stylesheet" href="/dashboard.css?v=3" />
+<link rel="stylesheet" href="/dashboard.css?v=4" />
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
 <!-- defer preserva a ordem: auth-refresh (patch do fetch) → modals → app-mode →
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=10"></script>
+<script defer src="/dashboard.js?v=11"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=11"></script>
+<script defer src="/dashboard.js?v=12"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,7 +20,7 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
-<link rel="stylesheet" href="/dashboard.css?v=4" />
+<link rel="stylesheet" href="/dashboard.css?v=5" />
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
 <!-- defer preserva a ordem: auth-refresh (patch do fetch) → modals → app-mode →
      dashboard.js. Nenhum script inline depende deles durante o parse. -->

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -277,6 +277,38 @@ function isCurrentViewData(data) {
   return Number(data?.year) === Number(viewYear) && Number(data?.month) === Number(viewMonth);
 }
 
+/* ─── Snapshot em sessionStorage: paint instantâneo entre páginas ──────────
+   O app troca /home <-> /app (Dashboard) com reload de página inteira; sem
+   isso a Visão Geral mostrava skeleton e esperava o WebSocket a cada troca.
+   Guardamos só o snapshot no ESTADO PADRÃO da aba (pág 1, filtro "all", sem
+   busca), escopado ao USER_ID. sessionStorage some quando o app é fechado de
+   vez — nada de dado financeiro gravado no disco a longo prazo. */
+function _snapSessionKey(year, month) {
+  return `pb_snap_${USER_ID}_${year}_${String(month).padStart(2, "0")}`;
+}
+function persistSnapshotToSession(data) {
+  if (!data || !data.year || !data.month || !USER_ID) return;
+  const page = data.launches_pagination?.page || 1;
+  const type = data.launches_pagination?.filter_type || "all";
+  const text = data.launches_pagination?.query || "";
+  if (page !== 1 || (type && type !== "all") || text) return; // só o estado padrão
+  try { sessionStorage.setItem(_snapSessionKey(data.year, data.month), JSON.stringify(data)); } catch {}
+}
+function restoreSnapshotFromSession() {
+  if (!USER_ID) return false;
+  try {
+    const raw = sessionStorage.getItem(_snapSessionKey(viewYear, viewMonth));
+    if (!raw) return false;
+    const data = JSON.parse(raw);
+    if (!isCurrentViewData(data)) return false;
+    lastData = data;
+    cacheMonthData(data);
+    render(data);              // pinta na hora; o WebSocket revalida em seguida
+    setLaunchesLoading(false);
+    return true;
+  } catch { return false; }
+}
+
 async function logoutDashboard() {
   try {
     await fetch(`${API}/auth/logout`, {
@@ -286,6 +318,8 @@ async function logoutDashboard() {
     });
   } catch {}
   clearMenuCache();  // não deixa o chrome de um usuário vazar pro próximo login
+  // Limpa os snapshots da sessão (defense-in-depth; já são escopados ao userId).
+  try { Object.keys(sessionStorage).forEach(k => { if (k.startsWith("pb_snap_")) sessionStorage.removeItem(k); }); } catch {}
   localStorage.setItem('finbot_logout_at', String(Date.now()));
   window.location.replace('/?logout=1');
 }
@@ -6645,6 +6679,7 @@ function connect() {
       if (!isCurrentViewData(msg.data)) return;
       lastData = msg.data;
       cacheMonthData(msg.data);
+      persistSnapshotToSession(msg.data);
       render(msg.data);
       stopSpin();
       setLaunchesLoading(false);
@@ -6655,6 +6690,7 @@ function connect() {
       if (serverYear === viewYear && serverMonth === viewMonth) {
         lastData = msg.data;
         cacheMonthData(msg.data);
+        persistSnapshotToSession(msg.data);
         render(msg.data);
         showToast();
       }
@@ -9515,6 +9551,10 @@ function _showAccessError(title, msg) {
 	  updateInvestmentRateHint();
 	  updateInvestmentTaxHint();
 	  updateMonthLabel();
+	  // Paint instantâneo: se há snapshot do mês corrente guardado na sessão
+	  // (troca de aba /home <-> /app), pinta a Visão Geral AGORA, sem esperar o
+	  // WebSocket. O connect() logo abaixo revalida e substitui pelos dados frescos.
+	  restoreSnapshotFromSession();
 	  // Dispara WS connect IMEDIATAMENTE (não espera /auth/dashboard-profile).
 	  // Antes era serial: validate → profile → connect. Agora profile + connect
 	  // rodam em paralelo, cortando ~3.5s do carregamento inicial.

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -6964,18 +6964,54 @@ function renderLaunches() {
 }
 
 // Clique numa linha da Visão Geral: abre o detalhe com a descrição COMPLETA
-// (que não cabe inteira no celular) + os campos principais. Reusa o modal
-// genérico (corpo com white-space:pre-wrap, então as quebras de linha valem).
+// (que não cabe inteira no celular) + os campos principais. Modal dedicado com
+// altura mínima e respiro — não usa o alertModal genérico (que encolhe até o
+// texto e ficava apertado com pouca informação).
+function _ensureLaunchDetailModal() {
+  if (document.getElementById("launch-detail-overlay")) return;
+  const html = `
+    <div class="overlay" id="launch-detail-overlay">
+      <div class="modal launch-detail">
+        <h3>Detalhe do lançamento</h3>
+        <div class="ld-desc" id="ld-desc"></div>
+        <div class="ld-meta" id="ld-meta"></div>
+        <div class="modal-acts">
+          <button type="button" class="btn-save" id="ld-close">Fechar</button>
+        </div>
+      </div>
+    </div>`;
+  document.body.insertAdjacentHTML("beforeend", html);
+  const ov = document.getElementById("launch-detail-overlay");
+  ov.addEventListener("click", e => { if (e.target === ov) closeLaunchDetail(); });
+  document.getElementById("ld-close").addEventListener("click", closeLaunchDetail);
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape" && ov.classList.contains("open")) closeLaunchDetail();
+  });
+}
+
+function closeLaunchDetail() {
+  const ov = document.getElementById("launch-detail-overlay");
+  if (ov) ov.classList.remove("open");
+}
+
 function openLaunchDetail(idx) {
   const l = (_renderedLaunches || [])[idx];
   if (!l) return;
+  _ensureLaunchDetailModal();
   const typeLabel = LAUNCH_TYPE_LABELS[l.tipo] || String(l.tipo || "").replaceAll("_", " ");
   const desc = describeLaunch(l).replace(/<[^>]+>/g, "").trim() || "—";
-  const lines = [desc, "", `Valor: ${fmt(l.valor)}`, `Tipo: ${typeLabel}`];
-  if (l.categoria) lines.push(`Categoria: ${l.categoria}`);
-  if (l.is_internal_movement) lines.push("Movimentação interna");
-  lines.push(`Data: ${fmtDate(l.criado_em)}`);
-  alertModal(lines.join("\n"), { title: "Detalhe do lançamento", okText: "Fechar" });
+  document.getElementById("ld-desc").textContent = desc;
+
+  const rows = [["Valor", fmt(l.valor)], ["Tipo", typeLabel]];
+  if (l.categoria) rows.push(["Categoria", l.categoria]);
+  if (l.is_internal_movement) rows.push(["Movimentação", "interna"]);
+  rows.push(["Data", fmtDate(l.criado_em)]);
+  document.getElementById("ld-meta").innerHTML = rows.map(([k, v]) =>
+    `<div class="ld-row"><span class="ld-k">${escapeHtmlSafe(k)}</span>` +
+    `<span class="ld-v">${escapeHtmlSafe(String(v))}</span></div>`
+  ).join("");
+
+  document.getElementById("launch-detail-overlay").classList.add("open");
 }
 
 /* ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Resumo
Dois ajustes de UX no dashboard, a partir do teste no app iOS.

## 1) Modal de detalhe do lançamento (tamanho mínimo e respiro)
O modal que abre ao clicar num lançamento variava de tamanho conforme o texto e ficava apertado com pouca informação.
- **Modal dedicado** (não usa mais o `alertModal` genérico).
- **Altura mínima** com botão **Fechar** ancorado no rodapé — ar de limpeza mesmo com poucos campos.
- Descrição completa em bloco destacado; campos (valor, tipo, categoria, movimentação, data) em linhas com divisores.
- `max-height:86vh` + `overflow:auto` e `min-height:min(320px,86vh)` para não cortar em telas baixas (celular em paisagem).
- Fecha por botão, clique no backdrop ou **Esc**. Não afeta os demais alertas.

## 2) Paint instantâneo da Visão Geral entre trocas de aba
No app, a tabbar troca `/home` ↔ `/app` com **reload de página inteira**, então a Visão Geral mostrava skeleton e esperava o WebSocket a cada troca.
- Guarda o snapshot do mês corrente (estado padrão: pág 1, filtro "all", sem busca) em **sessionStorage**, escopado ao `USER_ID`.
- No load, pinta a tela na hora; o WebSocket revalida e substitui pelos dados frescos.
- **sessionStorage** some ao fechar o app — nada de dado financeiro gravado no disco a longo prazo. Limpo também no logout.

## Cache busting
`dashboard.js` v10→v12, `dashboard.css` v3→v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT