### PR TITLE
feat(agents): energia por agente com orçamento por plano

### DIFF
--- a/core/services/plan_limits.py
+++ b/core/services/plan_limits.py
@@ -37,24 +37,37 @@ class PlanLimits(TypedDict):
     image_ocr_enabled: bool             # leitura de cupom/comprovante por IA
     bills_enabled: bool                 # agenda de boletos / contas a pagar
     of_banks_max: int | None            # bancos conectáveis no Open Finance (0 = sem OF)
-    agents_max: int | None              # agentes do Piggy ativos (prateleira futura)
+    agents_max: int | None              # teto de agentes ativos (legado; hoje o limite real é a energia)
+    agents_energy_budget: int           # orçamento de energia p/ ativar agentes (0 = sem agentes)
 
 
 # Ordem canônica da escada. Comparações de tier usam este ranking.
 TIER_ORDER: dict[str, int] = {"free": 0, "essencial": 1, "plus": 2, "pro": 3}
 
-# Tier mínimo POR AGENTE (escada v2). Prateleira começa no Plus — Grátis e
-# Essencial têm 0 agentes (decisão 2026-08-06). Fase A = Plus+; Fase B
-# (detetive/cofre/barao, quando existirem) = Pro+. Kind não mapeado cai em
-# "pro" por segurança. Fonte única: rotas E runners leem daqui.
-AGENT_KIND_MIN_TIER: dict[str, str] = {
-    "xerife": "plus",
-    "reporter": "plus",
-    "carteiro": "plus",
-    "detetive": "pro",   # Fase B: caça-assinaturas (tier Pro/pro_max)
-    "cofre": "pro",      # Fase B: Banqueiro (aporte na caixinha OF → meta)
-    "barao": "pro",      # Fase B: Barão (dinheiro parado vs CDI)
+# Custo de ENERGIA de cada agente (modelo 2026-08-13). Calibrado por quanto o
+# agente custa pra gente rodar: frequência + dependência de Open Finance + peso
+# de processamento. Os leves (leitura mensal) custam 1; os pesados (varredura
+# contínua de histórico OF) custam 3. Fonte única: rotas, runners e UI leem daqui.
+#
+# Regra dos planos (todos os agentes ficam liberados em Plus e Pro; o limitador
+# é a energia): Plus tem orçamento 4 → cabem os 3 baratos (1+1+2), ou 2 se um
+# for caro (⚡3). Pro tem 12 → cabem os 6 (1+1+2+2+3+3). Grátis/Essencial = 0.
+AGENT_ENERGY_COST: dict[str, int] = {
+    "reporter": 1,   # mensal, só lê o mês fechado
+    "carteiro": 1,   # contínuo, mas só checa data de boleto
+    "xerife": 2,     # diário + a cada sync, análise de anomalia
+    "barao": 2,      # mensal, mas depende de Open Finance
+    "detetive": 3,   # contínuo + varre 6 meses de histórico OF a cada sync
+    "cofre": 3,      # contínuo + acompanha caixinhas OF a cada sync
 }
+
+# Custo default de kind não mapeado: o mais caro, por segurança.
+_DEFAULT_AGENT_ENERGY_COST = 3
+
+
+def agent_energy_cost(kind: str) -> int:
+    """Energia que ativar este agente consome. Kind desconhecido → custo máximo."""
+    return AGENT_ENERGY_COST.get(kind, _DEFAULT_AGENT_ENERGY_COST)
 
 
 # Escada FINAL v3 (2026-08-06): Grátis R$0 · Essencial 9,90 · Plus 19,90 ·
@@ -81,6 +94,7 @@ FREE_LIMITS: PlanLimits = {
     "bills_enabled": False,
     "of_banks_max": 0,                   # Grátis não tem Open Finance (trial usa o tier assinado)
     "agents_max": 0,                     # Grátis não tem agentes (trial usa o tier assinado)
+    "agents_energy_budget": 0,           # Grátis não tem energia p/ agentes
 }
 
 
@@ -102,6 +116,7 @@ ESSENCIAL_LIMITS: PlanLimits = {
     "bills_enabled": True,
     "of_banks_max": 1,                   # 1 conexão viva (pode trocar de banco)
     "agents_max": 0,                     # prateleira de agentes começa no Plus
+    "agents_energy_budget": 0,           # Essencial ainda não tem energia p/ agentes
 }
 
 
@@ -122,7 +137,8 @@ PLUS_LIMITS: PlanLimits = {
     "image_ocr_enabled": True,
     "bills_enabled": True,
     "of_banks_max": 2,
-    "agents_max": 3,                     # Xerife + Repórter + Carteiro
+    "agents_max": 3,                     # legado (headline "até 3"); o limite real é a energia
+    "agents_energy_budget": 4,           # cabem os 3 baratos (1+1+2), ou 2 se um for caro (⚡3)
 }
 
 
@@ -130,7 +146,8 @@ PRO_LIMITS: PlanLimits = {
     **PLUS_LIMITS,
     "history_days": 730,                 # 24 meses
     "of_banks_max": 5,
-    "agents_max": 6,                     # + Detetive, Banqueiro (kind "cofre"), Barão
+    "agents_max": 6,                     # legado; o limite real é a energia
+    "agents_energy_budget": 12,          # cabem os 6 (1+1+2+2+3+3)
 }
 
 

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -356,9 +356,13 @@ def agents_energy_budget(user_id: int) -> int:
     limita quantos você ativa é a energia. Plus 4 / Pro 12 / Grátis e Essencial 0.
     Com v2 OFF devolve o orçamento do Plus pra quem é pago (is_pro), senão 0 —
     espelhando a semântica legada (pago ativa agentes, grátis não)."""
-    from .plan_limits import PLUS_LIMITS
+    from .plan_limits import PLUS_LIMITS, PRO_LIMITS
     if not plans_v2_enabled():
         return PLUS_LIMITS["agents_energy_budget"] if is_pro(user_id) else 0
+    # Testers do beta usam TODOS os agentes, independe do tier (mesma isenção do
+    # agent_kind_allowed) → orçamento cheio (Pro) pra caber a equipe inteira.
+    if agents_beta_tester(int(user_id)):
+        return PRO_LIMITS["agents_energy_budget"]
     return int(get_user_limits(user_id).get("agents_energy_budget", 0))
 
 

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -349,24 +349,38 @@ def feature_enabled(user_id: int, key: str) -> bool:
     return bool(get_user_limits(user_id).get(key, False))
 
 
+def agents_energy_budget(user_id: int) -> int:
+    """Orçamento de energia do tier pra ativar agentes (0 = sem agentes).
+
+    Modelo 2026-08-13: todos os agentes ficam liberados em Plus e Pro; quem
+    limita quantos você ativa é a energia. Plus 4 / Pro 12 / Grátis e Essencial 0.
+    Com v2 OFF devolve o orçamento do Plus pra quem é pago (is_pro), senão 0 —
+    espelhando a semântica legada (pago ativa agentes, grátis não)."""
+    from .plan_limits import PLUS_LIMITS
+    if not plans_v2_enabled():
+        return PLUS_LIMITS["agents_energy_budget"] if is_pro(user_id) else 0
+    return int(get_user_limits(user_id).get("agents_energy_budget", 0))
+
+
 def agent_kind_allowed(user_id: int, kind: str) -> bool:
-    """O tier do usuário dá direito a este agente? (escada v2: 0/0/3/6).
+    """O tier do usuário dá direito a AGENTES? (modelo de energia: Plus/Pro sim,
+    Grátis/Essencial não). Sem trava por kind — todos os agentes ficam liberados
+    nos tiers com energia; quem limita quantos é o orçamento (checado na
+    ativação). O `kind` fica na assinatura por compat com os call sites.
 
     Com v2 OFF devolve True — o gate legado (Free 1 / Plus+ todos) mora na
     rota de ativação e os runners não filtravam por plano no v1.
     Usado pelos RUNNERS também: agente ativado no trial para de disparar
-    quando o usuário cai pro Grátis."""
+    quando o usuário cai pro Grátis (orçamento 0)."""
     if not plans_v2_enabled():
         return True
     # Testers do beta usam QUALQUER agente, independe do tier — pra o plano de
-    # teste (Lucas/Hiago) conseguir ver os agentes Pro (ex.: Detetive) sem
-    # precisar assinar. Não afeta o público: agents_beta_tester ignora o flag
-    # global e só casa com o allowlist explícito.
+    # teste (Lucas/Hiago) conseguir ver todos os agentes sem precisar assinar.
+    # Não afeta o público: agents_beta_tester ignora o flag global e só casa com
+    # o allowlist explícito.
     if agents_beta_tester(int(user_id)):
         return True
-    from .plan_limits import AGENT_KIND_MIN_TIER
-    minimum = AGENT_KIND_MIN_TIER.get(kind, "pro")
-    return tier_at_least(get_plan_tier(int(user_id)), minimum)
+    return agents_energy_budget(int(user_id)) > 0
 
 
 def require_min_tier(user_id: int, minimum: str) -> bool:

--- a/db/agents.py
+++ b/db/agents.py
@@ -64,23 +64,44 @@ def count_active_agents(user_id: int) -> int:
 
 
 def activate_agent(
-    user_id: int, kind: str, config: dict | None = None, allow_multiple: bool = True
+    user_id: int, kind: str, config: dict | None = None, allow_multiple: bool = True,
+    energy_budget: int | None = None, energy_cost_by_kind: dict[str, int] | None = None,
 ) -> dict[str, Any] | None:
     """Cria (ou reativa) o agente. Upsert idempotente por (user_id, kind).
 
-    Com `allow_multiple=False` (plano sem direito a vários agentes), a checagem
-    de limite e a ativação acontecem na MESMA transação, serializadas por um
-    advisory lock por usuário — senão duas ativações concorrentes de kinds
-    diferentes leem count=0 e ambas ativam, furando o teto do Free (TOCTOU).
-    Retorna None quando o limite bloqueia (o usuário já tem outro agente ativo).
-    Reativar o MESMO kind nunca conta como novo agente (kind <> %s no count).
+    Dois modos de gate, ambos serializados por um advisory lock por usuário pra
+    fechar o TOCTOU (duas ativações concorrentes lendo o mesmo estado e furando
+    o limite):
+
+      • energy_budget != None (modelo de energia): soma o custo dos agentes já
+        ativos (fora o próprio kind) e bloqueia se `usado + custo(kind) > budget`.
+        Reativar o MESMO kind não recontabiliza (ele fica de fora da soma).
+      • allow_multiple=False (legado v1/v2-off): teto binário — bloqueia se já
+        houver QUALQUER outro agente ativo.
+
+    Retorna None quando o gate bloqueia. Reativar o MESMO kind nunca é bloqueado
+    (kind <> %s exclui o próprio da checagem).
     """
     if kind not in AGENT_KINDS:
         raise ValueError(f"kind inválido: {kind}")
     cfg = json.dumps(config or {})
     with get_conn() as conn:
         with conn.cursor() as cur:
-            if not allow_multiple:
+            if energy_budget is not None:
+                # Lock por usuário (liberado no fim da transação). hashtext→int4,
+                # promovido a bigint pela assinatura de 1 arg da função.
+                cur.execute("select pg_advisory_xact_lock(hashtext(%s))", (f"agent_activate:{user_id}",))
+                cur.execute(
+                    "select kind from agents"
+                    " where user_id=%s and status='active' and kind <> %s",
+                    (user_id, kind),
+                )
+                costs = energy_cost_by_kind or {}
+                used = sum(int(costs.get(r["kind"], 0)) for r in (cur.fetchall() or []))
+                if used + int(costs.get(kind, 0)) > int(energy_budget):
+                    conn.rollback()
+                    return None
+            elif not allow_multiple:
                 # Lock por usuário (liberado no fim da transação). hashtext→int4,
                 # promovido a bigint pela assinatura de 1 arg da função.
                 cur.execute("select pg_advisory_xact_lock(hashtext(%s))", (f"agent_activate:{user_id}",))

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -2108,7 +2108,6 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
 .ag-dot-on { background: var(--neon); }
 .ag-dot-off { background: var(--text-3); }
 .ag-dot-fire { background: var(--purple); }
-.ag-money { color: var(--neon); font-weight: 700; }
 
 .ag-shelf { display: grid; grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); gap: 14px; }
 .ag-card {
@@ -2124,7 +2123,6 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
 .ag-chips { display: flex; gap: 6px; flex-wrap: wrap; }
 .ag-chip { font-size: 10.5px; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--glass-border); color: var(--text-2); }
 .ag-chip-fire { border-color: rgba(255, 201, 77, .4); color: #FFC94D; }
-.ag-chip-money { border-color: rgba(198, 241, 26, .4); color: var(--neon); }
 
 .ag-avatar {
   border-radius: 14px; aspect-ratio: 1.35; overflow: hidden;

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -2109,6 +2109,22 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
 .ag-dot-off { background: var(--text-3); }
 .ag-dot-fire { background: var(--purple); }
 
+/* Medidor de energia do plano (Plus/Pro). Ocupa a linha toda abaixo dos contadores. */
+.ag-energy {
+  flex-basis: 100%;
+  display: inline-flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  margin-top: 4px; padding: 8px 12px;
+  background: var(--glass-bg); border: 1px solid var(--glass-border); border-radius: 12px;
+}
+.ag-energy-over { border-color: rgba(255, 45, 142, .5); }
+.ag-energy-label { font-size: 12.5px; color: var(--text-2); }
+.ag-energy-label b { color: var(--text); font-variant-numeric: tabular-nums; }
+.ag-pips { display: inline-flex; gap: 4px; }
+.ag-pip { width: 20px; height: 9px; border-radius: 3px; background: rgba(255, 255, 255, .1); }
+.ag-pip-on { background: linear-gradient(90deg, #FFC94D, #ffe08a); box-shadow: 0 0 8px rgba(255, 201, 77, .4); }
+.ag-pip-over { background: linear-gradient(90deg, var(--purple), #ff7ab6); }
+.ag-energy-hint { font-size: 11px; color: var(--text-3); }
+
 .ag-shelf { display: grid; grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); gap: 14px; }
 .ag-card {
   background: var(--glass-bg); border: 1px solid var(--glass-border);
@@ -2123,6 +2139,7 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
 .ag-chips { display: flex; gap: 6px; flex-wrap: wrap; }
 .ag-chip { font-size: 10.5px; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--glass-border); color: var(--text-2); }
 .ag-chip-fire { border-color: rgba(255, 201, 77, .4); color: #FFC94D; }
+.ag-chip-energy { border-color: rgba(255, 201, 77, .45); color: #FFC94D; font-weight: 700; }
 
 .ag-avatar {
   border-radius: 14px; aspect-ratio: 1.35; overflow: hidden;
@@ -2148,6 +2165,7 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
 .ag-btn-on:hover { filter: brightness(1.08); }
 .ag-btn-active { background: transparent; border-color: var(--neon); color: var(--neon); }
 .ag-btn-soon { background: var(--glass-bg); color: var(--text-3); cursor: default; }
+.ag-btn-noenergy { background: var(--glass-bg); color: var(--text-3); border-color: var(--glass-border); cursor: not-allowed; }
 
 .ag-feed-title { margin: 26px 0 12px; }
 .ag-feed { display: flex; flex-direction: column; gap: 10px; max-width: 760px; }

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9475,6 +9475,10 @@ function _renderAgentes(data) {
   if (!shelf) return;
 
   const s = data.summary || {};
+  // Modelo de energia só vale com a escada v2 ligada (energy_enabled). Com v2 off
+  // (freio de emergência) o gate legado decide e a UI não mostra medidor nem
+  // trava por energia — senão travaria botões que o backend legado aceitaria.
+  const energyOn = data.energy_enabled === true;
   const budget = Number(data.energy_budget || 0);
   const used = Number(data.energy_used || 0);
   if (counters) {
@@ -9482,7 +9486,7 @@ function _renderAgentes(data) {
       <span class="ag-counter"><i class="ag-dot ag-dot-on"></i> Ativos <b>${s.ativos || 0}</b></span>
       <span class="ag-counter"><i class="ag-dot ag-dot-off"></i> Pausados <b>${s.pausados || 0}</b></span>
       <span class="ag-counter"><i class="ag-dot ag-dot-fire"></i> Disparos <b>${s.disparos_mes || 0}</b></span>
-      ${_energyMeter(used, budget)}
+      ${energyOn ? _energyMeter(used, budget) : ""}
     `;
   }
 
@@ -9491,14 +9495,14 @@ function _renderAgentes(data) {
     const cost = Number(card.energy_cost || 0);
     const chips = [
       `<span class="ag-chip">${esc(card.freq)}</span>`,
-      (card.disponivel && cost > 0) ? `<span class="ag-chip ag-chip-energy"><i class="ph ph-lightning" aria-hidden="true"></i> ${cost}</span>` : "",
+      (energyOn && card.disponivel && cost > 0) ? `<span class="ag-chip ag-chip-energy"><i class="ph ph-lightning" aria-hidden="true"></i> ${cost}</span>` : "",
     ].filter(Boolean).join("");
     // can_activate vem do backend (Grátis/Essencial: orçamento 0 → sem agentes).
     // Gate visível: o botão vira cadeado que abre o upgrade direto.
     const canActivate = data.can_activate !== false;
-    // Modelo de energia: com plano, todos os agentes ficam liberados, mas só
-    // ativa quem ainda cabe no orçamento (usado + custo <= orçamento).
-    const affordable = used + cost <= budget;
+    // Energia: com plano, todos os agentes ficam liberados, mas só ativa quem
+    // ainda cabe no orçamento. Com v2 off (energyOn false), nunca trava por aqui.
+    const affordable = !energyOn || (used + cost <= budget);
     const btn = !card.disponivel
       ? `<button class="ag-btn ag-btn-soon" disabled>Em breve</button>`
       : active
@@ -9506,7 +9510,7 @@ function _renderAgentes(data) {
         : !canActivate
           ? `<button class="ag-btn ag-btn-on" onclick="showUpgradeModal('agents')"><i class="ph ph-lock" aria-hidden="true"></i> Ativar</button>`
           : affordable
-            ? `<button class="ag-btn ag-btn-on" onclick="activateAgent('${card.kind}')">Ativar · <i class="ph ph-lightning" aria-hidden="true"></i> ${cost}</button>`
+            ? `<button class="ag-btn ag-btn-on" onclick="activateAgent('${card.kind}')">Ativar${energyOn && cost > 0 ? ` · <i class="ph ph-lightning" aria-hidden="true"></i> ${cost}` : ""}</button>`
             : `<button class="ag-btn ag-btn-noenergy" disabled title="Pause um agente ou vá pro Pro"><i class="ph ph-lightning-slash" aria-hidden="true"></i> Sem energia</button>`;
     // Opt-out por agente: quando ativo, deixa ligar/desligar o e-mail (o feed
     // continua). Padrão = ligado. Estilo inline pra não exigir bump de cache CSS.

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9475,31 +9475,39 @@ function _renderAgentes(data) {
   if (!shelf) return;
 
   const s = data.summary || {};
+  const budget = Number(data.energy_budget || 0);
+  const used = Number(data.energy_used || 0);
   if (counters) {
     counters.innerHTML = `
       <span class="ag-counter"><i class="ag-dot ag-dot-on"></i> Ativos <b>${s.ativos || 0}</b></span>
       <span class="ag-counter"><i class="ag-dot ag-dot-off"></i> Pausados <b>${s.pausados || 0}</b></span>
       <span class="ag-counter"><i class="ag-dot ag-dot-fire"></i> Disparos <b>${s.disparos_mes || 0}</b></span>
+      ${_energyMeter(used, budget)}
     `;
   }
 
   shelf.innerHTML = (data.catalog || []).map(card => {
     const active = card.status === "active";
+    const cost = Number(card.energy_cost || 0);
     const chips = [
       `<span class="ag-chip">${esc(card.freq)}</span>`,
-      card.fired_30d > 0 ? `<span class="ag-chip ag-chip-fire"><i class="ph ph-lightning" aria-hidden="true"></i> ${card.fired_30d}</span>` : "",
+      (card.disponivel && cost > 0) ? `<span class="ag-chip ag-chip-energy"><i class="ph ph-lightning" aria-hidden="true"></i> ${cost}</span>` : "",
     ].filter(Boolean).join("");
-    // can_activate vem do backend (escada v2: Grátis/Essencial não ativam).
-    // Gate visível: o card aparece normal, mas o botão vira cadeado que abre o
-    // upgrade direto — sem POST fadado a 403. Ausente (backend antigo) = true.
+    // can_activate vem do backend (Grátis/Essencial: orçamento 0 → sem agentes).
+    // Gate visível: o botão vira cadeado que abre o upgrade direto.
     const canActivate = data.can_activate !== false;
+    // Modelo de energia: com plano, todos os agentes ficam liberados, mas só
+    // ativa quem ainda cabe no orçamento (usado + custo <= orçamento).
+    const affordable = used + cost <= budget;
     const btn = !card.disponivel
       ? `<button class="ag-btn ag-btn-soon" disabled>Em breve</button>`
       : active
         ? `<button class="ag-btn ag-btn-active" onclick="pauseAgent('${card.kind}')"><i class="ph ph-check" aria-hidden="true"></i> Ativo · Pausar</button>`
-        : canActivate
-          ? `<button class="ag-btn ag-btn-on" onclick="activateAgent('${card.kind}')">Ativar</button>`
-          : `<button class="ag-btn ag-btn-on" onclick="showUpgradeModal('agents')"><i class="ph ph-lock" aria-hidden="true"></i> Ativar</button>`;
+        : !canActivate
+          ? `<button class="ag-btn ag-btn-on" onclick="showUpgradeModal('agents')"><i class="ph ph-lock" aria-hidden="true"></i> Ativar</button>`
+          : affordable
+            ? `<button class="ag-btn ag-btn-on" onclick="activateAgent('${card.kind}')">Ativar · <i class="ph ph-lightning" aria-hidden="true"></i> ${cost}</button>`
+            : `<button class="ag-btn ag-btn-noenergy" disabled title="Pause um agente ou vá pro Pro"><i class="ph ph-lightning-slash" aria-hidden="true"></i> Sem energia</button>`;
     // Opt-out por agente: quando ativo, deixa ligar/desligar o e-mail (o feed
     // continua). Padrão = ligado. Estilo inline pra não exigir bump de cache CSS.
     const emailOn = ((card.config || {}).email_enabled) !== false;
@@ -9566,6 +9574,25 @@ function _agentName(kind) {
   return card ? card.nome : kind;
 }
 
+// Medidor de energia do plano: pips preenchidos = energia usada. Só aparece
+// pra quem tem orçamento (Plus/Pro); Grátis/Essencial (0) não veem barra.
+function _energyMeter(used, budget) {
+  if (!budget || budget <= 0) return "";
+  const over = used > budget;
+  let pips = "";
+  for (let i = 0; i < budget; i++) {
+    const on = i < used;
+    pips += `<i class="ag-pip${on ? (over ? " ag-pip-over" : " ag-pip-on") : ""}"></i>`;
+  }
+  const rem = budget - used;
+  const hint = over ? "acima do plano" : (rem > 0 ? `${rem} sobrando` : "cheio");
+  return `<span class="ag-energy${over ? " ag-energy-over" : ""}">
+    <span class="ag-energy-label"><i class="ph ph-lightning" aria-hidden="true"></i> Energia <b>${used}/${budget}</b></span>
+    <span class="ag-pips">${pips}</span>
+    <span class="ag-energy-hint">${hint}</span>
+  </span>`;
+}
+
 async function activateAgent(kind) {
   try {
     const res = await fetch(`${API}/agents/${USER_ID}/${kind}/activate`, {
@@ -9574,8 +9601,13 @@ async function activateAgent(kind) {
       body: JSON.stringify({}),
     });
     const data = await readResponsePayload(res);
-    if (res.status === 403 && (data.detail || {}).error === "pro_required") {
+    const detail = data.detail || {};
+    if (res.status === 403 && detail.error === "pro_required") {
       showUpgradeModal("agents");
+      return;
+    }
+    if (res.status === 403 && detail.error === "no_energy") {
+      alert("⚡ Sem energia no seu plano pra ativar mais esse agente. Pause um que você usa menos, ou vá pro Pro pra ter energia pra todos.");
       return;
     }
     if (!res.ok) throw new Error((data.detail && data.detail.error) || data.detail || "Não deu pra ativar o agente.");

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9480,7 +9480,6 @@ function _renderAgentes(data) {
       <span class="ag-counter"><i class="ag-dot ag-dot-on"></i> Ativos <b>${s.ativos || 0}</b></span>
       <span class="ag-counter"><i class="ag-dot ag-dot-off"></i> Pausados <b>${s.pausados || 0}</b></span>
       <span class="ag-counter"><i class="ag-dot ag-dot-fire"></i> Disparos <b>${s.disparos_mes || 0}</b></span>
-      ${s.salvos_ano > 0 ? `<span class="ag-counter ag-money"><i class="ph ph-coins" aria-hidden="true"></i> ${fmt(s.salvos_ano)} salvos</span>` : ""}
     `;
   }
 
@@ -9489,7 +9488,6 @@ function _renderAgentes(data) {
     const chips = [
       `<span class="ag-chip">${esc(card.freq)}</span>`,
       card.fired_30d > 0 ? `<span class="ag-chip ag-chip-fire"><i class="ph ph-lightning" aria-hidden="true"></i> ${card.fired_30d}</span>` : "",
-      card.saved_365d > 0 ? `<span class="ag-chip ag-chip-money"><i class="ph ph-coins" aria-hidden="true"></i> ${fmtShort(card.saved_365d)}</span>` : "",
     ].filter(Boolean).join("");
     // can_activate vem do backend (escada v2: Grátis/Essencial não ativam).
     // Gate visível: o card aparece normal, mas o botão vira cadeado que abre o

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -96,7 +96,7 @@
             <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;19,90</span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;199</span></div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>2&nbsp;bancos conectados</strong> (Open&nbsp;Finance)</span></li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>3&nbsp;agentes</strong>: Xerife, Repórter e Carteiro</span></li>
+              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Agentes</strong>: energia pra até 3 — você escolhe quais</span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA sem limites</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Alertas de gastos fora do padrão</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Histórico de 12 meses + tudo do Essencial</li>
@@ -110,7 +110,7 @@
             <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;49,90</span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;499</span></div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>5&nbsp;bancos conectados</strong></span></li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>6&nbsp;agentes</strong>: + Detetive, Banqueiro e Barão</span></li>
+              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Todos os 6 agentes</strong>: energia pra rodar a equipe inteira</span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Previsão de saldo 30/60/90 dias</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Histórico de 24 meses</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Cobranças duplicadas e caça-assinaturas</li>

--- a/frontend/preview_agentes.html
+++ b/frontend/preview_agentes.html
@@ -40,14 +40,12 @@ const fmtShort = v => "R$ " + v;
 document.getElementById("agentes-counters").innerHTML = `
   <span class="ag-counter"><i class="ag-dot ag-dot-on"></i> Ativos <b>2</b></span>
   <span class="ag-counter"><i class="ag-dot ag-dot-off"></i> Pausados <b>0</b></span>
-  <span class="ag-counter"><i class="ag-dot ag-dot-fire"></i> Disparos <b>7</b></span>
-  <span class="ag-counter ag-money">💰 R$ 340 salvos</span>`;
+  <span class="ag-counter"><i class="ag-dot ag-dot-fire"></i> Disparos <b>7</b></span>`;
 document.getElementById("agentes-shelf").innerHTML = catalog.map(card => {
   const active = card.status === "active";
   const chips = [
     `<span class="ag-chip">${esc(card.freq)}</span>`,
     card.fired_30d > 0 ? `<span class="ag-chip ag-chip-fire">⚡ ${card.fired_30d}</span>` : "",
-    card.saved_365d > 0 ? `<span class="ag-chip ag-chip-money">💰 ${fmtShort(card.saved_365d)}</span>` : "",
   ].join("");
   const btn = !card.disponivel
     ? `<button class="ag-btn ag-btn-soon" disabled>Em breve</button>`

--- a/frontend/routes/agents.py
+++ b/frontend/routes/agents.py
@@ -114,21 +114,26 @@ async def agents_shelf_route(request: Request, user_id: int):
     _require_agents_beta(user_id)
     from db import agents_summary, list_agents
     from core.services.plan_limits import agent_energy_cost
-    from core.services.plan_service import agents_energy_budget
+    from core.services.plan_service import agents_energy_budget, plans_v2_enabled
 
-    mine, summary, multi, energy_budget = await asyncio.gather(
+    # Modelo de energia SÓ vale com a escada v2 ligada. Com v2 off (freio de
+    # emergência), o gate legado decide (Free 1 agente / pago todos) e a UI não
+    # deve mostrar medidor nem travar por energia — senão trava botões que o
+    # backend legado aceitaria.
+    energy_enabled = plans_v2_enabled()
+    mine, summary, multi = await asyncio.gather(
         asyncio.to_thread(list_agents, user_id),
         asyncio.to_thread(agents_summary, user_id),
         asyncio.to_thread(_plan_allows_multiple, user_id),
-        asyncio.to_thread(agents_energy_budget, user_id),
     )
+    energy_budget = await asyncio.to_thread(agents_energy_budget, user_id) if energy_enabled else 0
     by_kind = {a["kind"]: a for a in mine}
     catalog = []
     energy_used = 0
     for card in AGENT_CATALOG:
         mine_a = by_kind.get(card["kind"])
         status = (mine_a or {}).get("status")
-        cost = agent_energy_cost(card["kind"]) if card.get("disponivel") else 0
+        cost = agent_energy_cost(card["kind"]) if (energy_enabled and card.get("disponivel")) else 0
         if status == "active":
             energy_used += cost
         catalog.append({
@@ -139,12 +144,12 @@ async def agents_shelf_route(request: Request, user_id: int):
             "saved_365d": float((mine_a or {}).get("saved_365d") or 0),
             "energy_cost": cost,
         })
-    # v2: Grátis/Essencial veem a prateleira mas não ativam (gates visíveis →
-    # descoberta/conversão); can_activate deixa o front desenhar o cadeado.
-    v2_on, v2_allowed = await asyncio.to_thread(_v2_agents_gate, user_id, None)
-    can_activate = v2_allowed if v2_on else True
+    # v2: Grátis/Essencial veem a prateleira mas não ativam (orçamento 0 → cadeado
+    # que abre o upgrade). Com v2 off, o gate legado libera (can_activate True).
+    can_activate = (energy_budget > 0) if energy_enabled else True
     return {"ok": True, "summary": summary, "catalog": catalog,
             "multi_allowed": multi, "can_activate": can_activate,
+            "energy_enabled": energy_enabled,
             "energy_budget": int(energy_budget), "energy_used": int(energy_used)}
 
 

--- a/frontend/routes/agents.py
+++ b/frontend/routes/agents.py
@@ -82,21 +82,18 @@ def _plan_allows_multiple(user_id: int) -> bool:
 
 
 def _v2_agents_gate(user_id: int, kind: str | None = None) -> tuple[bool, bool]:
-    """(v2_ativo, permitido). Com a escada ligada, o direito é por tier e por
-    kind (fonte única: AGENT_KIND_MIN_TIER em plan_limits): Grátis/Essencial =
-    nenhum agente; Plus = detectores da Fase A; Pro+ = todos. Com v2 off
-    devolve (False, True) — gate legado decide."""
+    """(v2_ativo, tem_direito_a_agentes). Modelo de energia: todos os agentes
+    ficam liberados em Plus e Pro (sem trava por kind); Grátis/Essencial não têm
+    energia (orçamento 0) → nenhum agente. Este gate só responde "o tier permite
+    agentes?"; QUANTOS cabem é a energia, checada na ativação. Com v2 off devolve
+    (False, True) — gate legado decide."""
     try:
-        from core.services.plan_service import (
-            plans_v2_enabled, require_min_tier, agent_kind_allowed,
-        )
+        from core.services.plan_service import plans_v2_enabled, agents_energy_budget
     except ImportError:
         return False, True
     if not plans_v2_enabled():
         return False, True
-    if kind is None:
-        return True, require_min_tier(user_id, "plus")
-    return True, agent_kind_allowed(user_id, kind)
+    return True, agents_energy_budget(user_id) > 0
 
 
 class ActivateBody(BaseModel):
@@ -116,29 +113,39 @@ async def agents_shelf_route(request: Request, user_id: int):
     shared.authorize_dashboard_access(request, user_id)
     _require_agents_beta(user_id)
     from db import agents_summary, list_agents
+    from core.services.plan_limits import agent_energy_cost
+    from core.services.plan_service import agents_energy_budget
 
-    mine, summary, multi = await asyncio.gather(
+    mine, summary, multi, energy_budget = await asyncio.gather(
         asyncio.to_thread(list_agents, user_id),
         asyncio.to_thread(agents_summary, user_id),
         asyncio.to_thread(_plan_allows_multiple, user_id),
+        asyncio.to_thread(agents_energy_budget, user_id),
     )
     by_kind = {a["kind"]: a for a in mine}
     catalog = []
+    energy_used = 0
     for card in AGENT_CATALOG:
         mine_a = by_kind.get(card["kind"])
+        status = (mine_a or {}).get("status")
+        cost = agent_energy_cost(card["kind"]) if card.get("disponivel") else 0
+        if status == "active":
+            energy_used += cost
         catalog.append({
             **card,
-            "status": (mine_a or {}).get("status"),
+            "status": status,
             "config": (mine_a or {}).get("config") or {},
             "fired_30d": int((mine_a or {}).get("fired_30d") or 0),
             "saved_365d": float((mine_a or {}).get("saved_365d") or 0),
+            "energy_cost": cost,
         })
     # v2: Grátis/Essencial veem a prateleira mas não ativam (gates visíveis →
     # descoberta/conversão); can_activate deixa o front desenhar o cadeado.
     v2_on, v2_allowed = await asyncio.to_thread(_v2_agents_gate, user_id, None)
     can_activate = v2_allowed if v2_on else True
     return {"ok": True, "summary": summary, "catalog": catalog,
-            "multi_allowed": multi, "can_activate": can_activate}
+            "multi_allowed": multi, "can_activate": can_activate,
+            "energy_budget": int(energy_budget), "energy_used": int(energy_used)}
 
 
 @router.post("/agents/{user_id}/{kind}/activate")
@@ -153,29 +160,37 @@ async def agents_activate_route(request: Request, user_id: int, kind: str, body:
             else "Agente desconhecido."
         raise HTTPException(status_code=400, detail=detail)
 
-    # Escada v2: gate por tier e por kind ANTES de qualquer coisa — Grátis e
-    # Essencial não ativam agente nenhum (0 na escada); Plus ativa os 3 da
-    # Fase A; kinds avançados (Fase B) exigirão Pro.
+    # Modelo de energia: Grátis/Essencial não têm energia (orçamento 0) → nenhum
+    # agente. Plus/Pro têm todos os agentes liberados; QUANTOS cabem é a energia,
+    # enforçada dentro de activate_agent (mesma transação, fecha o TOCTOU).
     v2_on, v2_allowed = await asyncio.to_thread(_v2_agents_gate, user_id, kind)
     if v2_on and not v2_allowed:
+        # Tier sem energia p/ agentes (Grátis/Essencial) → modal de upgrade.
         raise HTTPException(status_code=403, detail={"error": "pro_required", "feature": "agents"})
-
-    existing = await asyncio.to_thread(get_agent, user_id, kind)
-    already_active = bool(existing and existing["status"] == "active")
-    # Reativar o MESMO kind não adiciona agente → não passa pelo teto. Só uma
-    # ativação de kind novo precisa do direito a múltiplos. O teto é aplicado
-    # DENTRO de activate_agent (mesma transação) pra fechar o TOCTOU.
-    # No v2 o teto é por kind/tier (checado acima) — múltiplos liberados.
-    if v2_on:
-        allow_multiple = True
-    else:
-        allow_multiple = already_active or await asyncio.to_thread(_plan_allows_multiple, user_id)
 
     config = (body.config if body else None) or {}
-    agent = await asyncio.to_thread(activate_agent, user_id, kind, config, allow_multiple)
-    if agent is None:
-        # Mesmo payload de 403 do resto do app → frontend abre o modal de upgrade.
-        raise HTTPException(status_code=403, detail={"error": "pro_required", "feature": "agents"})
+    if v2_on:
+        from core.services.plan_limits import AGENT_ENERGY_COST, agent_energy_cost
+        from core.services.plan_service import agents_energy_budget
+        budget = await asyncio.to_thread(agents_energy_budget, user_id)
+        agent = await asyncio.to_thread(
+            activate_agent, user_id, kind, config, True, budget, AGENT_ENERGY_COST,
+        )
+        if agent is None:
+            # Tem plano, mas o orçamento não comporta mais esse agente → o front
+            # mostra "sem energia" (pausar um agente ou subir pro Pro), não upgrade.
+            raise HTTPException(status_code=403, detail={
+                "error": "no_energy", "feature": "agents",
+                "cost": agent_energy_cost(kind), "budget": int(budget),
+            })
+    else:
+        existing = await asyncio.to_thread(get_agent, user_id, kind)
+        already_active = bool(existing and existing["status"] == "active")
+        # Reativar o MESMO kind não adiciona agente → não passa pelo teto legado.
+        allow_multiple = already_active or await asyncio.to_thread(_plan_allows_multiple, user_id)
+        agent = await asyncio.to_thread(activate_agent, user_id, kind, config, allow_multiple)
+        if agent is None:
+            raise HTTPException(status_code=403, detail={"error": "pro_required", "feature": "agents"})
     return {"ok": True, "agent": {
         "kind": agent["kind"], "status": agent["status"], "config": agent["config"],
     }}

--- a/tests/test_plan_tiers.py
+++ b/tests/test_plan_tiers.py
@@ -333,6 +333,19 @@ class TestAgentGates:
         _patch_user(monkeypatch, _user("free"))
         assert plan_service.agent_kind_allowed(1, "xerife") is True  # gate legado decide na rota
 
+    def test_beta_tester_orcamento_cheio(self, v2, monkeypatch):
+        """Tester do beta usa TODOS os agentes independe do tier: orçamento cheio
+        (Pro) mesmo em Free, pra a isenção valer de ponta a ponta — no gate da
+        rota (budget > 0) E na checagem transacional de energia (budget comporta
+        todos). Usuário comum em Free continua sem energia."""
+        monkeypatch.setenv("AGENTS_BETA_USER_IDS", "99")
+        monkeypatch.setenv("AGENTS_BETA_EMAILS", "")  # zera a allowlist por e-mail
+        _patch_user(monkeypatch, _user("free"))
+        assert plan_service.agents_energy_budget(99) == 12
+        assert plan_service.agent_kind_allowed(99, "detetive") is True
+        assert plan_service.agents_energy_budget(1) == 0
+        assert plan_service.agent_kind_allowed(1, "xerife") is False
+
     def test_custo_de_energia_por_agente(self):
         from core.services.plan_limits import agent_energy_cost
         assert agent_energy_cost("reporter") == 1

--- a/tests/test_plan_tiers.py
+++ b/tests/test_plan_tiers.py
@@ -219,6 +219,13 @@ class TestLimits:
         assert PLUS_LIMITS["agents_max"] == 3
         assert PRO_LIMITS["agents_max"] == 6
 
+    def test_orcamento_de_energia_por_plano(self):
+        # Modelo de energia (2026-08-13): Grátis/Essencial 0 · Plus 4 · Pro 12.
+        assert FREE_LIMITS["agents_energy_budget"] == 0
+        assert ESSENCIAL_LIMITS["agents_energy_budget"] == 0
+        assert PLUS_LIMITS["agents_energy_budget"] == 4
+        assert PRO_LIMITS["agents_energy_budget"] == 12
+
     def test_tier_at_least(self):
         assert tier_at_least("plus", "essencial")
         assert tier_at_least("pro", "plus")
@@ -290,26 +297,32 @@ class TestLimits:
 
 class TestAgentGates:
     def test_free_e_essencial_sem_agentes(self, v2, monkeypatch):
+        # Orçamento de energia 0 → nenhum agente (o kind não importa).
         _patch_user(monkeypatch, _user("free"))
+        assert plan_service.agents_energy_budget(1) == 0
         assert plan_service.agent_kind_allowed(1, "xerife") is False
         _patch_user(monkeypatch, _user("essencial", FUTURE))
+        assert plan_service.agents_energy_budget(1) == 0
         assert plan_service.agent_kind_allowed(1, "xerife") is False
 
-    def test_plus_ativa_os_3_da_fase_a(self, v2, monkeypatch):
-        _patch_user(monkeypatch, _user("pro", FUTURE))  # 'pro' legado = Plus
-        for kind in ("xerife", "reporter", "carteiro"):
+    def test_plus_libera_todos_os_agentes(self, v2, monkeypatch):
+        """Modelo de energia: SEM trava por kind — Plus libera todos os agentes
+        (inclusive Detetive/Banqueiro/Barão). Quem limita quantos é o orçamento
+        (⚡4), checado na ativação. 'pro' legado = Plus."""
+        _patch_user(monkeypatch, _user("pro", FUTURE))
+        assert plan_service.agents_energy_budget(1) == 4
+        for kind in ("xerife", "reporter", "carteiro", "detetive", "cofre", "barao"):
             assert plan_service.agent_kind_allowed(1, kind) is True
 
-    def test_kind_desconhecido_exige_pro(self, v2, monkeypatch):
-        """Fase B (detetive/cofre/barao) e qualquer kind não mapeado → Pro+."""
-        _patch_user(monkeypatch, _user("pro", FUTURE))  # Plus
-        assert plan_service.agent_kind_allowed(1, "detetive") is False
+    def test_pro_tem_energia_pra_todos(self, v2, monkeypatch):
         _patch_user(monkeypatch, _user("pro_max", FUTURE))  # Pro novo
-        assert plan_service.agent_kind_allowed(1, "detetive") is True
+        assert plan_service.agents_energy_budget(1) == 12
+        for kind in ("xerife", "detetive", "cofre", "barao"):
+            assert plan_service.agent_kind_allowed(1, kind) is True
 
     def test_trial_stripe_ativa_agentes_do_plano(self, v2, monkeypatch):
         """Trial é o plano escolhido: trial de Plus (assinatura trialing) libera
-        os agentes da Fase A. trial_started_at sozinho (sem assinatura) = free."""
+        agentes. trial_started_at sozinho (sem assinatura) = free = sem energia."""
         _patch_user(monkeypatch, _user("pro", FUTURE))          # trial de Plus
         assert plan_service.agent_kind_allowed(1, "xerife") is True
         _patch_user(monkeypatch, _user("free", trial_started=NOW))  # sem assinatura
@@ -319,6 +332,29 @@ class TestAgentGates:
         monkeypatch.setenv("PLANS_V2_ENABLED", "0")  # freio: default agora é LIGADO
         _patch_user(monkeypatch, _user("free"))
         assert plan_service.agent_kind_allowed(1, "xerife") is True  # gate legado decide na rota
+
+    def test_custo_de_energia_por_agente(self):
+        from core.services.plan_limits import agent_energy_cost
+        assert agent_energy_cost("reporter") == 1
+        assert agent_energy_cost("carteiro") == 1
+        assert agent_energy_cost("xerife") == 2
+        assert agent_energy_cost("barao") == 2
+        assert agent_energy_cost("detetive") == 3
+        assert agent_energy_cost("cofre") == 3
+        assert agent_energy_cost("desconhecido") == 3  # default = o mais caro
+
+    def test_calibracao_plus_3_baratos_ou_2_caros(self):
+        """A regra 'até 3 baratos, ou 2 se caro' cai da calibração dos números:
+        os 3 baratos somam exatamente o orçamento do Plus; um caro (⚡3) só deixa
+        espaço pra mais 1 barato."""
+        from core.services.plan_limits import agent_energy_cost, PLUS_LIMITS
+        budget = PLUS_LIMITS["agents_energy_budget"]
+        baratos = (agent_energy_cost("reporter") + agent_energy_cost("carteiro")
+                   + agent_energy_cost("xerife"))
+        assert baratos == budget == 4                                  # 3 baratos = 4/4
+        assert agent_energy_cost("detetive") + agent_energy_cost("reporter") == 4  # caro + 1 = 2 agentes
+        assert (agent_energy_cost("detetive") + agent_energy_cost("reporter")
+                + agent_energy_cost("carteiro")) > budget              # não cabe um 3º
 
 
 class TestAIQuota:


### PR DESCRIPTION
## O que muda

Reformula a prateleira de **Agentes do Piggy** em dois passos:

1. **Remove as moedas 🪙 "R$ salvos"** — o chip de cada card e o placar `R$ X salvos` do topo. O número misturava naturezas diferentes (potencial de economia do Detetive/Barão vs. dinheiro efetivamente aportado no Banqueiro) e confundia mais do que ajudava.
2. **Introduz o modelo de ENERGIA** — cada agente tem um custo (calibrado por quanto custa pra gente rodar) e cada plano tem um orçamento. Todos os agentes ficam liberados no Plus e no Pro; quem limita quantos você ativa é a energia.

## Modelo de energia

| Agente | Custo | Por quê |
|---|---|---|
| 🎤 Repórter · 📬 Carteiro | ⚡1 | leitura leve, baixa frequência |
| 🤠 Xerife · 🎩 Barão | ⚡2 | diário/anomalia · Open Finance |
| 🔍 Detetive · 🎯 Banqueiro | ⚡3 | varredura contínua de histórico OF |

| Plano | Orçamento | Cabe |
|---|---|---|
| Grátis / Essencial | ⚡0 | nenhum |
| Plus | ⚡4 | até 3 baratos, ou 2 se um for caro |
| Pro | ⚡12 | os 6 |

**Calibração:** os 3 baratos somam exatamente 4 (Plus = "até 3 agentes"); um agente caro (⚡3) só deixa espaço pra mais 1 barato → 2 agentes. Pro (⚡12) cabe a equipe inteira.

## Alterações por arquivo

- **`core/services/plan_limits.py`** — `AGENT_ENERGY_COST` + `agent_energy_cost()`; `agents_energy_budget` por tier; **remove `AGENT_KIND_MIN_TIER`** (fim da trava por kind).
- **`core/services/plan_service.py`** — `agents_energy_budget(user_id)`; `agent_kind_allowed` agora só responde "o tier tem energia p/ agentes?" (Plus/Pro sim, Grátis/Essencial não), sem trava por kind.
- **`db/agents.py`** — `activate_agent` enforça o orçamento na **mesma transação** (advisory lock por usuário, fecha o TOCTOU): bloqueia se `usado + custo(kind) > orçamento`. Reativar o mesmo kind nunca é bloqueado.
- **`frontend/routes/agents.py`** — expõe `energy_cost` por card + `energy_used`/`energy_budget`; a ativação distingue **`pro_required`** (Grátis/Essencial, abre upgrade) de **`no_energy`** (tem plano mas o orçamento estourou).
- **`frontend/dashboard.js` + `dashboard.css`** — medidor de energia (pips) nos contadores, chip de custo ⚡ no card, botão **"Sem energia"** quando não cabe, e aviso amigável no 403 `no_energy`. O ⚡ do card agora significa **custo**, não mais nº de disparos.
- **`frontend/precos.html`** — copy dos planos passa a falar de energia p/ agentes.
- **`tests/test_plan_tiers.py`** — cobre orçamentos por tier, custos por agente, a calibração 3-baratos/2-caros e o novo `agent_kind_allowed` (sem trava por kind).

## Testes

`pytest` não roda no ambiente da sessão (o `requirements.txt` fixa `audioop-lts`, que exige Python 3.13). Validei a lógica de plano com um harness isolado (stub do `db`): **34/34 checagens passaram** — custos, orçamentos, calibração e o comportamento de `agent_kind_allowed`/`agents_energy_budget` em todos os tiers, incluindo o modo v2-off (legado). Todos os arquivos Python passam no `py_compile` e o `dashboard.js` no `node --check`.

## Nota de rollout

O gate dos runners (`agent_kind_allowed`) ficou em nível de tier ("tem energia?"). No caso de **downgrade Pro→Plus** com mais de ⚡4 ativos, os agentes já ativos continuam disparando até o usuário pausar/trocar — a checagem de orçamento é aplicada na **ativação**. Fica de sugestão de follow-up um webhook que auto-pausa os agentes mais caros até caber no novo orçamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018R2NkbVbvg5RfTaCkj7Xe3

---
_Generated by [Claude Code](https://claude.ai/code/session_018R2NkbVbvg5RfTaCkj7Xe3)_