### PR TITLE
Safe-area do topo + modal de detalhe do lançamento com Editar/Excluir (Visão Geral e Histórico)

### DIFF
--- a/db/analytics.py
+++ b/db/analytics.py
@@ -745,6 +745,7 @@ def list_history(
             launches_params.extend(search_params)
         launches_sql = f"""
           SELECT id, tipo, valor, alvo, nota, categoria, criado_em,
+                 installments_total, installment_no,
                  COALESCE(source, 'manual') AS origin,
                  (SELECT c.institution_name
                     FROM open_finance_transactions o
@@ -793,6 +794,7 @@ def list_history(
         credit_sql = f"""
           SELECT ct.id, 'credito' AS tipo, ct.valor,
                  c.name AS alvo, ct.nota, ct.categoria, ct.created_at AS criado_em,
+                 ct.installments_total, ct.installment_no,
                  COALESCE(ct.source, 'manual') AS origin,
                  (SELECT conn.institution_name
                     FROM open_finance_accounts a
@@ -830,6 +832,7 @@ def list_history(
             cur.execute(
                 f"""
                 SELECT id, tipo, valor, alvo, nota, categoria, criado_em,
+                       installments_total, installment_no,
                        origin, bank_name, reconciliation_status
                 FROM ({union_sql}) merged
                 ORDER BY criado_em DESC, id ASC
@@ -848,6 +851,10 @@ def list_history(
             "nota": r["nota"],
             "categoria": r["categoria"],
             "criado_em": r["criado_em"].isoformat() if r["criado_em"] else None,
+            # Parcelamento (crédito): total e nº da parcela — usado pra avisar
+            # na exclusão que o grupo inteiro será removido e pra "N/X".
+            "installments_total": r["installments_total"],
+            "installment_no": r["installment_no"],
             # Origem (Open Finance): de onde veio e o estado da conciliação.
             "origin": r["origin"],                                # manual | open_finance | ofx
             "bank_name": r["bank_name"],                          # banco, se veio/casou com OF

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -252,7 +252,11 @@ html.pb-app body.pb-page-app header h1 {
 }
 html.pb-app body.pb-page-app header .hbtn[onclick*="openOfxImport"],
 html.pb-app body.pb-page-app header .hbtn[onclick*="exportToEmail"] { display: none !important; }
-/* Topbar fina: o WebView já desvia do notch, sem padding extra de safe-area */
+/* Reserva a área segura do topo (notch / Dynamic Island) — o dashboard é o
+   único que faltava (home/settings/comandos já reservam). Requer viewport-fit=
+   cover no <meta viewport> pra env() reportar o inset real. */
+html.pb-app body.pb-page-app { padding-top: env(safe-area-inset-top); }
+/* Topbar fina abaixo da área segura. */
 html.pb-app body.pb-page-app header {
   padding: 8px 12px !important;
   margin-bottom: 10px !important;

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 <title>O que pedir — PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -80,7 +80,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <link rel="stylesheet" href="/app-mode.css?v=20" />
   <script src="/app-mode.js?v=19"></script>
 </head>
 <body>

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -1578,6 +1578,12 @@ body.light .ov-period-tabs { background:rgba(0,0,0,.04); }
 .ld-k { color:var(--text-3);flex-shrink:0; }
 .ld-v { color:var(--text);font-weight:600;text-align:right;word-break:break-word; }
 .modal.launch-detail .modal-acts { margin-top:auto;padding-top:22px; }
+.modal.launch-detail .modal-acts.ld-acts { justify-content:space-between;align-items:center;flex-wrap:wrap;gap:10px; }
+.ld-acts-right { display:flex;gap:10px;margin-left:auto; }
+.ld-del { background:transparent;border:1px solid var(--glass-border);color:#ff6b6b;
+  padding:8px 14px;border-radius:9px;cursor:pointer;font-size:.82rem;
+  display:inline-flex;align-items:center;gap:6px;transition:background .2s; }
+.ld-del:hover { background:rgba(255,45,45,.12); }
 .modal h3 { font-size:1rem;font-weight:650;margin-bottom:5px; }
 .modal .msub { font-size:.78rem;color:var(--text-2);margin-bottom:18px; }
 .modal-inp { width:100%;background:rgba(255,255,255,.07);border:1px solid var(--glass-border);

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=13"></script>
+<script defer src="/dashboard.js?v=14"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 <title>PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -26,7 +26,7 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <link rel="stylesheet" href="/app-mode.css?v=20" />
   <script defer src="/app-mode.js?v=19"></script>
 </head>
 <body class="has-sidenav">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,7 +20,7 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
-<link rel="stylesheet" href="/dashboard.css?v=5" />
+<link rel="stylesheet" href="/dashboard.css?v=6" />
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
 <!-- defer preserva a ordem: auth-refresh (patch do fetch) → modals → app-mode →
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=12"></script>
+<script defer src="/dashboard.js?v=13"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -7489,7 +7489,9 @@ async function submitEditLaunch() {
     closeEditLaunchModal();
     showLaunchSuccessToast(editingLaunchIsCredit ? "Compra atualizada" : "Lançamento atualizado");
     sendRefreshSilent();
-    if (_returnToHistory) loadHistoryView(true);  // veio do Histórico → atualiza a timeline
+    // Veio do Histórico → recarrega a timeline resetando a paginação (senão,
+    // se o usuário tinha dado "Carregar mais", recarregaria só a página N).
+    if (_returnToHistory) _historyResetAndReload();
   } catch (err) {
     showEditLaunchError("Erro: " + err.message);
   } finally {
@@ -7566,7 +7568,8 @@ async function confirmDeleteLaunch(launchId, descricao, valor, isCredit = false,
     renderLaunches();
     showLaunchSuccessToast(msg);
     sendRefreshSilent();
-    if (_returnToHistory) loadHistoryView(true);  // veio do Histórico → atualiza a timeline
+    // Veio do Histórico → recarrega resetando a paginação (ver edição acima).
+    if (_returnToHistory) _historyResetAndReload();
   } catch (err) {
     await alertModal(err.message, { title: "Erro ao apagar" });
   } finally {

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -5423,6 +5423,10 @@ function _clearHistoryFilters() {
   _historyResetAndReload();
 }
 
+// Itens do Histórico atualmente renderizados — indexados pra o clique na linha
+// abrir o modal de detalhe (openHistoryDetail).
+let _renderedHistoryItems = [];
+
 function renderHistoryTimeline(payload, append = false) {
   const root = document.getElementById("history-timeline");
   const moreWrap = document.getElementById("history-load-more-wrap");
@@ -5434,7 +5438,14 @@ function renderHistoryTimeline(payload, append = false) {
   }
 
   const items = payload.items || [];
+  // Indexa os itens no array global pra o clique na linha (openHistoryDetail).
+  const _base = append ? _renderedHistoryItems.length : 0;
+  if (append) _renderedHistoryItems.push(...items);
+  else _renderedHistoryItems = items.slice();
+  items.forEach((it, n) => { it._ldx = _base + n; });
+
   if (!items.length) {
+    if (!append) _renderedHistoryItems = [];
     root.innerHTML = `<div class="empty" style="padding:30px;text-align:center;color:var(--text-3)">Nenhum lançamento encontrado com os filtros atuais.</div>`;
     if (moreWrap) moreWrap.style.display = "none";
     return;
@@ -5523,8 +5534,9 @@ function _historyRowHTML(i) {
   if (isCredito && i.alvo)  meta.push(`Cartão ${i.alvo}`);
   if (!isCredito && i.nota && i.alvo && i.nota !== i.alvo) meta.push(i.nota);
   if (time) meta.push(time);
+  const clickable = i._ldx != null ? ` style="cursor:pointer" onclick="openHistoryDetail(${i._ldx})"` : "";
   return `
-    <div class="tx-row">
+    <div class="tx-row"${clickable}>
       <div class="tx-icon" style="color:${isReceita ? "#00F078" : (isCredito ? "#7E5FE6" : "#fbbf24")}">${icon}</div>
       <div class="tx-main">
         <div class="tx-desc">${escapeHtmlSafe(_truncate(desc, 60))}</div>
@@ -6973,13 +6985,8 @@ function renderLaunches() {
       const valClass   = isInternal ? '' : (l.tipo==='receita'||l.tipo==='entrada' ? 'g' : 'r');
       const valStyle   = isInternal ? 'color:var(--text-2)' : '';
       const typeLabel  = TYPE_LABELS[l.tipo] || l.tipo.replaceAll("_", " ");
-      const editable   = l.id != null;
-      const editBtn    = editable
-        ? `<button class="bgt-btn launch-edit-btn" onclick="event.stopPropagation();openEditLaunchModal(${l.id})" title="Editar lançamento"><i class="ph ph-pencil-simple" aria-hidden="true"></i></button>`
-        : '';
-      const deleteBtn  = editable
-        ? `<button class="bgt-btn launch-delete-btn" onclick="event.stopPropagation();confirmDeleteLaunch(${l.id}, ${JSON.stringify(describeLaunch(l).replace(/<[^>]+>/g, '').trim()).replace(/"/g, '&quot;')}, ${l.valor}, ${l.tipo === 'credito' ? 'true' : 'false'}, ${l.installments_total || 'null'})" title="Apagar lançamento"><i class="ph ph-trash" aria-hidden="true"></i></button>`
-        : '';
+      // Editar/Excluir migraram pro modal de detalhe (clique na linha) — sem
+      // ícones inline, que causavam toque errado no celular.
       return `
       <div class="row" style="cursor:pointer;${isInternal?'opacity:.75':''}" onclick="openLaunchDetail(${idx})">
         <span class="lbl">
@@ -6992,17 +6999,21 @@ function renderLaunches() {
         <span style="display:flex;flex-direction:column;align-items:flex-end;gap:2px">
           <span class="val ${valClass}" style="${valStyle}"
                 data-num="lnc_${l.criado_em}_${l.valor}" data-val="${l.valor}">${fmt(l.valor)}</span>
-          <span style="font-size:.65rem;color:var(--text-3)">${fmtDate(l.criado_em)}${editBtn}${deleteBtn}</span>
+          <span style="font-size:.65rem;color:var(--text-3)">${fmtDate(l.criado_em)}</span>
         </span>
       </div>
     `}).join("")
     + renderLaunchesPagination(meta.total || items.length, meta.total_pages || 1);
 }
 
-// Clique numa linha da Visão Geral: abre o detalhe com a descrição COMPLETA
-// (que não cabe inteira no celular) + os campos principais. Modal dedicado com
-// altura mínima e respiro — não usa o alertModal genérico (que encolhe até o
-// texto e ficava apertado com pouca informação).
+// Clique numa linha (Visão Geral OU Histórico): abre o detalhe com a descrição
+// COMPLETA + campos principais e ações Editar/Excluir. Modal dedicado com
+// altura mínima e respiro. Edit/delete roteiam por tipo (crédito vs launch),
+// então funcionam nas duas origens sem colisão de id.
+let _launchDetailCurrent = null;
+let _launchDetailSource = "overview";   // 'overview' | 'history'
+let _editDeleteReturnTo = null;         // 'history' → recarrega o histórico após a ação
+
 function _ensureLaunchDetailModal() {
   if (document.getElementById("launch-detail-overlay")) return;
   const html = `
@@ -7011,8 +7022,12 @@ function _ensureLaunchDetailModal() {
         <h3>Detalhe do lançamento</h3>
         <div class="ld-desc" id="ld-desc"></div>
         <div class="ld-meta" id="ld-meta"></div>
-        <div class="modal-acts">
-          <button type="button" class="btn-save" id="ld-close">Fechar</button>
+        <div class="modal-acts ld-acts">
+          <button type="button" class="ld-del" id="ld-delete"><i class="ph ph-trash" aria-hidden="true"></i> Excluir</button>
+          <span class="ld-acts-right">
+            <button type="button" class="btn-cancel" id="ld-edit"><i class="ph ph-pencil-simple" aria-hidden="true"></i> Editar</button>
+            <button type="button" class="btn-save" id="ld-close">Fechar</button>
+          </span>
         </div>
       </div>
     </div>`;
@@ -7020,6 +7035,8 @@ function _ensureLaunchDetailModal() {
   const ov = document.getElementById("launch-detail-overlay");
   ov.addEventListener("click", e => { if (e.target === ov) closeLaunchDetail(); });
   document.getElementById("ld-close").addEventListener("click", closeLaunchDetail);
+  document.getElementById("ld-edit").addEventListener("click", _launchDetailEdit);
+  document.getElementById("ld-delete").addEventListener("click", _launchDetailDelete);
   document.addEventListener("keydown", e => {
     if (e.key === "Escape" && ov.classList.contains("open")) closeLaunchDetail();
   });
@@ -7030,9 +7047,7 @@ function closeLaunchDetail() {
   if (ov) ov.classList.remove("open");
 }
 
-function openLaunchDetail(idx) {
-  const l = (_renderedLaunches || [])[idx];
-  if (!l) return;
+function _renderLaunchDetail(l) {
   _ensureLaunchDetailModal();
   const typeLabel = LAUNCH_TYPE_LABELS[l.tipo] || String(l.tipo || "").replaceAll("_", " ");
   const desc = describeLaunch(l).replace(/<[^>]+>/g, "").trim() || "—";
@@ -7047,7 +7062,45 @@ function openLaunchDetail(idx) {
     `<span class="ld-v">${escapeHtmlSafe(String(v))}</span></div>`
   ).join("");
 
+  // Editar/Excluir só com id e fora de movimentação interna (que não tem edição).
+  const editable = l.id != null && !l.is_internal_movement;
+  document.getElementById("ld-edit").style.display = editable ? "" : "none";
+  document.getElementById("ld-delete").style.display = editable ? "" : "none";
+
   document.getElementById("launch-detail-overlay").classList.add("open");
+}
+
+function openLaunchDetail(idx) {
+  const l = (_renderedLaunches || [])[idx];
+  if (!l) return;
+  _launchDetailCurrent = l;
+  _launchDetailSource = "overview";
+  _renderLaunchDetail(l);
+}
+
+function openHistoryDetail(idx) {
+  const l = (_renderedHistoryItems || [])[idx];
+  if (!l) return;
+  _launchDetailCurrent = l;
+  _launchDetailSource = "history";
+  _renderLaunchDetail(l);
+}
+
+function _launchDetailEdit() {
+  const l = _launchDetailCurrent;
+  if (!l || l.id == null) return;
+  _editDeleteReturnTo = (_launchDetailSource === "history") ? "history" : null;
+  closeLaunchDetail();
+  openEditLaunchModal(l.id, l);
+}
+
+function _launchDetailDelete() {
+  const l = _launchDetailCurrent;
+  if (!l || l.id == null) return;
+  _editDeleteReturnTo = (_launchDetailSource === "history") ? "history" : null;
+  closeLaunchDetail();
+  const descTxt = describeLaunch(l).replace(/<[^>]+>/g, "").trim();
+  confirmDeleteLaunch(l.id, descTxt, l.valor, l.tipo === "credito", l.installments_total || null);
 }
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -7301,9 +7354,11 @@ function toLocalDatetimeInput(iso) {
   return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}`;
 }
 
-function openEditLaunchModal(launchId) {
+function openEditLaunchModal(launchId, launchObj = null) {
   if (!launchId) return;
-  const launch = (lastData?.recent_launches || []).find(l => l.id === launchId);
+  // launchObj vem do modal de detalhe (inclui itens do Histórico, que não
+  // estão em recent_launches). Fallback: procura no snapshot da Visão Geral.
+  const launch = launchObj || (lastData?.recent_launches || []).find(l => l.id === launchId);
   if (!launch) return;
 
   editingLaunchId = launchId;
@@ -7341,6 +7396,7 @@ function openEditLaunchModal(launchId) {
 function closeEditLaunchModal() {
   document.getElementById("edit-launch-overlay").classList.remove("open");
   editingLaunchId = null;
+  _editDeleteReturnTo = null;  // cancelou → não recarrega o histórico
 }
 
 function hideEditLaunchError() {
@@ -7357,6 +7413,7 @@ function showEditLaunchError(msg) {
 async function submitEditLaunch() {
   if (editLaunchSubmitting || !editingLaunchId) return;
   hideEditLaunchError();
+  const _returnToHistory = (_editDeleteReturnTo === "history");
 
   let categoria = document.getElementById("edit-launch-categoria").value;
   if (categoria === EDIT_LAUNCH_CUSTOM_VALUE) {
@@ -7432,6 +7489,7 @@ async function submitEditLaunch() {
     closeEditLaunchModal();
     showLaunchSuccessToast(editingLaunchIsCredit ? "Compra atualizada" : "Lançamento atualizado");
     sendRefreshSilent();
+    if (_returnToHistory) loadHistoryView(true);  // veio do Histórico → atualiza a timeline
   } catch (err) {
     showEditLaunchError("Erro: " + err.message);
   } finally {
@@ -7448,6 +7506,8 @@ let deleteLaunchInFlight = false;
 async function confirmDeleteLaunch(launchId, descricao, valor, isCredit = false, installmentsTotal = null) {
   if (deleteLaunchInFlight) return;
   if (!launchId) return;
+  const _returnToHistory = (_editDeleteReturnTo === "history");
+  _editDeleteReturnTo = null;  // consome o flag (independe do usuário confirmar)
   const valFmt = (typeof valor === "number") ? fmt(valor) : "";
   const desc   = (descricao || "").trim() || "este lançamento";
 
@@ -7506,6 +7566,7 @@ async function confirmDeleteLaunch(launchId, descricao, valor, isCredit = false,
     renderLaunches();
     showLaunchSuccessToast(msg);
     sendRefreshSilent();
+    if (_returnToHistory) loadHistoryView(true);  // veio do Histórico → atualiza a timeline
   } catch (err) {
     await alertModal(err.message, { title: "Erro ao apagar" });
   } finally {

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 <title>PigBank · Início</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -381,7 +381,7 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <link rel="stylesheet" href="/app-mode.css?v=20" />
   <script src="/app-mode.js?v=19"></script>
 </head>
 <body>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
 <meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 <title>Configurações — PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <meta name="theme-color" content="#111111" />
@@ -1097,7 +1097,7 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=18" />
+  <link rel="stylesheet" href="/app-mode.css?v=20" />
   <script src="/app-mode.js?v=19"></script>
 </head>
 <body>


### PR DESCRIPTION
## Resumo
Três ajustes de UX a partir do teste no app iOS.

## 1) Área segura do topo (notch / Dynamic Island)
O conteúdo da Visão Geral aparecia **atrás da Dynamic Island**.
- Causa: faltava `viewport-fit=cover` no `<meta viewport>`, então `env(safe-area-inset-*)` reportava **0** e todas as regras de safe-area do `app-mode.css` (home/settings/comandos) ficavam sem efeito. Além disso, a página do dashboard (`pb-page-app`) era a única sem a regra de `padding-top`.
- Fix: `viewport-fit=cover` nas páginas do app + `padding-top: env(safe-area-inset-top)` em `pb-page-app` (igual às irmãs).

## 2) "Modal errado ao clicar para editar" na Visão Geral
Os ícones de editar/apagar na linha causavam toque errado no celular (abriam a edição sem querer).
- Fix: os ícones inline saem da linha. Clicar na linha abre o **modal de detalhe**, que agora tem botões **Editar** e **Excluir**.

## 3) Clique no Histórico → modal com info + Editar/Excluir
- As linhas do Histórico viram clicáveis e abrem o **mesmo** modal de detalhe, com Editar/Excluir.
- Edit/delete roteiam por tipo (`credito` → `/credit-transactions`, normal → `/launches`), então funcionam tanto para launch quanto para crédito **sem colisão de id**.
- Após editar/excluir vindo do Histórico, a timeline é recarregada.
- `openEditLaunchModal` passa a aceitar o objeto do lançamento (itens do Histórico não estão em `recent_launches`).

## Cache busting
`dashboard.js` v12→v13, `dashboard.css` v5→v6, `app-mode.css` v18→v20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT)_