### PR TITLE
Hotfix: erro ao carregar o Histórico (coluna de parcelamento inexistente em launches)

### DIFF
--- a/db/analytics.py
+++ b/db/analytics.py
@@ -745,7 +745,9 @@ def list_history(
             launches_params.extend(search_params)
         launches_sql = f"""
           SELECT id, tipo, valor, alvo, nota, categoria, criado_em,
-                 installments_total, installment_no,
+                 -- launches não tem parcelamento (isso só existe em
+                 -- credit_transactions); NULL mantém as colunas do UNION.
+                 NULL::int AS installments_total, NULL::int AS installment_no,
                  COALESCE(source, 'manual') AS origin,
                  (SELECT c.institution_name
                     FROM open_finance_transactions o


### PR DESCRIPTION
## Problema
A página **Histórico** passou a dar "Erro ao carregar" após o #43.

## Causa
No #43 adicionei `installments_total`/`installment_no` ao ramo de **launches** do UNION em `list_history`, mas essas colunas só existem em `credit_transactions` — a tabela `launches` **não as tem**. A query falhava com erro de coluna inexistente.

## Correção
- Ramo de **launches**: usa `NULL::int AS installments_total, NULL::int AS installment_no` (parcelamento só existe no crédito — launches nunca são parcelas). Mesmo padrão que o snapshot da Visão Geral já usava.
- Ramo de **credit_transactions**: mantém as colunas reais, então o aviso "TODAS as N parcelas" na exclusão continua funcionando.

Hotfix de regressão — sem mudança de frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSL7RNtcRWJ1FU965Y4BUT)_