### PR TITLE
fix(admin): card Usuários conta contas registradas, não interações do bot

### DIFF
--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -898,7 +898,7 @@ function renderOpsHealthGrid(ops) {
 /* ── Summary cards ───────────────────────────────────────────────── */
 function renderSummary(s) {
   const cards = [
-    { label:"Usuários",          val: fInt(s.total_users),       sub:`+${fInt(s.accounts_30d)} em 30d` },
+    { label:"Usuários",          val: fInt(s.total_accounts),    sub:`+${fInt(s.accounts_30d)} em 30d` },
     { label:"Ativos 30d",        val: fInt(s.active_users_30d),  sub:`${fInt(s.active_users_7d)} ativos 7d` },
     { label:"Logins ok 30d",     val: fInt(s.login_success_30d), sub:`${s.login_success_rate_30d}% taxa sucesso` },
     { label:"Transações 30d",    val: fInt(s.transactions_30d),  sub:"Movimentações externas" },


### PR DESCRIPTION
## Contexto

No painel de monitoramento, o card **"USUÁRIOS"** exibia **314**, o que levantou a dúvida se realmente havia 314 usuários na plataforma.

## Diagnóstico

O número vinha de `total_users` → `SELECT COUNT(*) FROM users` (`core/admin_dashboard.py:390`). Essa tabela **não** representa contas registradas: ela é populada de forma lazy por `ensure_user()` (`db/users.py:19-24`) a cada interação com o bot:

```python
cur.execute("insert into users(id) values (%s) on conflict do nothing", (user_id,))
```

Ou seja, `users` contabiliza qualquer identidade que já tocou o bot — mensagens no WhatsApp/Discord, identidades duplicadas antes de merge, contas de teste, e pessoas que nunca se registraram no app.

Além disso, o card **misturava duas populações**: o número grande vinha de `users`, mas o delta `+X em 30d` vinha de `auth_accounts` (`accounts_30d`) — tornando o card enganoso.

| Parte do card | Antes | Fonte |
|---|---|---|
| Número grande | `total_users` | tabela `users` (qualquer interação) |
| Legenda `+X em 30d` | `accounts_30d` | tabela `auth_accounts` (cadastros) |

## Mudança

O card passa a usar `total_accounts` → `SELECT COUNT(*) FROM auth_accounts` (contas registradas de verdade), mantendo o delta `accounts_30d`. Agora número e delta vêm da **mesma fonte** (`auth_accounts`) e representam usuários da plataforma.

```diff
- { label:"Usuários", val: fInt(s.total_users),    sub:`+${fInt(s.accounts_30d)} em 30d` },
+ { label:"Usuários", val: fInt(s.total_accounts), sub:`+${fInt(s.accounts_30d)} em 30d` },
```

## Notas

- Sem alteração no backend: `total_accounts` já era calculado na query (`admin_dashboard.py:391`), só não estava sendo exibido.
- `total_users` foi mantido na query, disponível para um eventual card separado de "contatos que já usaram o bot".

## Efeito

Quando publicado, o card deixa de mostrar o total inflado (314) e passa a exibir o número real de contas cadastradas (`auth_accounts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1qupjgDkiYnS5TRH1qHqD)_