### PR TITLE
Allow pricing link in PigBank app paywall modal

### DIFF
--- a/frontend/auth-refresh.js
+++ b/frontend/auth-refresh.js
@@ -78,11 +78,14 @@
   // diretrizes da App Store proíbem link/CTA de compra externa, então os
   // anchors pra /precos somem via CSS e as páginas usam window.PB_IN_APP
   // pra trocar o redirect de paywall por uma tela neutra.
+  // Exceção: elementos marcados com .pb-keep-in-app continuam visíveis — ex.:
+  // o botão "Ver planos" do modal de paywall do dashboard, que precisa
+  // redirecionar o usuário sem plano pra tela de planos.
   if (/PigBankApp/.test(navigator.userAgent)) {
     window.PB_IN_APP = true;
     document.documentElement.classList.add("pb-app");
     const st = document.createElement("style");
-    st.textContent = 'html.pb-app a[href^="/precos"]{display:none !important}';
+    st.textContent = 'html.pb-app a[href^="/precos"]:not(.pb-keep-in-app){display:none !important}';
     (document.head || document.documentElement).appendChild(st);
   }
 })();

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -837,7 +837,7 @@
     </div>
     <div class="modal-acts">
       <button class="btn-cancel" type="button" onclick="closeUpgradeModal()">Agora não</button>
-      <a class="btn-upgrade" href="/precos" id="upg-cta">Ver planos <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
+      <a class="btn-upgrade pb-keep-in-app" href="/precos" id="upg-cta">Ver planos <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
This PR fixes the pricing link visibility in the PigBank app's paywall modal by introducing a CSS exception mechanism that allows specific links to remain visible despite the app's general restriction on external pricing page links.

## Changes
- **auth-refresh.js**: Updated the CSS rule that hides pricing links in the PigBank app to use a `:not(.pb-keep-in-app)` selector, allowing links with the `pb-keep-in-app` class to remain visible. Added explanatory comments about the exception use case.
- **dashboard.html**: Added the `pb-keep-in-app` class to the "Ver planos" (View plans) button in the upgrade modal, ensuring users without a plan can navigate to the pricing page from the dashboard paywall.

## Implementation Details
The App Store guidelines prohibit external purchase links, so the app hides all `/precos` (pricing) links via CSS and uses the `window.PB_IN_APP` flag to redirect paywalls to a neutral screen. This change creates an exception for the dashboard's upgrade modal button, which needs to direct unpaid users to the pricing page to complete their upgrade flow.

https://claude.ai/code/session_015gW4y93w8GbwmordM9apMy