### PR TITLE
feat(dashboard): detalhar "Sobrou este mês" ao clicar no card

### DIFF
--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -1578,6 +1578,29 @@ body.light .ov-period-tabs { background:rgba(0,0,0,.04); }
 .ld-k { color:var(--text-3);flex-shrink:0; }
 .ld-v { color:var(--text);font-weight:600;text-align:right;word-break:break-word; }
 .modal.launch-detail .modal-acts { margin-top:auto;padding-top:22px; }
+
+/* Detalhe do "Sobrou este mês": reusa launch-detail, com linha de total
+   destacada e a explicação saldo × sobrou embaixo. */
+.modal.sobrou-detail { min-height:auto; }
+.sobrou-detail .msub { margin-bottom:14px; }
+.sobrou-detail .ld-v.sd-plus  { color:var(--green); }
+.sobrou-detail .ld-v.sd-minus { color:var(--text-2); }
+.sobrou-detail .ld-row.sd-total { border-top:2px solid var(--div);margin-top:4px;
+  padding-top:16px;font-size:1rem; }
+.sobrou-detail .ld-row.sd-total .ld-k { color:var(--text);font-weight:650; }
+.sobrou-detail .ld-row.sd-total .ld-v { font-size:1.15rem;font-weight:750; }
+.sobrou-detail .ld-v.pos { color:var(--green); }
+.sobrou-detail .ld-v.neg { color:var(--red); }
+.sd-note { margin-top:16px;font-size:.82rem;line-height:1.55;color:var(--text-2);
+  background:rgba(255,255,255,.04);border:1px solid var(--glass-border);
+  border-radius:12px;padding:13px 14px; }
+.sd-note b { color:var(--text);font-weight:650; }
+
+/* Card "Sobrou" clicável na Visão Geral. */
+.ov-stat-clickable { cursor:pointer;transition:border-color .15s,transform .15s; }
+.ov-stat-clickable:hover { border-color:rgba(198,241,26,.28);transform:translateY(-1px); }
+.ov-stat-clickable:focus-visible { outline:2px solid var(--neon);outline-offset:2px; }
+.ov-lbl-info { font-size:.9em;opacity:.5;vertical-align:middle; }
 .modal.launch-detail .modal-acts.ld-acts { justify-content:space-between;align-items:center;flex-wrap:wrap;gap:10px; }
 .ld-acts-right { display:flex;gap:10px;margin-left:auto; }
 .ld-del { background:transparent;border:1px solid var(--glass-border);color:#ff6b6b;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,7 +20,7 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
-<link rel="stylesheet" href="/dashboard.css?v=6" />
+<link rel="stylesheet" href="/dashboard.css?v=7" />
 <link rel="stylesheet" href="/dashboard-mobile.css" media="(max-width: 900px)" />
 <!-- defer preserva a ordem: auth-refresh (patch do fetch) → modals → app-mode →
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
@@ -1538,7 +1538,7 @@
   </div>
 </div>
 
-<script defer src="/dashboard.js?v=14"></script>
+<script defer src="/dashboard.js?v=15"></script>
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9307,7 +9307,7 @@ function render(d) {
              <div class="ov-delta" style="opacity:.8">Patrimônio total <b style="color:var(--text-2)"><span data-num="pat" data-val="${pat}">${fmt(pat)}</span></b></div>`
           : `<div class="ov-delta">Patrimônio total <b style="color:var(--text-2)"><span data-num="pat" data-val="${pat}">${fmt(pat)}</span></b></div>`}
       </div>
-      <div class="ov-stat ov-stat-clickable" style="animation-delay:60ms" role="button" tabindex="0" aria-label="Ver como este valor foi calculado" onclick="openSobrouDetail()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openSobrouDetail();}">
+      <div class="ov-stat ov-stat-clickable" style="animation-delay:60ms" role="button" tabindex="0" aria-label="${escapeHtmlSafe((sav>=0?'Sobrou este mês':'Déficit do mês') + ': ' + fmt(sav) + '. ' + savDeltaTxt + '. Toque para ver como este valor foi calculado.')}" onclick="openSobrouDetail()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openSobrouDetail();}">
         <div class="ov-ico neon">${svgTrend}</div>
         <div class="ov-lbl">${sav>=0?'Sobrou este mês':'Déficit do mês'} <i class="ph ph-info ov-lbl-info" aria-hidden="true"></i></div>
         <div class="ov-val ${sav>=0?'pos':'neg'}"><span data-num="sav" data-val="${sav}">${fmt(sav)}</span></div>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -6955,6 +6955,9 @@ const LAUNCH_TYPE_LABELS = {
 // Guarda os lançamentos renderizados pra o clique na linha abrir o detalhe.
 let _renderedLaunches = [];
 
+// Guarda o detalhamento do "Sobrou este mês" pro modal explicativo (clique no card).
+let _sobrouDetail = null;
+
 function renderLaunches() {
   if (!lastData) return;
 
@@ -7076,6 +7079,83 @@ function openLaunchDetail(idx) {
   _launchDetailCurrent = l;
   _launchDetailSource = "overview";
   _renderLaunchDetail(l);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+   "SOBROU ESTE MÊS" — detalhamento (clique no card da Visão Geral)
+   Mostra a conta (receitas − gastos − aportes = sobrou) e explica por que
+   isso ≠ saldo: o saldo é acumulado (arrasta meses, ajustes e movimentações)
+   e pode estar negativo mesmo num mês que sobrou.
+═══════════════════════════════════════════════════════════════════════ */
+function _ensureSobrouDetailModal() {
+  if (document.getElementById("sobrou-detail-overlay")) return;
+  const html = `
+    <div class="overlay" id="sobrou-detail-overlay">
+      <div class="modal launch-detail sobrou-detail">
+        <h3 id="sd-title">Sobrou este mês</h3>
+        <div class="msub" id="sd-sub"></div>
+        <div class="ld-meta" id="sd-rows"></div>
+        <div class="sd-note" id="sd-note"></div>
+        <div class="modal-acts">
+          <button type="button" class="btn-save" id="sd-close">Entendi</button>
+        </div>
+      </div>
+    </div>`;
+  document.body.insertAdjacentHTML("beforeend", html);
+  const ov = document.getElementById("sobrou-detail-overlay");
+  ov.addEventListener("click", e => { if (e.target === ov) closeSobrouDetail(); });
+  document.getElementById("sd-close").addEventListener("click", closeSobrouDetail);
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape" && ov.classList.contains("open")) closeSobrouDetail();
+  });
+}
+
+function closeSobrouDetail() {
+  const ov = document.getElementById("sobrou-detail-overlay");
+  if (ov) ov.classList.remove("open");
+}
+
+function openSobrouDetail() {
+  const s = _sobrouDetail;
+  if (!s) return;
+  _ensureSobrouDetailModal();
+  const deficit = s.sav < 0;
+  const monthLbl = (PT_MONTHS[(s.month || 1) - 1] || "") +
+    (s.year ? "/" + String(s.year).slice(-2) : "");
+
+  document.getElementById("sd-title").textContent = deficit ? "Déficit do mês" : "Sobrou este mês";
+  document.getElementById("sd-sub").textContent =
+    "É o fluxo de " + monthLbl + ": o que entrou menos o que saiu no mês. Não é o seu saldo.";
+
+  const row = (k, v, cls) =>
+    `<div class="ld-row"><span class="ld-k">${escapeHtmlSafe(k)}</span>` +
+    `<span class="ld-v ${cls || ""}">${v}</span></div>`;
+
+  document.getElementById("sd-rows").innerHTML =
+    row("Receitas do mês", "+ " + fmt(s.inc), "sd-plus") +
+    row("Gastos do mês", "− " + fmt(s.exp), "sd-minus") +
+    row("Aportes (investimentos + caixinhas)", "− " + fmt(s.apt), "sd-minus") +
+    `<div class="ld-row sd-total"><span class="ld-k">${deficit ? "Déficit do mês" : "Sobrou este mês"}</span>` +
+    `<span class="ld-v ${deficit ? "neg" : "pos"}">${fmt(s.sav)}</span></div>`;
+
+  // Explica a divergência que confunde: saldo (acumulado) vs sobrou (só o mês).
+  const saldoNeg = s.saldoAtual < 0;
+  let note;
+  if (saldoNeg) {
+    note = "Seu <b>saldo</b> está negativo (" + fmt(s.saldoAtual) + "), mas ainda assim " +
+      (deficit ? "o mês fechou como está acima" : "sobrou dinheiro <b>neste mês</b>") + ". " +
+      "Não é contradição: o saldo é acumulado — arrasta meses anteriores, ajustes e movimentações entre contas —, " +
+      "enquanto este valor olha só receitas, gastos e aportes de " + monthLbl + ".";
+  } else {
+    note = "O <b>saldo</b> é acumulado (arrasta meses anteriores, ajustes e movimentações entre contas). " +
+      "Este valor considera só receitas, gastos e aportes de " + monthLbl + " — por isso os dois podem divergir.";
+  }
+  if (s.apt > 0) {
+    note += " Aportes não são gasto: viram patrimônio seu (investimentos e caixinhas), mas saem do que “sobra livre” no mês.";
+  }
+  document.getElementById("sd-note").innerHTML = note;
+
+  document.getElementById("sobrou-detail-overlay").classList.add("open");
 }
 
 function openHistoryDetail(idx) {
@@ -9098,6 +9178,10 @@ function render(d) {
   const saldoAtual = carteira + ofBank;
   const pat = saldoAtual + ni + np;
 
+  // Detalhamento do "Sobrou este mês" pro modal explicativo (clique no card).
+  // Guarda exatamente o que está na tela, inclusive em mês histórico.
+  _sobrouDetail = { inc, exp, apt, sav, rate, saldoAtual, month: rm, year: ry };
+
   const nPk = (d.pockets||[]).length;
   const nCc = (d.credit_cards||[]).length;
 
@@ -9195,9 +9279,9 @@ function render(d) {
              <div class="ov-delta" style="opacity:.8">Patrimônio total <b style="color:var(--text-2)"><span data-num="pat" data-val="${pat}">${fmt(pat)}</span></b></div>`
           : `<div class="ov-delta">Patrimônio total <b style="color:var(--text-2)"><span data-num="pat" data-val="${pat}">${fmt(pat)}</span></b></div>`}
       </div>
-      <div class="ov-stat" style="animation-delay:60ms">
+      <div class="ov-stat ov-stat-clickable" style="animation-delay:60ms" role="button" tabindex="0" aria-label="Ver como este valor foi calculado" onclick="openSobrouDetail()" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openSobrouDetail();}">
         <div class="ov-ico neon">${svgTrend}</div>
-        <div class="ov-lbl">${sav>=0?'Sobrou este mês':'Déficit do mês'}</div>
+        <div class="ov-lbl">${sav>=0?'Sobrou este mês':'Déficit do mês'} <i class="ph ph-info ov-lbl-info" aria-hidden="true"></i></div>
         <div class="ov-val ${sav>=0?'pos':'neg'}"><span data-num="sav" data-val="${sav}">${fmt(sav)}</span></div>
         <div class="ov-delta ${savDeltaCls}">${savDeltaTxt}</div>
       </div>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -6957,6 +6957,8 @@ let _renderedLaunches = [];
 
 // Guarda o detalhamento do "Sobrou este mês" pro modal explicativo (clique no card).
 let _sobrouDetail = null;
+// Elemento que tinha o foco antes de abrir o modal (pra restaurar ao fechar).
+let _sobrouReturnFocus = null;
 
 function renderLaunches() {
   if (!lastData) return;
@@ -7091,7 +7093,7 @@ function _ensureSobrouDetailModal() {
   if (document.getElementById("sobrou-detail-overlay")) return;
   const html = `
     <div class="overlay" id="sobrou-detail-overlay">
-      <div class="modal launch-detail sobrou-detail">
+      <div class="modal launch-detail sobrou-detail" role="dialog" aria-modal="true" aria-labelledby="sd-title">
         <h3 id="sd-title">Sobrou este mês</h3>
         <div class="msub" id="sd-sub"></div>
         <div class="ld-meta" id="sd-rows"></div>
@@ -7106,13 +7108,27 @@ function _ensureSobrouDetailModal() {
   ov.addEventListener("click", e => { if (e.target === ov) closeSobrouDetail(); });
   document.getElementById("sd-close").addEventListener("click", closeSobrouDetail);
   document.addEventListener("keydown", e => {
-    if (e.key === "Escape" && ov.classList.contains("open")) closeSobrouDetail();
+    if (!ov.classList.contains("open")) return;
+    if (e.key === "Escape") { closeSobrouDetail(); return; }
+    // Trap de foco: o diálogo tem um único controle (Fechar). Sem isso o Tab
+    // vazaria pro dashboard atrás do overlay, contrariando aria-modal.
+    if (e.key === "Tab") {
+      e.preventDefault();
+      const closeBtn = document.getElementById("sd-close");
+      if (closeBtn) closeBtn.focus();
+    }
   });
 }
 
 function closeSobrouDetail() {
   const ov = document.getElementById("sobrou-detail-overlay");
   if (ov) ov.classList.remove("open");
+  // Devolve o foco pra quem abriu o modal (o card), pra teclado/leitor de tela
+  // não ficarem perdidos atrás do overlay.
+  if (_sobrouReturnFocus && typeof _sobrouReturnFocus.focus === "function") {
+    _sobrouReturnFocus.focus();
+  }
+  _sobrouReturnFocus = null;
 }
 
 function openSobrouDetail() {
@@ -7139,9 +7155,15 @@ function openSobrouDetail() {
     `<span class="ld-v ${deficit ? "neg" : "pos"}">${fmt(s.sav)}</span></div>`;
 
   // Explica a divergência que confunde: saldo (acumulado) vs sobrou (só o mês).
-  const saldoNeg = s.saldoAtual < 0;
+  // Em mês histórico NÃO comparamos com o saldo: o snapshot só traz o saldo
+  // ATUAL da conta (não o saldo daquele mês) e ainda exclui Open Finance, então
+  // afirmar "seu saldo está negativo" ali seria enganoso. Mostra só a natureza
+  // do número (fluxo daquele mês).
   let note;
-  if (saldoNeg) {
+  if (s.hist) {
+    note = "Este é o fluxo de " + monthLbl + " — só receitas, gastos e aportes daquele mês. " +
+      "Não é um saldo: o saldo é acumulado e reflete o momento atual, não o fim de um mês passado.";
+  } else if (s.saldoAtual < 0) {
     note = "Seu <b>saldo</b> está negativo (" + fmt(s.saldoAtual) + "), mas ainda assim " +
       (deficit ? "o mês fechou como está acima" : "sobrou dinheiro <b>neste mês</b>") + ". " +
       "Não é contradição: o saldo é acumulado — arrasta meses anteriores, ajustes e movimentações entre contas —, " +
@@ -7155,7 +7177,13 @@ function openSobrouDetail() {
   }
   document.getElementById("sd-note").innerHTML = note;
 
+  // Guarda quem tinha o foco (o card) pra restaurar ao fechar, e joga o foco
+  // pro botão de fechar — assim o leitor de tela anuncia o diálogo e o Tab não
+  // vaza pro dashboard atrás do overlay.
+  _sobrouReturnFocus = document.activeElement;
   document.getElementById("sobrou-detail-overlay").classList.add("open");
+  const closeBtn = document.getElementById("sd-close");
+  if (closeBtn) closeBtn.focus();
 }
 
 function openHistoryDetail(idx) {
@@ -9180,7 +9208,7 @@ function render(d) {
 
   // Detalhamento do "Sobrou este mês" pro modal explicativo (clique no card).
   // Guarda exatamente o que está na tela, inclusive em mês histórico.
-  _sobrouDetail = { inc, exp, apt, sav, rate, saldoAtual, month: rm, year: ry };
+  _sobrouDetail = { inc, exp, apt, sav, rate, saldoAtual, month: rm, year: ry, hist };
 
   const nPk = (d.pockets||[]).length;
   const nCc = (d.credit_cards||[]).length;


### PR DESCRIPTION
## O que muda

O card **"Sobrou este mês"** da Visão Geral agora é **clicável** (mouse, toque e teclado, com ícone ⓘ de dica) e abre um modal detalhando de onde vem o valor.

### Motivação
O usuário se confundia ao ver o **saldo negativo** enquanto o **"Sobrou este mês" aparecia positivo**. Os dois medem coisas diferentes, mas nada na UI explicava isso.

### O modal mostra
A conta que já era feita internamente (`sobrou = receitas − gastos − aportes`):

| | |
|---|---|
| Receitas do mês | **+ R$ …** |
| Gastos do mês | − R$ … |
| Aportes (investimentos + caixinhas) | − R$ … |
| **Sobrou este mês** | **R$ …** |

E uma nota que resolve a confusão **saldo × sobrou**: o saldo é *acumulado* (arrasta meses anteriores, ajustes e movimentações entre contas), enquanto "sobrou" é só o *fluxo do mês*. Quando o saldo está negativo, a nota diz isso explicitamente. O texto se adapta a mês de déficit e esclarece que aporte não é gasto (vira patrimônio).

## Detalhes técnicos
- **Sem endpoint novo** — o modal lê valores já presentes no snapshot (gravados em `_sobrouDetail` no `render()`), então funciona inclusive em meses históricos.
- Reaproveita a infraestrutura de modal existente (`.overlay` / `.launch-detail`; fecha no backdrop, Esc e botão).
- Acessível: `role="button"`, `tabindex`, ativação por Enter/Espaço, `aria-label` e `focus-visible`.
- Cache-busters atualizados (`dashboard.css?v=7`, `dashboard.js?v=15`).

## Verificação
- `node --check frontend/dashboard.js` ✔
- Layout validado num harness isolado reproduzindo CSS + markup no cenário saldo-negativo/sobra-positiva. Não foi possível rodar o dashboard real (depende de login + WebSocket com dados de conta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)