### PR TITLE
feat(app): tab bar vira dock de menisco (a chapa derrete em volta da bolha)

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -222,7 +222,8 @@ html.pb-app .pb-dock-bead-ico svg { animation: pb-bead-pop 0.22s ease-out; }
   to   { opacity: 1; transform: scale(1); }
 }
 @media (prefers-reduced-motion: reduce) {
-  html.pb-app .pb-dock-bead-ico { animation: none; }
+  /* mira o SVG, que é quem tem a animação (o span só é o contêiner) */
+  html.pb-app .pb-dock-bead-ico svg { animation: none; }
 }
 
 /* Telas estreitas (iPhone SE/mini): as abas das pontas chegam perto demais do

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -65,8 +65,19 @@ html.pb-app.pb-no-tabs body {
   padding-bottom: 0 !important;
 }
 
-/* ─── Tab bar flutuante (pílula estilo WhatsApp/iOS) ───────────────────── */
+/* ─── Tab bar flutuante — dock "menisco" ───────────────────────────────────
+   A barra NÃO é uma caixa com fundo: é um único path SVG (.pb-dock-skin)
+   desenhado pelo app-mode.js. A aba ativa não ganha um indicador que desliza —
+   a chapa derrete em volta da bolha (.pb-dock-bead), que fica encaixada num
+   soquete paramétrico. Por isso aqui não tem background/border/radius: a
+   silhueta inteira (cantos + soquete) sai do path.                          */
 html.pb-app .pb-tabbar {
+  --pb-acc: #FF2D8E;
+  /* Geometria do soquete. O JS lê estas três daqui (measure()), então uma
+     media query retempera chapa + bolha + solda de uma vez só. */
+  --pb-dock-r:  20px;   /* raio dos cantos da chapa */
+  --pb-dock-rb: 22px;   /* raio da bolha */
+  --pb-dock-s:  22px;   /* raio base do ombro (o filete da solda) */
   position: fixed;
   left: 10px; right: 10px;
   bottom: max(8px, calc(env(safe-area-inset-bottom) - 14px));
@@ -75,15 +86,42 @@ html.pb-app .pb-tabbar {
   display: flex;
   align-items: center;
   height: 66px;
-  padding: 0 6px;
-  border-radius: 999px;
-  background: rgba(24, 22, 26, 0.86);
-  -webkit-backdrop-filter: blur(24px) saturate(1.4);
-  backdrop-filter: blur(24px) saturate(1.4);
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.5);
+  /* Folga lateral: o soquete precisa de chapa entre a aba da ponta e o canto
+     arredondado — sem ela a solda encosta no canto e some */
+  padding: 0 22px;
 }
+
+/* Chapa: um path só (fill = placa, stroke = aro). O viewBox é maior que a
+   barra (folga de 4px) pra sobrar espaço pro traço do aro. */
+html.pb-app .pb-dock-skin {
+  position: absolute;
+  left: -4px; top: -4px;
+  width: calc(100% + 8px);
+  height: calc(100% + 8px);
+  z-index: 1;
+  pointer-events: none;
+  overflow: visible;
+  filter: drop-shadow(0 12px 30px rgba(0, 0, 0, 0.55));
+}
+/* Brilho do acento: só aparece FORA da chapa (a placa é opaca) — no recorte
+   do soquete e no chão embaixo do dock */
+html.pb-app .pb-dock-glow {
+  position: absolute;
+  left: 0; top: 0;
+  width: 230px; height: 120px;
+  margin: -24px 0 0 -115px;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.55;
+  background: radial-gradient(50% 50% at 50% 50%, rgba(255, 45, 142, 0.34), transparent 70%);
+  background: radial-gradient(50% 50% at 50% 50%,
+    color-mix(in srgb, var(--pb-acc) 34%, transparent), transparent 70%);
+  will-change: transform;
+}
+
 html.pb-app .pb-tab {
+  position: relative;
+  z-index: 2;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -92,7 +130,7 @@ html.pb-app .pb-tab {
   gap: 3px;
   min-height: 52px;
   margin: 7px 0;
-  border-radius: 999px;
+  border-radius: 18px;
   color: rgba(255, 255, 255, 0.6);
   text-decoration: none;
   font-family: "Inter", -apple-system, sans-serif;
@@ -100,7 +138,7 @@ html.pb-app .pb-tab {
   font-weight: 600;
   letter-spacing: 0.01em;
   -webkit-tap-highlight-color: transparent;
-  transition: color 0.15s ease, background 0.15s ease;
+  transition: color 0.18s ease;
 }
 html.pb-app .pb-tab svg {
   width: 24px;
@@ -111,25 +149,118 @@ html.pb-app .pb-tab svg {
   stroke-linecap: round;
   stroke-linejoin: round;
 }
-/* Aba ativa: casulo destacado (como o WhatsApp) */
-html.pb-app .pb-tab.active {
-  color: #FF2D8E;
-  background: rgba(255, 255, 255, 0.10);
+html.pb-app .pb-tab-ico {
+  display: flex;
+  transition: opacity 0.16s ease, transform 0.16s ease;
 }
+/* O ícone da aba que está DEBAIXO da bolha sai de cena — quem carrega o
+   ícone ali é a própria bolha (o rótulo continua, abaixo do soquete) */
+html.pb-app .pb-tab.pb-under .pb-tab-ico {
+  opacity: 0;
+  transform: scale(0.6);
+}
+/* Aba ativa (ou a que a bolha está prevendo, durante o arrasto) */
+html.pb-app .pb-tab.pb-live { color: var(--pb-acc); }
 html.pb-app .pb-tab:active { color: #FF80B8; }
+html.pb-app .pb-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(255, 45, 142, 0.7);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--pb-acc) 70%, transparent);
+}
 
-/* Botão central de lançamento (círculo rosa dentro da pílula) */
+/* A bolha: encaixada no soquete, arrastável ao longo da barra */
+html.pb-app .pb-dock-bead {
+  position: absolute;
+  left: 0; top: 0;
+  width: calc(var(--pb-dock-rb) * 2);
+  height: calc(var(--pb-dock-rb) * 2);
+  /* o JS translada pelo CENTRO da bolha */
+  margin: calc(var(--pb-dock-rb) * -1) 0 0 calc(var(--pb-dock-rb) * -1);
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: #1A0209;
+  background:
+    radial-gradient(circle at 36% 24%, rgba(255, 255, 255, 0.28), transparent 46%),
+    linear-gradient(180deg, #FF4E9C, var(--pb-acc) 52%, #DE1C76);
+  background:
+    radial-gradient(circle at 36% 24%, rgba(255, 255, 255, 0.28), transparent 46%),
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--pb-acc) 92%, #fff),
+      var(--pb-acc) 52%,
+      color-mix(in srgb, var(--pb-acc) 86%, #000));
+  box-shadow:
+    0 8px 20px rgba(255, 45, 142, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.16) inset,
+    0 -5px 12px rgba(0, 0, 0, 0.22) inset;
+  box-shadow:
+    0 8px 20px color-mix(in srgb, var(--pb-acc) 45%, transparent),
+    0 0 0 1px rgba(255, 255, 255, 0.16) inset,
+    0 -5px 12px rgba(0, 0, 0, 0.22) inset;
+  touch-action: none;           /* arrasto não rola a página */
+  cursor: grab;
+  will-change: transform;
+}
+html.pb-app .pb-dock-dragging .pb-dock-bead { cursor: grabbing; }
+html.pb-app .pb-dock-bead svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+html.pb-app .pb-dock-bead-ico { display: flex; }
+/* A animação mora no SVG, não no span: o JS troca o innerHTML do span a cada
+   aba, então o SVG nasce de novo e o pop re-dispara sozinho */
+html.pb-app .pb-dock-bead-ico svg { animation: pb-bead-pop 0.22s ease-out; }
+@keyframes pb-bead-pop {
+  from { opacity: 0; transform: scale(0.55); }
+  to   { opacity: 1; transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  html.pb-app .pb-dock-bead-ico { animation: none; }
+}
+
+/* Telas estreitas (iPhone SE/mini): as abas das pontas chegam perto demais do
+   canto e a bolha fica pendurada na quina. Chapa e bolha encolhem juntas —
+   o soquete continua cabendo inteiro na chapa. */
+@media (max-width: 360px) {
+  html.pb-app .pb-tabbar {
+    --pb-dock-r:  16px;
+    --pb-dock-rb: 20px;
+    --pb-dock-s:  18px;
+    padding: 0 20px;
+  }
+  html.pb-app .pb-tab-fab > span { width: 46px; height: 46px; }
+  html.pb-app .pb-dock-bead svg { width: 20px; height: 20px; }
+}
+
+/* Botão central de lançamento. O acento do dock é a bolha — se o + também
+   fosse um disco rosa cheio, o dock teria dois "ativos" competindo. Então
+   ele vira um disco de chapa com o + e o aro no acento: continua sendo o
+   alvo mais óbvio da barra, sem disputar com a bolha.
+   (Pra voltar ao disco rosa: background e color como estavam.) */
 html.pb-app .pb-tab-fab { flex: 0 0 auto; margin: 0 4px; }
 html.pb-app .pb-tab-fab > span {
   width: 52px;
   height: 52px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #FF2D8E, #C7186B);
+  background: linear-gradient(180deg, #2E2B34, #1A181D);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
-  box-shadow: 0 6px 18px rgba(255, 45, 142, 0.45);
+  color: #FF2D8E;
+  color: var(--pb-acc);
+  box-shadow:
+    0 0 0 1px rgba(255, 45, 142, 0.55),
+    0 6px 16px rgba(0, 0, 0, 0.45);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--pb-acc) 55%, transparent),
+    0 6px 16px rgba(0, 0, 0, 0.45);
 }
 html.pb-app .pb-tab-fab > span svg { width: 26px; height: 26px; stroke-width: 2.4; }
 html.pb-app .pb-tab-fab:active > span { transform: scale(0.94); }

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -89,17 +89,249 @@
     bar.setAttribute("aria-label", "Navegação principal");
     const tabHtml = t => {
       const active = PAGES[t.href] === page;
-      return `<a class="pb-tab${active ? " active" : ""}" href="${t.href}"` +
-        `${active ? ' aria-current="page"' : ""}>${t.icon}<span>${t.label}</span></a>`;
+      return `<a class="pb-tab${active ? " active pb-live" : ""}" href="${t.href}"` +
+        `${active ? ' aria-current="page"' : ""}>` +
+        `<span class="pb-tab-ico">${t.icon}</span><span>${t.label}</span></a>`;
     };
     const fabHtml =
       '<a class="pb-tab pb-tab-fab" href="/app?lancar=1" aria-label="Lançar"><span>' +
       '<svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" ' +
       'stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></span></a>';
+    // A chapa e a bolha são irmãs das abas: o path desenha a silhueta inteira
+    // (cantos + soquete) e a bolha é um elemento próprio, arrastável.
     bar.innerHTML =
-      tabHtml(TABS[0]) + tabHtml(TABS[1]) + fabHtml + tabHtml(TABS[2]) + tabHtml(TABS[3]);
+      '<div class="pb-dock-glow" aria-hidden="true"></div>' +
+      '<svg class="pb-dock-skin" aria-hidden="true" focusable="false">' +
+      '<defs>' +
+      '<linearGradient id="pbDockPlate" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0" stop-color="#23212A"/><stop offset="1" stop-color="#131216"/>' +
+      "</linearGradient>" +
+      '<linearGradient id="pbDockRim" x1="0" y1="0" x2="0" y2="1">' +
+      '<stop offset="0" stop-color="#fff" stop-opacity=".24"/>' +
+      '<stop offset=".5" stop-color="#fff" stop-opacity=".07"/>' +
+      '<stop offset="1" stop-color="#fff" stop-opacity=".03"/>' +
+      "</linearGradient></defs>" +
+      '<path class="pb-dock-fill" fill="url(#pbDockPlate)" stroke="url(#pbDockRim)" stroke-width="1"/>' +
+      "</svg>" +
+      tabHtml(TABS[0]) + tabHtml(TABS[1]) + fabHtml + tabHtml(TABS[2]) + tabHtml(TABS[3]) +
+      '<span class="pb-dock-bead" aria-hidden="true"><span class="pb-dock-bead-ico"></span></span>';
     bar.querySelector(".pb-tab-fab").addEventListener("click", fabLaunch);
     document.body.appendChild(bar);
+    initDock(bar);
+  }
+
+  // ─── Dock "menisco" ──────────────────────────────────────────────────────
+  // A aba ativa não ganha um indicador que desliza: a chapa DERRETE em volta
+  // da bolha. O soquete é paramétrico — cada ombro é um círculo tangente à
+  // borda de cima E à bolha, então |C_ombro − C_bolha| = s + rb e a
+  // meia-largura do soquete cai da conta (reachOf). Tangência exata nos dois
+  // lados = solda lisa, sem quina onde a borda vira socket.
+  // r/rb/s vêm do CSS (measure() relê a cada layout) — ver --pb-dock-* lá.
+  const DK = {
+    h:    66,   // altura da chapa (bate com o CSS)
+    r:    20,   // raio dos cantos
+    rb:   22,   // raio da bolha
+    by:    2,   // profundidade do centro da bolha (+ = abaixo da borda de cima)
+    s:    22,   // raio base do ombro (o filete soldado)
+    vmax:  2.4, // px/frame que satura a inclinação por velocidade
+  };
+
+  const clamp = (v, a, b) => (v < a ? a : v > b ? b : v);
+
+  // meia-largura do soquete pra um ombro de raio s
+  function reachOf(s, rb, by) {
+    const a = (s + rb) * (s + rb) - (s - by) * (s - by);
+    return a > 0 ? Math.sqrt(a) : 0;
+  }
+  // inverso de reachOf: maior ombro cujo soquete ainda cabe em L de chapa
+  function shoulderFor(L, rb, by) {
+    return (L * L - rb * rb + by * by) / (2 * (rb + by));
+  }
+
+  // Silhueta inteira: borda de cima (com o soquete em bx) + cantos + base.
+  function socketPath(W, bx, by, sL, sR) {
+    const h = DK.h, r = DK.r, rb = DK.rb;
+    const dl = reachOf(sL, rb, by);
+    const dr = reachOf(sR, rb, by);
+    // tangência ombro↔bolha: no segmento que une os centros, a s do ombro
+    const tan = (cx, s) => {
+      const dx = bx - cx, dy = by - s;
+      const d = Math.hypot(dx, dy) || 1;
+      return [cx + (s * dx) / d, s + (s * dy) / d];
+    };
+    const a = tan(bx - dl, sL);
+    const z = tan(bx + dr, sR);
+    const n = v => v.toFixed(2);
+    return (
+      `M ${r} 0 L ${n(bx - dl)} 0` +
+      ` A ${n(sL)} ${n(sL)} 0 0 1 ${n(a[0])} ${n(a[1])}` +   // ombro de trás
+      ` A ${rb} ${rb} 0 0 0 ${n(z[0])} ${n(z[1])}` +          // a tigela
+      ` A ${n(sR)} ${n(sR)} 0 0 1 ${n(bx + dr)} 0` +          // ombro da frente
+      ` L ${W - r} 0 A ${r} ${r} 0 0 1 ${W} ${r}` +
+      ` L ${W} ${h - r} A ${r} ${r} 0 0 1 ${W - r} ${h}` +
+      ` L ${r} ${h} A ${r} ${r} 0 0 1 0 ${h - r}` +
+      ` L 0 ${r} A ${r} ${r} 0 0 1 ${r} 0 Z`
+    );
+  }
+
+  function initDock(bar) {
+    const tabs = Array.prototype.slice.call(
+      bar.querySelectorAll(".pb-tab:not(.pb-tab-fab)"));
+    const path = bar.querySelector(".pb-dock-fill");
+    const skin = bar.querySelector(".pb-dock-skin");
+    const glow = bar.querySelector(".pb-dock-glow");
+    const bead = bar.querySelector(".pb-dock-bead");
+    const beadIco = bar.querySelector(".pb-dock-bead-ico");
+    if (!tabs.length || !path || !bead) return;
+
+    const smooth = !(window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+
+    const home = Math.max(0, tabs.findIndex(a => a.classList.contains("active")));
+    let W = 0, stops = [], x = 0, target = 0, vel = 0, prev = 0;
+    let live = home, raf = 0, running = false, drag = null;
+
+    function measure() {
+      const cs = getComputedStyle(bar);
+      const px = (name, fallback) => {
+        const v = parseFloat(cs.getPropertyValue(name));
+        return isFinite(v) && v > 0 ? v : fallback;
+      };
+      DK.r  = px("--pb-dock-r", 20);
+      DK.rb = px("--pb-dock-rb", 22);
+      DK.s  = px("--pb-dock-s", 22);
+
+      const bb = bar.getBoundingClientRect();
+      W = bb.width;
+      stops = tabs.map(a => {
+        const r = a.getBoundingClientRect();
+        return r.left - bb.left + r.width / 2;
+      });
+      skin.setAttribute("viewBox", `-4 -4 ${W + 8} ${DK.h + 8}`);
+      target = stops[live];
+      if (!drag && !running) { x = target; prev = x; }
+      draw();
+    }
+
+    function draw() {
+      if (!W) return;
+      const q = clamp(vel / DK.vmax, -1, 1);
+      const mag = Math.abs(q);
+      const bx = clamp(x, DK.r + 1, W - DK.r - 1);
+
+      // Chapa disponível de cada lado até o canto arredondado. Se nem a
+      // tigela nua couber, a bolha sobe um tico (o soquete estreita junto) —
+      // é o que impede a solda de invadir o canto nas abas das pontas.
+      const gapL = Math.max(1, bx - DK.r);
+      const gapR = Math.max(1, W - DK.r - bx);
+      const gap = Math.min(gapL, gapR);
+      let by = DK.by;
+      if (gap < DK.rb) by = Math.min(by, -Math.sqrt(DK.rb * DK.rb - gap * gap));
+
+      // Velocidade inclina a superfície: o ombro de trás se estica, o da
+      // frente aperta (q > 0 = indo pra direita).
+      const sL = clamp(DK.s * (1 + 0.06 * mag + 0.40 * q), 0,
+        Math.max(0, shoulderFor(gapL, DK.rb, by)));
+      const sR = clamp(DK.s * (1 + 0.06 * mag - 0.40 * q), 0,
+        Math.max(0, shoulderFor(gapR, DK.rb, by)));
+
+      path.setAttribute("d", socketPath(W, bx, by, sL, sR));
+      bead.style.transform = `translate3d(${bx.toFixed(2)}px, ${by.toFixed(2)}px, 0)`;
+      if (glow) glow.style.transform = `translate3d(${bx.toFixed(2)}px, 0, 0)`;
+      // Quem está debaixo da bolha esconde o próprio ícone
+      for (let i = 0; i < tabs.length; i++) {
+        tabs[i].classList.toggle("pb-under", Math.abs(stops[i] - bx) < DK.rb + 4);
+      }
+    }
+
+    function tick() {
+      if (drag) {
+        vel = x - prev;
+        prev = x;
+      } else if (smooth) {
+        vel = (vel + (target - x) * 0.20) * 0.76;
+        x += vel;
+        prev = x;
+        if (Math.abs(target - x) < 0.2 && Math.abs(vel) < 0.2) {
+          x = target; vel = 0; running = false;
+        }
+      } else {
+        x = target; vel = 0; prev = x; running = false;
+      }
+      draw();
+      raf = running || drag ? requestAnimationFrame(tick) : 0;
+    }
+    function start() {
+      running = true;
+      if (!raf) raf = requestAnimationFrame(tick);
+    }
+
+    function setLive(i) {
+      if (i === live) return;
+      live = i;
+      tabs.forEach((a, k) => a.classList.toggle("pb-live", k === i));
+      beadIco.innerHTML = TABS[i].icon;      // reinicia o pop do ícone
+    }
+    const nearest = px => {
+      let best = 0;
+      for (let i = 1; i < stops.length; i++) {
+        if (Math.abs(stops[i] - px) < Math.abs(stops[best] - px)) best = i;
+      }
+      return best;
+    };
+    function goTo(i, navigate) {
+      setLive(i);
+      target = stops[i];
+      start();
+      if (navigate && i !== home) {
+        const href = tabs[i].getAttribute("href");
+        if (smooth) setTimeout(() => { location.href = href; }, 190);
+        else location.href = href;
+      }
+    }
+
+    beadIco.innerHTML = TABS[home].icon;
+
+    tabs.forEach((a, i) => {
+      a.addEventListener("click", ev => {
+        // clique com modificador (abrir em outra aba) segue o link normal
+        if (ev.button > 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
+        ev.preventDefault();          // a chapa derrete antes de navegar
+        goTo(i, true);
+      });
+    });
+
+    // Arrasto da bolha: preview ao vivo (a aba acende ao passar) e, ao soltar,
+    // encaixa na mais próxima projetando um tico da velocidade.
+    bead.addEventListener("pointerdown", ev => {
+      if (ev.button > 0) return;
+      const bb = bar.getBoundingClientRect();
+      drag = { id: ev.pointerId, left: bb.left, off: ev.clientX - bb.left - x };
+      try { bead.setPointerCapture(ev.pointerId); } catch (_) {}
+      bar.classList.add("pb-dock-dragging");
+      start();
+      ev.preventDefault();
+    });
+    bead.addEventListener("pointermove", ev => {
+      if (!drag || ev.pointerId !== drag.id) return;
+      x = clamp(ev.clientX - drag.left - drag.off, stops[0], stops[stops.length - 1]);
+      setLive(nearest(x));
+      ev.preventDefault();
+    });
+    const drop = ev => {
+      if (!drag || (ev && ev.pointerId !== drag.id)) return;
+      drag = null;
+      bar.classList.remove("pb-dock-dragging");
+      goTo(nearest(clamp(x + vel * 5, stops[0], stops[stops.length - 1])), true);
+    };
+    bead.addEventListener("pointerup", drop);
+    bead.addEventListener("pointercancel", drop);
+
+    measure();
+    window.addEventListener("resize", measure);
+    window.addEventListener("orientationchange", () => setTimeout(measure, 120));
+    // Fontes/ícones chegando depois mudam a largura das abas → remede
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(measure).catch(() => {});
   }
 
   // Glifos de texto (☰, 🐷) viram SVG/imagem — WebView pode não ter as fontes

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -318,14 +318,18 @@
       setLive(nearest(x));
       ev.preventDefault();
     });
-    const drop = ev => {
+    const finish = (ev, canceled) => {
       if (!drag || (ev && ev.pointerId !== drag.id)) return;
       drag = null;
       bar.classList.remove("pb-dock-dragging");
+      // pointercancel = o sistema tomou o gesto no meio (giro de tela, gesto
+      // do iOS). Não é escolha do usuário: a bolha volta pra aba da página
+      // atual em vez de navegar pra onde ela tinha parado.
+      if (canceled) { goTo(home, false); return; }
       goTo(nearest(clamp(x + vel * 5, stops[0], stops[stops.length - 1])), true);
     };
-    bead.addEventListener("pointerup", drop);
-    bead.addEventListener("pointercancel", drop);
+    bead.addEventListener("pointerup", ev => finish(ev, false));
+    bead.addEventListener("pointercancel", ev => finish(ev, true));
 
     measure();
     window.addEventListener("resize", measure);

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,8 +16,8 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=18" />
-  <script src="/app-mode.js?v=19"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,8 +80,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=20" />
-  <script src="/app-mode.js?v=19"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,8 +26,8 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=20" />
-  <script defer src="/app-mode.js?v=19"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <script defer src="/app-mode.js?v=20"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -381,8 +381,8 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=20" />
-  <script src="/app-mode.js?v=19"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,8 +15,8 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=18" />
-  <script src="/app-mode.js?v=19"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1097,8 +1097,8 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=20" />
-  <script src="/app-mode.js?v=19"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
 


### PR DESCRIPTION
A aba ativa não ganha mais um casulo que desliza: a barra passou a ser um
único path SVG e a bolha da aba ativa fica encaixada num soquete que a
chapa abre pra ela.

O soquete é paramétrico, não uma pilha de curvas na mão. Cada ombro é um
círculo tangente à borda de cima E à bolha, então |C_ombro − C_bolha| =
s + rb e a meia-largura do soquete cai da conta:

    reach = √((s + rb)² − (s − by)²)

Como a tangência é exata dos dois lados, a solda é lisa (G1) — não tem
quina onde a borda vira soquete. O inverso da mesma conta dá o maior
ombro que ainda cabe entre a aba e o canto arredondado, que é como as
abas das pontas mantêm a solda dentro da chapa em vez de vazar pro canto.

Velocidade inclina a superfície: o ombro de trás se estica e o da frente
aperta (±40% do raio base), então arrastar a bolha deforma o soquete pro
lado certo em vez de ele só transladar.

Também:
- bolha arrastável (pointer events + captura), com preview ao vivo da aba
  e encaixe na mais próxima ao soltar, projetando um tico da velocidade;
- a bolha carrega o ícone da aba ativa e a aba embaixo dela apaga o seu;
- geometria (raio dos cantos / da bolha / do ombro) vem de --pb-dock-* no
  CSS, então a media query de telas estreitas retempera tudo junto;
- prefers-reduced-motion: sem mola e sem espera pra navegar;
- o + central deixa de ser disco rosa cheio e vira disco de chapa com aro
  no acento — com a bolha, dois discos rosa disputavam o mesmo papel.

Medido em Chromium (390x844, CPU 6x throttled): mediana 16,6ms/frame,
p95 18,8ms durante o arrasto.