### PR TITLE
feat(conta): botão de sair no pé dos Ajustes + atalho pra landing no menu

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -440,6 +440,13 @@ html.pb-app body.pb-page-app .user-menu-btn {
 }
 html.pb-app body.pb-page-app .user-menu-btn .user-menu-main { display: none !important; }
 
+/* "Ir para o site" sai do menu no modo app: a landing é chrome de site, não
+   do app. Na PWA ela é inalcançável de propósito (o app-mode.js manda "/" pro
+   /login), e no WebView ela abriria o site de marketing dentro do app, sem a
+   nav dele. Na web o atalho continua lá. */
+html.pb-app .user-menu-link[data-landing],
+html.pb-app .dd-link[data-landing] { display: none !important; }
+
 /* Dropdown da conta: a regra mobile do dashboard.css (≤600px) posiciona com
    left:0 e width:100% do pai — mas no app o botão da conta é um círculo de
    44px, então o menu virava uma faixa de 44px colada na borda direita com o

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <link rel="stylesheet" href="/app-mode.css?v=22" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,7 +80,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <link rel="stylesheet" href="/app-mode.css?v=22" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,7 +26,7 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <link rel="stylesheet" href="/app-mode.css?v=22" />
   <script defer src="/app-mode.js?v=20"></script>
 </head>
 <body class="has-sidenav">
@@ -152,6 +152,7 @@
           <button class="user-menu-link" type="button" role="menuitem" onclick="connectWhatsAppFromDashboard(event)"><span class="user-menu-icon"><i class="ph ph-whatsapp-logo" aria-hidden="true"></i></span>Conectar WhatsApp</button>
           <a class="user-menu-link" href="/settings?view=security" role="menuitem"><span class="user-menu-icon"><i class="ph ph-gear" aria-hidden="true"></i></span>Configurações</a>
           <a class="user-menu-link" href="/conta" role="menuitem"><span class="user-menu-icon"><i class="ph ph-credit-card" aria-hidden="true"></i></span>Gerenciar assinatura</a>
+          <a class="user-menu-link" href="/" data-landing role="menuitem"><span class="user-menu-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
           <button class="user-menu-link danger" type="button" role="menuitem" onclick="logoutDashboard()"><span class="user-menu-icon"><i class="ph ph-sign-out" aria-hidden="true"></i></span>Sair</button>
         </div>
       </div>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -381,7 +381,7 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <link rel="stylesheet" href="/app-mode.css?v=22" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
@@ -425,6 +425,7 @@ footer a:hover { color:var(--text); }
           <button class="dd-link" type="button" onclick="connectWhatsAppFromHome(event)"><span class="dd-icon"><i class="ph ph-whatsapp-logo" aria-hidden="true"></i></span>Conectar WhatsApp</button>
           <a class="dd-link" href="/settings?view=security"><span class="dd-icon"><i class="ph ph-gear" aria-hidden="true"></i></span>Configurações</a>
           <a class="dd-link" href="/conta"><span class="dd-icon"><i class="ph ph-credit-card" aria-hidden="true"></i></span>Gerenciar assinatura</a>
+          <a class="dd-link" href="/" data-landing><span class="dd-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
           <button class="dd-link danger" type="button" onclick="logoutFromHome()"><span class="dd-icon">↪</span>Sair</button>
         </div>
       </div>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,7 +15,7 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <link rel="stylesheet" href="/app-mode.css?v=22" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -308,6 +308,12 @@ a { color: inherit; text-decoration: none; }
 .data-title { color: var(--ink); font-size: .88rem; font-weight: 780; }
 .data-sub { color: var(--muted); font-size: .75rem; line-height: 1.5; margin-top: 2px; }
 .data-actions { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+/* "Sair da conta" no pé da página. O outro "Sair" mora na topbar, que o modo
+   app esconde por ser redundante com a tab bar — sem este aqui, não existe
+   saída de conta pelo app/PWA. (A regra de largura fica ANTES do @media de
+   880px de propósito: lá o botão volta a ocupar a linha toda.) */
+.signout { margin-top: 18px; }
+.signout .btn-danger { width: auto; min-width: 170px; padding: 0 18px; }
 .danger-panel {
   border: 1px solid rgba(220,38,38,.22);
   border-radius: var(--radius-md);
@@ -1097,7 +1103,7 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=21" />
+  <link rel="stylesheet" href="/app-mode.css?v=22" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>
@@ -1705,6 +1711,20 @@ a { color: inherit; text-decoration: none; }
       </section>
 
     </main>
+  </div>
+
+  <!-- Sair da conta: fica no corpo da página (e não só na topbar) porque o
+       modo app esconde a topbar — era o único caminho de logout por lá. -->
+  <div class="data-row signout">
+    <span>
+      <span class="data-title">Sair da conta</span>
+      <span class="data-sub">Encerra a sessão neste dispositivo. Seus lançamentos e configurações continuam salvos.</span>
+    </span>
+    <span class="data-actions">
+      <button class="btn-danger" type="button" id="signout-btn" onclick="logoutSettings()">
+        <i class="ph ph-sign-out" aria-hidden="true"></i> Sair
+      </button>
+    </span>
   </div>
 </div>
 


### PR DESCRIPTION
## O problema

Sair da conta pelo app **não existia**. O único "Sair" das Configurações mora na `topbar`, e o modo app esconde a topbar inteira (`html.pb-app body.pb-page-settings .topbar { display: none }`), por ser redundante com a tab bar. Quem estava no app/PWA ficava sem saída de conta.

## O que muda

**1. Cartão "Sair da conta" no pé dos Ajustes** (`/settings`), reusando o `logoutSettings()` que já existia. Fica fora do `.layout`, então acompanha as 5 seções da página. Usa as classes que a página já tem (`.data-row` / `.btn-danger`), então no mobile ele empilha e o botão ocupa a linha toda, igual às outras linhas.

**2. "Ir para o site" no menu da conta** (dashboard e home), levando à landing. **Escondido no modo app**: na PWA o `/` já é redirecionado pro `/login` pelo próprio `app-mode.js`, então o item seria um beco sem saída; no WebView abriria o site de marketing dentro do app, sem a nav dele. É atalho de web.

## Verificação

Com o app rodando de verdade (Postgres local, usuário e sessão reais), não só inspeção de markup:

| verificação | resultado |
|---|---|
| web — clicar em Sair | vai pra `/?logout=1` e `/auth/validate` passa a responder **401** (sessão encerrada de fato) |
| app — topbar e o "Sair" dela | invisíveis, como antes |
| app — botão novo | visível, 328px de largura, **sem** ser encoberto pela tab bar (`elementFromPoint` no centro devolve o botão) |
| botão nas 5 seções (Open Finance, Segurança, Notificações, Meus dados, Legal) | visível em todas |
| "Ir para o site" nos dois menus | `href="/"`, clique cai na landing |
| modo app — "Ir para o site" | escondido nos dois menus |
| erros de JS nas páginas | nenhum |

Suíte comparada contra o `origin/main` limpo (worktree separado, mesmo ambiente): **12 falhas / 981 passes dos dois lados, listas idênticas**. As falhas são pré-existentes, de dependências que não compilam no container local (`ofxparse` e afins) — o CI, que tem as dependências completas, roda esses módulos normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXPgcaw6whFE1EUHaEh6w8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXPgcaw6whFE1EUHaEh6w8)_