### PR TITLE
fix(conta): "Ir para o site" volta a aparecer no app e escapa do redirect da PWA

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -440,13 +440,6 @@ html.pb-app body.pb-page-app .user-menu-btn {
 }
 html.pb-app body.pb-page-app .user-menu-btn .user-menu-main { display: none !important; }
 
-/* "Ir para o site" sai do menu no modo app: a landing é chrome de site, não
-   do app. Na PWA ela é inalcançável de propósito (o app-mode.js manda "/" pro
-   /login), e no WebView ela abriria o site de marketing dentro do app, sem a
-   nav dele. Na web o atalho continua lá. */
-html.pb-app .user-menu-link[data-landing],
-html.pb-app .dd-link[data-landing] { display: none !important; }
-
 /* Dropdown da conta: a regra mobile do dashboard.css (≤600px) posiciona com
    left:0 e width:100% do pai — mas no app o botão da conta é um círculo de
    44px, então o menu virava uma faixa de 44px colada na borda direita com o

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=22" />
+  <link rel="stylesheet" href="/app-mode.css?v=23" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,7 +80,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=22" />
+  <link rel="stylesheet" href="/app-mode.css?v=23" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,7 +26,7 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=22" />
+  <link rel="stylesheet" href="/app-mode.css?v=23" />
   <script defer src="/app-mode.js?v=20"></script>
 </head>
 <body class="has-sidenav">

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -152,7 +152,7 @@
           <button class="user-menu-link" type="button" role="menuitem" onclick="connectWhatsAppFromDashboard(event)"><span class="user-menu-icon"><i class="ph ph-whatsapp-logo" aria-hidden="true"></i></span>Conectar WhatsApp</button>
           <a class="user-menu-link" href="/settings?view=security" role="menuitem"><span class="user-menu-icon"><i class="ph ph-gear" aria-hidden="true"></i></span>Configurações</a>
           <a class="user-menu-link" href="/conta" role="menuitem"><span class="user-menu-icon"><i class="ph ph-credit-card" aria-hidden="true"></i></span>Gerenciar assinatura</a>
-          <a class="user-menu-link" href="/" data-landing role="menuitem"><span class="user-menu-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
+          <a class="user-menu-link" href="/?site=1" data-landing role="menuitem"><span class="user-menu-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
           <button class="user-menu-link danger" type="button" role="menuitem" onclick="logoutDashboard()"><span class="user-menu-icon"><i class="ph ph-sign-out" aria-hidden="true"></i></span>Sair</button>
         </div>
       </div>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -381,7 +381,7 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=22" />
+  <link rel="stylesheet" href="/app-mode.css?v=23" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -425,7 +425,7 @@ footer a:hover { color:var(--text); }
           <button class="dd-link" type="button" onclick="connectWhatsAppFromHome(event)"><span class="dd-icon"><i class="ph ph-whatsapp-logo" aria-hidden="true"></i></span>Conectar WhatsApp</button>
           <a class="dd-link" href="/settings?view=security"><span class="dd-icon"><i class="ph ph-gear" aria-hidden="true"></i></span>Configurações</a>
           <a class="dd-link" href="/conta"><span class="dd-icon"><i class="ph ph-credit-card" aria-hidden="true"></i></span>Gerenciar assinatura</a>
-          <a class="dd-link" href="/" data-landing><span class="dd-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
+          <a class="dd-link" href="/?site=1" data-landing><span class="dd-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
           <button class="dd-link danger" type="button" onclick="logoutFromHome()"><span class="dd-icon">↪</span>Sair</button>
         </div>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,8 +11,11 @@
 <meta property="og:type" content="website" />
 <script>
 /* PWA instalada (start_url antiga "/"): entra pelo app, não pela landing —
-   /login pula direto pro /home quando a sessão está viva. */
-if ((window.matchMedia && matchMedia("(display-mode: standalone)").matches) || navigator.standalone === true) {
+   /login pula direto pro /home quando a sessão está viva.
+   Exceção: ?site=1 é o usuário PEDINDO o site pelo menu da conta ("Ir para o
+   site"). Sem essa saída, o atalho virava um pulo de volta pro /home. */
+if (!/[?&]site=1(&|$)/.test(location.search) &&
+    ((window.matchMedia && matchMedia("(display-mode: standalone)").matches) || navigator.standalone === true)) {
   location.replace("/login");
 }
 </script>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,7 +15,7 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=22" />
+  <link rel="stylesheet" href="/app-mode.css?v=23" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1103,7 +1103,7 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=22" />
+  <link rel="stylesheet" href="/app-mode.css?v=23" />
   <script src="/app-mode.js?v=20"></script>
 </head>
 <body>


### PR DESCRIPTION
## O que estava errado

No #54 eu escondi o "Ir para o site" no modo app com dois motivos. **Os dois estavam errados**, e o teste derruba os dois:

| justificativa que eu dei | o que é de fato |
|---|---|
| "no WebView abriria o site sem a nav dele" | a regra que esconde a nav é do `app-mode.css`, que a `index.html` **não carrega**. Dentro do app a landing abre como o site normal, com a nav — e com o CTA "Ir para o dashboard" que o `nav-auth.js` injeta quando há sessão. |
| "na PWA o `/` é redirecionado pro `/login`" | **parcialmente certo, pelo motivo errado.** O redirect que eu olhei mora no `app-mode.js`, que a landing não carrega — esse nunca roda em `/`. Mas existe um **segundo**, inline na própria `index.html`, que roda sempre. |

O segundo redirect foi apontado na revisão do Codex neste PR, depois de eu já ter afirmado que não havia nenhum. Ele estava certo.

## O que muda

**1.** Some a regra que escondia o item no modo app — ele volta a aparecer nos dois menus (dashboard e home).

```diff
-html.pb-app .user-menu-link[data-landing],
-html.pb-app .dd-link[data-landing] { display: none !important; }
```

**2.** O item aponta pra `/?site=1`, e o redirect inline da `index.html` deixa esse caso passar. A entrada normal da PWA (abrir `/` pelo ícone) continua indo pro app — só o pedido explícito pelo menu escapa.

```diff
-if ((window.matchMedia && matchMedia("(display-mode: standalone)").matches) || navigator.standalone === true) {
+if (!/[?&]site=1(&|$)/.test(location.search) &&
+    ((window.matchMedia && matchMedia("(display-mode: standalone)").matches) || navigator.standalone === true)) {
```

## Verificação

O defeito da PWA foi **reproduzido antes de consertar**, forçando `navigator.standalone = true` (a condição que a `index.html` checa). Meu teste anterior tinha passado porque usei só o UA do WebView (`PigBankApp`), onde essa condição é falsa — foi por isso que eu não vi.

| contexto | antes | depois |
|---|---|---|
| PWA abrindo `/` (início normal pelo ícone) | `/login` → `/home` | `/home` (inalterado) |
| PWA pelo menu (`/?site=1`) | `/login` → `/home` ✗ | **landing** ✓ |
| WebView (UA `PigBankApp`) pelo menu | landing | landing ✓ |
| navegador | landing | landing ✓ |
| caminho de volta na landing | — | "Ir para o dashboard" presente no DOM |
| erros de JS | — | nenhum |

Também descartei uma alternativa que cheguei a implementar (barra fixa "Voltar ao app" injetada pelo `app-mode.js`): o teste mostrou que ela nunca renderizaria na landing, porque essa página não carrega o script. Preferi jogar fora a deixar código morto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXPgcaw6whFE1EUHaEh6w8