### PR TITLE
feat(app): WebView até a borda (contentInset never) + safe area em todo o app

### DIFF
--- a/frontend/agents.html
+++ b/frontend/agents.html
@@ -83,6 +83,7 @@
     .agents-grid { grid-template-columns: 1fr; gap: 18px; }
   }
 </style>
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -19,6 +19,22 @@ html.pb-app body {
   overflow-x: hidden !important;
 }
 
+/* ─── Cor do canvas: o que o elástico revela ────────────────────────────
+   Puxar a tela além do fim mostra o canvas do documento. O html não tem
+   fundo, então o canvas herda o #111111 do body — mas a borda VISÍVEL do
+   conteúdo é ameixa, porque o roxo vem das orbs (position:absolute), que
+   rolam junto e deixam a área revelada chapada. É essa diferença que se lê
+   como "faixa preta", não preto de verdade.
+   Os tons abaixo saíram de amostra de pixel do render em 390px, não de
+   palpite: dashboard #2E111F, início #311221, o que pedir #2C101E, e
+   ajustes #0B0B0D (tem paleta própria).
+   Isto NÃO mexe no elástico — ele continua acontecendo, só deixa de revelar
+   uma cor que destoa. */
+html.pb-app.pb-root-app,
+html.pb-app.pb-root-home,
+html.pb-app.pb-root-comandos { background-color: #2E111F; }
+html.pb-app.pb-root-settings { background-color: #0B0B0D; }
+
 /* ─── Safe area com o WebView indo até a borda ──────────────────────────
    contentInset "never" (capacitor.config.json) desliga o ajuste nativo nos
    QUATRO lados: a partir daí é o CSS que reserva notch, Dynamic Island,

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -69,9 +69,18 @@ html.pb-app .mfa-overlay {
 }
 html.pb-app .modal,
 html.pb-app .modal.wide,
-html.pb-app .mfa-modal,
-html.pb-app .pig-modal {
+html.pb-app .mfa-modal {
   width: auto !important;
+  max-width: calc(100vw - 24px
+    - env(safe-area-inset-left) - env(safe-area-inset-right)) !important;
+  max-height: calc(100vh - 40px
+    - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important;
+}
+/* O .pig-modal (alertModal/confirmModal) já tem largura própria pensada —
+   min(440px, 92vw), com width:100% no mobile. Só LIMITAMOS pela área segura;
+   pôr width:auto aqui encolheria diálogos de mensagem curta, e o !important
+   impediria a regra mobile do componente de recuperar a largura. */
+html.pb-app .pig-modal {
   max-width: calc(100vw - 24px
     - env(safe-area-inset-left) - env(safe-area-inset-right)) !important;
   max-height: calc(100vh - 40px

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -34,6 +34,12 @@ html.pb-app.pb-root-app,
 html.pb-app.pb-root-home,
 html.pb-app.pb-root-comandos { background-color: #2E111F; }
 html.pb-app.pb-root-settings { background-color: #0B0B0D; }
+/* Modo claro do dashboard: o applyTheme espelha a classe no <html> por causa
+   desta regra. Sem ela o canvas continuaria ameixa enquanto a página vira
+   #F6F4F1 — a mesma faixa, invertida. Tom medido no claro: #E8E4E2.
+   (O tema claro só existe no dashboard: o applyTheme mora no dashboard.js,
+   carregado só por ele.) */
+html.pb-app.light.pb-root-app { background-color: #E8E4E2; }
 
 /* ─── Safe area com o WebView indo até a borda ──────────────────────────
    contentInset "never" (capacitor.config.json) desliga o ajuste nativo nos

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -19,12 +19,41 @@ html.pb-app body {
   overflow-x: hidden !important;
 }
 
-/* Modais sempre cabem na tela */
+/* ─── Safe area com o WebView indo até a borda ──────────────────────────
+   contentInset "never" (capacitor.config.json) desliga o ajuste nativo nos
+   QUATRO lados: a partir daí é o CSS que reserva notch, Dynamic Island,
+   cantos arredondados e home indicator. O Info.plist habilita landscape no
+   iPhone, então as laterais contam. Em pé, e em aparelho sem notch, env()
+   vale 0 — as regras só "acendem" onde há inset de verdade.
+   (box-sizing:border-box já é global nas páginas, então o padding lateral
+   não estoura o max-width:100vw.) */
+html.pb-app body {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+/* Modais sempre cabem na tela — e dentro da área segura. Os overlays são
+   fixed/inset:0, então o padding do body não os alcança; e 100vw/100vh
+   incluem a área do notch. São três classes diferentes de overlay no
+   produto: .overlay (dashboard), .pig-modal-overlay (modals.js) e
+   .mfa-overlay (settings). */
+html.pb-app .overlay,
+html.pb-app .pig-modal-overlay,
+html.pb-app .mfa-overlay {
+  padding: max(20px, env(safe-area-inset-top))
+           max(20px, env(safe-area-inset-right))
+           max(20px, env(safe-area-inset-bottom))
+           max(20px, env(safe-area-inset-left)) !important;
+}
 html.pb-app .modal,
 html.pb-app .modal.wide,
-html.pb-app .mfa-modal {
+html.pb-app .mfa-modal,
+html.pb-app .pig-modal {
   width: auto !important;
-  max-width: calc(100vw - 24px) !important;
+  max-width: calc(100vw - 24px
+    - env(safe-area-inset-left) - env(safe-area-inset-right)) !important;
+  max-height: calc(100vh - 40px
+    - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important;
 }
 
 /* Strings compridas (e-mail, IP, telefone) quebram linha em vez de esticar
@@ -64,6 +93,13 @@ html.pb-app body {
 html.pb-app.pb-no-tabs body {
   padding-bottom: 0 !important;
 }
+/* Login/cadastro não têm tab bar e por isso ficavam fora das regras de safe
+   area por página. Sem isto o cartão de login entra sob o notch — e é a tela
+   de entrada do app (server.url aponta pro /login). */
+html.pb-app.pb-no-tabs body {
+  padding-top: env(safe-area-inset-top) !important;
+  padding-bottom: env(safe-area-inset-bottom) !important;
+}
 
 /* ─── Tab bar flutuante — dock "menisco" ───────────────────────────────────
    A barra NÃO é uma caixa com fundo: é um único path SVG (.pb-dock-skin)
@@ -79,7 +115,9 @@ html.pb-app .pb-tabbar {
   --pb-dock-rb: 22px;   /* raio da bolha */
   --pb-dock-s:  22px;   /* raio base do ombro (o filete da solda) */
   position: fixed;
-  left: 10px; right: 10px;
+  /* laterais: 10px normais, mas nunca por baixo do notch/cantos (landscape) */
+  left: max(10px, env(safe-area-inset-left));
+  right: max(10px, env(safe-area-inset-right));
   bottom: max(8px, calc(env(safe-area-inset-bottom) - 14px));
   /* Abaixo dos overlays de modal (800/900): modal aberto cobre a tab bar */
   z-index: 700;
@@ -449,19 +487,46 @@ html.pb-app .user-dropdown {
   left: auto !important;
   right: 0 !important;
   width: min(300px, calc(100vw - 24px)) !important;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 120px - env(safe-area-inset-top));
   overflow-y: auto;
   overflow-wrap: normal;
 }
 
 /* Flutuantes (FAB do chat, toast) sobem acima da tab bar */
+/* O painel do chat é o par do FAB: mover só o botão deixaria o painel (e o
+   X de fechar) na área insegura. A altura conta também — a regra de ≤560px
+   do dashboard usa height:calc(100vh - 100px), o que põe o topo sob o
+   status bar quando o inset é real. */
+html.pb-app #piggy-panel {
+  right: calc(22px + env(safe-area-inset-right)) !important;
+  bottom: calc(88px + env(safe-area-inset-bottom)) !important;
+  width: min(400px, calc(100vw - 32px
+    - env(safe-area-inset-left) - env(safe-area-inset-right))) !important;
+  height: min(580px, calc(100vh - 130px
+    - env(safe-area-inset-top) - env(safe-area-inset-bottom))) !important;
+}
 html.pb-app #piggy-fab {
   bottom: calc(84px + env(safe-area-inset-bottom)) !important;
+  right: calc(14px + env(safe-area-inset-right)) !important;
   /* Abaixo do vidro dos modais (800): FAB não compete com botões de modal */
   z-index: 700 !important;
 }
 html.pb-app #toast {
   bottom: calc(88px + env(safe-area-inset-bottom)) !important;
+}
+/* Só o toast do dashboard é ancorado à direita. O do settings é centralizado
+   (left:50% + translateX) — pôr "right" nele faria a largura automática
+   esticar de uma borda à outra em vez de abraçar o texto. */
+html.pb-app body.pb-page-app #toast {
+  right: calc(26px + env(safe-area-inset-right)) !important;
+}
+/* Toasts centralizados: centralizar na horizontal não os torna seguros na
+   VERTICAL — presos por bottom fixo, a borda de baixo cai no home indicator. */
+html.pb-app .modal-success-toast {
+  bottom: calc(24px + env(safe-area-inset-bottom)) !important;
+}
+html.pb-app .upgrade-toast {
+  bottom: calc(32px + env(safe-area-inset-bottom)) !important;
 }
 
 /* ─── Settings ─────────────────────────────────────────────────────────── */
@@ -605,6 +670,10 @@ html.pb-app .sidenav {
    pra rolar até o fim no iPhone. */
 html.pb-app .sidenav {
   z-index: 760;
+  /* fixed não herda o padding de safe area do body: o menu reserva por conta
+     própria o topo (status bar) e a esquerda (notch deitado) */
+  padding-top: calc(18px + env(safe-area-inset-top));
+  padding-left: calc(14px + env(safe-area-inset-left));
   padding-bottom: calc(14px + env(safe-area-inset-bottom));
 }
 html.pb-app .sidenav-backdrop.open { z-index: 750; }

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -75,6 +75,11 @@ html.pb-app .mfa-modal {
     - env(safe-area-inset-left) - env(safe-area-inset-right)) !important;
   max-height: calc(100vh - 40px
     - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important;
+  /* Limitar a altura sem poder rolar seria pior que não limitar: o .modal
+     base (dashboard.css) não tem overflow, então os campos e os botões de
+     ação escapariam do card em vez de ficarem alcançáveis. O .wide e o
+     .launch-detail já rolam; aqui a regra vale pros 12 modais simples. */
+  overflow: auto !important;
 }
 /* O .pig-modal (alertModal/confirmModal) já tem largura própria pensada —
    min(440px, 92vw), com width:100% no mobile. Só LIMITAMOS pela área segura;

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -83,6 +83,9 @@
   function buildTabbar() {
     if (!page) { root.classList.add("pb-no-tabs"); return; }
     document.body.classList.add("pb-page-" + page);
+    // no <html> também: o fundo do CANVAS (o que o elástico revela) vem do
+    // html, e ele precisa acompanhar a paleta de cada tela
+    root.classList.add("pb-root-" + page);
 
     const bar = document.createElement("nav");
     bar.className = "pb-tabbar";

--- a/frontend/blog-article.html
+++ b/frontend/blog-article.html
@@ -17,6 +17,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos.html
+++ b/frontend/comandos.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/como-funciona.html
+++ b/frontend/como-funciona.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -5622,6 +5622,10 @@ document.addEventListener("keydown", (e) => {
 function applyTheme(theme) {
   const isLight = theme === "light";
   document.body.classList.toggle("light", isLight);
+  // espelha no <html>: o fundo do CANVAS (o que o elástico revela no app)
+  // vem do html, então ele precisa saber do tema — senão o claro fica com
+  // canvas escuro e a faixa reaparece, invertida
+  document.documentElement.classList.toggle("light", isLight);
   const icon  = document.getElementById("theme-toggle-icon");
   const label = document.getElementById("theme-toggle-label");
   if (icon)  icon.innerHTML = isLight

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4628,6 +4628,7 @@ async def dashboard_short_link(
 <html lang="pt-BR">
 <head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Link expirado</title>
+<script src="/safe-area.js?v=1"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
 body{background:#070b14;font-family:-apple-system,BlinkMacSystemFont,"SF Pro Display","Segoe UI",sans-serif;
@@ -4758,6 +4759,7 @@ async def unsubscribe(uid: int, token: str):
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <script src="/safe-area.js?v=1"></script>
   <title>Descadastro — PigBank</title>
   <style>
     body{margin:0;padding:0;background:#0a0d18;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;

--- a/frontend/funcionalidades.html
+++ b/frontend/funcionalidades.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,6 +53,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     .plan-solo-amount { font-size: 2.6rem; }
   }
 </style>
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/onboarding.html
+++ b/frontend/onboarding.html
@@ -21,6 +21,7 @@
   .back { display: inline-block; text-align: center; width: 100%; color: var(--ink-3); font-size: .84rem; margin-top: 16px; }
   .back:hover { color: var(--pink); }
 </style>
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -18,6 +18,7 @@
   #toast.err { border-color: rgba(255,45,45,.5); }
   .btn.loading { opacity: .7; pointer-events: none; }
 </style>
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/reset-password.html
+++ b/frontend/reset-password.html
@@ -23,6 +23,7 @@
   .back { display: inline-block; text-align: center; width: 100%; color: var(--ink-3); font-size: .84rem; margin-top: 18px; }
   .back:hover { color: var(--pink); }
 </style>
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -377,6 +377,18 @@ async def serve_app_mode_css():
     )
 
 
+@router.get("/safe-area.js")
+async def serve_safe_area_js():
+    """Reserva de safe area para as páginas fora do modo app (precos, landing,
+    legal…). O WebView usa contentInset "never" e vai até a borda em todas as
+    rotas; o app-mode.css só cobre seis páginas. Inerte fora do app."""
+    return FileResponse(
+        FRONTEND_DIR / "safe-area.js",
+        media_type="application/javascript",
+        headers={"Cache-Control": "public, max-age=300"},
+    )
+
+
 @router.get("/nav-auth.js")
 async def serve_nav_auth_js():
     """Nav ciente de login nas páginas de marketing: troca 'Entrar/Começar'

--- a/frontend/safe-area.js
+++ b/frontend/safe-area.js
@@ -42,7 +42,7 @@
     "padding-right:env(safe-area-inset-right);" +
     "padding-bottom:env(safe-area-inset-bottom);" +
     "padding-left:env(safe-area-inset-left);" +
-    "box-sizing:border-box;overscroll-behavior:none}" +
+    "box-sizing:border-box}" +
     // A nav do site é sticky com top:16px (site.css): quando gruda, o padding
     // do body já rolou pra fora, então ela precisa do inset no próprio top.
     "html.pb-safe .nav{top:calc(16px + env(safe-area-inset-top));" +

--- a/frontend/safe-area.js
+++ b/frontend/safe-area.js
@@ -1,0 +1,51 @@
+/**
+ * safe-area.js — reserva de área segura para as páginas que NÃO carregam o
+ * app-mode (precos, landing, legal, blog…).
+ *
+ * Por que existe: o WebView do app usa contentInset "never", então ele vai
+ * até a borda física da tela em TODAS as páginas do mesmo domínio — e o
+ * allowNavigation do capacitor.config permite qualquer rota de pigbankai.com.
+ * O app-mode.css só é carregado por seis páginas; sem este shim, as outras
+ * (ex.: /precos, alcançável pelo "Ver planos" do dashboard) desenhariam sob
+ * o status bar, o notch e o home indicator.
+ *
+ * Diferença pro app-mode: aqui NÃO há reskin. Nada de esconder nav, footer
+ * ou montar tab bar — só o respiro das bordas. A landing, por exemplo,
+ * precisa continuar mostrando a nav dela (é o caminho de volta pro app).
+ *
+ * Inerte fora do app: sem o user agent do app (nem PWA instalada, nem
+ * ?pbapp=1), não faz nada.
+ */
+(() => {
+  let stored = null;
+  try { stored = localStorage.getItem("pbApp"); } catch (_) {}
+  const standalone =
+    (window.matchMedia && window.matchMedia("(display-mode: standalone)").matches) ||
+    window.navigator.standalone === true;
+  const inApp =
+    /PigBankApp/.test(navigator.userAgent) ||
+    stored === "1" ||
+    new URLSearchParams(location.search).get("pbapp") === "1" ||
+    standalone;
+  if (!inApp) return;
+
+  document.documentElement.classList.add("pb-safe");
+
+  // viewport-fit=cover é o que faz env(safe-area-inset-*) reportar valor real
+  const m = document.querySelector('meta[name="viewport"]');
+  if (m && !/viewport-fit/.test(m.content)) m.content += ", viewport-fit=cover";
+
+  const css = document.createElement("style");
+  css.textContent =
+    "html.pb-safe body{" +
+    "padding-top:env(safe-area-inset-top);" +
+    "padding-right:env(safe-area-inset-right);" +
+    "padding-bottom:env(safe-area-inset-bottom);" +
+    "padding-left:env(safe-area-inset-left);" +
+    "box-sizing:border-box;overscroll-behavior:none}" +
+    // elementos grudados nas bordas (nav sticky, botões flutuantes) precisam
+    // reservar por conta própria: padding no body não alcança fixed
+    "html.pb-safe [style*='position:fixed'],html.pb-safe .sticky-nav,html.pb-safe .nav{" +
+    "padding-left:env(safe-area-inset-left);padding-right:env(safe-area-inset-right)}";
+  document.head.appendChild(css);
+})();

--- a/frontend/safe-area.js
+++ b/frontend/safe-area.js
@@ -43,9 +43,14 @@
     "padding-bottom:env(safe-area-inset-bottom);" +
     "padding-left:env(safe-area-inset-left);" +
     "box-sizing:border-box;overscroll-behavior:none}" +
-    // elementos grudados nas bordas (nav sticky, botões flutuantes) precisam
-    // reservar por conta própria: padding no body não alcança fixed
-    "html.pb-safe [style*='position:fixed'],html.pb-safe .sticky-nav,html.pb-safe .nav{" +
-    "padding-left:env(safe-area-inset-left);padding-right:env(safe-area-inset-right)}";
+    // A nav do site é sticky com top:16px (site.css): quando gruda, o padding
+    // do body já rolou pra fora, então ela precisa do inset no próprio top.
+    "html.pb-safe .nav{top:calc(16px + env(safe-area-inset-top));" +
+    "padding-left:max(18px,env(safe-area-inset-left));" +
+    "padding-right:max(18px,env(safe-area-inset-right))}" +
+    // Fixos presos à base: margin-bottom empurra pra cima SEM sobrescrever o
+    // "bottom" que cada página escolheu (o /precos usa 26px, por exemplo).
+    "html.pb-safe #toast,html.pb-safe .toast{" +
+    "margin-bottom:env(safe-area-inset-bottom)}";
   document.head.appendChild(css);
 })();

--- a/frontend/suporte.html
+++ b/frontend/suporte.html
@@ -19,6 +19,7 @@
   .faq-a .guide-prose > *:first-child { margin-top: 0; }
   .faq-a .guide-prose > p:first-of-type { font-size: 1rem; color: var(--ink); }
 </style>
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/whatsapp.html
+++ b/frontend/whatsapp.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/brand.css?v=4" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
+<script src="/safe-area.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/mobile/capacitor.config.json
+++ b/mobile/capacitor.config.json
@@ -14,7 +14,7 @@
     ]
   },
   "ios": {
-    "contentInset": "automatic",
+    "contentInset": "never",
     "appendUserAgent": "PigBankApp/1.0",
     "backgroundColor": "#111111"
   }


### PR DESCRIPTION
**Este PR foi dividido.** As correções de web (botão da conta na Início e o preto ao puxar a tela) saíram para o **#57**, que sobe no deploy sem depender de nada. Aqui ficou só a parte nativa e o trabalho de safe area que ela implica — que **só tem efeito depois de um build novo do app**.

## O problema

A faixa preta sob o status bar vem do `contentInset: "automatic"`, que encolhe o WKWebView para fora daquela área. O que aparece ali (e no overscroll) é o `backgroundColor` do próprio WebView — daí o corte seco com o fundo da página.

```diff
-    "contentInset": "automatic",
+    "contentInset": "never",
```

## O custo disso

Trocar para `"never"` desliga o ajuste nativo nos **quatro** lados, em **todas** as rotas do domínio. A partir daí é o CSS que reserva notch, Dynamic Island, cantos arredondados e home indicator. As rodadas de revisão deste PR mostraram esse raio — o inventário coberto agora:

| onde | por quê |
|---|---|
| corpo das páginas | os quatro insets |
| login/cadastro | sem tab bar, ficavam fora das regras por página — e é a tela de entrada do app |
| dock, sidenav, FAB, painel do chat, toast do dashboard | `fixed` não herda o padding do `body` |
| overlays de modal — `.overlay`, `.pig-modal-overlay`, `.mfa-overlay` | são três classes diferentes no produto, todas `fixed; inset:0` |
| largura/altura máximas dos modais | `100vw`/`100vh` incluem a área insegura |
| `.modal-success-toast`, `.upgrade-toast` | centralizar na horizontal não os torna seguros na **vertical**, presos por `bottom` fixo |
| páginas fora do modo app (`/precos`, landing, legal, blog…) | o WebView vai até a borda em qualquer rota, mas o `app-mode.css` só é carregado por seis páginas |

O último item é atendido por um shim novo (`safe-area.js`): ele **só** reserva as bordas, sem reskin. Isso é proposital — a landing, por exemplo, precisa continuar mostrando a nav dela, que é o caminho de volta pro app (#55).

## Verificação

`env()` não é injetável no navegador, então os casos com inset foram medidos aplicando os mesmos cálculos com valores fixos.

| verificação | resultado |
|---|---|
| dock com inset lateral de 47px | recolhe de `x=10 w=370` para `x=47 w=296`; centros das abas recalculam e o soquete se redesenha junto |
| painel do chat com inset de 59px no topo | topo vai para 142px (pela conta antiga ficaria em 20px, sob o status bar) |
| modal com inset de 59px | fica em `top: 347`, dentro da área segura |
| toast do settings | continua centralizado e encolhendo no conteúdo (55px / 160px / 362px) — não foi afetado pelo offset do dashboard |
| shim no UA do app | ativa, adiciona `viewport-fit=cover`, **não** esconde a nav do site |
| shim no navegador | inerte |
| em pé, `env()` = 0 | nada muda nas quatro telas; sem erro de JS |

## O que não dá pra verificar daqui

O comportamento do WKWebView em si — `contentInset` e o elástico — só no aparelho, depois do build. O que está verificado é que o CSS/JS aplica corretamente e que nada regride com `env()` zerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXPgcaw6whFE1EUHaEh6w8