### PR TITLE
fix(app): botão da conta na tela Início

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -19,6 +19,21 @@ html.pb-app body {
   overflow-x: hidden !important;
 }
 
+/* ─── Sem preto ao puxar a tela ─────────────────────────────────────────
+   Puxar a página além do fim fazia a borracha do iOS revelar o fundo do
+   WebView — uma faixa preta que não é a página. overscroll-behavior tira o
+   arrasto elástico do documento, e o fundo explícito no html garante que,
+   onde quer que o sistema pinte o canvas fora do conteúdo, a cor seja a da
+   página e não preto solto. */
+html.pb-app {
+  background: var(--bg-page, #111111);
+  overscroll-behavior: none;
+}
+html.pb-app body {
+  overscroll-behavior: none;
+  background-color: var(--bg-page, #111111);
+}
+
 /* Modais sempre cabem na tela */
 html.pb-app .modal,
 html.pb-app .modal.wide,
@@ -363,9 +378,29 @@ html.pb-app .pb-bill-val small.late { color: var(--red, #FF2D2D); }
 html.pb-app .nav { display: none !important; }
 
 /* ─── Home ─────────────────────────────────────────────────────────────── */
-/* Header do site some (nav vive na tab bar; conta fica em Ajustes) */
-html.pb-app body.pb-page-home > header,
-html.pb-app body.pb-page-home header:first-of-type { display: none !important; }
+/* O header FICA — é onde mora o botão da conta. Some só a nav de links, que
+   é redundante com a tab bar. (Antes o header inteiro era escondido, e a
+   Início ficava sem nenhum acesso à conta.)
+   Atenção ao seletor: aqui o <header> mora DENTRO de .page, não é filho
+   direto do body — por isso :first-of-type, e não "> header". */
+html.pb-app body.pb-page-home header:first-of-type {
+  /* a home.html empilha o header em ≤600px (flex-direction:column) — no app
+     ele volta pra UMA linha: marca à esquerda, conta à direita */
+  flex-direction: row !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  flex-wrap: nowrap !important;
+  padding: 10px 14px !important;
+  margin-bottom: 14px !important;
+}
+html.pb-app body.pb-page-home .nav-links { display: none !important; }
+/* ...e a conta deixa de ocupar a linha toda (regra de ≤600px do site) */
+html.pb-app body.pb-page-home .user-menu,
+html.pb-app body.pb-page-home .header-right {
+  width: auto !important;
+  max-width: none !important;
+  flex: 0 0 auto !important;
+}
 html.pb-app body.pb-page-home { padding-top: env(safe-area-inset-top); }
 html.pb-app footer { display: none !important; }
 
@@ -431,14 +466,16 @@ html.pb-app body.pb-page-app .header-right {
   flex-wrap: nowrap !important;
 }
 html.pb-app body.pb-page-app .user-menu { flex: 0 0 auto !important; }
-html.pb-app body.pb-page-app .user-menu-btn {
+html.pb-app body.pb-page-app .user-menu-btn,
+html.pb-app body.pb-page-home .user-menu-btn {
   width: 44px !important;
   min-height: 44px !important;
   padding: 0 !important;
   justify-content: center !important;
   border-radius: 50% !important;
 }
-html.pb-app body.pb-page-app .user-menu-btn .user-menu-main { display: none !important; }
+html.pb-app body.pb-page-app .user-menu-btn .user-menu-main,
+html.pb-app body.pb-page-home .user-menu-btn .user-menu-main { display: none !important; }
 
 /* Dropdown da conta: a regra mobile do dashboard.css (≤600px) posiciona com
    left:0 e width:100% do pai — mas no app o botão da conta é um círculo de

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -19,21 +19,6 @@ html.pb-app body {
   overflow-x: hidden !important;
 }
 
-/* ─── Sem preto ao puxar a tela ─────────────────────────────────────────
-   Puxar a página além do fim fazia a borracha do iOS revelar o fundo do
-   WebView — uma faixa preta que não é a página. overscroll-behavior tira o
-   arrasto elástico do documento, e o fundo explícito no html garante que,
-   onde quer que o sistema pinte o canvas fora do conteúdo, a cor seja a da
-   página e não preto solto. */
-html.pb-app {
-  background: var(--bg-page, #111111);
-  overscroll-behavior: none;
-}
-html.pb-app body {
-  overscroll-behavior: none;
-  background-color: var(--bg-page, #111111);
-}
-
 /* Modais sempre cabem na tela */
 html.pb-app .modal,
 html.pb-app .modal.wide,

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -346,8 +346,10 @@
     document.querySelectorAll(".sidenav-toggle").forEach(el => {
       el.innerHTML = burger;
     });
-    // Botão da conta: ícone de pessoa (era um segundo hambúrguer, confundia)
-    document.querySelectorAll(".hamburger-icon").forEach(el => {
+    // Botão da conta: ícone de pessoa. No dashboard o slot é .hamburger-icon
+    // (era um segundo hambúrguer, confundia); na Início é .user-caret, um "▾"
+    // que sozinho no círculo não diz que ali mora a conta.
+    document.querySelectorAll(".hamburger-icon, .user-caret").forEach(el => {
       el.innerHTML =
         '<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" ' +
         'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,8 +16,8 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=23" />
-  <script src="/app-mode.js?v=20"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=24" />
+  <script src="/app-mode.js?v=22"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,8 +80,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=23" />
-  <script src="/app-mode.js?v=20"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=24" />
+  <script src="/app-mode.js?v=22"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,8 +26,8 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=23" />
-  <script defer src="/app-mode.js?v=20"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=24" />
+  <script defer src="/app-mode.js?v=22"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -381,8 +381,8 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=23" />
-  <script src="/app-mode.js?v=20"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=24" />
+  <script src="/app-mode.js?v=22"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,8 +15,8 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=23" />
-  <script src="/app-mode.js?v=20"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=24" />
+  <script src="/app-mode.js?v=22"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1103,8 +1103,8 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=23" />
-  <script src="/app-mode.js?v=20"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=24" />
+  <script src="/app-mode.js?v=22"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Parte **web** do que foi relatado no app — vale no deploy, sem depender de build novo. É metade do #56, separado a pedido: a outra metade (o `contentInset` nativo e todo o trabalho de safe area que ele implica) fica lá, porque só tem efeito depois de um build e tem raio de alcance muito maior.

## A Início não tinha o botão da conta

O cabeçalho **inteiro** da Início era escondido no modo app ("a nav vive na tab bar") — mas é dentro dele que mora a conta. Naquela tela não havia nenhum acesso a ela.

Agora o cabeçalho fica e some só a `.nav-links`. Dois detalhes que só apareceram testando:

- a `home.html` empilha o header em ≤600px (`flex-direction: column`), então o círculo caía para uma segunda linha — no modo app ele volta a uma linha só;
- ali o slot do ícone é `.user-caret` (um "▾"), não o `.hamburger-icon` do dashboard — sozinho dentro do círculo não dizia "conta". Passa a receber o mesmo ícone de pessoa.

## O que saiu daqui (e por quê)

A primeira versão deste PR também tentava resolver o preto do overscroll com `overscroll-behavior: none` + fundo no `html`. **Os dois pedaços estavam errados e foram removidos em 4d44840:**

- o `overscroll-behavior: none` matava o arrasto elástico do iOS — que é comportamento **desejado**, não o problema. O incômodo era outro: a faixa preta permanente sob o status bar, que é nativa;
- o fundo no `html` pintava `#111111`, exatamente a cor que já vinha herdada do `body` — não mudava nada.

O tratamento correto do canvas (incluindo o modo claro, apontado pelo Codex nas duas frentes) foi para o **#56**, onde ele faz sentido: é lá que o WebView passa a ir até a borda, e aí o que o elástico revela importa de verdade.

Confirmado por grep no diff: este PR **não** contém `overscroll`, nenhuma regra de safe area e nenhuma mudança em `capacitor.config.json`.

## Verificação

WebView simulado com o UA real do app (`PigBankApp/1.0`):

| verificação | resultado |
|---|---|
| Início — botão da conta | **44×44, círculo, à direita** (x=319) |
| Início — header | uma linha só, `.nav-links` oculta |
| Início — menu | abre completo (inclui "Ir para o site" e "Sair") |
| /home, /app, /comandos-app, /settings | dock e bolha presentes, sem regressão |
| elástico (`overscroll-behavior`) | segue `auto` nas quatro telas — preservado |
| erros de JS | nenhum |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXPgcaw6whFE1EUHaEh6w8