### PR TITLE
test(security_alerts): limpa estado entre execuções contra o mesmo banco

### DIFF
--- a/tests/test_security_alerts.py
+++ b/tests/test_security_alerts.py
@@ -3,6 +3,13 @@
 Integração leve: usa o banco de teste (como test_audit.py). Exercita o novo
 desenho — detecção em transação própria, depois do commit do login, com
 cooldown por IP. Cada teste usa um IP distinto pra não interferir nos outros.
+
+Os testes escrevem em duas tabelas que ninguém mais limpa: `auth_login_events`
+(as falhas sintéticas) e `system_event_logs` (o marcador de cooldown). Sem
+limpeza, uma segunda execução contra o MESMO banco herda o estado da primeira —
+o cooldown de 30min suprime o alerta e as contagens de marcador acumulam. Daí o
+fixture `_clean_test_ips` abaixo (limpa antes E depois, pra também curar um
+banco já sujo de execuções anteriores).
 """
 import asyncio
 
@@ -10,15 +17,50 @@ import pytest
 
 from core.services import admin_notify, security_alerts
 
+# IPs de teste (TEST-NET-3, RFC 5737). Exclusivos deste arquivo — o fixture de
+# limpeza apaga tudo que estiver associado a eles, então não reutilize em outro
+# módulo de teste.
+_TEST_IPS = (
+    "203.0.113.201",
+    "203.0.113.202",
+    "203.0.113.203",
+    "203.0.113.204",
+)
+
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+async def _purge_test_ips() -> None:
+    """Apaga falhas de login e marcadores de alerta dos IPs deste arquivo."""
+    from core.admin_dashboard import db_connect
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "delete from auth_login_events where ip_address = any(%s)",
+                (list(_TEST_IPS),),
+            )
+            await cur.execute(
+                "delete from system_event_logs "
+                "where event_type = 'auth_spike_alert' "
+                "  and details->>'key' = any(%s)",
+                ([f"ip:{ip}" for ip in _TEST_IPS],),
+            )
+        await conn.commit()
 
 
 @pytest.fixture(autouse=True)
 def _ensure_tables():
     from core.admin_dashboard import ensure_admin_tables
     _run(ensure_admin_tables())
+
+
+@pytest.fixture(autouse=True)
+def _clean_test_ips(_ensure_tables):
+    _run(_purge_test_ips())
+    yield
+    _run(_purge_test_ips())
 
 
 async def _insert_failures(ip: str, n: int) -> None:


### PR DESCRIPTION
## Problema

Três testes de `tests/test_security_alerts.py` passam contra um banco recém-criado, mas **falham numa segunda execução contra o mesmo banco**:

- `test_abaixo_do_threshold_nao_alerta`
- `test_no_threshold_alerta_e_grava_marcador`
- `test_cooldown_nao_realerta`

O CI não pega porque provisiona um banco novo a cada execução. Só aparece em dev local, onde se reusa a mesma instância — e aí parece (falsamente) que a branch em que você está trabalhando quebrou algo. Pré-existente na `main`, sem relação com nenhuma branch de feature.

```bash
pytest tests/test_security_alerts.py -q   # passa
pytest tests/test_security_alerts.py -q   # falha 3
```

## Causa

**Duas** tabelas vazavam, não uma:

1. **`system_event_logs`** — o marcador de cooldown sobrevive ao teste. Dentro dos 30min ele suprime o alerta seguinte e, pior, `_marker_count()` conta **sem filtro de tempo**: os marcadores acumulam para sempre e a asserção `== 1` quebra em definitivo, não só dentro do cooldown.
2. **`auth_login_events`** — as falhas sintéticas somam entre execuções. Dentro da janela de 5min, 4 + 4 = 8 ≥ threshold 5, e o teste "abaixo do threshold" passa a alertar.

Estado encontrado num banco local já sujo:

```
 ip:203.0.113.202 | 2 marcadores      203.0.113.201 |  8 falhas
 ip:203.0.113.203 | 2 marcadores      203.0.113.202 | 10 falhas
                                      203.0.113.203 | 12 falhas
```

## Solução

Fixture autouse `_clean_test_ips` que apaga as duas tabelas para os IPs deste arquivo, **antes e depois** de cada teste. O "antes" não é redundante: é o que cura um banco já sujo de execuções anteriores, sem exigir um drop manual.

Ficou no próprio arquivo em vez de estender o `conftest.py` porque o cleanup é específico dessas duas tabelas e desses IPs — o padrão de lá (`_cleanup_user`) é orientado a `user_id`, e essas tabelas não têm esse vínculo aqui. Os IPs viraram a constante `_TEST_IPS`, com um comentário avisando que são exclusivos deste módulo (os outros testes usam `203.0.113.1/.5/.10/.42`, verificado).

## Validação

- `tests/test_security_alerts.py` 3× seguidas contra o mesmo banco, a primeira contra o banco já sujo: **5 passed** nas três.
- Suíte completa 2× seguidas: **1020 passed** nas duas.
- Banco após as rodadas: 0 marcadores e 0 linhas de `auth_login_events` para os IPs de teste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)