### PR TITLE
feat(app): puxar pra atualizar nas telas do app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,37 @@ espere alguém perguntar.
 **Merge só com autorização explícita do dono do repositório.** Aprovação do Codex e
 CI verde deixam o PR *pronto*; não autorizam o merge. Avise e pergunte.
 
+**O ciclo de correção também precisa de inventário — senão vira gerador de bug.**
+Registro do PR #60 (puxar pra atualizar): 14 rodadas de revisão, 21 apontamentos,
+e **quase metade nasceu das próprias correções**, não do código original. Os dois
+mecanismos que produziram isso, para nunca repetir:
+
+1. **Corrigir a instância e não a classe.** O gate do `PBRefresh` foi consertado
+   na Início sem perguntar "quem mais registra isso cedo demais?" — o dashboard
+   tinha o bug idêntico e virou a rodada seguinte. A proteção de digitação foi
+   posta nas telas de reload sem olhar as de refresh mole — a chave Pix virou a
+   rodada seguinte. A regra já estava neste arquivo (§2: "achei um caso" ≠
+   "resolvi a categoria") e vale DOBRADO para apontamento de revisor: antes de
+   responder a thread, nomear a classe e varrer os irmãos com grep. Quando a
+   varredura foi feita (rodada 3, os 12 branches do `PBRefresh`), ela achou bug
+   que o revisor não tinha visto.
+
+2. **Remendar transição em vez de enumerar a máquina.** Da rodada 7 em diante os
+   apontamentos eram todos transições de uma máquina de estados (gesto ×
+   refresh) construída um remendo por vez, reagindo ao revisor. Um único campo
+   (a chave Pix) consumiu TRÊS rodadas: sucesso, falha, edição durante o fetch —
+   três caminhos que uma tabela de estados teria mostrado de uma vez. **Se duas
+   rodadas seguidas batem no mesmo subsistema, pare de remendar: enumere
+   estados × eventos por escrito e feche tudo num commit.** A enumeração feita
+   ao final achou 2 bugs que o revisor ainda não tinha apontado.
+
+O custo disso não foi abstrato. Erros meus que chegaram a existir no branch e
+seriam produção sem o ciclo de revisão: reload por cima dos códigos de backup do
+MFA (que aparecem uma vez); totais financeiros zerados renderizados com cara de
+sucesso; cache bom sobrescrito com histórico vazio; pedido velho sobrescrevendo
+resposta mais nova; PATCH de preferências abortado no meio. Cada um entrou num
+commit que "corrigia" outra coisa.
+
 **Separe por verificabilidade, não por tamanho.** Se parte do trabalho pode ser
 comprovada agora e parte só depois (build de app, deploy, acesso a produção), abra
 dois PRs. A metade verificável sobe sem ficar refém da outra.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,243 @@
+# PigBank — como trabalhar neste repositório
+
+> **Contexto de domínio** (tabelas, endpoints, fluxos de cadastro, e-mail, roadmap):
+> `docs/CLAUDE.md`. Guia de desenvolvimento: `docs/dev_guide.md`.
+>
+> **Este arquivo é sobre o processo**: o que fazer antes de escrever, como validar,
+> e as armadilhas deste código que já custaram caro.
+
+---
+
+## 1. Antes de escrever a primeira linha
+
+**Entenda a queixa antes de diagnosticar.** Relato de usuário quase nunca é
+diagnóstico. Se a descrição admite mais de uma causa, pergunte pelo estado em que
+elas se separam — não escolha uma e comece a codar.
+
+> Custou um branch inteiro: "aparecem barras pretas ao puxar a tela" tinha duas
+> leituras (o preto *durante* o arrasto elástico e uma faixa *permanente* sob o
+> status bar). Foi tratada a errada. A pergunta que resolvia era uma só:
+> "como fica com a tela parada, sem tocar?"
+
+**Planeje antes, e por escrito.** Para qualquer coisa além de uma correção local:
+liste o que vai mudar, onde, e o que pode quebrar — antes de editar. Se o plano
+tem mais de três passos ou toca em mais de um arquivo, mostre-o e confirme.
+
+**Pergunte o que a mudança torna verdade no resto do sistema.** A pergunta certa
+nunca é só "isso resolve?". Uma flag de configuração de 8 caracteres pode transferir
+responsabilidade para todo o produto.
+
+> `contentInset: "never"` no `capacitor.config.json` é uma linha. Ela desliga o
+> ajuste nativo de área segura nos **quatro** lados, em **todas** as rotas do
+> domínio, em todas as orientações. Virou 21 arquivos e 15 apontamentos de revisão.
+
+---
+
+## 2. Medir o alcance — o inventário
+
+Mudança transversal (CSS global, config nativa, middleware, schema, helper usado em
+muitos lugares) **começa por uma varredura, não por uma edição**. O inventário se faz
+com `grep`, nunca de memória.
+
+Perguntas que se respondem com busca, não com raciocínio:
+
+- **Quem mais está nesta categoria?** Corrigiu um elemento — o que mais é da mesma
+  classe? (`position: fixed`, `100vw`/`100vh`, `bottom:` fixo, `z-index` alto…)
+- **Com o que isto faz par?** Elementos costumam vir em pares que precisam mudar
+  juntos: botão e painel, overlay e conteúdo, escrita e leitura, migração e query.
+- **Quem carrega isto × quem é alcançável?** No frontend as duas listas são
+  diferentes, e é aí que mora o buraco (§5).
+- **Existe versão gerada fora do template?** Sim, existe (§5).
+
+> O padrão que se repetiu 15 vezes num único PR foi sempre o mesmo erro: tratar
+> "achei um caso" como "resolvi a categoria". Corrigiu o FAB e não o painel que é
+> par dele; corrigiu os lados do painel e não a altura; varreu os `.html` e esqueceu
+> o HTML gerado em Python.
+
+**Seletor parecido não é contrato igual.** Antes de aplicar uma regra a N seletores,
+leia o que cada um já declara. `.modal`, `.modal.wide`, `.mfa-modal` e `.pig-modal`
+parecem intercambiáveis e não são — um tem largura própria, outro não tem `overflow`.
+Isso gerou dois apontamentos separados.
+
+---
+
+## 3. Testar e validar antes de empurrar
+
+**Nunca empurrar sem rodar a suíte.** Ela precisa de Postgres no ar e das variáveis
+de ambiente — sem isso o pytest morre com `INTERNALERROR` no import, o que **não** é
+falha de teste e não deve ser lido como tal:
+
+```bash
+export DATABASE_URL="postgresql://…"     # Postgres acessível
+export JWT_SECRET="…"                    # 32+ bytes
+export PII_ENCRYPTION_KEY="…" PII_HASH_PEPPER="…"
+export PII_AUDIT_DISABLED=1 RUN_BACKGROUND_TASKS=0
+
+PYTHONPATH=. python3 -m pytest -q                 # tudo
+PYTHONPATH=. python3 -m pytest tests/test_x.py -q # durante o desenvolvimento
+```
+
+Use `python3 -m pytest`, não `pytest` solto — o binário no PATH pode ser de outro
+interpretador, sem as dependências instaladas.
+
+O CI (`.github/workflows/tests.yml`) sobe seu próprio Postgres 16 e roda `pytest`
+(bloqueante) e `audit` de CVEs (não-bloqueante) em todo push e PR. Não use o CI como
+primeiro teste — ele é a confirmação, não a descoberta.
+
+**Compare com a baseline, não com zero.** Rode a suíte **antes** de mexer e guarde o
+número. Falha que já existia não é regressão sua; falha nova é. Sem a baseline não dá
+para distinguir as duas, e sobra "os testes estão vermelhos" sem conclusão.
+
+**A baseline local oscila — compare por nome de teste, não por contagem.** Duas
+execuções idênticas, seguidas, deram resultados diferentes:
+
+```
+execução A:   9 failed, 984 passed
+execução B:  12 failed, 981 passed
+```
+
+O núcleo estável são os **7** de `tests/test_statement_import.py` (dependem do
+`ofxparse`, §6). Os demais — `test_export_email`, `test_nlp_and_pending_flow`,
+`test_security_alerts` — aparecem e somem entre execuções: há dependência de ordem ou
+de estado compartilhado no banco de teste. **Consequência prática:** um número de
+falhas maior que o da sua baseline não prova regressão, e um igual não prova ausência
+dela. Compare a **lista de nomes**, e na dúvida rode o arquivo suspeito isolado
+(`pytest tests/test_x.py -q`), onde o efeito de ordem não existe.
+
+**Frontend também se testa.** Há Chromium com Playwright disponível
+(`/opt/pw-browsers/`, use `NODE_PATH=$(npm root -g)`). Mudou layout, mediu; não
+"pareceu certo". E as duas perguntas que separam medição de teatro:
+
+1. **Quanto isso daria se a correção não fizesse nada?** Se a resposta for "o mesmo
+   número", a medição não mede nada — corrija o teste antes de reportar o resultado.
+2. **Que classe de bug esta verificação nunca pegaria?** Se existe uma classe cega,
+   ela precisa de outro método (enumeração, revisão linha a linha), porque testar
+   mais do mesmo não vai alcançá-la.
+
+> As duas perguntas vêm de erros reais: uma medição de largura de modal que dava o
+> mesmo valor com e sem a correção (a CSS do componente nem estava na página), e uma
+> bateria inteira de testes de área segura que era estruturalmente cega ao erro que
+> estava sendo cometido, porque `env(safe-area-inset-*)` vale 0 no navegador headless.
+
+**Verifique que não quebrou nada em volta.** Toda regra nova de CSS global, todo
+helper alterado, toda mudança de schema: confira o caminho vizinho, não só o que você
+consertou. `git diff` antes do commit, lido de ponta a ponta.
+
+---
+
+## 4. PR, Codex e threads
+
+**Toda mudança vai por PR.** Nunca empurre direto na `main`.
+
+**Espere o Codex.** Ele revisa automaticamente ao abrir o PR e responde a
+`@codex review` num comentário. Não merje antes do parecer dele — mesmo com o CI
+verde, mesmo parecendo trivial.
+
+**Responda cada thread, e peça revisão de novo.** O ciclo completo:
+
+1. o Codex aponta;
+2. corrija — ou explique por que o apontamento não procede, com evidência;
+3. **responda na própria thread**, citando o commit da correção e o que foi medido;
+4. comente `@codex review` para ele reavaliar o head novo;
+5. repita até ele aprovar ("Didn't find any major issues").
+
+Nunca deixe thread sem resposta e nunca afirme que threads estão respondidas sem
+abrir e conferir. **Se você pediu revisão, é sua obrigação ir ler o parecer** — não
+espere alguém perguntar.
+
+**Merge só com autorização explícita do dono do repositório.** Aprovação do Codex e
+CI verde deixam o PR *pronto*; não autorizam o merge. Avise e pergunte.
+
+**Separe por verificabilidade, não por tamanho.** Se parte do trabalho pode ser
+comprovada agora e parte só depois (build de app, deploy, acesso a produção), abra
+dois PRs. A metade verificável sobe sem ficar refém da outra.
+
+---
+
+## 5. Armadilhas conhecidas deste repositório
+
+### Frontend: o app é o mesmo site
+
+O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView com
+`allowNavigation` para o domínio inteiro. Consequências que já causaram bug:
+
+- **Quem carrega o CSS ≠ quem é alcançável.** `app-mode.css`/`app-mode.js` são
+  carregados por **6** páginas (`login`, `cadastro`, `home`, `dashboard`,
+  `comandos-app`, `settings`). Mas qualquer rota do domínio abre no app — o "Ver
+  planos" do dashboard leva ao `/precos`, que não carrega nenhum dos dois. Por isso
+  existe o shim `frontend/safe-area.js`, incluído em outras **14** páginas.
+  As **5** restantes (`admin-login`, `admin-dashboard`, mockups e previews) não têm
+  nem um nem outro, de propósito — se alguma virar rota alcançável pelo app, precisa
+  entrar no shim.
+- **Existe HTML gerado em Python**, fora de qualquer template:
+  `frontend/finance_bot_websocket_custom.py` devolve duas páginas standalone
+  (link expirado do `/d/{code}`, descadastro). O `AppDelegate.swift` carrega o
+  `/d/{code}` **direto no WebView**. Toda mudança global de frontend esquece essas
+  duas — já esqueceu.
+- **O modo app é `html.pb-app`**, inerte na web. A classe da página vai no `<body>`
+  (`pb-page-*`) **e** no `<html>` (`pb-root-*`) — o fundo do canvas (o que o elástico
+  revela) vem do `<html>`, não do `<body>`.
+- **`position: fixed` não herda o padding do `body`.** Todo fixo ancorado numa borda
+  precisa reservar a área segura por conta própria.
+- **Paisagem está habilitada no iPhone** (`mobile/ios/App/App/Info.plist`), então os
+  insets laterais contam. Não trate área segura como assunto de topo.
+
+### Componentes fragmentados
+
+Três overlays (`.overlay`, `.pig-modal-overlay`, `.mfa-overlay`) e quatro modais
+(`.modal`, `.modal.wide`, `.mfa-modal`, `.pig-modal`) fazem o mesmo trabalho com
+contratos diferentes. Qualquer regra transversal precisa ser escrita para os três/quatro
+— e conferindo o que cada um já declara. Enquanto isso não for unificado, é imposto
+fixo de toda mudança de layout.
+
+### Backend
+
+- **`db/` é um pacote**, não o `db.py` único que o `docs/CLAUDE.md` descreve — aquele
+  arquivo está desatualizado nesse ponto. As rotas também estão divididas em
+  `frontend/routes/`.
+- **Isolamento por usuário é regra dura**: toda query com `WHERE user_id = %s`.
+  Nunca vazar dado entre usuários.
+
+---
+
+## 6. Limites deste ambiente (não são bugs, não tente contornar)
+
+- **A produção não é acessível.** O proxy bloqueia `pigbankai.com` (403). Não dá para
+  conferir o comportamento real do site daqui.
+- **CDNs são bloqueados.** Chart.js e afins falham; `applyTheme` do dashboard, por
+  exemplo, lança no meio por causa disso. Saiba disso ao interpretar um teste.
+- **`env(safe-area-inset-*)` vale sempre 0** no Chromium headless. Regras de área
+  segura são inertes aqui; só dá para verificar a aritmética substituindo valores fixos.
+- **Comportamento nativo do WKWebView não é reproduzível.** `contentInset`, elástico,
+  teclado: só no aparelho, depois do build.
+- **`ofxparse` não está instalado aqui** (o `pip install` falha pelo proxy). Isso não
+  faz "alguns testes falharem": são **9 erros de coleta**, e o pytest **interrompe a
+  suíte inteira** antes de rodar qualquer teste. Sem tratar isso você não tem sinal
+  nenhum — nem verde, nem vermelho. Para obter baseline local:
+
+  ```bash
+  PYTHONPATH=. python3 -m pytest -q $(python3 -m pytest -q 2>&1 \
+    | grep "^ERROR tests/" | sed 's/^ERROR /--ignore=/' | tr '\n' ' ')
+  ```
+
+  Com esses 9 fora, a suíte roda em ~70s: **981–984 passam**, e as falhas restantes
+  incluem sempre os **7** de `tests/test_statement_import.py`, que importam `ofxparse`
+  de forma indireta e não são pegos pelo `--ignore` acima.
+
+  No CI o `ofxparse` está presente (`requirements.txt:56`), então lá esses módulos
+  rodam normalmente — a exclusão é só local.
+
+Nunca desligue verificação de TLS nem tire o `HTTPS_PROXY` para contornar bloqueio.
+
+---
+
+## 7. Como reportar o que foi feito
+
+- **Diga o que mediu e o que não mediu.** Se algo não pôde ser verificado, diga com
+  todas as letras, e diga o que *falta* para verificar ("só no aparelho, depois do
+  build"). Silêncio sobre o não-verificado lê-se como verificado.
+- **Números, não adjetivos.** "O botão fica dentro do card em 844×390" vale; "parece
+  ok" não vale.
+- **Erro admitido em uma frase, e segue.** Sem autoflagelação e sem esconder.
+- **Não afirme estado sem consultar.** Antes de dizer "o CI está verde", "as threads
+  estão respondidas" ou "o Codex aprovou" — abra e confira.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,19 @@ causa só** — são dois grupos de dependência ausente (§6). Os demais —
 de estado compartilhado no banco de teste. **Consequência prática:** um número de
 falhas maior que o da sua baseline não prova regressão, e um igual não prova ausência
 dela. Compare a **lista de nomes**, e na dúvida rode o arquivo suspeito isolado
-(`pytest tests/test_x.py -q`), onde o efeito de ordem não existe.
+(`pytest tests/test_x.py -q`). Isso corta a interferência **dos outros arquivos**, e só
+isso: os testes de dentro do arquivo continuam no mesmo processo, na ordem de definição,
+compartilhando estado global e as mesmas linhas de banco. Se a falha persistir isolada,
+ainda pode ser ordem interna. Para descartar, desça mais um nível: rode o teste
+**sozinho** (`pytest "tests/test_x.py::test_y" -q`) e depois varie a ordem passando os
+node IDs explicitamente na linha de comando — o pytest executa na ordem em que você os
+lista (não há plugin de ordenação instalado aqui; o único plugin é o `anyio`):
+
+```bash
+pytest -v "tests/test_x.py::test_b" "tests/test_x.py::test_a"
+```
+
+"Passou isolado" nunca é prova de que não há efeito de ordem.
 
 **Frontend também se testa.** Há Chromium com Playwright disponível
 (`/opt/pw-browsers/`, use `NODE_PATH=$(npm root -g)`). Mudou layout, mediu; não
@@ -162,22 +174,35 @@ dois PRs. A metade verificável sobe sem ficar refém da outra.
 O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView com
 `allowNavigation` para o domínio inteiro. Consequências que já causaram bug:
 
-- **Quem carrega o CSS ≠ quem é alcançável.** `app-mode.css`/`app-mode.js` são
-  carregados por **6** páginas (`login`, `cadastro`, `home`, `dashboard`,
-  `comandos-app`, `settings`). Mas qualquer rota do domínio abre no app — o "Ver
-  planos" do dashboard leva ao `/precos`, que não carrega nenhum dos dois. Por isso
-  existe o shim `frontend/safe-area.js`, incluído em outras **14** páginas.
-  As **5** restantes (`admin-login`, `admin-dashboard`, mockups e previews) não têm
-  nem um nem outro, de propósito — se alguma virar rota alcançável pelo app, precisa
-  entrar no shim.
+- **Quem carrega o CSS ≠ quem é alcançável, e não há rede de segurança.** Das **25**
+  páginas em `frontend/`, apenas **6** carregam `app-mode.css`/`app-mode.js`
+  (`login`, `cadastro`, `home`, `dashboard`, `comandos-app`, `settings`). As outras
+  **19** não têm tratamento nenhum de área segura: `env(safe-area-inset-*)` aparece em
+  **um único arquivo do repositório**, o `frontend/app-mode.css`
+  (`grep -rl safe-area-inset frontend/`). Não existe shim, fallback nem base comum —
+  se você mexer em `/precos`, `/termos`, `/onboarding` ou qualquer uma das 19, está
+  numa página sem proteção alguma.
+
+  Isso importa porque **qualquer rota do domínio abre no app**: o "Ver planos" do
+  dashboard leva ao `/precos`, que é uma das 19. Ao tornar uma dessas rotas alcançável
+  pelo app, o tratamento tem de ser adicionado — não há para onde "herdar".
 - **Existe HTML gerado em Python**, fora de qualquer template:
   `frontend/finance_bot_websocket_custom.py` devolve duas páginas standalone
   (link expirado do `/d/{code}`, descadastro). O `AppDelegate.swift` carrega o
   `/d/{code}` **direto no WebView**. Toda mudança global de frontend esquece essas
   duas — já esqueceu.
-- **O modo app é `html.pb-app`**, inerte na web. A classe da página vai no `<body>`
-  (`pb-page-*`) **e** no `<html>` (`pb-root-*`) — o fundo do canvas (o que o elástico
-  revela) vem do `<html>`, não do `<body>`.
+- **O modo app é `html.pb-app`**, inerte na web. O `app-mode.js` põe no `<html>` só
+  `pb-app` e, quando a rota não tem tab bar, `pb-no-tabs`; a classe da **página** vai
+  no `<body>` como `pb-page-*` (`app-mode.js:30`, `:84`, `:85`). Não existe
+  `pb-root-*` — CSS escrito contra esse seletor nunca casa. O escopo real é
+  `html.pb-app body.pb-page-x`.
+
+  Cuidado com o fundo que o elástico revela: ele vem do **canvas**, e o canvas herda
+  do `<html>`. Hoje nenhuma regra define `background` no `<html>` — o único fundo perto
+  da raiz é `html.pb-app body.pb-page-settings { background: #0B0B0D !important }`
+  (`app-mode.css:505`), que funciona por propagação do `<body>`. Se um dia alguém
+  pintar o `<html>`, essa propagação para de valer e o `<body>` deixa de mandar no
+  canvas.
 - **`position: fixed` não herda o padding do `body`.** Todo fixo ancorado numa borda
   precisa reservar a área segura por conta própria.
 - **Paisagem está habilitada no iPhone** (`mobile/ios/App/App/Info.plist`), então os

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,10 +242,39 @@ fixo de toda mudança de layout.
   suíte inteira** antes de rodar qualquer teste. Sem tratar isso você não tem sinal
   nenhum — nem verde, nem vermelho. Para obter baseline local:
 
+  A lista é **fixa** — são estes 9, e só estes:
+
   ```bash
-  PYTHONPATH=. python3 -m pytest -q $(python3 -m pytest -q 2>&1 \
-    | grep "^ERROR tests/" | sed 's/^ERROR /--ignore=/' | tr '\n' ' ')
+  IGNORADOS=(
+    tests/test_audio_clarification.py
+    tests/test_audio_multi_launch_ask_value.py
+    tests/test_full_handler_smoke.py
+    tests/test_handle_incoming_routing.py
+    tests/test_recurring_value.py
+    tests/test_split_audio_transactions.py
+    tests/test_whatsapp_confirmations.py
+    tests/test_whatsapp_daily_report.py
+    tests/test_whatsapp_simulation.py
+  )
+
+  # Guarda: erro de coleta fora da lista é problema SEU, não do ambiente.
+  NOVOS=$(PYTHONPATH=. python3 -m pytest -q 2>&1 \
+    | grep "^ERROR tests/" | sed 's/^ERROR //' \
+    | grep -vxF "$(printf '%s\n' "${IGNORADOS[@]}")")
+  if [ -n "$NOVOS" ]; then
+    echo "ERRO DE COLETA NOVO — corrija antes de tirar baseline:"; echo "$NOVOS"
+  else
+    PYTHONPATH=. python3 -m pytest -q "${IGNORADOS[@]/#/--ignore=}"
+  fi
   ```
+
+  **Não gere essa lista com `grep ERROR | sed s/^ERROR/--ignore=/`.** Esse atalho
+  ignora *qualquer* erro de coleta, inclusive um que a sua própria mudança acabou de
+  introduzir: um `ImportError` ou erro de sintaxe num arquivo de teste vira mais um
+  `--ignore`, a rodada seguinte passa verde e o arquivo inteiro nunca roda. Testado:
+  com um arquivo de sintaxe quebrada em `tests/`, o pipeline montou **10** `--ignore`
+  em vez de 9 e engoliu o arquivo quebrado sem uma linha de aviso. A guarda acima
+  pega esse caso — foi verificada nos dois sentidos, em `bash` e em `zsh`.
 
   Com esses 9 fora, a suíte roda em ~70s: **981–984 passam**, e as falhas restantes
   incluem sempre os **7** de `tests/test_statement_import.py`. Esses 7 **não vêm todos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,9 @@ execução A:   9 failed, 984 passed
 execução B:  12 failed, 981 passed
 ```
 
-O núcleo estável são os **7** de `tests/test_statement_import.py` (dependem do
-`ofxparse`, §6). Os demais — `test_export_email`, `test_nlp_and_pending_flow`,
+O núcleo estável são os **7** de `tests/test_statement_import.py`, e eles **não têm uma
+causa só** — são dois grupos de dependência ausente (§6). Os demais —
+`test_export_email`, `test_nlp_and_pending_flow`,
 `test_security_alerts` — aparecem e somem entre execuções: há dependência de ordem ou
 de estado compartilhado no banco de teste. **Consequência prática:** um número de
 falhas maior que o da sua baseline não prova regressão, e um igual não prova ausência
@@ -210,7 +211,8 @@ fixo de toda mudança de layout.
   segura são inertes aqui; só dá para verificar a aritmética substituindo valores fixos.
 - **Comportamento nativo do WKWebView não é reproduzível.** `contentInset`, elástico,
   teclado: só no aparelho, depois do build.
-- **`ofxparse` não está instalado aqui** (o `pip install` falha pelo proxy). Isso não
+- **Faltam pacotes de `requirements.txt` aqui** — pelo menos `ofxparse`, `reportlab` e
+  `pypdf` (o `pip install` falha pelo proxy). A ausência do `ofxparse` não
   faz "alguns testes falharem": são **9 erros de coleta**, e o pytest **interrompe a
   suíte inteira** antes de rodar qualquer teste. Sem tratar isso você não tem sinal
   nenhum — nem verde, nem vermelho. Para obter baseline local:
@@ -221,11 +223,27 @@ fixo de toda mudança de layout.
   ```
 
   Com esses 9 fora, a suíte roda em ~70s: **981–984 passam**, e as falhas restantes
-  incluem sempre os **7** de `tests/test_statement_import.py`, que importam `ofxparse`
-  de forma indireta e não são pegos pelo `--ignore` acima.
+  incluem sempre os **7** de `tests/test_statement_import.py`. Esses 7 **não vêm todos
+  do `ofxparse`** — são dois grupos, e vale saber qual é qual, porque só o primeiro
+  desaparece se o `ofxparse` voltar:
 
-  No CI o `ofxparse` está presente (`requirements.txt:56`), então lá esses módulos
-  rodam normalmente — a exclusão é só local.
+  | testes | dependência que falta | onde estoura |
+  |---|---|---|
+  | `test_attachment_detection`, `test_import_statement_bytes_csv_idempotente`, `test_import_statement_bytes_vazio_ou_grande` | `ofxparse` (import indireto, não pego pelo `--ignore` acima) | `core/handle_incoming.py` → `core/services/ofx_service.py`; e o import tardio em `statement_import.py:583` → `ofx_import.py:8` |
+  | `test_parse_pdf_sicoob_like`, `test_parse_pdf_valor_e_saldo_na_mesma_linha`, `test_parse_pdf_sufixo_c_nao_engole_palavra`, `test_parse_pdf_sem_transacoes` | `reportlab` (helper `_make_pdf` do teste) e `pypdf` (`_extract_pdf_text`, `statement_import.py:463`) | o `_make_pdf` estoura primeiro; qualquer um dos dois ausente derruba os mesmos 4 |
+
+  Os outros dois testes de PDF do arquivo (`test_parse_pdf_nubank_extrato` e
+  `test_parse_pdf_nubank_sem_secao_usa_palavra_chave`) passam mesmo sem esses pacotes:
+  operam sobre texto puro, sem gerar nem ler PDF. E nada fora de
+  `tests/test_statement_import.py` usa `reportlab`/`pypdf`, por isso o estrago fica
+  contido nesse arquivo.
+
+  **Não trate os 7 como um bloco.** Se você mexer no parser de PDF e um desses 4 mudar
+  de mensagem — de `ImportError` para uma falha de asserção, ou vice-versa — isso é
+  sinal, não baseline.
+
+  No CI os três pacotes estão presentes (`requirements.txt:56–57,66`), então lá tudo
+  isso roda normalmente — a exclusão é só local.
 
 Nunca desligue verificação de TLS nem tire o `HTTPS_PROXY` para contornar bloqueio.
 

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -692,13 +692,18 @@ html.pb-app .pb-ptr-arc {
 
 /* Atualizando: o arco vira um risco curto girando (indeterminado) */
 html.pb-app .pb-ptr-busy svg { animation: pb-ptr-spin 0.85s linear infinite; }
-html.pb-app .pb-ptr-busy .pb-ptr-arc {
-  stroke-dasharray: 26 80;
-  stroke-dashoffset: 0;
-}
+/* O arco curto do "girando" é setado no JS, não aqui: o dasharray é estilo
+   inline (o puxão o usa pra fechar o anel) e inline vence classe. */
+html.pb-app .pb-ptr-busy .pb-ptr-arc { stroke-dashoffset: 0; }
 @keyframes pb-ptr-spin { to { transform: rotate(270deg); } }
 
 @media (prefers-reduced-motion: reduce) {
   html.pb-app .pb-ptr-busy svg { animation: none; }
-  html.pb-app .pb-ptr-busy .pb-ptr-arc { stroke-dasharray: none; }
 }
+
+/* Refresh falhou: o anel fecha em âmbar e para de girar por um instante antes
+   de recolher. A página mantém o dado antigo (melhor que destruir a tela), e
+   sem este aviso o usuário juraria que atualizou. */
+html.pb-app .pb-ptr-fail svg { animation: none; }
+html.pb-app .pb-ptr-fail .pb-ptr-track { stroke: rgba(255, 176, 32, 0.22); }
+html.pb-app .pb-ptr-fail .pb-ptr-arc { stroke: #FFB020; }

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -630,3 +630,75 @@ html.pb-app .sidenav {
   padding-bottom: calc(14px + env(safe-area-inset-bottom));
 }
 html.pb-app .sidenav-backdrop.open { z-index: 750; }
+
+/* ─── Puxar pra atualizar ──────────────────────────────────────────────────
+   O indicador desce sozinho por cima da página — o conteúdo NÃO se mexe (ver
+   o porquê no app-mode.js, initPullToRefresh). Posição e escala vêm de lá;
+   aqui fica só a aparência.
+
+   z-index 690: abaixo da tab bar (700) e dos modais (800/900), acima do
+   conteúdo. Puxar com modal aberto não deve desenhar nada por cima dele. */
+html.pb-app .pb-ptr {
+  position: fixed;
+  z-index: 690;
+  left: 50%;
+  top: calc(env(safe-area-inset-top) + 4px);
+  width: 40px;
+  height: 40px;
+  margin-left: -20px;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate3d(0, 0, 0) scale(0.5);
+  will-change: transform, opacity;
+}
+
+html.pb-app .pb-ptr-disc {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: #1B1A20;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
+}
+html.pb-app .pb-ptr-disc img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  display: block;
+}
+
+/* O anel mora sobre o disco; -90deg faz o arco começar às 12h */
+html.pb-app .pb-ptr svg {
+  position: absolute;
+  inset: 0;
+  width: 40px;
+  height: 40px;
+  transform: rotate(-90deg);
+}
+html.pb-app .pb-ptr-track {
+  fill: none;
+  stroke: rgba(255, 45, 142, 0.22);
+  stroke-width: 2.5;
+}
+html.pb-app .pb-ptr-arc {
+  fill: none;
+  stroke: #FF2D8E;
+  stroke-width: 2.5;
+  stroke-linecap: round;
+}
+
+/* Atualizando: o arco vira um risco curto girando (indeterminado) */
+html.pb-app .pb-ptr-busy svg { animation: pb-ptr-spin 0.85s linear infinite; }
+html.pb-app .pb-ptr-busy .pb-ptr-arc {
+  stroke-dasharray: 26 80;
+  stroke-dashoffset: 0;
+}
+@keyframes pb-ptr-spin { to { transform: rotate(270deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  html.pb-app .pb-ptr-busy svg { animation: none; }
+  html.pb-app .pb-ptr-busy .pb-ptr-arc { stroke-dasharray: none; }
+}

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -588,7 +588,8 @@
       window.matchMedia("(prefers-reduced-motion: reduce)").matches);
 
     let pull = 0, startY = 0, startX = 0, tracking = false, busy = false, raf = 0;
-    let dragged = false;   // este gesto puxou de verdade (tap nunca arma)
+    let dragged = false;    // este gesto puxou de verdade (tap nunca arma)
+    let inFlight = null;    // PBRefresh pendente (o watchdog libera o ciclo, não o pedido)
 
     const damp = o => PTR.rubber * (1 - 1 / (o / PTR.rubber + 1));
     const atTop = () =>
@@ -672,11 +673,19 @@
         setTimeout(() => finish(ok), Math.max(0, PTR.floor - (Date.now() - t0)));
       };
       setTimeout(() => done(false), PTR.watchdog);   // pendurado conta como falha
-      // A falha NÃO é engolida: vira aviso no indicador. Antes o catch vazio
-      // recolhia igual ao sucesso, e a tela ficava com dado velho sem dizer.
-      Promise.resolve()
-        .then(() => window.PBRefresh())
-        .then(() => done(true), () => done(false));
+      // A falha NÃO é engolida: vira aviso no indicador. E os PBRefresh são
+      // SERIALIZADOS: o watchdog libera o ciclo visual, não o pedido — sem a
+      // fila, um pedido estourado seguia vivo e podia terminar DEPOIS do
+      // puxão seguinte, sobrescrevendo resposta mais nova no DOM e no cache.
+      // Na fila, o novo só dispara quando o antigo assentar; se o antigo
+      // nunca assentar, o watchdog pinta âmbar de novo — honesto e sem
+      // corrida. O catch() na fila evita rejeição não tratada do elo velho.
+      const prev = inFlight;
+      const p = Promise.resolve(prev)
+        .catch(() => {})
+        .then(() => window.PBRefresh());
+      inFlight = p.catch(() => {});
+      p.then(() => done(true), () => done(false));
     }
 
     // Duas coisas mandam no gesto delas, e não no puxão da página:

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -612,16 +612,29 @@
       })();
     }
 
-    function finish() {
+    function finish(ok) {
       if (!busy) return;
       busy = false;
       el.classList.remove("pb-ptr-busy");
-      spring(0);
+      arc.style.strokeDasharray = circ.toFixed(1);   // volta a ser anel inteiro
+      if (ok) { spring(0); return; }
+      // Falhou: avisa em âmbar em vez de recolher como se tivesse dado certo.
+      // A página mantém o dado antigo na tela (é o certo — melhor dado velho
+      // que tela destruída), então sem este aviso o usuário juraria que
+      // atualizou.
+      el.classList.add("pb-ptr-fail");
+      arc.style.strokeDashoffset = "0";
+      setTimeout(() => { el.classList.remove("pb-ptr-fail"); spring(0); }, 900);
     }
 
     function run() {
       busy = true;
       el.classList.add("pb-ptr-busy");
+      // O dasharray é inline (o puxão desenha o anel fechando com ele), e
+      // inline vence classe CSS — então o arco curto do "girando" tem que ser
+      // setado aqui. Sem isto o anel fica CHEIO girando, que é visualmente
+      // idêntico a um anel parado: parecia travado durante o refresh.
+      arc.style.strokeDasharray = "26 80";
       spring(PTR.hold);
 
       if (typeof window.PBRefresh !== "function") {
@@ -631,28 +644,41 @@
       }
       const t0 = Date.now();
       let settled = false;
-      const done = () => {
+      const done = ok => {
         if (settled) return;
         settled = true;
-        setTimeout(finish, Math.max(0, PTR.floor - (Date.now() - t0)));
+        // piso de 500ms: sumir instantâneo pareceria que nada aconteceu
+        setTimeout(() => finish(ok), Math.max(0, PTR.floor - (Date.now() - t0)));
       };
-      setTimeout(done, PTR.watchdog);
+      setTimeout(() => done(false), PTR.watchdog);   // pendurado conta como falha
+      // A falha NÃO é engolida: vira aviso no indicador. Antes o catch vazio
+      // recolhia igual ao sucesso, e a tela ficava com dado velho sem dizer.
       Promise.resolve()
         .then(() => window.PBRefresh())
-        .catch(() => {})          // erro de rede não pode travar o indicador
-        .then(done);
+        .then(() => done(true), () => done(false));
     }
 
-    // Área com rolagem própria manda no gesto dela — o puxão é só da página.
-    // Olha a rolagem DE VERDADE em vez de casar uma lista de classes: lista
-    // envelhece. A .mfa-modal e a .bankpick-list dos Ajustes já ficavam de
-    // fora, e lá o puxão viraria RELOAD (Ajustes não tem PBRefresh) no meio de
-    // um setup de MFA ou por cima dos códigos de backup, que aparecem uma vez.
-    function inScrollable(node) {
+    // Duas coisas mandam no gesto delas, e não no puxão da página:
+    //
+    //  1. Estar dentro de um overlay FIXO. Nesta base todo diálogo é
+    //     position:fixed (.mfa-overlay e .bankpick-overlay dos Ajustes, .overlay
+    //     do dashboard), assim como a tab bar e o FAB — arrastar em qualquer um
+    //     deles nunca deveria puxar a página atrás. Vale MESMO QUE o diálogo
+    //     não transborde: um passo curto do MFA cabe na tela, e ali o puxão
+    //     viraria reload (Ajustes não tem PBRefresh) por cima dos códigos de
+    //     backup, que só aparecem uma vez. Conteúdo de página vive no fluxo
+    //     normal e nunca cai aqui; header sticky é `sticky`, não `fixed`.
+    //
+    //  2. Ser uma área com rolagem própria dentro do fluxo (lista, tabela).
+    //
+    // Regra medida em vez de lista de classes: lista envelhece — foi ela que
+    // deixou .mfa-modal e .bankpick-list de fora na primeira versão.
+    function ownsGesture(node) {
       for (let el = node; el && el !== document.body; el = el.parentElement) {
         if (el.nodeType !== 1) continue;
-        const oy = getComputedStyle(el).overflowY;
-        if ((oy === "auto" || oy === "scroll" || oy === "overlay") &&
+        const st = getComputedStyle(el);
+        if (st.position === "fixed") return true;
+        if ((st.overflowY === "auto" || st.overflowY === "scroll" || st.overflowY === "overlay") &&
             el.scrollHeight > el.clientHeight + 1) return true;
       }
       return false;
@@ -660,7 +686,7 @@
 
     addEventListener("touchstart", ev => {
       if (busy || ev.touches.length !== 1) return;
-      if (inScrollable(ev.target)) return;
+      if (ownsGesture(ev.target)) return;
       tracking = atTop();
       startY = ev.touches[0].clientY;
       startX = ev.touches[0].clientX;

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -713,6 +713,14 @@
       // espera na fila consumir a janela do pedido — âmbar antes de qualquer
       // rede. E ciclo que estourou na fila NÃO roda depois: sem isso o
       // "falhou" rodava silencioso quando o pedido velho enfim assentava.
+      // Estouro de relógio também SOLTA a corrente (inFlight = null): sem
+      // isso, um PBRefresh que nunca assenta envenenava a fila pra sempre —
+      // todo puxão seguinte esperava atrás dele, estourava sem nunca rodar, e
+      // o refresh morria até recarregar a página. Custo assumido ao soltar:
+      // se o pedido pendurado assentar MUITO depois, a escrita dele pode
+      // repintar dado mais velho uma vez (caso patológico; sem a fila isso
+      // acontecia com QUALQUER pedido acima do watchdog, e blindar de vez
+      // exigiria sinal de geração dentro de cada loader).
       let started = false;
       const prev = inFlight;
       const p = Promise.resolve(prev)
@@ -720,12 +728,20 @@
         .then(() => {
           if (settled) return;                            // estourou esperando: não vira fantasma
           started = true;
-          setTimeout(() => done(false), PTR.watchdog);    // relógio do pedido real
+          setTimeout(() => {                              // relógio do pedido real
+            done(false);
+            if (inFlight === chain) inFlight = null;
+          }, PTR.watchdog);
           return window.PBRefresh();
         });
       // relógio da fila: só conta enquanto o pedido deste ciclo não começou
-      setTimeout(() => { if (!started) done(false); }, PTR.watchdog);
-      inFlight = p.catch(() => {});
+      setTimeout(() => {
+        if (started) return;
+        done(false);
+        if (inFlight === chain) inFlight = null;
+      }, PTR.watchdog);
+      const chain = p.catch(() => {});
+      inFlight = chain;
       p.then(() => done(true), () => done(false));
     }
 

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -687,6 +687,13 @@
         if (el.nodeType !== 1) continue;
         const st = getComputedStyle(el);
         if (st.position === "fixed") return true;
+        // Popover: absoluto empilhado ACIMA do conteúdo (dropdown da conta,
+        // z-index 40). Arrastar dentro dele é gesto do popover, mesmo quando
+        // o conteúdo cabe sem rolar. Inventário (grep absolute+z-index nos
+        // CSS das 4 páginas): só o .user-dropdown está nessa faixa hoje;
+        // decoração absoluta é z=0 e pointer-events:none, nunca vira target.
+        if (st.position === "absolute" && st.zIndex !== "auto" &&
+            parseInt(st.zIndex, 10) >= 10) return true;
         if ((st.overflowY === "auto" || st.overflowY === "scroll" || st.overflowY === "overlay") &&
             el.scrollHeight > el.clientHeight + 1) return true;
       }

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -643,11 +643,24 @@
         .then(done);
     }
 
+    // Área com rolagem própria manda no gesto dela — o puxão é só da página.
+    // Olha a rolagem DE VERDADE em vez de casar uma lista de classes: lista
+    // envelhece. A .mfa-modal e a .bankpick-list dos Ajustes já ficavam de
+    // fora, e lá o puxão viraria RELOAD (Ajustes não tem PBRefresh) no meio de
+    // um setup de MFA ou por cima dos códigos de backup, que aparecem uma vez.
+    function inScrollable(node) {
+      for (let el = node; el && el !== document.body; el = el.parentElement) {
+        if (el.nodeType !== 1) continue;
+        const oy = getComputedStyle(el).overflowY;
+        if ((oy === "auto" || oy === "scroll" || oy === "overlay") &&
+            el.scrollHeight > el.clientHeight + 1) return true;
+      }
+      return false;
+    }
+
     addEventListener("touchstart", ev => {
       if (busy || ev.touches.length !== 1) return;
-      // Áreas com rolagem própria (modal, menu ☰, dropdown da conta) mandam
-      // no gesto delas — o puxão é só da página.
-      if (ev.target.closest && ev.target.closest(".modal, .sidenav, .user-dropdown")) return;
+      if (inScrollable(ev.target)) return;
       tracking = atTop();
       startY = ev.touches[0].clientY;
       startX = ev.touches[0].clientX;
@@ -672,13 +685,17 @@
       draw();
     }, { passive: false });
 
-    function release() {
+    function release(canceled) {
       if (!tracking || busy) { tracking = false; return; }
       tracking = false;
-      if (pull >= PTR.threshold) run(); else spring(0);
+      if (!canceled && pull >= PTR.threshold) run(); else spring(0);
     }
-    addEventListener("touchend", release, { passive: true });
-    addEventListener("touchcancel", release, { passive: true });
+    addEventListener("touchend", () => release(false), { passive: true });
+    // touchcancel = o SISTEMA tomou o gesto no meio (giro de tela, troca de
+    // app, gesto do iOS). Não é escolha do usuário, então recolhe sem
+    // atualizar — senão um puxão interrompido viraria reload nas telas sem
+    // PBRefresh. Mesma regra que a bolha do dock usa no pointercancel.
+    addEventListener("touchcancel", () => release(true), { passive: true });
 
     // rAF congela com o app em segundo plano: ao voltar, termina a molinha.
     document.addEventListener("visibilitychange", () => {

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -714,6 +714,10 @@
       if (ev.touches.length !== 1) { cancelPull(); return; }
       if (ownsGesture(ev.target)) return;
       tracking = atTop();
+      // Retry rápido: se a molinha do ciclo anterior ainda está recolhendo,
+      // o rAF dela seguiria empurrando pull pra zero por baixo do touchmove
+      // — o puxão novo desabava no meio. Gesto aceito mata a molinha.
+      if (tracking && raf) { cancelAnimationFrame(raf); raf = 0; }
       dragged = false;
       startY = ev.touches[0].clientY;
       startX = ev.touches[0].clientX;
@@ -734,7 +738,10 @@
         tracking = false;
         return;
       }
-      if (!atTop()) { tracking = false; return; }
+      // Sem spring aqui o pull ficava congelado no ar: release() com
+      // tracking=false retorna cedo e nunca recolhe. Mesma família do bail
+      // de dy<=0 logo acima.
+      if (!atTop()) { tracking = false; if (pull > 0) spring(0); return; }
       if (ev.cancelable) ev.preventDefault();   // mata o elástico nativo
       dragged = true;
       pull = Math.min(PTR.max, damp(dy));

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -545,7 +545,148 @@
     })();
   }
 
-  function init() { fixViewport(); buildTabbar(); hardenGlyphs(); enhanceOverview(); enhanceSettings(); wireGoogleLogin(); wirePush(); maybeOpenLaunch(); }
+  // ─── Puxar pra atualizar ─────────────────────────────────────────────────
+  // Medido no aparelho (iPhone 17 Pro / iOS 26): o WebView NÃO reporta scrollY
+  // negativo durante o elástico do topo — ele trava em 0. Então não dá pra ler
+  // o overscroll nativo. O que dá é CANCELAR o elástico (o touchmove no topo é
+  // cancelável) e desenhar o gesto por conta própria.
+  //
+  // O conteúdo não se move junto: um transform em html/body viraria bloco de
+  // contenção e arrastaria tudo que é position:fixed — a tab bar, o FAB do
+  // chat, o toast. Só o indicador desce, por cima da página.
+  //
+  // O que "atualizar" significa é da página, não daqui: quem sabe se refazer
+  // expõe window.PBRefresh (devolvendo promise). Sem isso cai no reload — que
+  // nas telas paradas (Ajustes, O que pedir) é barato e não perde estado.
+  const PTR = {
+    threshold: 62,   // puxão que arma o refresh
+    hold:      66,   // onde o indicador para enquanto atualiza
+    rubber:   280,   // resistência: maior = elástico mais duro
+    max:      150,   // teto do puxão
+    floor:    500,   // tempo mínimo girando (sumir na hora parece que falhou)
+    watchdog: 12000, // PBRefresh pendurado não deixa o indicador girando pra sempre
+  };
+
+  function initPullToRefresh() {
+    if (!page) return;                        // só nas telas logadas do app
+    if (!("ontouchstart" in window)) return;  // preview no desktop não tem gesto
+
+    const el = document.createElement("div");
+    el.className = "pb-ptr";
+    el.setAttribute("aria-hidden", "true");
+    const r = 17, circ = 2 * Math.PI * r;
+    el.innerHTML =
+      '<span class="pb-ptr-disc"><img src="/brand/mascot.webp" alt="" />' +
+      '<svg viewBox="0 0 40 40" aria-hidden="true">' +
+      `<circle class="pb-ptr-track" cx="20" cy="20" r="${r}"/>` +
+      `<circle class="pb-ptr-arc" cx="20" cy="20" r="${r}"/></svg></span>`;
+    document.body.appendChild(el);
+    const arc = el.querySelector(".pb-ptr-arc");
+    arc.style.strokeDasharray = circ.toFixed(1);
+
+    const smooth = !(window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+
+    let pull = 0, startY = 0, startX = 0, tracking = false, busy = false, raf = 0;
+
+    const damp = o => PTR.rubber * (1 - 1 / (o / PTR.rubber + 1));
+    const atTop = () =>
+      (window.scrollY || (document.scrollingElement || {}).scrollTop || 0) <= 0;
+
+    function draw() {
+      const p = Math.min(1, pull / PTR.threshold);
+      el.style.transform =
+        "translate3d(0," + pull.toFixed(1) + "px,0) scale(" + (0.5 + 0.5 * p).toFixed(3) + ")";
+      el.style.opacity = Math.min(1, p * 1.6).toFixed(2);
+      if (!busy) arc.style.strokeDashoffset = (circ * (1 - p)).toFixed(1);
+    }
+
+    function spring(goal) {
+      if (raf) { cancelAnimationFrame(raf); raf = 0; }
+      if (!smooth) { pull = goal; draw(); return; }
+      (function step() {
+        pull += (goal - pull) * 0.22;
+        if (Math.abs(pull - goal) < 0.5) { pull = goal; raf = 0; draw(); return; }
+        draw();
+        raf = requestAnimationFrame(step);
+      })();
+    }
+
+    function finish() {
+      if (!busy) return;
+      busy = false;
+      el.classList.remove("pb-ptr-busy");
+      spring(0);
+    }
+
+    function run() {
+      busy = true;
+      el.classList.add("pb-ptr-busy");
+      spring(PTR.hold);
+
+      if (typeof window.PBRefresh !== "function") {
+        // Tela que não sabe se refazer: recarrega. Ali não há estado a perder.
+        setTimeout(() => location.reload(), 220);
+        return;
+      }
+      const t0 = Date.now();
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        setTimeout(finish, Math.max(0, PTR.floor - (Date.now() - t0)));
+      };
+      setTimeout(done, PTR.watchdog);
+      Promise.resolve()
+        .then(() => window.PBRefresh())
+        .catch(() => {})          // erro de rede não pode travar o indicador
+        .then(done);
+    }
+
+    addEventListener("touchstart", ev => {
+      if (busy || ev.touches.length !== 1) return;
+      // Áreas com rolagem própria (modal, menu ☰, dropdown da conta) mandam
+      // no gesto delas — o puxão é só da página.
+      if (ev.target.closest && ev.target.closest(".modal, .sidenav, .user-dropdown")) return;
+      tracking = atTop();
+      startY = ev.touches[0].clientY;
+      startX = ev.touches[0].clientX;
+    }, { passive: true });
+
+    addEventListener("touchmove", ev => {
+      if (!tracking || busy || ev.touches.length !== 1) return;
+      const dy = ev.touches[0].clientY - startY;
+      const dx = ev.touches[0].clientX - startX;
+      // Gesto horizontal (carrossel, tabela que rola de lado) não é puxão.
+      // Só entrega o gesto de volta enquanto o puxão ainda não pegou — no meio
+      // dele um tremido lateral não pode cancelar tudo.
+      if (pull === 0 && Math.abs(dx) > Math.abs(dy)) { tracking = false; return; }
+      if (dy <= 0) {                    // virou rolagem normal: devolve o gesto
+        if (pull > 0) spring(0);        // recolhe na molinha, não em corte seco
+        tracking = false;
+        return;
+      }
+      if (!atTop()) { tracking = false; return; }
+      if (ev.cancelable) ev.preventDefault();   // mata o elástico nativo
+      pull = Math.min(PTR.max, damp(dy));
+      draw();
+    }, { passive: false });
+
+    function release() {
+      if (!tracking || busy) { tracking = false; return; }
+      tracking = false;
+      if (pull >= PTR.threshold) run(); else spring(0);
+    }
+    addEventListener("touchend", release, { passive: true });
+    addEventListener("touchcancel", release, { passive: true });
+
+    // rAF congela com o app em segundo plano: ao voltar, termina a molinha.
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden && !raf && !busy && pull !== 0) spring(0);
+    });
+  }
+
+  function init() { fixViewport(); buildTabbar(); hardenGlyphs(); enhanceOverview(); enhanceSettings(); wireGoogleLogin(); wirePush(); maybeOpenLaunch(); initPullToRefresh(); }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);
   } else {

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -588,6 +588,7 @@
       window.matchMedia("(prefers-reduced-motion: reduce)").matches);
 
     let pull = 0, startY = 0, startX = 0, tracking = false, busy = false, raf = 0;
+    let dragged = false;   // este gesto puxou de verdade (tap nunca arma)
 
     const damp = o => PTR.rubber * (1 - 1 / (o / PTR.rubber + 1));
     const atTop = () =>
@@ -614,17 +615,25 @@
 
     function finish(ok) {
       if (!busy) return;
-      busy = false;
       el.classList.remove("pb-ptr-busy");
       arc.style.strokeDasharray = circ.toFixed(1);   // volta a ser anel inteiro
-      if (ok) { spring(0); return; }
+      if (ok) { busy = false; spring(0); return; }
       // Falhou: avisa em âmbar em vez de recolher como se tivesse dado certo.
       // A página mantém o dado antigo na tela (é o certo — melhor dado velho
       // que tela destruída), então sem este aviso o usuário juraria que
       // atualizou.
+      //
+      // busy fica TRUE até o âmbar recolher: o pull ainda está em HOLD (66px,
+      // acima do limiar), e liberar o toque aqui deixava um TAP parado no topo
+      // commitar outro refresh — e o timeout deste âmbar recolhia o indicador
+      // do refresh novo no meio. Âmbar é estado terminal do ciclo, não idle.
       el.classList.add("pb-ptr-fail");
       arc.style.strokeDashoffset = "0";
-      setTimeout(() => { el.classList.remove("pb-ptr-fail"); spring(0); }, 900);
+      setTimeout(() => {
+        el.classList.remove("pb-ptr-fail");
+        busy = false;
+        spring(0);
+      }, 900);
     }
 
     function run() {
@@ -688,6 +697,7 @@
       if (busy || ev.touches.length !== 1) return;
       if (ownsGesture(ev.target)) return;
       tracking = atTop();
+      dragged = false;
       startY = ev.touches[0].clientY;
       startX = ev.touches[0].clientX;
     }, { passive: true });
@@ -707,6 +717,7 @@
       }
       if (!atTop()) { tracking = false; return; }
       if (ev.cancelable) ev.preventDefault();   // mata o elástico nativo
+      dragged = true;
       pull = Math.min(PTR.max, damp(dy));
       draw();
     }, { passive: false });
@@ -714,7 +725,9 @@
     function release(canceled) {
       if (!tracking || busy) { tracking = false; return; }
       tracking = false;
-      if (!canceled && pull >= PTR.threshold) run(); else spring(0);
+      // dragged: só arma se ESTE gesto puxou. Sem isso, pull retido de um
+      // ciclo anterior (ex.: o âmbar segurando em HOLD) deixava um tap commitar.
+      if (!canceled && dragged && pull >= PTR.threshold) run(); else spring(0);
     }
     addEventListener("touchend", () => release(false), { passive: true });
     // touchcancel = o SISTEMA tomou o gesto no meio (giro de tela, troca de

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -647,7 +647,19 @@
       spring(PTR.hold);
 
       if (typeof window.PBRefresh !== "function") {
-        // Tela que não sabe se refazer: recarrega. Ali não há estado a perder.
+        // Tela que não sabe se refazer: recarrega — MENOS com digitação
+        // pendente. Nos Ajustes os editores (nome/e-mail/telefone, senhas de
+        // exportação/exclusão) vivem no fluxo normal da página; um reload
+        // apagaria o que o usuário escreveu. "Pendente" = campo visível cujo
+        // value difere do defaultValue: os editores são preenchidos via JS
+        // (defaultValue fica vazio) e ficam display:none até abrir, então a
+        // regra dispara exatamente com um editor aberto ou senha digitada.
+        // Recusa com âmbar — o mesmo sinal de "não deu" da falha de rede.
+        const dirty = Array.prototype.some.call(
+          document.querySelectorAll("input, textarea"),
+          f => f.offsetParent !== null && f.value !== f.defaultValue
+        );
+        if (dirty) { finish(false); return; }
         setTimeout(() => location.reload(), 220);
         return;
       }
@@ -713,6 +725,10 @@
       if (busy) return;
       if (ev.touches.length !== 1) { cancelPull(); return; }
       if (ownsGesture(ev.target)) return;
+      // Arrasto que NASCE num campo de texto é gesto do campo (seleção,
+      // cursor), nunca puxão — e um puxão dali poderia virar reload por cima
+      // da digitação. Os campos vivem no fluxo normal; ownsGesture não os vê.
+      if (ev.target.closest && ev.target.closest("input, textarea, select, [contenteditable]")) return;
       tracking = atTop();
       // Retry rápido: se a molinha do ciclo anterior ainda está recolhendo,
       // o rAF dela seguiria empurrando pull pra zero por baixo do touchmove

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -700,8 +700,18 @@
       return false;
     }
 
+    // Segundo dedo no meio do puxão CANCELA (não pausa): deixar o estado
+    // armado fazia o primeiro touchend commitar refresh dentro de um gesto
+    // multi-touch — nas telas sem PBRefresh, um reload inteiro.
+    function cancelPull() {
+      tracking = false;
+      dragged = false;
+      if (pull > 0) spring(0);
+    }
+
     addEventListener("touchstart", ev => {
-      if (busy || ev.touches.length !== 1) return;
+      if (busy) return;
+      if (ev.touches.length !== 1) { cancelPull(); return; }
       if (ownsGesture(ev.target)) return;
       tracking = atTop();
       dragged = false;
@@ -710,7 +720,9 @@
     }, { passive: true });
 
     addEventListener("touchmove", ev => {
-      if (!tracking || busy || ev.touches.length !== 1) return;
+      if (busy) return;
+      if (ev.touches.length !== 1) { cancelPull(); return; }
+      if (!tracking) return;
       const dy = ev.touches[0].clientY - startY;
       const dx = ev.touches[0].clientX - startX;
       // Gesto horizontal (carrossel, tabela que rola de lado) não é puxão.

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -595,13 +595,25 @@
     // pode atropelar um save em voo — o PATCH das preferências de notificação
     // dos Ajustes, por exemplo, seria abortado e a escolha recém-aceita pela
     // UI se perderia. Contador genérico em vez de contrato novo por página.
+    // Mesmo padrão do auth-refresh.js, que também envelopa o window.fetch (lá
+    // pra renovar 401, aqui só pra contar). Este wrap fica por FORA do dele:
+    // o retry interno do 401 usa o fetch nativo direto, então conta como um
+    // pedido só — o contador segue ≥1 até a sequência inteira assentar.
     let pageFetches = 0;
     if (window.fetch) {
       const nativeFetch = window.fetch;
       window.fetch = function () {
         pageFetches++;
         const dec = () => { pageFetches--; };
-        const r = nativeFetch.apply(this, arguments);
+        let r;
+        try {
+          r = nativeFetch.apply(this, arguments);
+        } catch (err) {
+          // throw síncrono (argumento inválido) não pode vazar o contador —
+          // preso em >0, o reload ficaria recusado pra sempre na página.
+          dec();
+          throw err;
+        }
         r.then(dec, dec);
         return r;
       };
@@ -784,9 +796,16 @@
       const dy = ev.touches[0].clientY - startY;
       const dx = ev.touches[0].clientX - startX;
       // Gesto horizontal (carrossel, tabela que rola de lado) não é puxão.
-      // Só entrega o gesto de volta enquanto o puxão ainda não pegou — no meio
-      // dele um tremido lateral não pode cancelar tudo.
-      if (pull === 0 && Math.abs(dx) > Math.abs(dy)) { tracking = false; return; }
+      // Só entrega o gesto de volta enquanto ESTE gesto ainda não puxou — no
+      // meio dele um tremido lateral não pode cancelar tudo. O predicado é
+      // !dragged, não pull===0: um retry rápido mata a molinha do ciclo
+      // anterior deixando pull residual > 0, e com pull===0 esse resíduo
+      // desligava a detecção — um arrasto horizontal virava puxão.
+      if (!dragged && Math.abs(dx) > Math.abs(dy)) {
+        tracking = false;
+        if (pull > 0) spring(0);        // resíduo da molinha morta recolhe
+        return;
+      }
       if (dy <= 0) {                    // virou rolagem normal: devolve o gesto
         if (pull > 0) spring(0);        // recolhe na molinha, não em corte seco
         tracking = false;

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -591,6 +591,22 @@
     let dragged = false;    // este gesto puxou de verdade (tap nunca arma)
     let inFlight = null;    // PBRefresh pendente (o watchdog libera o ciclo, não o pedido)
 
+    // Fetches pendentes DA PÁGINA (não do puxão): o fallback de reload não
+    // pode atropelar um save em voo — o PATCH das preferências de notificação
+    // dos Ajustes, por exemplo, seria abortado e a escolha recém-aceita pela
+    // UI se perderia. Contador genérico em vez de contrato novo por página.
+    let pageFetches = 0;
+    if (window.fetch) {
+      const nativeFetch = window.fetch;
+      window.fetch = function () {
+        pageFetches++;
+        const dec = () => { pageFetches--; };
+        const r = nativeFetch.apply(this, arguments);
+        r.then(dec, dec);
+        return r;
+      };
+    }
+
     const damp = o => PTR.rubber * (1 - 1 / (o / PTR.rubber + 1));
     const atTop = () =>
       (window.scrollY || (document.scrollingElement || {}).scrollTop || 0) <= 0;
@@ -660,7 +676,9 @@
           document.querySelectorAll("input, textarea"),
           f => f.offsetParent !== null && f.value !== f.defaultValue
         );
-        if (dirty) { finish(false); return; }
+        // pageFetches: um save da página em voo (PATCH de notificação) seria
+        // abortado pelo reload — recusa e deixa ele terminar.
+        if (dirty || pageFetches > 0) { finish(false); return; }
         setTimeout(() => location.reload(), 220);
         return;
       }
@@ -672,18 +690,29 @@
         // piso de 500ms: sumir instantâneo pareceria que nada aconteceu
         setTimeout(() => finish(ok), Math.max(0, PTR.floor - (Date.now() - t0)));
       };
-      setTimeout(() => done(false), PTR.watchdog);   // pendurado conta como falha
       // A falha NÃO é engolida: vira aviso no indicador. E os PBRefresh são
       // SERIALIZADOS: o watchdog libera o ciclo visual, não o pedido — sem a
       // fila, um pedido estourado seguia vivo e podia terminar DEPOIS do
       // puxão seguinte, sobrescrevendo resposta mais nova no DOM e no cache.
-      // Na fila, o novo só dispara quando o antigo assentar; se o antigo
-      // nunca assentar, o watchdog pinta âmbar de novo — honesto e sem
-      // corrida. O catch() na fila evita rejeição não tratada do elo velho.
+      //
+      // Dois relógios, um por fase: o de fila cobre a espera atrás de um
+      // pedido pendurado; o de pedido só começa quando o PBRefresh deste
+      // ciclo dispara de verdade. Um timer único a partir do puxão deixava a
+      // espera na fila consumir a janela do pedido — âmbar antes de qualquer
+      // rede. E ciclo que estourou na fila NÃO roda depois: sem isso o
+      // "falhou" rodava silencioso quando o pedido velho enfim assentava.
+      let started = false;
       const prev = inFlight;
       const p = Promise.resolve(prev)
         .catch(() => {})
-        .then(() => window.PBRefresh());
+        .then(() => {
+          if (settled) return;                            // estourou esperando: não vira fantasma
+          started = true;
+          setTimeout(() => done(false), PTR.watchdog);    // relógio do pedido real
+          return window.PBRefresh();
+        });
+      // relógio da fila: só conta enquanto o pedido deste ciclo não começou
+      setTimeout(() => { if (!started) done(false); }, PTR.watchdog);
       inFlight = p.catch(() => {});
       p.then(() => done(true), () => done(false));
     }

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,8 +16,8 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=24" />
-  <script src="/app-mode.js?v=22"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=25" />
+  <script src="/app-mode.js?v=23"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,8 +80,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=24" />
-  <script src="/app-mode.js?v=22"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=25" />
+  <script src="/app-mode.js?v=23"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,8 +26,8 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=24" />
-  <script defer src="/app-mode.js?v=22"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=25" />
+  <script defer src="/app-mode.js?v=23"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10041,7 +10041,14 @@ window.PBRefresh = function () {
     case "installments": return loadInstallmentsView(true);
     case "categories":   return loadCategoriesView(true);
     case "budgets":      return loadBudgetsView(true);
-    case "fixed":        return loadFixedView(true);
+    // "Recorrentes" tem quatro abas internas e só uma está visível. Recarregar
+    // sempre a de gastos deixaria a que o usuário está vendo parada, com o
+    // indicador dando a entender que atualizou. Espelha o setRecurringTab.
+    case "fixed":
+      if (_recurringTab === "overview") return loadRecurringOverview();
+      if (_recurringTab === "incomes")  return loadRecurringIncomeView(true);
+      if (_recurringTab === "bills")    return loadBillsView(true);
+      return loadFixedView(true);
     case "goals":        return loadGoalsView(true);
     case "affiliate":    return loadAffiliateView(true);
     case "agentes":      return loadAgentesView(true);

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10075,7 +10075,21 @@ function _pbDashboardRefresh() {
       if (_recurringTab === "bills")    return loadBillsView(true);
       return loadFixedView(true);
     case "goals":        return loadGoalsView(true);
-    case "affiliate":    return loadAffiliateView(true);
+    case "affiliate": {
+      // O refresh reconstrói o #affiliate-body inteiro, e a chave Pix mora
+      // num input dentro dele. O input nasce sempre vazio (nenhum caminho o
+      // preenche com dado do servidor), então qualquer valor ali é digitação
+      // do usuário — sobrevive à troca de DOM.
+      const pix = document.getElementById("affiliate-pix-input");
+      const pending = pix ? pix.value : "";
+      return loadAffiliateView(true).then(r => {
+        if (pending) {
+          const el = document.getElementById("affiliate-pix-input");
+          if (el) el.value = pending;
+        }
+        return r;
+      });
+    }
     case "agentes":      return loadAgentesView(true);
     default:
       // Visão geral e investimentos vivem do snapshot do mês.

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10082,12 +10082,15 @@ function _pbDashboardRefresh() {
       // skeleton antes do fetch e, em erro, pelo aviso — a chave morre nos
       // dois caminhos. A restauração é incondicional porque o input nasce
       // sempre vazio: qualquer valor ali é digitação do usuário.
-      const pix = document.getElementById("affiliate-pix-input");
-      const pending = pix ? pix.value : "";
       return fetch(`${API}/api/affiliate/me`, { credentials: "same-origin" })
         .then(async res => {
           const data = await readResponsePayload(res);
           if (!res.ok) throw new Error(data.detail || "refresh de afiliado falhou");
+          // A chave é lida do input VIVO no último instante antes do render:
+          // o campo segue editável durante o fetch, e um snapshot tirado
+          // antes descartaria o que foi digitado nesse meio-tempo.
+          const pix = document.getElementById("affiliate-pix-input");
+          const pending = pix ? pix.value : "";
           _affiliateCache = data;
           _renderAffiliateView(data);
           if (pending) {

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10076,19 +10076,25 @@ function _pbDashboardRefresh() {
       return loadFixedView(true);
     case "goals":        return loadGoalsView(true);
     case "affiliate": {
-      // O refresh reconstrói o #affiliate-body inteiro, e a chave Pix mora
-      // num input dentro dele. O input nasce sempre vazio (nenhum caminho o
-      // preenche com dado do servidor), então qualquer valor ali é digitação
-      // do usuário — sobrevive à troca de DOM.
+      // Fetch ANTES de render: em falha o DOM não é tocado — o body (e a
+      // chave Pix digitada nele) fica como está e o indicador avisa em âmbar.
+      // O loadAffiliateView(true) não serve aqui: ele troca o body pelo
+      // skeleton antes do fetch e, em erro, pelo aviso — a chave morre nos
+      // dois caminhos. A restauração é incondicional porque o input nasce
+      // sempre vazio: qualquer valor ali é digitação do usuário.
       const pix = document.getElementById("affiliate-pix-input");
       const pending = pix ? pix.value : "";
-      return loadAffiliateView(true).then(r => {
-        if (pending) {
-          const el = document.getElementById("affiliate-pix-input");
-          if (el) el.value = pending;
-        }
-        return r;
-      });
+      return fetch(`${API}/api/affiliate/me`, { credentials: "same-origin" })
+        .then(async res => {
+          const data = await readResponsePayload(res);
+          if (!res.ok) throw new Error(data.detail || "refresh de afiliado falhou");
+          _affiliateCache = data;
+          _renderAffiliateView(data);
+          if (pending) {
+            const el = document.getElementById("affiliate-pix-input");
+            if (el) el.value = pending;
+          }
+        });
     }
     case "agentes":      return loadAgentesView(true);
     default:

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -3728,10 +3728,14 @@ function setRecurringTab(tab) {
 // ── Previsão mensal: o que entra (receitas fixas) × o que sai (gastos fixos +
 // boletos) × resultado, + próximos vencimentos. Deixa explícito que é RECORRENTE
 // (não colide com "Receitas/Gastos do mês" do dashboard principal). ─────────────
-async function loadRecurringOverview() {
+async function loadRecurringOverview({ background = false } = {}) {
   const wrap = document.getElementById("recurring-overview-cards");
   if (!wrap) return;
-  wrap.innerHTML = `<div class="mock-card"><div class="empty" style="padding:16px;color:var(--text-3)">Carregando…</div></div>`;
+  // background (puxar pra atualizar): sem skeleton — o render bom fica na
+  // tela até os dados novos chegarem.
+  if (!background) {
+    wrap.innerHTML = `<div class="mock-card"><div class="empty" style="padding:16px;color:var(--text-3)">Carregando…</div></div>`;
+  }
   const j = async (url) => {
     try { const r = await fetch(url, { credentials: "same-origin" }); if (!r.ok) return null; return await r.json(); }
     catch (_) { return null; }
@@ -3741,6 +3745,13 @@ async function loadRecurringOverview() {
     j(`${API}/recurring-incomes/${USER_ID}`),
     j(`${API}/recurring-bills/${USER_ID}?include_paid=false`),
   ]);
+  // No puxão, endpoint que falhou NÃO pode virar total zerado: o j() acima
+  // converte falha em null e o reduce embaixo somaria zero por cima de números
+  // que estavam certos na tela. Rejeita sem tocar no DOM — o indicador do
+  // gesto (app-mode.js) fica âmbar e o render antigo sobrevive.
+  if (background && (exp === null || inc === null || bills === null)) {
+    throw new Error("recurring overview: fetch falhou no refresh");
+  }
 
   const gastos = ((exp && exp.recurring) || []).filter(r => r.is_active && (r.payment_mode || "autopay") === "autopay");
   const totalGastos = gastos.reduce((s, r) => s + _recMonthlyEquiv(r), 0);
@@ -6631,12 +6642,16 @@ async function fetchMonthHttp(year, month, page = 1, limit = LAUNCHES_LIMIT, { b
     stopSpin();
     setLaunchesLoading(false);
   } catch(err) {
-    if (err.name === "AbortError") return;
+    if (err.name === "AbortError") return;   // superado por outro pedido: neutro
     console.error("fetchMonthHttp error:", err);
     if (seq === monthRequestSeq && !background) {
       stopSpin();
       setLaunchesLoading(false);
     }
+    // O render antigo fica (certo), mas quem chamou precisa saber que nada
+    // veio — o puxar pra atualizar usa isto pra ficar âmbar em vez de
+    // recolher como sucesso. Callers antigos ignoram o retorno.
+    return false;
   } finally {
     if (seq === monthRequestSeq) {
       monthAbortController = null;
@@ -10045,7 +10060,8 @@ window.PBRefresh = function () {
     // sempre a de gastos deixaria a que o usuário está vendo parada, com o
     // indicador dando a entender que atualizou. Espelha o setRecurringTab.
     case "fixed":
-      if (_recurringTab === "overview") return loadRecurringOverview();
+      // background: sem skeleton, e falha REJEITA em vez de renderizar zeros
+      if (_recurringTab === "overview") return loadRecurringOverview({ background: true });
       if (_recurringTab === "incomes")  return loadRecurringIncomeView(true);
       if (_recurringTab === "bills")    return loadBillsView(true);
       return loadFixedView(true);
@@ -10058,6 +10074,9 @@ window.PBRefresh = function () {
       // atualizar tem que ir na fonte, senão o gesto mente.
       // smoothScroll off: o usuário está no topo, jogar a página nos
       // lançamentos seria roubar o lugar dele.
-      return fetchMonthHttp(viewYear, viewMonth, launchesPage, LAUNCHES_LIMIT);
+      // false = a busca falhou (o render antigo ficou): rejeita pro indicador
+      // ficar âmbar. undefined (pedido superado/stale) conta como sucesso.
+      return fetchMonthHttp(viewYear, viewMonth, launchesPage, LAUNCHES_LIMIT)
+        .then(ok => { if (ok === false) throw new Error("refresh do mês falhou"); });
   }
 };

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10019,3 +10019,38 @@ async function toggleAgentEmail(kind, enabled) {
     alert(String(err.message || err));
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   PUXAR PRA ATUALIZAR (app iOS / PWA)
+   ═══════════════════════════════════════════════════════════════════════
+   O gesto mora no app-mode.js — aqui só respondemos o que "atualizar"
+   significa no dashboard: refazer a aba que está aberta, sem recarregar a
+   página (o reload perderia filtro, mês escolhido e posição da rolagem).
+
+   Devolve promise: o indicador do puxão só some quando ela resolve. */
+window.PBRefresh = function () {
+  const active = DASH_VIEWS.find(v => {
+    const el = document.getElementById(v + "-view");
+    return el && el.classList.contains("active");
+  }) || "overview";
+
+  switch (active) {
+    case "analytics":    return loadAnalyticsView(true);
+    case "history":      return loadHistoryView(true);
+    case "cards":        return loadCardsView(true);
+    case "installments": return loadInstallmentsView(true);
+    case "categories":   return loadCategoriesView(true);
+    case "budgets":      return loadBudgetsView(true);
+    case "fixed":        return loadFixedView(true);
+    case "goals":        return loadGoalsView(true);
+    case "affiliate":    return loadAffiliateView(true);
+    case "agentes":      return loadAgentesView(true);
+    default:
+      // Visão geral e investimentos vivem do snapshot do mês.
+      // preferHttp: com o WS aberto o pedido volta do cache dele — puxar pra
+      // atualizar tem que ir na fonte, senão o gesto mente.
+      // smoothScroll off: o usuário está no topo, jogar a página nos
+      // lançamentos seria roubar o lugar dele.
+      return fetchMonthHttp(viewYear, viewMonth, launchesPage, LAUNCHES_LIMIT);
+  }
+};

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10053,24 +10053,6 @@ async function toggleAgentEmail(kind, enabled) {
    um puxão precoce rodar com USER_ID=0 (/data/0) durante um launch lento —
    e seguir ativo depois do _showAccessError trocar o body inteiro. */
 function _pbDashboardRefresh() {
-  // Puxar = quero fresco. Descarta qualquer promise de dedup em voo dos
-  // loaders antes de delegar: sem isto, um fetch que pendurou deixa
-  // `_xxxFetchInFlight` preso (o `finally` que zera só roda quando a promise
-  // assenta), e todo forceFresh seguinte reusa a promise MORTA em vez de
-  // pedir de novo — a aba trava até a página recarregar. O watchdog do gesto
-  // (app-mode.js) libera a fila DELE, mas não alcança estes dedups privados.
-  //
-  // Zerar todos, não só o da aba ativa, é de propósito: só um loader roda por
-  // puxão, então os outros já são null ou seguram uma revalidação de fundo
-  // cujo descarte é inofensivo (nenhum caller concorrente). É stopgap — o fim
-  // definitivo (loaders abortáveis com AbortSignal) é o refactor separado.
-  // Var faltando aqui = aquela aba mantém o comportamento pré-existente, não
-  // uma regressão nova.
-  _cardsFetchInFlight = _instFetchInFlight = _categoriesFetchInFlight =
-    _budgetsFetchInFlight = _goalsFetchInFlight = _recurringFetchInFlight =
-    _recurringIncomeFetchInFlight = _analyticsFetchInFlight =
-    _historyListInFlight = null;
-
   const active = DASH_VIEWS.find(v => {
     const el = document.getElementById(v + "-view");
     return el && el.classList.contains("active");

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9781,6 +9781,11 @@ function _showAccessError(title, msg) {
 
   WS_URL = `${BASE_WS}/ws/${USER_ID}`;
 
+  // Puxar pra atualizar: o contrato só nasce com a sessão validada e o
+  // paywall vencido — os returns acima (_showAccessError, /precos) saem antes
+  // daqui e o puxão nessas telas cai no reload, que é o que elas pedem.
+  window.PBRefresh = _pbDashboardRefresh;
+
 	  updateInvestmentRateHint();
 	  updateInvestmentTaxHint();
 	  updateMonthLabel();
@@ -10042,8 +10047,12 @@ async function toggleAgentEmail(kind, enabled) {
    significa no dashboard: refazer a aba que está aberta, sem recarregar a
    página (o reload perderia filtro, mês escolhido e posição da rolagem).
 
-   Devolve promise: o indicador do puxão só some quando ela resolve. */
-window.PBRefresh = function () {
+   Devolve promise: o indicador do puxão só some quando ela resolve.
+
+   Registrado no bootstrap (não aqui): expor na definição do script deixava
+   um puxão precoce rodar com USER_ID=0 (/data/0) durante um launch lento —
+   e seguir ativo depois do _showAccessError trocar o body inteiro. */
+function _pbDashboardRefresh() {
   const active = DASH_VIEWS.find(v => {
     const el = document.getElementById(v + "-view");
     return el && el.classList.contains("active");
@@ -10079,4 +10088,4 @@ window.PBRefresh = function () {
       return fetchMonthHttp(viewYear, viewMonth, launchesPage, LAUNCHES_LIMIT)
         .then(ok => { if (ok === false) throw new Error("refresh do mês falhou"); });
   }
-};
+}

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10053,6 +10053,24 @@ async function toggleAgentEmail(kind, enabled) {
    um puxão precoce rodar com USER_ID=0 (/data/0) durante um launch lento —
    e seguir ativo depois do _showAccessError trocar o body inteiro. */
 function _pbDashboardRefresh() {
+  // Puxar = quero fresco. Descarta qualquer promise de dedup em voo dos
+  // loaders antes de delegar: sem isto, um fetch que pendurou deixa
+  // `_xxxFetchInFlight` preso (o `finally` que zera só roda quando a promise
+  // assenta), e todo forceFresh seguinte reusa a promise MORTA em vez de
+  // pedir de novo — a aba trava até a página recarregar. O watchdog do gesto
+  // (app-mode.js) libera a fila DELE, mas não alcança estes dedups privados.
+  //
+  // Zerar todos, não só o da aba ativa, é de propósito: só um loader roda por
+  // puxão, então os outros já são null ou seguram uma revalidação de fundo
+  // cujo descarte é inofensivo (nenhum caller concorrente). É stopgap — o fim
+  // definitivo (loaders abortáveis com AbortSignal) é o refactor separado.
+  // Var faltando aqui = aquela aba mantém o comportamento pré-existente, não
+  // uma regressão nova.
+  _cardsFetchInFlight = _instFetchInFlight = _categoriesFetchInFlight =
+    _budgetsFetchInFlight = _goalsFetchInFlight = _recurringFetchInFlight =
+    _recurringIncomeFetchInFlight = _analyticsFetchInFlight =
+    _historyListInFlight = null;
+
   const active = DASH_VIEWS.find(v => {
     const el = document.getElementById(v + "-view");
     return el && el.classList.contains("active");

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -381,8 +381,8 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=24" />
-  <script src="/app-mode.js?v=22"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=25" />
+  <script src="/app-mode.js?v=23"></script>
 </head>
 <body>
 
@@ -1009,6 +1009,7 @@ function clearHomeCache() {
 }
 
 /* ─── Init ────────────────────────────────────────────────────────────── */
+let _homeMe = null;   // /auth/me da abertura, reusado pelas recargas
 (async () => {
   // 1) Valida sessão
   let userId = 0;
@@ -1060,7 +1061,18 @@ function clearHomeCache() {
     return;
   }
 
-  // 3) Carrega snapshot + histórico em paralelo
+  // 3 e 4) Busca + render moram em loadHomeData() porque o "puxar pra
+  // atualizar" do app (app-mode.js) precisa refazer exatamente este pedaço.
+  _homeMe = me;
+  await loadHomeData();
+})();
+
+/* ─── Recarga dos dados da Início ──────────────────────────────────────────
+   Devolve promise: o indicador do puxão fica girando até ela resolver.
+   Guarda o /auth/me da abertura — plano e e-mail não mudam a cada puxão, e
+   refazer essa chamada só atrasaria o gesto. */
+async function loadHomeData() {
+  const me = _homeMe;
   let snapshot = null, history = [];
   try {
     const [dataRes, histRes] = await Promise.all([
@@ -1084,7 +1096,6 @@ function clearHomeCache() {
     return;
   }
 
-  // 4) Renderiza tudo
   const email = (me && me.email) || PROFILE_EMAIL || "";
   const displayName = (me && me.display_name) || PROFILE_DISPLAY_NAME || "";
   renderGreeting(snapshot, email, displayName);
@@ -1096,7 +1107,10 @@ function clearHomeCache() {
 
   // Guarda pra próxima abertura pintar na hora (troca de aba /home <-> /app).
   persistHomeCache(USER_ID, snapshot, history, email, displayName);
-})();
+}
+
+// Contrato com o app-mode.js: quem sabe se refazer expõe PBRefresh.
+window.PBRefresh = loadHomeData;
 
 function renderFreeBanner(me) {
   const banner = document.getElementById("free-banner");

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1120,11 +1120,16 @@ async function loadHomeData({ initial = false } = {}) {
 
   // Guarda pra próxima abertura pintar na hora (troca de aba /home <-> /app).
   persistHomeCache(USER_ID, snapshot, history, email, displayName);
-}
 
-// Contrato com o app-mode.js: quem sabe se refazer expõe PBRefresh.
-// Sem initial: uma falha aqui NÃO pode trocar a tela pelo erro.
-window.PBRefresh = () => loadHomeData();
+  // Contrato com o app-mode.js: quem sabe se refazer expõe PBRefresh — mas só
+  // AGORA, com a carga assentada e render bom na tela. Expor na definição do
+  // script deixava um puxão precoce correr contra a init (validate → me →
+  // primeira carga): a carga velha terminava depois e sobrescrevia a nova.
+  // E se a init morrer antes daqui (sessão inválida, paywall, erro de rede),
+  // o contrato nunca aparece — o puxão cai no reload, que é o que essas telas
+  // de erro pedem. Sem initial: falha de puxão NÃO troca a tela pelo erro.
+  window.PBRefresh = () => loadHomeData();
+}
 
 function renderFreeBanner(me) {
   const banner = document.getElementById("free-banner");

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1084,6 +1084,11 @@ async function loadHomeData({ initial = false } = {}) {
     if (histRes.ok) {
       const hj = await histRes.json();
       history = hj.data || [];
+    } else if (!initial) {
+      // Num puxão, /history falhando não pode virar "sem histórico": o delta
+      // mês-a-mês sumiria da tela e o persist logo abaixo gravaria o vazio por
+      // cima do cache bom. Rejeita — o indicador fica âmbar e nada é tocado.
+      throw new Error("history falhou no refresh");
     }
   } catch (err) {
     // Só a carga inicial troca a tela pelo erro — ali não há nada a perder.

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1064,14 +1064,14 @@ let _homeMe = null;   // /auth/me da abertura, reusado pelas recargas
   // 3 e 4) Busca + render moram em loadHomeData() porque o "puxar pra
   // atualizar" do app (app-mode.js) precisa refazer exatamente este pedaço.
   _homeMe = me;
-  await loadHomeData();
+  await loadHomeData({ initial: true });
 })();
 
 /* ─── Recarga dos dados da Início ──────────────────────────────────────────
    Devolve promise: o indicador do puxão fica girando até ela resolver.
    Guarda o /auth/me da abertura — plano e e-mail não mudam a cada puxão, e
    refazer essa chamada só atrasaria o gesto. */
-async function loadHomeData() {
+async function loadHomeData({ initial = false } = {}) {
   const me = _homeMe;
   let snapshot = null, history = [];
   try {
@@ -1085,7 +1085,15 @@ async function loadHomeData() {
       const hj = await histRes.json();
       history = hj.data || [];
     }
-  } catch {
+  } catch (err) {
+    // Só a carga inicial troca a tela pelo erro — ali não há nada a perder.
+    //
+    // Num puxão a tela JÁ TEM dado bom. Trocar o #content pelo erro destruiria
+    // ele em definitivo: os renderers procuram elementos que deixariam de
+    // existir, então nem um puxão bem-sucedido depois recuperaria — só
+    // recarregando a página. Mantém o que está na tela e devolve a falha; quem
+    // avisa é o indicador do puxão (app-mode.js pinta o anel de âmbar).
+    if (!initial) throw err;
     document.getElementById("content").innerHTML = `
       <div class="access-error">
         <h2><i class="ph ph-warning" aria-hidden="true"></i> Erro ao carregar</h2>
@@ -1110,7 +1118,8 @@ async function loadHomeData() {
 }
 
 // Contrato com o app-mode.js: quem sabe se refazer expõe PBRefresh.
-window.PBRefresh = loadHomeData;
+// Sem initial: uma falha aqui NÃO pode trocar a tela pelo erro.
+window.PBRefresh = () => loadHomeData();
 
 function renderFreeBanner(me) {
   const banner = document.getElementById("free-banner");

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,8 +15,8 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=24" />
-  <script src="/app-mode.js?v=22"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=25" />
+  <script src="/app-mode.js?v=23"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1103,8 +1103,8 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=24" />
-  <script src="/app-mode.js?v=22"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=25" />
+  <script src="/app-mode.js?v=23"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Puxar pra baixo no topo de **Início**, **Dashboard**, **O que pedir** e **Ajustes** atualiza a tela. Não existia nada disso antes — o dedo só esticava a página e voltava.

## Onde o gesto mora

No **site** (`app-mode.js`), não na moldura do iPhone. Ajuste vai pro ar sem build nem análise da Apple, é o mesmo desenho do resto do modo app (a moldura faz o mínimo, o site faz o resto), e a PWA ganha junto.

## A premissa que caiu na medição

Eu ia ler o elástico nativo pelo `scrollY` negativo. Medindo no iPhone 17 Pro (iOS 26): **o WebView nunca reporta negativo, trava em 0.** A técnica não existia.

O que funciona é cancelar o elástico — o `touchmove` no topo é cancelável — e assumir o gesto. **Consequência real: no topo dessas quatro telas o elástico do iOS não aparece mais**, quem responde é o indicador. É uma troca deliberada e reversível.

## O conteúdo não desce junto

Só o indicador desce, por cima da página. Mover o conteúdo exigiria um `transform` no `body`, o que o torna bloco de contenção e arrasta junto tudo que é `position: fixed` — a tab bar de menisco, o FAB do chat, o toast. Não valia quebrar a dock.

## O contrato

Quem sabe se refazer expõe `window.PBRefresh()` devolvendo promise; o indicador gira até ela resolver. Quem não expõe cai no `location.reload()`.

| Tela | O que o puxão faz |
|---|---|
| Dashboard | refaz a aba aberta com `forceFresh` |
| Início | `loadHomeData()` — snapshot + histórico |
| Ajustes, O que pedir | reload (telas paradas, sem estado a perder) |

Na Visão geral vai no HTTP direto em vez do WebSocket: com o WS aberto o pedido voltaria do cache dele e o gesto mentiria.

Em `home.html` a busca + render saíram da IIFE de init pra `loadHomeData()`, que o `PBRefresh` chama de novo. O `/auth/me` da abertura fica guardado — plano e e-mail não mudam a cada puxão e refazer só atrasaria o gesto.

## Guardas

- Não sequestra a rolagem quando a página já está rolada (precisa levantar o dedo e puxar de novo, como no iOS).
- Swipe horizontal devolve o gesto — carrossel e tabela que rola de lado seguem funcionando.
- Ignora áreas com rolagem própria: modal, menu ☰, dropdown da conta.
- `z-index: 690` — abaixo da tab bar (700) e dos modais (800/900).
- Watchdog de 12 s: `PBRefresh` pendurado não deixa o indicador girando pra sempre.
- Piso de 500 ms: sumir instantâneo pareceria que nada aconteceu.
- Erro de rede é engolido — o indicador recolhe em vez de travar.
- `prefers-reduced-motion` desliga a molinha e o giro.
- Não monta em `/login` nem `/cadastro` (sem `page`), nem fora de toque.

## Verificado no simulador (iPhone 17 Pro, iOS 26)

| | |
|---|---|
| `touchmove` cancelável no topo | sim |
| Gesto arma e dispara | sim — `pull: 120, armou: true` |
| Puxar com a página rolada | não sequestra |
| Tab bar fica parada | sim |
| Volta ao repouso | sim |

**O que não foi verificado:** o visual em movimento. O screenshot do painel demora mais que o ciclo inteiro do gesto, então nunca peguei o frame com o indicador girando. A mecânica está provada pelos contadores; **o acabamento precisa de olho humano no aparelho.**

Se algo estiver fora do ponto, os números estão juntos no topo de `initPullToRefresh`: `threshold` (62), `rubber` (280), `hold` (66), `floor` (500 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
