### PR TITLE
feat(admin): painel de usuários & assinaturas no card Usuários

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -741,12 +741,20 @@ def _derive_account_status(row: dict, now: datetime) -> str:
     """Classifica a conta numa categoria única de assinatura.
 
     A fonte é o par (plan, last_payment_status) mantido pelos webhooks do
-    Stripe; contas Pro sem stripe_customer_id são grants manuais (cortesia).
+    Stripe. Atenção: customer.subscription.deleted volta plan pra 'free'
+    ANTES de gravar last_payment_status='canceled' — por isso conta free com
+    pagamento cancelado é ex-assinante ('canceled'), não 'free'. Pro sem
+    status de pagamento é grant manual ('granted'), mas só enquanto
+    plan_expires_at não passou.
+
+    ESPELHO SQL: _ACCOUNT_STATUS_SQL logo abaixo tem de decidir idêntico —
+    toda mudança aqui muda lá (o teste de paridade em
+    tests/test_admin_users_panel.py compara os dois).
     """
-    plan = (row.get("plan") or "free").strip().lower()
-    if plan in ("", "free"):
-        return "free"
+    plan = (row.get("plan") or "free").strip().lower() or "free"
     pay = (row.get("last_payment_status") or "").strip().lower()
+    if plan == "free":
+        return "canceled" if pay in ("canceled", "incomplete_expired") else "free"
     if pay == "trialing":
         return "trial"
     if pay == "active":
@@ -755,14 +763,30 @@ def _derive_account_status(row: dict, now: datetime) -> str:
         return "past_due"
     if pay in ("canceled", "incomplete_expired"):
         return "canceled"
-    if not row.get("stripe_customer_id"):
-        return "granted"
-    # Pro com customer Stripe mas sem status de pagamento registrado: se já
-    # expirou trata como cancelada, senão como cortesia (estado legado raro).
     expires = row.get("plan_expires_at")
     if expires is not None and expires < now:
         return "canceled"
     return "granted"
+
+
+# Espelho em SQL de _derive_account_status, pra filtrar/agregar no banco sem
+# trazer a base inteira pro Python. Assume alias `a` pra auth_accounts.
+_ACCOUNT_STATUS_SQL = """
+    CASE
+        WHEN lower(coalesce(nullif(trim(a.plan), ''), 'free')) = 'free' THEN
+            CASE WHEN lower(coalesce(a.last_payment_status, ''))
+                      IN ('canceled', 'incomplete_expired')
+                 THEN 'canceled' ELSE 'free' END
+        WHEN lower(coalesce(a.last_payment_status, '')) = 'trialing' THEN 'trial'
+        WHEN lower(coalesce(a.last_payment_status, '')) = 'active' THEN 'paying'
+        WHEN lower(coalesce(a.last_payment_status, ''))
+             IN ('past_due', 'unpaid', 'incomplete') THEN 'past_due'
+        WHEN lower(coalesce(a.last_payment_status, ''))
+             IN ('canceled', 'incomplete_expired') THEN 'canceled'
+        WHEN a.plan_expires_at IS NOT NULL AND a.plan_expires_at < now() THEN 'canceled'
+        ELSE 'granted'
+    END
+"""
 
 
 _billing_summary_cache: dict[str, Any] = {"fetched_at": None, "data": None}
@@ -867,9 +891,14 @@ async def fetch_admin_users(
 ) -> dict[str, Any]:
     """Lista paginada de contas com classificação de assinatura + agregados.
 
-    Minimização de PII: só decifra e-mail das rows da página devolvida —
-    exceto com busca (q), que precisa decifrar a base pra casar substring.
-    Cada decrypt é auditado em pii_access_log (purpose=render_admin_users_list).
+    Agregados, filtros de status/plano e paginação rodam em SQL sobre a base
+    INTEIRA (_ACCOUNT_STATUS_SQL). A única exceção é a busca (q): e-mail é
+    cifrado no banco, então o match de substring exige decifrar — esse caminho
+    varre no máximo _ADMIN_USERS_HARD_CAP contas mais recentes e devolve
+    truncated=True quando bateu no teto.
+
+    Minimização de PII: sem busca, só as rows da página devolvida são
+    decifradas. Cada decrypt é auditado (purpose=render_admin_users_list).
     """
     q = (q or "").strip().lower()
     plan = (plan or "").strip().lower()
@@ -881,11 +910,7 @@ async def fetch_admin_users(
     order_col = "last_activity_at" if sort == "last_activity_at" else "created_at"
     now = datetime.now(timezone.utc)
 
-    async with await db_connect() as conn:
-        async with conn.cursor() as cur:
-            await cur.execute(
-                f"""
-                SELECT
+    select_cols = f"""
                     a.user_id,
                     a.email,
                     a.email_enc,
@@ -900,48 +925,91 @@ async def fetch_admin_users(
                     a.phone_status,
                     a.whatsapp_verified_at,
                     a.deletion_status,
+                    {_ACCOUNT_STATUS_SQL} AS account_status,
                     EXISTS (
                         SELECT 1 FROM user_identities ui
                         WHERE ui.user_id = a.user_id AND ui.provider = 'whatsapp'
                     ) AS has_whatsapp_identity
+    """
+    order_sql = f"ORDER BY a.{order_col} DESC NULLS LAST, a.user_id DESC"
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    if plan:
+        clauses.append("lower(coalesce(nullif(trim(a.plan), ''), 'free')) = %s")
+        params.append(plan)
+    if status:
+        clauses.append(f"{_ACCOUNT_STATUS_SQL} = %s")
+        params.append(status)
+    where_sql = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    truncated = False
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            # Agregados: base inteira, sempre, independente dos filtros
+            await cur.execute(
+                f"""
+                SELECT {_ACCOUNT_STATUS_SQL} AS account_status,
+                       COUNT(*) AS n,
+                       COUNT(*) FILTER (
+                           WHERE a.phone_status = 'confirmed'
+                              OR EXISTS (
+                                  SELECT 1 FROM user_identities ui
+                                  WHERE ui.user_id = a.user_id
+                                    AND ui.provider = 'whatsapp'
+                              )
+                       ) AS wa
                 FROM auth_accounts a
-                ORDER BY {order_col} DESC NULLS LAST, a.user_id DESC
-                LIMIT %s
-                """,
-                (_ADMIN_USERS_HARD_CAP,),
+                GROUP BY 1
+                """
             )
-            rows = [dict(r) for r in await cur.fetchall()]
-
-            for row in rows:
-                row["account_status"] = _derive_account_status(row, now)
-
             aggregates: dict[str, int] = {s: 0 for s in _USER_STATUSES}
-            for row in rows:
-                aggregates[row["account_status"]] += 1
-            aggregates["total"] = len(rows)
-            aggregates["whatsapp_connected"] = sum(
-                1 for r in rows
-                if r["has_whatsapp_identity"] or r.get("phone_status") == "confirmed"
-            )
+            aggregates["whatsapp_connected"] = 0
+            for r in await cur.fetchall():
+                aggregates[r["account_status"]] = int(r["n"])
+                aggregates["whatsapp_connected"] += int(r["wa"])
+            aggregates["total"] = sum(aggregates[s] for s in _USER_STATUSES)
 
-            if plan:
-                rows = [r for r in rows if (r.get("plan") or "free").lower() == plan]
-            if status:
-                rows = [r for r in rows if r["account_status"] == status]
-
-            if q:
-                # Busca casa contra o e-mail decifrado: decifra a base filtrada
-                # inteira (batch de auditoria em quem chama).
+            if not q:
+                await cur.execute(
+                    f"SELECT COUNT(*) AS n FROM auth_accounts a {where_sql}",
+                    tuple(params),
+                )
+                total_filtered = int((await cur.fetchone())["n"])
+                await cur.execute(
+                    f"""
+                    SELECT {select_cols}
+                    FROM auth_accounts a
+                    {where_sql}
+                    {order_sql}
+                    LIMIT %s OFFSET %s
+                    """,
+                    tuple(params) + (per_page, page * per_page),
+                )
+                page_rows = [dict(r) for r in await cur.fetchall()]
+                for row in page_rows:
+                    _decrypt_admin_row(row, admin_user, "render_admin_users_list")
+            else:
+                # Busca: match contra o e-mail decifrado, varrendo as
+                # _ADMIN_USERS_HARD_CAP contas mais recentes que passam nos
+                # filtros SQL (batch de auditoria em quem chama).
+                await cur.execute(
+                    f"""
+                    SELECT {select_cols}
+                    FROM auth_accounts a
+                    {where_sql}
+                    {order_sql}
+                    LIMIT %s
+                    """,
+                    tuple(params) + (_ADMIN_USERS_HARD_CAP,),
+                )
+                rows = [dict(r) for r in await cur.fetchall()]
+                truncated = len(rows) >= _ADMIN_USERS_HARD_CAP
                 for row in rows:
                     _decrypt_admin_row(row, admin_user, "render_admin_users_list")
                 rows = [r for r in rows if q in (r.get("email") or "").lower()]
-
-            total_filtered = len(rows)
-            start = page * per_page
-            page_rows = rows[start:start + per_page]
-            if not q:
-                for row in page_rows:
-                    _decrypt_admin_row(row, admin_user, "render_admin_users_list")
+                total_filtered = len(rows)
+                page_rows = rows[page * per_page:(page + 1) * per_page]
 
             tx_by_user: dict[int, int] = {}
             if page_rows:
@@ -960,9 +1028,6 @@ async def fetch_admin_users(
 
     for row in page_rows:
         row["tx_30d"] = tx_by_user.get(int(row["user_id"]), 0)
-        # colunas _enc nunca vazam; rows fora da página não passaram pelo
-        # _decrypt_admin_row (que já as remove)
-        row.pop("email_enc", None)
 
     return {
         "generated_at": now,
@@ -972,6 +1037,7 @@ async def fetch_admin_users(
         "page": page,
         "per_page": per_page,
         "total": total_filtered,
+        "truncated": truncated,
         "filters": {"q": q, "plan": plan, "status": status, "sort": order_col},
     }
 

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -732,6 +732,346 @@ async def _fetch_admin_overview_inner(days: int = 30, admin_user: str = "admin")
     }
 
 
+# ── Painel de usuários (/admin/api/users) ────────────────────────────────────
+
+_USER_STATUSES = ("paying", "trial", "past_due", "canceled", "granted", "free")
+
+
+def _derive_account_status(row: dict, now: datetime) -> str:
+    """Classifica a conta numa categoria única de assinatura.
+
+    A fonte é o par (plan, last_payment_status) mantido pelos webhooks do
+    Stripe; contas Pro sem stripe_customer_id são grants manuais (cortesia).
+    """
+    plan = (row.get("plan") or "free").strip().lower()
+    if plan in ("", "free"):
+        return "free"
+    pay = (row.get("last_payment_status") or "").strip().lower()
+    if pay == "trialing":
+        return "trial"
+    if pay == "active":
+        return "paying"
+    if pay in ("past_due", "unpaid", "incomplete"):
+        return "past_due"
+    if pay in ("canceled", "incomplete_expired"):
+        return "canceled"
+    if not row.get("stripe_customer_id"):
+        return "granted"
+    # Pro com customer Stripe mas sem status de pagamento registrado: se já
+    # expirou trata como cancelada, senão como cortesia (estado legado raro).
+    expires = row.get("plan_expires_at")
+    if expires is not None and expires < now:
+        return "canceled"
+    return "granted"
+
+
+_billing_summary_cache: dict[str, Any] = {"fetched_at": None, "data": None}
+_BILLING_CACHE_TTL_SECONDS = 300
+
+
+def _fetch_stripe_billing_sync() -> dict[str, Any]:
+    """Resume as assinaturas direto da API do Stripe (fonte da verdade de
+    preço): MRR, ticket médio e contagens por status. Valores anuais são
+    normalizados pra base mensal (unit_amount/12)."""
+    if not STRIPE_SECRET_KEY:
+        return {"available": False, "reason": "stripe_not_configured"}
+    import stripe
+
+    stripe.api_key = STRIPE_SECRET_KEY
+    counts = {"active": 0, "trialing": 0, "past_due": 0, "canceled": 0, "other": 0}
+    mrr = 0.0
+    trial_mrr = 0.0
+    active_amounts: list[float] = []
+    scanned = 0
+    try:
+        subs = stripe.Subscription.list(status="all", limit=100)
+        for sub in subs.auto_paging_iter():
+            scanned += 1
+            if scanned > 1000:  # guarda contra base gigante; hoje são <10
+                break
+            status = str(getattr(sub, "status", "") or "")
+            if status in ("active", "trialing", "past_due"):
+                counts[status] += 1
+            elif status in ("canceled", "incomplete_expired"):
+                counts["canceled"] += 1
+            else:
+                counts["other"] += 1
+
+            monthly = 0.0
+            items = getattr(getattr(sub, "items", None), "data", None) or []
+            if items:
+                price = getattr(items[0], "price", None)
+                unit = getattr(price, "unit_amount", None) if price else None
+                recurring = getattr(price, "recurring", None) if price else None
+                interval = str(getattr(recurring, "interval", "month") or "month")
+                interval_count = int(getattr(recurring, "interval_count", 1) or 1)
+                if unit is not None:
+                    monthly = (float(unit) / 100.0) / interval_count
+                    if interval == "year":
+                        monthly /= 12.0
+                    elif interval == "week":
+                        monthly *= 4.345
+                    elif interval == "day":
+                        monthly *= 30.0
+            if status == "active":
+                mrr += monthly
+                active_amounts.append(monthly)
+            elif status == "trialing":
+                trial_mrr += monthly
+    except Exception as exc:
+        logging.getLogger(__name__).warning("[admin] Stripe billing summary falhou: %s", exc)
+        return {"available": False, "reason": str(exc)[:200]}
+
+    return {
+        "available": True,
+        "subscriptions": counts,
+        "mrr": round(mrr, 2),
+        "ticket_medio": round(sum(active_amounts) / len(active_amounts), 2) if active_amounts else 0.0,
+        "trial_mrr_potencial": round(trial_mrr, 2),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
+    """Wrapper cacheado (5 min) do resumo Stripe — a lista de usuários abre a
+    cada clique no card e não deve martelar a API do Stripe."""
+    now = datetime.now(timezone.utc)
+    cached_at = _billing_summary_cache.get("fetched_at")
+    if (
+        not force
+        and cached_at is not None
+        and (now - cached_at).total_seconds() < _BILLING_CACHE_TTL_SECONDS
+        and _billing_summary_cache.get("data") is not None
+    ):
+        return _billing_summary_cache["data"]
+    data = await asyncio.to_thread(_fetch_stripe_billing_sync)
+    # Falha de API não substitui um cache bom ainda recente na memória
+    if data.get("available") or _billing_summary_cache.get("data") is None:
+        _billing_summary_cache["data"] = data
+        _billing_summary_cache["fetched_at"] = now
+    return _billing_summary_cache["data"]
+
+
+_ADMIN_USERS_HARD_CAP = 2000
+
+
+async def fetch_admin_users(
+    *,
+    q: str = "",
+    plan: str = "",
+    status: str = "",
+    page: int = 0,
+    per_page: int = 50,
+    sort: str = "created_at",
+    admin_user: str = "admin",
+) -> dict[str, Any]:
+    """Lista paginada de contas com classificação de assinatura + agregados.
+
+    Minimização de PII: só decifra e-mail das rows da página devolvida —
+    exceto com busca (q), que precisa decifrar a base pra casar substring.
+    Cada decrypt é auditado em pii_access_log (purpose=render_admin_users_list).
+    """
+    q = (q or "").strip().lower()
+    plan = (plan or "").strip().lower()
+    status = (status or "").strip().lower()
+    if status and status not in _USER_STATUSES:
+        status = ""
+    page = max(0, int(page or 0))
+    per_page = max(1, min(int(per_page or 50), 200))
+    order_col = "last_activity_at" if sort == "last_activity_at" else "created_at"
+    now = datetime.now(timezone.utc)
+
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"""
+                SELECT
+                    a.user_id,
+                    a.email,
+                    a.email_enc,
+                    a.plan,
+                    a.plan_expires_at,
+                    a.last_payment_status,
+                    a.stripe_customer_id,
+                    a.trial_started_at,
+                    a.plan_selected_at,
+                    a.created_at,
+                    a.last_activity_at,
+                    a.phone_status,
+                    a.whatsapp_verified_at,
+                    a.deletion_status,
+                    EXISTS (
+                        SELECT 1 FROM user_identities ui
+                        WHERE ui.user_id = a.user_id AND ui.provider = 'whatsapp'
+                    ) AS has_whatsapp_identity
+                FROM auth_accounts a
+                ORDER BY {order_col} DESC NULLS LAST, a.user_id DESC
+                LIMIT %s
+                """,
+                (_ADMIN_USERS_HARD_CAP,),
+            )
+            rows = [dict(r) for r in await cur.fetchall()]
+
+            for row in rows:
+                row["account_status"] = _derive_account_status(row, now)
+
+            aggregates: dict[str, int] = {s: 0 for s in _USER_STATUSES}
+            for row in rows:
+                aggregates[row["account_status"]] += 1
+            aggregates["total"] = len(rows)
+            aggregates["whatsapp_connected"] = sum(
+                1 for r in rows
+                if r["has_whatsapp_identity"] or r.get("phone_status") == "confirmed"
+            )
+
+            if plan:
+                rows = [r for r in rows if (r.get("plan") or "free").lower() == plan]
+            if status:
+                rows = [r for r in rows if r["account_status"] == status]
+
+            if q:
+                # Busca casa contra o e-mail decifrado: decifra a base filtrada
+                # inteira (batch de auditoria em quem chama).
+                for row in rows:
+                    _decrypt_admin_row(row, admin_user, "render_admin_users_list")
+                rows = [r for r in rows if q in (r.get("email") or "").lower()]
+
+            total_filtered = len(rows)
+            start = page * per_page
+            page_rows = rows[start:start + per_page]
+            if not q:
+                for row in page_rows:
+                    _decrypt_admin_row(row, admin_user, "render_admin_users_list")
+
+            tx_by_user: dict[int, int] = {}
+            if page_rows:
+                await cur.execute(
+                    """
+                    SELECT user_id, COUNT(*) AS n
+                    FROM launches
+                    WHERE user_id = ANY(%s)
+                      AND criado_em >= NOW() - INTERVAL '30 days'
+                      AND is_internal_movement = false
+                    GROUP BY user_id
+                    """,
+                    ([int(r["user_id"]) for r in page_rows],),
+                )
+                tx_by_user = {int(r["user_id"]): int(r["n"]) for r in await cur.fetchall()}
+
+    for row in page_rows:
+        row["tx_30d"] = tx_by_user.get(int(row["user_id"]), 0)
+        # colunas _enc nunca vazam; rows fora da página não passaram pelo
+        # _decrypt_admin_row (que já as remove)
+        row.pop("email_enc", None)
+
+    return {
+        "generated_at": now,
+        "aggregates": aggregates,
+        "billing": await fetch_billing_summary(),
+        "users": page_rows,
+        "page": page,
+        "per_page": per_page,
+        "total": total_filtered,
+        "filters": {"q": q, "plan": plan, "status": status, "sort": order_col},
+    }
+
+
+async def fetch_admin_user_detail(user_id: int, admin_user: str = "admin") -> dict[str, Any] | None:
+    """Drill-down de uma conta pro suporte: perfil + assinatura + agregados de
+    uso + eventos recentes. LGPD: nada de conteúdo de transação — só contagens
+    e datas; e-mail/telefone/nome decifrados com auditoria individual."""
+    now = datetime.now(timezone.utc)
+    async with await db_connect() as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT
+                    a.user_id,
+                    a.email, a.email_enc,
+                    a.phone_e164, a.phone_enc,
+                    a.display_name, a.display_name_enc,
+                    a.plan, a.plan_expires_at, a.last_payment_status,
+                    a.stripe_customer_id, a.trial_started_at, a.plan_selected_at,
+                    a.created_at, a.last_activity_at,
+                    a.phone_status, a.whatsapp_verified_at, a.whatsapp_updates_opt_out,
+                    a.engagement_opt_out, a.tip_email_opt_out, a.insight_email_opt_out,
+                    a.deletion_status, a.deletion_requested_at,
+                    a.ai_messages_this_month,
+                    EXISTS (
+                        SELECT 1 FROM user_identities ui
+                        WHERE ui.user_id = a.user_id AND ui.provider = 'whatsapp'
+                    ) AS has_whatsapp_identity
+                FROM auth_accounts a
+                WHERE a.user_id = %s
+                """,
+                (int(user_id),),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return None
+            profile = _decrypt_admin_row(dict(row), admin_user, "render_admin_user_detail")
+            profile["account_status"] = _derive_account_status(profile, now)
+
+            await cur.execute(
+                """
+                SELECT
+                    COUNT(*) FILTER (WHERE is_internal_movement = false) AS tx_total,
+                    COUNT(*) FILTER (
+                        WHERE is_internal_movement = false
+                          AND criado_em >= NOW() - INTERVAL '30 days'
+                    ) AS tx_30d,
+                    MAX(criado_em) AS last_tx_at
+                FROM launches
+                WHERE user_id = %s
+                """,
+                (int(user_id),),
+            )
+            usage = dict(await cur.fetchone())
+
+            await cur.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM pockets      WHERE user_id = %(uid)s) AS pockets_count,
+                    (SELECT COUNT(*) FROM investments  WHERE user_id = %(uid)s) AS investments_count,
+                    (SELECT COUNT(*) FROM credit_cards WHERE user_id = %(uid)s) AS cards_count
+                """,
+                {"uid": int(user_id)},
+            )
+            usage.update(dict(await cur.fetchone()))
+
+            await cur.execute(
+                """
+                SELECT level, event_type, message, source, created_at
+                FROM system_event_logs
+                WHERE user_id = %s
+                ORDER BY created_at DESC
+                LIMIT 15
+                """,
+                (int(user_id),),
+            )
+            recent_events = [dict(r) for r in await cur.fetchall()]
+
+            await cur.execute(
+                """
+                SELECT success, failure_reason, ip_address, created_at
+                FROM auth_login_events
+                WHERE user_id = %s
+                ORDER BY created_at DESC
+                LIMIT 10
+                """,
+                (int(user_id),),
+            )
+            recent_logins = [dict(r) for r in await cur.fetchall()]
+
+    return {
+        "generated_at": now,
+        "profile": profile,
+        "usage": usage,
+        "recent_events": recent_events,
+        "recent_logins": recent_logins,
+    }
+
+
 async def log_admin_startup_warnings() -> None:
     # Coleta todos os avisos primeiro, depois faz UM único insert em batch.
     # Antes eram N chamadas sequenciais a log_system_event(), cada uma abrindo
@@ -967,6 +1307,44 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
     async def admin_api_overview(days: int = 30, username: str = Depends(_get_current_admin)):
         data = await fetch_admin_overview(days=days, admin_user=username)
         data["admin_user"] = username
+        return JSONResponse(content=_json_safe(data))
+
+    @app.get("/admin/api/users")
+    async def admin_api_users(
+        q: str = "",
+        plan: str = "",
+        status: str = "",
+        page: int = 0,
+        per_page: int = 50,
+        sort: str = "created_at",
+        username: str = Depends(_get_current_admin),
+    ):
+        """Painel de usuários: lista paginada + agregados de assinatura + resumo
+        Stripe (MRR/ticket médio). Decrypts auditados num único batch."""
+        audit = pii_audit_batch()
+        audit.__enter__()
+        try:
+            data = await fetch_admin_users(
+                q=q, plan=plan, status=status, page=page,
+                per_page=per_page, sort=sort, admin_user=username,
+            )
+        finally:
+            audit.__exit__(None, None, None)
+        return JSONResponse(content=_json_safe(data))
+
+    @app.get("/admin/api/users/{user_id}")
+    async def admin_api_user_detail(
+        user_id: int,
+        username: str = Depends(_get_current_admin),
+    ):
+        audit = pii_audit_batch()
+        audit.__enter__()
+        try:
+            data = await fetch_admin_user_detail(user_id, admin_user=username)
+        finally:
+            audit.__exit__(None, None, None)
+        if data is None:
+            raise HTTPException(status_code=404, detail="Conta não encontrada.")
         return JSONResponse(content=_json_safe(data))
 
     @app.delete("/admin/api/events/{event_id}")

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1086,7 +1086,7 @@ async def fetch_admin_user_detail(user_id: int, admin_user: str = "admin") -> di
                         WHERE is_internal_movement = false
                           AND criado_em >= NOW() - INTERVAL '30 days'
                     ) AS tx_30d,
-                    MAX(criado_em) AS last_tx_at
+                    MAX(criado_em) FILTER (WHERE is_internal_movement = false) AS last_tx_at
                 FROM launches
                 WHERE user_id = %s
                 """,

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1314,7 +1314,19 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
                         """
                         update auth_accounts
                            set plan = 'pro',
-                               plan_expires_at = now() + (%s || ' months')::interval
+                               plan_expires_at = now() + (%s || ' months')::interval,
+                               -- Grant sobre ex-assinante: status terminal
+                               -- (canceled/unpaid) viraria 'Cancelado' no
+                               -- painel de usuários mesmo com o grant vigente.
+                               -- Status em curso (active/trialing/past_due)
+                               -- fica intacto: a relação Stripe segue viva e
+                               -- os webhooks continuam donos dele.
+                               last_payment_status = case
+                                   when lower(coalesce(last_payment_status, ''))
+                                        in ('canceled', 'incomplete_expired', 'unpaid')
+                                   then 'inactive'
+                                   else last_payment_status
+                               end
                          where lower(email) = lower(%s)
                         returning user_id, email, plan, plan_expires_at
                         """,

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -755,6 +755,12 @@ def _derive_account_status(row: dict, now: datetime) -> str:
     pay = (row.get("last_payment_status") or "").strip().lower()
     if plan == "free":
         return "canceled" if pay in ("canceled", "incomplete_expired") else "free"
+    # Expiração vem ANTES do status de pagamento: plan_service._paid_plan_active
+    # trata tier pago vencido como inativo mesmo com status 'active' (webhook
+    # perdido) — o painel tem de concordar com o entitlement real.
+    expires = row.get("plan_expires_at")
+    if expires is not None and expires < now:
+        return "canceled"
     if pay == "trialing":
         return "trial"
     if pay == "active":
@@ -762,9 +768,6 @@ def _derive_account_status(row: dict, now: datetime) -> str:
     if pay in ("past_due", "unpaid", "incomplete"):
         return "past_due"
     if pay in ("canceled", "incomplete_expired"):
-        return "canceled"
-    expires = row.get("plan_expires_at")
-    if expires is not None and expires < now:
         return "canceled"
     return "granted"
 
@@ -777,13 +780,13 @@ _ACCOUNT_STATUS_SQL = """
             CASE WHEN lower(coalesce(a.last_payment_status, ''))
                       IN ('canceled', 'incomplete_expired')
                  THEN 'canceled' ELSE 'free' END
+        WHEN a.plan_expires_at IS NOT NULL AND a.plan_expires_at < now() THEN 'canceled'
         WHEN lower(coalesce(a.last_payment_status, '')) = 'trialing' THEN 'trial'
         WHEN lower(coalesce(a.last_payment_status, '')) = 'active' THEN 'paying'
         WHEN lower(coalesce(a.last_payment_status, ''))
              IN ('past_due', 'unpaid', 'incomplete') THEN 'past_due'
         WHEN lower(coalesce(a.last_payment_status, ''))
              IN ('canceled', 'incomplete_expired') THEN 'canceled'
-        WHEN a.plan_expires_at IS NOT NULL AND a.plan_expires_at < now() THEN 'canceled'
         ELSE 'granted'
     END
 """
@@ -858,7 +861,12 @@ def _fetch_stripe_billing_sync() -> dict[str, Any]:
 
 async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
     """Wrapper cacheado (5 min) do resumo Stripe — a lista de usuários abre a
-    cada clique no card e não deve martelar a API do Stripe."""
+    cada clique no card e não deve martelar a API do Stripe.
+
+    O carimbo do cache avança TAMBÉM quando a chamada falha: o TTL vira
+    backoff de retry, senão uma queda do Stripe adicionaria a latência da
+    API falhando em toda requisição do painel. Payload bom anterior é
+    preservado com stale=True (o fetched_at interno dele mostra a idade)."""
     now = datetime.now(timezone.utc)
     cached_at = _billing_summary_cache.get("fetched_at")
     if (
@@ -869,10 +877,12 @@ async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
     ):
         return _billing_summary_cache["data"]
     data = await asyncio.to_thread(_fetch_stripe_billing_sync)
-    # Falha de API não substitui um cache bom ainda recente na memória
     if data.get("available") or _billing_summary_cache.get("data") is None:
         _billing_summary_cache["data"] = data
-        _billing_summary_cache["fetched_at"] = now
+    else:
+        # Falha com payload bom em mãos: preserva os números, marcados stale
+        _billing_summary_cache["data"] = {**_billing_summary_cache["data"], "stale": True}
+    _billing_summary_cache["fetched_at"] = now
     return _billing_summary_cache["data"]
 
 

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1458,9 +1458,12 @@ function renderUsersTable(data) {
 
   const totalPages = Math.max(1, Math.ceil(data.total / usersState.perPage));
   const start = data.page * usersState.perPage;
-  $id('users-foot-meta').textContent = data.total
+  const truncWarn = data.truncated
+    ? ' · ⚠ busca limitada às contas mais recentes — refine o termo'
+    : '';
+  $id('users-foot-meta').textContent = (data.total
     ? `${start + 1}–${start + data.users.length} de ${fInt(data.total)} conta${data.total === 1 ? '' : 's'}`
-    : '0 contas';
+    : '0 contas') + truncWarn;
   $id('users-pagination').innerHTML = totalPages <= 1 ? '' : `
     <button class="pagination-btn" ${data.page === 0 ? 'disabled' : ''} onclick="changeUsersPage(-1)">◀</button>
     <span class="pagination-info">Página ${data.page + 1} de ${totalPages}</span>

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -163,6 +163,102 @@ button:disabled { opacity: .6; cursor: wait; }
 .badge-ok      { background: rgba(34,197,94,.1);   color: #86efac; border: 1px solid rgba(34,197,94,.2); }
 .badge-info    { background: rgba(255,128,184,.1);  color: #93c5fd; border: 1px solid rgba(255,128,184,.2); }
 .badge-muted   { background: rgba(255,255,255,.05); color: var(--muted); }
+.badge-purple  { background: rgba(255,45,142,.12);  color: #f9a8d4; border: 1px solid rgba(255,45,142,.25); }
+
+/* ── Card clicável (abre painel) ─────────────────────────────────────── */
+.card-clickable { cursor: pointer; transition: border-color .15s, transform .15s; }
+.card-clickable:hover { border-color: rgba(255,128,184,.45); transform: translateY(-2px); }
+.card-clickable .metric-sub::after { content: " · clique para detalhar"; color: var(--soft); }
+
+/* ── Modal de usuários ───────────────────────────────────────────────── */
+#users-modal {
+  display: none;
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(4,10,17,.72);
+  backdrop-filter: blur(6px);
+  align-items: center; justify-content: center;
+  padding: 24px;
+}
+#users-modal.visible { display: flex; }
+.users-dialog {
+  width: min(1240px, 96vw);
+  height: min(860px, 92vh);
+  display: flex; flex-direction: column;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  box-shadow: 0 24px 80px rgba(0,0,0,.5);
+  overflow: hidden;
+}
+.users-dialog-head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; padding: 18px 22px 12px;
+}
+.users-dialog-head h2 { font-size: 18px; font-weight: 700; }
+.users-close { font-size: 20px; padding: 4px 10px; border-radius: 10px; }
+.users-chips {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  padding: 0 22px 12px;
+}
+.user-chip {
+  display: inline-flex; flex-direction: column; gap: 1px;
+  padding: 8px 14px; border-radius: 12px;
+  background: var(--panel-2); border: 1px solid var(--border);
+  cursor: pointer; transition: border-color .15s;
+  min-width: 86px;
+}
+.user-chip:hover { border-color: rgba(255,128,184,.4); }
+.user-chip.active { border-color: var(--purple); background: rgba(255,45,142,.08); }
+.user-chip.static { cursor: default; }
+.user-chip.static:hover { border-color: var(--border); }
+.user-chip b { font-size: 17px; font-weight: 750; }
+.user-chip span { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .07em; }
+.user-chip b.green  { color: var(--green); }
+.user-chip b.blue   { color: var(--blue); }
+.user-chip b.yellow { color: var(--yellow); }
+.user-chip b.red    { color: var(--red); }
+.user-chip b.purple { color: var(--purple); }
+.users-toolbar {
+  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+  padding: 0 22px 12px;
+}
+.users-toolbar input[type="text"] {
+  background: var(--panel-2); border: 1px solid var(--border);
+  color: var(--text); border-radius: 10px; padding: 9px 12px;
+  font-size: 13px; width: 260px;
+}
+.users-body { flex: 1; overflow: auto; padding: 0 22px 8px; overscroll-behavior: contain; }
+.users-body .table th { position: sticky; top: 0; background: #0b1826; z-index: 1; }
+.users-body .table td { font-size: 12.5px; }
+.users-row { cursor: pointer; }
+.users-row:hover td { background: rgba(255,255,255,.03); }
+.users-dialog-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 8px; padding: 10px 22px 16px; border-top: 1px solid var(--border);
+}
+.users-foot-meta { color: var(--muted); font-size: 12px; }
+.stripe-link { color: var(--blue); text-decoration: none; font-size: 12px; }
+.stripe-link:hover { text-decoration: underline; }
+
+/* Drill-down */
+#user-detail { display: none; flex: 1; overflow: auto; padding: 0 22px 16px; overscroll-behavior: contain; }
+.detail-grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px; margin-bottom: 16px;
+}
+.detail-item {
+  background: var(--panel-2); border: 1px solid var(--border);
+  border-radius: 12px; padding: 10px 14px;
+}
+.detail-item .k { color: var(--soft); font-size: 10px; text-transform: uppercase; letter-spacing: .07em; margin-bottom: 4px; }
+.detail-item .v { font-size: 14px; font-weight: 600; word-break: break-all; }
+.detail-section-title { font-size: 13px; font-weight: 700; color: var(--muted); margin: 14px 0 8px; text-transform: uppercase; letter-spacing: .06em; }
+.detail-event {
+  display: flex; gap: 8px; align-items: baseline;
+  padding: 7px 0; border-bottom: 1px solid rgba(255,255,255,.05);
+  font-size: 12.5px;
+}
+.detail-event .t { color: var(--soft); font-size: 11px; white-space: nowrap; }
 
 /* ── Error list ──────────────────────────────────────────────────────── */
 .error-list  { display: grid; gap: 8px; }
@@ -496,6 +592,49 @@ button:disabled { opacity: .6; cursor: wait; }
   </section>
 
 </div><!-- .shell -->
+
+<!-- ── Modal de usuários (abre pelo card "Usuários") ─────────────────── -->
+<div id="users-modal" role="dialog" aria-modal="true" aria-label="Usuários e assinaturas">
+  <div class="users-dialog">
+    <div class="users-dialog-head">
+      <h2><i class="ph ph-users-three" aria-hidden="true"></i> Usuários &amp; assinaturas</h2>
+      <div style="display:flex;gap:8px;align-items:center">
+        <span class="meta" id="users-billing-meta"></span>
+        <button class="users-close" onclick="closeUsersModal()" title="Fechar (Esc)"><i class="ph ph-x" aria-hidden="true"></i></button>
+      </div>
+    </div>
+
+    <div class="users-chips" id="users-chips"></div>
+
+    <div class="users-toolbar" id="users-toolbar">
+      <input type="text" id="users-search" placeholder="Buscar por e-mail…" autocomplete="off" />
+      <select id="users-sort">
+        <option value="created_at">Mais recentes primeiro</option>
+        <option value="last_activity_at">Última atividade</option>
+      </select>
+      <span class="meta" id="users-loading"></span>
+    </div>
+
+    <div class="users-body" id="users-body">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>E-mail</th><th>Status</th><th>Plano</th><th>Expira</th>
+            <th>Cadastro</th><th>Últ. atividade</th><th>Tx 30d</th><th>WA</th><th>Stripe</th>
+          </tr>
+        </thead>
+        <tbody id="users-table-body"></tbody>
+      </table>
+    </div>
+
+    <div id="user-detail"></div>
+
+    <div class="users-dialog-foot">
+      <span class="users-foot-meta" id="users-foot-meta">—</span>
+      <div class="pagination" id="users-pagination"></div>
+    </div>
+  </div>
+</div>
 
 <script>
 /* ── Constantes e estado ─────────────────────────────────────────── */
@@ -898,7 +1037,8 @@ function renderOpsHealthGrid(ops) {
 /* ── Summary cards ───────────────────────────────────────────────── */
 function renderSummary(s) {
   const cards = [
-    { label:"Usuários",          val: fInt(s.total_accounts),    sub:`+${fInt(s.accounts_30d)} em 30d` },
+    { label:"Usuários",          val: fInt(s.total_accounts),    sub:`+${fInt(s.accounts_30d)} em 30d`,
+      click:"openUsersModal()" },
     { label:"Ativos 30d",        val: fInt(s.active_users_30d),  sub:`${fInt(s.active_users_7d)} ativos 7d` },
     { label:"Logins ok 30d",     val: fInt(s.login_success_30d), sub:`${s.login_success_rate_30d}% taxa sucesso` },
     { label:"Transações 30d",    val: fInt(s.transactions_30d),  sub:"Movimentações externas" },
@@ -909,7 +1049,7 @@ function renderSummary(s) {
     { label:"Cartões em aberto", val: fMoney(s.cards_due_open),  sub:"Faturas abertas/fechadas" },
   ];
   $id('summary-cards').innerHTML = cards.map(c => `
-    <article class="card">
+    <article class="card${c.click ? ' card-clickable' : ''}"${c.click ? ` onclick="${c.click}"` : ''}>
       <div class="metric-label">${c.label}</div>
       <div class="metric-value">${c.val}</div>
       <div class="metric-sub">${c.sub}</div>
@@ -1196,6 +1336,244 @@ function onPiiFilterChange() {
     loadPiiAccess();
   }, 250);
 }
+
+/* ── Modal de usuários & assinaturas ─────────────────────────────── */
+const USER_STATUS_META = {
+  paying:   { label: 'Pagante',      cls: 'badge-ok',      chip: 'green'  },
+  trial:    { label: 'Trial',        cls: 'badge-info',    chip: 'blue'   },
+  past_due: { label: 'Inadimplente', cls: 'badge-warning', chip: 'yellow' },
+  canceled: { label: 'Cancelado',    cls: 'badge-error',   chip: 'red'    },
+  granted:  { label: 'Cortesia',     cls: 'badge-purple',  chip: 'purple' },
+  free:     { label: 'Free',         cls: 'badge-muted',   chip: ''       },
+};
+const usersState = { q: '', status: '', page: 0, perPage: 50, sort: 'created_at', open: false };
+let usersSearchDebounce = null;
+let usersController = null;
+
+function openUsersModal() {
+  usersState.open = true;
+  $id('users-modal').classList.add('visible');
+  showUsersList();
+  loadUsers();
+}
+function closeUsersModal() {
+  usersState.open = false;
+  usersController?.abort();
+  $id('users-modal').classList.remove('visible');
+}
+function showUsersList() {
+  $id('user-detail').style.display = 'none';
+  $id('users-body').style.display = '';
+  $id('users-toolbar').style.display = '';
+  $id('users-chips').style.display = '';
+}
+
+async function loadUsers() {
+  usersController?.abort();
+  usersController = new AbortController();
+  $id('users-loading').textContent = 'Carregando…';
+  const params = new URLSearchParams({
+    page: usersState.page, per_page: usersState.perPage, sort: usersState.sort,
+  });
+  if (usersState.q)      params.set('q', usersState.q);
+  if (usersState.status) params.set('status', usersState.status);
+  try {
+    const res = await fetch(`/admin/api/users?${params}`, {
+      headers: authH(), cache: 'no-store', signal: usersController.signal,
+    });
+    if (res.status === 401) { window.location.href = '/admin/login'; return; }
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    renderUsersChips(data.aggregates, data.billing);
+    renderUsersTable(data);
+    $id('users-loading').textContent = '';
+  } catch (e) {
+    if (e?.name !== 'AbortError') {
+      $id('users-loading').textContent = 'Falha ao carregar.';
+      console.error('users:', e);
+    }
+  }
+}
+
+function renderUsersChips(agg, billing) {
+  const chips = [
+    { key: '',         label: 'Total',        val: fInt(agg.total),    chip: '' },
+    { key: 'paying',   label: 'Pagantes',     val: fInt(agg.paying),   chip: 'green' },
+    { key: 'trial',    label: 'Em trial',     val: fInt(agg.trial),    chip: 'blue' },
+    { key: 'past_due', label: 'Inadimpl.',    val: fInt(agg.past_due), chip: 'yellow' },
+    { key: 'canceled', label: 'Cancelados',   val: fInt(agg.canceled), chip: 'red' },
+    { key: 'granted',  label: 'Cortesia',     val: fInt(agg.granted),  chip: 'purple' },
+    { key: 'free',     label: 'Free',         val: fInt(agg.free),     chip: '' },
+  ];
+  let html = chips.map(c => `
+    <div class="user-chip${usersState.status === c.key ? ' active' : ''}" onclick="setUsersStatus('${c.key}')">
+      <b class="${c.chip}">${c.val}</b><span>${c.label}</span>
+    </div>`).join('');
+  html += `
+    <div class="user-chip static"><b>${fInt(agg.whatsapp_connected)}</b><span>WA conect.</span></div>`;
+  if (billing?.available) {
+    html += `
+    <div class="user-chip static"><b class="green">${fMoney(billing.mrr)}</b><span>MRR</span></div>
+    <div class="user-chip static"><b>${fMoney(billing.ticket_medio)}</b><span>Ticket médio</span></div>
+    <div class="user-chip static"><b class="blue">${fMoney(billing.trial_mrr_potencial)}</b><span>MRR em trial</span></div>`;
+    $id('users-billing-meta').textContent = `Stripe ${fRelTime(billing.fetched_at)}`;
+  } else {
+    $id('users-billing-meta').textContent = 'Stripe indisponível — contagens vêm do banco';
+  }
+  $id('users-chips').innerHTML = html;
+}
+
+function setUsersStatus(status) {
+  usersState.status = usersState.status === status ? '' : status;
+  usersState.page = 0;
+  loadUsers();
+}
+
+function renderUsersTable(data) {
+  const body = $id('users-table-body');
+  if (!data.users.length) {
+    body.innerHTML = `<tr><td colspan="9" class="empty">Nenhum usuário com esse filtro.</td></tr>`;
+  } else {
+    body.innerHTML = data.users.map(u => {
+      const meta = USER_STATUS_META[u.account_status] || USER_STATUS_META.free;
+      const stripe = u.stripe_customer_id
+        ? `<a class="stripe-link" href="https://dashboard.stripe.com/customers/${esc(u.stripe_customer_id)}"
+             target="_blank" rel="noopener" onclick="event.stopPropagation()" title="Abrir no Stripe">
+             <i class="ph ph-arrow-square-out" aria-hidden="true"></i></a>`
+        : '—';
+      return `
+      <tr class="users-row" onclick="openUserDetail(${Number(u.user_id)})">
+        <td title="user_id ${Number(u.user_id)}">${esc(u.email || '(sem e-mail)')}</td>
+        <td><span class="badge ${meta.cls}">${meta.label}</span></td>
+        <td>${esc(u.plan || 'free')}</td>
+        <td title="${fDate(u.plan_expires_at)}">${u.plan_expires_at ? fDate(u.plan_expires_at) : '—'}</td>
+        <td title="${fDate(u.created_at)}">${fRelTime(u.created_at)}</td>
+        <td title="${fDate(u.last_activity_at)}">${fRelTime(u.last_activity_at)}</td>
+        <td>${fInt(u.tx_30d)}</td>
+        <td>${(u.has_whatsapp_identity || u.phone_status === 'confirmed') ? '<i class="ph ph-check" style="color:var(--green)" aria-hidden="true"></i>' : '—'}</td>
+        <td>${stripe}</td>
+      </tr>`;
+    }).join('');
+  }
+
+  const totalPages = Math.max(1, Math.ceil(data.total / usersState.perPage));
+  const start = data.page * usersState.perPage;
+  $id('users-foot-meta').textContent = data.total
+    ? `${start + 1}–${start + data.users.length} de ${fInt(data.total)} conta${data.total === 1 ? '' : 's'}`
+    : '0 contas';
+  $id('users-pagination').innerHTML = totalPages <= 1 ? '' : `
+    <button class="pagination-btn" ${data.page === 0 ? 'disabled' : ''} onclick="changeUsersPage(-1)">◀</button>
+    <span class="pagination-info">Página ${data.page + 1} de ${totalPages}</span>
+    <button class="pagination-btn" ${data.page >= totalPages - 1 ? 'disabled' : ''} onclick="changeUsersPage(1)">▶</button>`;
+}
+
+function changeUsersPage(delta) {
+  usersState.page = Math.max(0, usersState.page + delta);
+  loadUsers();
+}
+
+/* ── Drill-down de um usuário ────────────────────────────────────── */
+async function openUserDetail(userId) {
+  const panel = $id('user-detail');
+  $id('users-body').style.display = 'none';
+  $id('users-toolbar').style.display = 'none';
+  $id('users-chips').style.display = 'none';
+  panel.style.display = 'block';
+  panel.innerHTML = `<div class="empty">Carregando conta ${userId}…</div>`;
+  try {
+    const res = await fetch(`/admin/api/users/${userId}`, { headers: authH(), cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    renderUserDetail(await res.json());
+  } catch (e) {
+    panel.innerHTML = `<div class="empty">Falha ao carregar a conta. <button onclick="showUsersList()">Voltar</button></div>`;
+    console.error('user-detail:', e);
+  }
+}
+
+function renderUserDetail(data) {
+  const p = data.profile, u = data.usage;
+  const meta = USER_STATUS_META[p.account_status] || USER_STATUS_META.free;
+  const item = (k, v) => `<div class="detail-item"><div class="k">${k}</div><div class="v">${v}</div></div>`;
+  const optOuts = [
+    p.engagement_opt_out && 'engajamento',
+    p.tip_email_opt_out && 'dicas',
+    p.insight_email_opt_out && 'insights',
+    p.whatsapp_updates_opt_out && 'updates WA',
+  ].filter(Boolean).join(', ') || 'nenhum';
+
+  $id('user-detail').innerHTML = `
+    <div style="display:flex;align-items:center;gap:10px;margin:4px 0 14px">
+      <button onclick="showUsersList()"><i class="ph ph-arrow-left" aria-hidden="true"></i> Voltar</button>
+      <h3 style="font-size:16px">${esc(p.email || `user ${p.user_id}`)}</h3>
+      <span class="badge ${meta.cls}">${meta.label}</span>
+      ${p.deletion_status ? `<span class="badge badge-error">exclusão: ${esc(p.deletion_status)}</span>` : ''}
+      ${p.stripe_customer_id ? `<a class="stripe-link" target="_blank" rel="noopener"
+          href="https://dashboard.stripe.com/customers/${esc(p.stripe_customer_id)}">abrir no Stripe <i class="ph ph-arrow-square-out" aria-hidden="true"></i></a>` : ''}
+    </div>
+
+    <div class="detail-grid">
+      ${item('User ID', p.user_id)}
+      ${item('Nome', esc(p.display_name || '—'))}
+      ${item('Telefone', esc(p.phone_e164 || '—'))}
+      ${item('Plano', `${esc(p.plan || 'free')}${p.plan_expires_at ? ` · expira ${fDate(p.plan_expires_at)}` : ''}`)}
+      ${item('Status pagamento', esc(p.last_payment_status || '—'))}
+      ${item('Trial iniciado', p.trial_started_at ? fDate(p.trial_started_at) : '—')}
+      ${item('Plano escolhido em', p.plan_selected_at ? fDate(p.plan_selected_at) : '—')}
+      ${item('Cadastro', fDate(p.created_at))}
+      ${item('Última atividade', p.last_activity_at ? `${fRelTime(p.last_activity_at)}` : '—')}
+      ${item('WhatsApp', (p.has_whatsapp_identity || p.phone_status === 'confirmed') ? 'conectado' : (p.phone_status || 'não conectado'))}
+      ${item('IA no mês', fInt(p.ai_messages_this_month))}
+      ${item('Opt-outs', optOuts)}
+    </div>
+
+    <div class="detail-section-title">Uso (contagens — sem conteúdo financeiro)</div>
+    <div class="detail-grid">
+      ${item('Transações (total)', fInt(u.tx_total))}
+      ${item('Transações 30d', fInt(u.tx_30d))}
+      ${item('Última transação', u.last_tx_at ? fRelTime(u.last_tx_at) : '—')}
+      ${item('Caixinhas', fInt(u.pockets_count))}
+      ${item('Investimentos', fInt(u.investments_count))}
+      ${item('Cartões', fInt(u.cards_count))}
+    </div>
+
+    <div class="detail-section-title">Eventos recentes desta conta</div>
+    ${data.recent_events.length ? data.recent_events.map(ev => `
+      <div class="detail-event">
+        ${levelBadge(ev.level)}
+        <span>${esc(ev.event_type)} — ${esc((ev.message || '').slice(0, 120))}</span>
+        <span class="t" title="${fDate(ev.created_at)}">${fRelTime(ev.created_at)}</span>
+      </div>`).join('') : '<div class="empty">Sem eventos registrados.</div>'}
+
+    <div class="detail-section-title">Logins recentes</div>
+    ${data.recent_logins.length ? data.recent_logins.map(lg => `
+      <div class="detail-event">
+        <span class="badge ${lg.success ? 'badge-ok' : 'badge-error'}">${lg.success ? 'ok' : 'falha'}</span>
+        <span>${esc(lg.ip_address || '')}${lg.failure_reason ? ` — ${esc(lg.failure_reason)}` : ''}</span>
+        <span class="t" title="${fDate(lg.created_at)}">${fRelTime(lg.created_at)}</span>
+      </div>`).join('') : '<div class="empty">Sem logins registrados.</div>'}
+  `;
+}
+
+/* Listeners do modal */
+$id('users-search').addEventListener('input', () => {
+  clearTimeout(usersSearchDebounce);
+  usersSearchDebounce = setTimeout(() => {
+    usersState.q = $id('users-search').value.trim();
+    usersState.page = 0;
+    loadUsers();
+  }, 300);
+});
+$id('users-sort').addEventListener('change', () => {
+  usersState.sort = $id('users-sort').value;
+  usersState.page = 0;
+  loadUsers();
+});
+$id('users-modal').addEventListener('click', (e) => {
+  if (e.target === $id('users-modal')) closeUsersModal();
+});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && usersState.open) closeUsersModal();
+});
 
 /* ── Auto-refresh ────────────────────────────────────────────────── */
 function startAutoRefresh() {

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1346,6 +1346,14 @@ const USER_STATUS_META = {
   granted:  { label: 'Cortesia',     cls: 'badge-purple',  chip: 'purple' },
   free:     { label: 'Free',         cls: 'badge-muted',   chip: ''       },
 };
+// Aliases internos da coluna plan → nome comercial (espelha
+// _STORED_PLAN_TO_TIER de core/services/plan_service.py: 'pro' legado é o
+// tier Plus; 'pro_max' é o tier Pro novo)
+const PLAN_LABELS = { free: 'Free', essencial: 'Essencial', pro: 'Plus', plus: 'Plus', pro_max: 'Pro' };
+function planLabel(p) {
+  const k = String(p || 'free').trim().toLowerCase() || 'free';
+  return PLAN_LABELS[k] || k;
+}
 const usersState = { q: '', status: '', page: 0, perPage: 50, sort: 'created_at', open: false };
 let usersSearchDebounce = null;
 let usersController = null;
@@ -1447,7 +1455,7 @@ function renderUsersTable(data) {
       <tr class="users-row" onclick="openUserDetail(${Number(u.user_id)})">
         <td title="user_id ${Number(u.user_id)}">${esc(u.email || '(sem e-mail)')}</td>
         <td><span class="badge ${meta.cls}">${meta.label}</span></td>
-        <td>${esc(u.plan || 'free')}</td>
+        <td>${esc(planLabel(u.plan))}</td>
         <td title="${fDate(u.plan_expires_at)}">${u.plan_expires_at ? fDate(u.plan_expires_at) : '—'}</td>
         <td title="${fDate(u.created_at)}">${fRelTime(u.created_at)}</td>
         <td title="${fDate(u.last_activity_at)}">${fRelTime(u.last_activity_at)}</td>
@@ -1520,7 +1528,7 @@ function renderUserDetail(data) {
       ${item('User ID', p.user_id)}
       ${item('Nome', esc(p.display_name || '—'))}
       ${item('Telefone', esc(p.phone_e164 || '—'))}
-      ${item('Plano', `${esc(p.plan || 'free')}${p.plan_expires_at ? ` · expira ${fDate(p.plan_expires_at)}` : ''}`)}
+      ${item('Plano', `${esc(planLabel(p.plan))}${p.plan_expires_at ? ` · expira ${fDate(p.plan_expires_at)}` : ''}`)}
       ${item('Status pagamento', esc(p.last_payment_status || '—'))}
       ${item('Trial iniciado', p.trial_started_at ? fDate(p.trial_started_at) : '—')}
       ${item('Plano escolhido em', p.plan_selected_at ? fDate(p.plan_selected_at) : '—')}

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1416,7 +1416,9 @@ function renderUsersChips(agg, billing) {
     <div class="user-chip static"><b class="green">${fMoney(billing.mrr)}</b><span>MRR</span></div>
     <div class="user-chip static"><b>${fMoney(billing.ticket_medio)}</b><span>Ticket médio</span></div>
     <div class="user-chip static"><b class="blue">${fMoney(billing.trial_mrr_potencial)}</b><span>MRR em trial</span></div>`;
-    $id('users-billing-meta').textContent = `Stripe ${fRelTime(billing.fetched_at)}`;
+    $id('users-billing-meta').textContent = billing.stale
+      ? `Stripe instável — último dado ${fRelTime(billing.fetched_at)}`
+      : `Stripe ${fRelTime(billing.fetched_at)}`;
   } else {
     $id('users-billing-meta').textContent = 'Stripe indisponível — contagens vêm do banco';
   }

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -1,0 +1,273 @@
+"""Testes do painel de usuários do admin (/admin/api/users e /{user_id}).
+
+Cobrem: exigência de auth, classificação de assinatura por conta
+(_derive_account_status), agregados, filtros por status/plano, busca por
+e-mail, paginação e o drill-down individual. O resumo Stripe roda com a
+chave vazia (billing.available == False) — a API externa nunca é chamada.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import core.admin_dashboard as admin_dashboard
+import frontend.finance_bot_websocket_custom as dashboard
+from db import ensure_user, get_conn
+
+NOW = datetime.now(timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def configured_admin(monkeypatch):
+    async def _noop_log(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(admin_dashboard, "ADMIN_DASHBOARD_PASSWORD", "secret-admin")
+    monkeypatch.setattr(admin_dashboard, "ADMIN_DASHBOARD_PASSWORD_HASH", "")
+    monkeypatch.setattr(admin_dashboard, "log_system_event", _noop_log)
+    # Stripe fora do ar nos testes: chave vazia + cache limpo entre testes.
+    monkeypatch.setattr(admin_dashboard, "STRIPE_SECRET_KEY", "")
+    monkeypatch.setattr(
+        admin_dashboard, "_billing_summary_cache", {"fetched_at": None, "data": None}
+    )
+
+
+def _admin_client() -> TestClient:
+    client = TestClient(dashboard.app, base_url="https://testserver")
+    csrf = "test-admin-csrf"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, csrf)
+    login = client.post(
+        "/admin/auth/login",
+        headers={dashboard.CSRF_HEADER_NAME: csrf},
+        json={"username": "admin", "password": "secret-admin"},
+    )
+    assert login.status_code == 200
+    return client
+
+
+def _mk_account(email: str, *, plan: str = "free", pay: str = "inactive",
+                stripe_customer: str | None = None, expires=None) -> int:
+    uid = int(uuid.uuid4().int % 10_000_000_000)
+    ensure_user(uid)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into auth_accounts
+                    (user_id, email, password_hash, plan, last_payment_status,
+                     stripe_customer_id, plan_expires_at)
+                values (%s, %s, 'x', %s, %s, %s, %s)
+                """,
+                (uid, email, plan, pay, stripe_customer, expires),
+            )
+        conn.commit()
+    return uid
+
+
+@pytest.fixture()
+def panel_accounts():
+    """Uma conta de cada categoria; e-mails com prefixo único pra busca."""
+    tag = uuid.uuid4().hex[:8]
+    uids = {
+        "paying": _mk_account(f"panel-{tag}-paying@test.local", plan="pro",
+                              pay="active", stripe_customer="cus_test1"),
+        "trial": _mk_account(f"panel-{tag}-trial@test.local", plan="pro",
+                             pay="trialing", stripe_customer="cus_test2"),
+        "past_due": _mk_account(f"panel-{tag}-pastdue@test.local", plan="pro",
+                                pay="past_due", stripe_customer="cus_test3"),
+        "canceled": _mk_account(f"panel-{tag}-canceled@test.local", plan="pro",
+                                pay="canceled", stripe_customer="cus_test4"),
+        "granted": _mk_account(f"panel-{tag}-granted@test.local", plan="pro"),
+        "free": _mk_account(f"panel-{tag}-free@test.local"),
+    }
+    yield tag, uids
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "delete from auth_accounts where user_id = any(%s)",
+                (list(uids.values()),),
+            )
+        conn.commit()
+
+
+# ── Classificação ──────────────────────────────────────────────────────────
+
+class TestDeriveAccountStatus:
+    def _st(self, **row):
+        return admin_dashboard._derive_account_status(row, NOW)
+
+    def test_free(self):
+        assert self._st(plan="free") == "free"
+        assert self._st(plan=None) == "free"
+
+    def test_paying(self):
+        assert self._st(plan="pro", last_payment_status="active",
+                        stripe_customer_id="cus_x") == "paying"
+
+    def test_trial(self):
+        assert self._st(plan="pro", last_payment_status="trialing",
+                        stripe_customer_id="cus_x") == "trial"
+
+    def test_past_due_variants(self):
+        for pay in ("past_due", "unpaid", "incomplete"):
+            assert self._st(plan="pro", last_payment_status=pay,
+                            stripe_customer_id="cus_x") == "past_due"
+
+    def test_canceled(self):
+        assert self._st(plan="pro", last_payment_status="canceled",
+                        stripe_customer_id="cus_x") == "canceled"
+
+    def test_granted_sem_stripe(self):
+        # 'inactive' é o default NOT NULL da coluna — o estado real de um grant
+        assert self._st(plan="pro", last_payment_status="inactive",
+                        stripe_customer_id=None) == "granted"
+
+    def test_legado_com_stripe_expirado_vira_canceled(self):
+        assert self._st(plan="pro", last_payment_status="inactive",
+                        stripe_customer_id="cus_x",
+                        plan_expires_at=NOW - timedelta(days=1)) == "canceled"
+
+
+# ── Resumo Stripe (MRR / ticket médio) ─────────────────────────────────────
+
+class _FakePrice:
+    def __init__(self, unit_amount, interval, interval_count=1):
+        self.unit_amount = unit_amount
+        self.recurring = type("R", (), {"interval": interval,
+                                        "interval_count": interval_count})()
+
+
+class _FakeSub:
+    def __init__(self, status, unit_amount, interval="month"):
+        self.status = status
+        item = type("I", (), {"price": _FakePrice(unit_amount, interval)})()
+        self.items = type("Items", (), {"data": [item]})()
+
+
+def test_stripe_billing_summary_normaliza_mrr(monkeypatch):
+    import sys
+    import types
+
+    subs = [
+        _FakeSub("active", 1990),            # R$ 19,90/mês
+        _FakeSub("active", 1990),
+        _FakeSub("active", 19900, "year"),   # R$ 199,00/ano → R$ 16,58/mês
+        _FakeSub("trialing", 1990),
+        _FakeSub("past_due", 1990),
+        _FakeSub("canceled", 1990),
+    ]
+
+    class _FakeList:
+        def auto_paging_iter(self):
+            return iter(subs)
+
+    fake_stripe = types.SimpleNamespace(
+        api_key=None,
+        Subscription=types.SimpleNamespace(list=lambda **kw: _FakeList()),
+    )
+    monkeypatch.setitem(sys.modules, "stripe", fake_stripe)
+    monkeypatch.setattr(admin_dashboard, "STRIPE_SECRET_KEY", "sk_test_fake")
+
+    data = admin_dashboard._fetch_stripe_billing_sync()
+    assert data["available"] is True
+    assert data["subscriptions"] == {
+        "active": 3, "trialing": 1, "past_due": 1, "canceled": 1, "other": 0,
+    }
+    # 19,90 + 19,90 + 199/12 = 56,38
+    assert data["mrr"] == pytest.approx(56.38, abs=0.01)
+    assert data["ticket_medio"] == pytest.approx(18.79, abs=0.01)
+    assert data["trial_mrr_potencial"] == pytest.approx(19.90, abs=0.01)
+
+
+# ── Endpoint de lista ──────────────────────────────────────────────────────
+
+def test_users_endpoint_requires_admin_auth():
+    response = TestClient(dashboard.app).get("/admin/api/users")
+    assert response.status_code == 401
+
+
+def test_users_list_aggregates_and_statuses(panel_accounts):
+    tag, uids = panel_accounts
+    client = _admin_client()
+
+    data = client.get(f"/admin/api/users?q=panel-{tag}").json()
+    assert data["total"] == 6
+    by_status = {u["account_status"]: u for u in data["users"]}
+    assert set(by_status) == {"paying", "trial", "past_due", "canceled", "granted", "free"}
+    assert by_status["paying"]["user_id"] == uids["paying"]
+    assert f"panel-{tag}-paying@test.local" == by_status["paying"]["email"]
+    # Colunas cifradas nunca vazam no JSON
+    assert all("email_enc" not in u for u in data["users"])
+
+    # Agregados são da base inteira (>= os 6 do fixture, uma de cada)
+    agg = data["aggregates"]
+    for status in ("paying", "trial", "past_due", "canceled", "granted", "free"):
+        assert agg[status] >= 1
+    assert agg["total"] >= 6
+
+    # Stripe indisponível nos testes → available False, sem quebrar a resposta
+    assert data["billing"]["available"] is False
+
+
+def test_users_list_filters_by_status_and_plan(panel_accounts):
+    tag, uids = panel_accounts
+    client = _admin_client()
+
+    data = client.get(f"/admin/api/users?q=panel-{tag}&status=trial").json()
+    assert data["total"] == 1
+    assert data["users"][0]["user_id"] == uids["trial"]
+
+    data = client.get(f"/admin/api/users?q=panel-{tag}&plan=free").json()
+    assert data["total"] == 1
+    assert data["users"][0]["user_id"] == uids["free"]
+
+    # status inválido é ignorado (não explode, não filtra)
+    data = client.get(f"/admin/api/users?q=panel-{tag}&status=xpto").json()
+    assert data["total"] == 6
+
+
+def test_users_list_pagination(panel_accounts):
+    tag, _uids = panel_accounts
+    client = _admin_client()
+
+    page0 = client.get(f"/admin/api/users?q=panel-{tag}&per_page=4&page=0").json()
+    page1 = client.get(f"/admin/api/users?q=panel-{tag}&per_page=4&page=1").json()
+    assert page0["total"] == page1["total"] == 6
+    assert len(page0["users"]) == 4
+    assert len(page1["users"]) == 2
+    ids0 = {u["user_id"] for u in page0["users"]}
+    ids1 = {u["user_id"] for u in page1["users"]}
+    assert not (ids0 & ids1)
+
+
+# ── Drill-down ─────────────────────────────────────────────────────────────
+
+def test_user_detail_requires_admin_auth(panel_accounts):
+    _tag, uids = panel_accounts
+    response = TestClient(dashboard.app).get(f"/admin/api/users/{uids['paying']}")
+    assert response.status_code == 401
+
+
+def test_user_detail_shape(panel_accounts):
+    tag, uids = panel_accounts
+    client = _admin_client()
+
+    data = client.get(f"/admin/api/users/{uids['trial']}").json()
+    profile = data["profile"]
+    assert profile["user_id"] == uids["trial"]
+    assert profile["email"] == f"panel-{tag}-trial@test.local"
+    assert profile["account_status"] == "trial"
+    assert "email_enc" not in profile and "phone_enc" not in profile
+
+    usage = data["usage"]
+    assert usage["tx_total"] == 0 and usage["tx_30d"] == 0
+    assert usage["pockets_count"] == 0
+    assert isinstance(data["recent_events"], list)
+    assert isinstance(data["recent_logins"], list)
+
+
+def test_user_detail_404_for_unknown_account():
+    client = _admin_client()
+    response = client.get("/admin/api/users/999999999999")
+    assert response.status_code == 404

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -390,6 +390,29 @@ def test_user_detail_ignora_movimentos_internos(panel_accounts):
             conn.commit()
 
 
+def test_grant_pro_em_ex_assinante_classifica_como_cortesia(panel_accounts):
+    """/admin/grant-pro sobre conta com status terminal (canceled) limpa o
+    last_payment_status — senão o grant vigente apareceria como 'Cancelado'
+    no painel. Status em curso (active) fica intacto: webhook é o dono."""
+    tag, uids = panel_accounts
+    client = _admin_client()
+
+    grant = client.get(
+        f"/admin/grant-pro?email=panel-{tag}-canceled@test.local&months=2"
+    ).json()
+    assert grant["ok"] is True
+    data = client.get(f"/admin/api/users?q=panel-{tag}-canceled").json()
+    assert data["users"][0]["account_status"] == "granted"
+
+    # Assinante ativo que ganha extensão continua Pagante
+    grant = client.get(
+        f"/admin/grant-pro?email=panel-{tag}-paying@test.local&months=2"
+    ).json()
+    assert grant["ok"] is True
+    data = client.get(f"/admin/api/users?q=panel-{tag}-paying").json()
+    assert data["users"][0]["account_status"] == "paying"
+
+
 def test_user_detail_404_for_unknown_account():
     client = _admin_client()
     response = client.get("/admin/api/users/999999999999")

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -315,6 +315,35 @@ def test_user_detail_shape(panel_accounts):
     assert isinstance(data["recent_logins"], list)
 
 
+def test_user_detail_ignora_movimentos_internos(panel_accounts):
+    """Movimento interno (ajuste de saldo, aporte) não pode aparecer como
+    'última transação' de quem tem zero transações externas."""
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into launches (user_id, tipo, valor, nota, criado_em,
+                                      is_internal_movement, source)
+                values (%s, 'despesa', 5.0, 'ajuste interno', now(), true, 'manual')
+                """,
+                (uid,),
+            )
+        conn.commit()
+    try:
+        client = _admin_client()
+        usage = client.get(f"/admin/api/users/{uid}").json()["usage"]
+        assert usage["tx_total"] == 0
+        assert usage["tx_30d"] == 0
+        assert usage["last_tx_at"] is None
+    finally:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("delete from launches where user_id = %s", (uid,))
+            conn.commit()
+
+
 def test_user_detail_404_for_unknown_account():
     client = _admin_client()
     response = client.get("/admin/api/users/999999999999")

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -116,6 +116,19 @@ class TestDeriveAccountStatus:
                         stripe_customer_id=None,
                         plan_expires_at=NOW - timedelta(days=1)) == "canceled"
 
+    def test_expiracao_vence_status_de_pagamento(self):
+        # Webhook de renovação perdido: status diz active/trialing mas o plano
+        # venceu — plan_service._paid_plan_active nega o entitlement, e o
+        # painel tem de concordar
+        for pay in ("active", "trialing", "past_due"):
+            assert self._st(plan="pro", last_payment_status=pay,
+                            stripe_customer_id="cus_x",
+                            plan_expires_at=NOW - timedelta(hours=1)) == "canceled"
+        # Vigente continua classificando pelo status normalmente
+        assert self._st(plan="pro", last_payment_status="active",
+                        stripe_customer_id="cus_x",
+                        plan_expires_at=NOW + timedelta(days=10)) == "paying"
+
     def test_paying(self):
         assert self._st(plan="pro", last_payment_status="active",
                         stripe_customer_id="cus_x") == "paying"
@@ -193,6 +206,39 @@ def test_stripe_billing_summary_normaliza_mrr(monkeypatch):
     assert data["mrr"] == pytest.approx(56.38, abs=0.01)
     assert data["ticket_medio"] == pytest.approx(18.79, abs=0.01)
     assert data["trial_mrr_potencial"] == pytest.approx(19.90, abs=0.01)
+
+
+def test_stripe_billing_cache_faz_backoff_apos_falha(monkeypatch):
+    """Queda do Stripe não pode virar retry a cada request: o carimbo do cache
+    avança mesmo na falha (TTL = backoff) e o payload bom fica com stale=True."""
+    import asyncio
+
+    calls = {"n": 0}
+    ok_payload = {"available": True, "mrr": 39.8, "fetched_at": "2026-01-01T00:00:00+00:00"}
+
+    def _fake_sync():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return dict(ok_payload)
+        return {"available": False, "reason": "boom"}
+
+    monkeypatch.setattr(admin_dashboard, "_fetch_stripe_billing_sync", _fake_sync)
+
+    # 1ª chamada: sucesso, entra no cache
+    data = asyncio.run(admin_dashboard.fetch_billing_summary())
+    assert data["available"] is True and "stale" not in data and calls["n"] == 1
+
+    # TTL vencido + Stripe fora: preserva números, marca stale, avança carimbo
+    admin_dashboard._billing_summary_cache["fetched_at"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=400)
+    )
+    data = asyncio.run(admin_dashboard.fetch_billing_summary())
+    assert data["available"] is True and data["stale"] is True
+    assert data["mrr"] == ok_payload["mrr"] and calls["n"] == 2
+
+    # Dentro do TTL pós-falha: NÃO tenta o Stripe de novo
+    data = asyncio.run(admin_dashboard.fetch_billing_summary())
+    assert data["stale"] is True and calls["n"] == 2
 
 
 # ── Endpoint de lista ──────────────────────────────────────────────────────

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -76,9 +76,14 @@ def panel_accounts():
                              pay="trialing", stripe_customer="cus_test2"),
         "past_due": _mk_account(f"panel-{tag}-pastdue@test.local", plan="pro",
                                 pay="past_due", stripe_customer="cus_test3"),
-        "canceled": _mk_account(f"panel-{tag}-canceled@test.local", plan="pro",
+        # Estado real pós-webhook customer.subscription.deleted:
+        # plan volta pra free E last_payment_status vira canceled
+        "canceled": _mk_account(f"panel-{tag}-canceled@test.local", plan="free",
                                 pay="canceled", stripe_customer="cus_test4"),
         "granted": _mk_account(f"panel-{tag}-granted@test.local", plan="pro"),
+        # Cortesia vencida: sem Stripe, plan_expires_at no passado → canceled
+        "granted_expired": _mk_account(f"panel-{tag}-grantexp@test.local", plan="pro",
+                                       expires=NOW - timedelta(days=2)),
         "free": _mk_account(f"panel-{tag}-free@test.local"),
     }
     yield tag, uids
@@ -100,6 +105,16 @@ class TestDeriveAccountStatus:
     def test_free(self):
         assert self._st(plan="free") == "free"
         assert self._st(plan=None) == "free"
+
+    def test_free_com_pagamento_cancelado_e_ex_assinante(self):
+        # customer.subscription.deleted volta plan pra 'free' e grava
+        # last_payment_status='canceled' — é ex-assinante, não free comum
+        assert self._st(plan="free", last_payment_status="canceled") == "canceled"
+
+    def test_cortesia_vencida_vira_canceled(self):
+        assert self._st(plan="pro", last_payment_status="inactive",
+                        stripe_customer_id=None,
+                        plan_expires_at=NOW - timedelta(days=1)) == "canceled"
 
     def test_paying(self):
         assert self._st(plan="pro", last_payment_status="active",
@@ -192,19 +207,37 @@ def test_users_list_aggregates_and_statuses(panel_accounts):
     client = _admin_client()
 
     data = client.get(f"/admin/api/users?q=panel-{tag}").json()
-    assert data["total"] == 6
-    by_status = {u["account_status"]: u for u in data["users"]}
-    assert set(by_status) == {"paying", "trial", "past_due", "canceled", "granted", "free"}
-    assert by_status["paying"]["user_id"] == uids["paying"]
-    assert f"panel-{tag}-paying@test.local" == by_status["paying"]["email"]
+    assert data["total"] == 7
+    assert data["truncated"] is False
+    status_by_uid = {u["user_id"]: u["account_status"] for u in data["users"]}
+    assert status_by_uid == {
+        uids["paying"]: "paying",
+        uids["trial"]: "trial",
+        uids["past_due"]: "past_due",
+        uids["canceled"]: "canceled",
+        uids["granted"]: "granted",
+        uids["granted_expired"]: "canceled",  # cortesia vencida
+        uids["free"]: "free",
+    }
+    email_by_uid = {u["user_id"]: u["email"] for u in data["users"]}
+    assert email_by_uid[uids["paying"]] == f"panel-{tag}-paying@test.local"
     # Colunas cifradas nunca vazam no JSON
     assert all("email_enc" not in u for u in data["users"])
 
-    # Agregados são da base inteira (>= os 6 do fixture, uma de cada)
+    # Paridade SQL ↔ Python: o account_status calculado pelo CASE no banco
+    # tem de bater com _derive_account_status sobre os mesmos campos crus
+    for u in data["users"]:
+        raw = dict(u)
+        if raw.get("plan_expires_at"):
+            raw["plan_expires_at"] = datetime.fromisoformat(raw["plan_expires_at"])
+        assert admin_dashboard._derive_account_status(raw, NOW) == u["account_status"], u
+
+    # Agregados são da base inteira (>= os do fixture)
     agg = data["aggregates"]
-    for status in ("paying", "trial", "past_due", "canceled", "granted", "free"):
+    for status in ("paying", "trial", "past_due", "granted", "free"):
         assert agg[status] >= 1
-    assert agg["total"] >= 6
+    assert agg["canceled"] >= 2
+    assert agg["total"] >= 7
 
     # Stripe indisponível nos testes → available False, sem quebrar a resposta
     assert data["billing"]["available"] is False
@@ -218,13 +251,18 @@ def test_users_list_filters_by_status_and_plan(panel_accounts):
     assert data["total"] == 1
     assert data["users"][0]["user_id"] == uids["trial"]
 
+    # plan=free traz o free comum E o ex-assinante (plan voltou pra free)
     data = client.get(f"/admin/api/users?q=panel-{tag}&plan=free").json()
-    assert data["total"] == 1
-    assert data["users"][0]["user_id"] == uids["free"]
+    assert data["total"] == 2
+    assert {u["user_id"] for u in data["users"]} == {uids["free"], uids["canceled"]}
+
+    # status=canceled junta ex-assinante e cortesia vencida
+    data = client.get(f"/admin/api/users?q=panel-{tag}&status=canceled").json()
+    assert {u["user_id"] for u in data["users"]} == {uids["canceled"], uids["granted_expired"]}
 
     # status inválido é ignorado (não explode, não filtra)
     data = client.get(f"/admin/api/users?q=panel-{tag}&status=xpto").json()
-    assert data["total"] == 6
+    assert data["total"] == 7
 
 
 def test_users_list_pagination(panel_accounts):
@@ -233,12 +271,22 @@ def test_users_list_pagination(panel_accounts):
 
     page0 = client.get(f"/admin/api/users?q=panel-{tag}&per_page=4&page=0").json()
     page1 = client.get(f"/admin/api/users?q=panel-{tag}&per_page=4&page=1").json()
-    assert page0["total"] == page1["total"] == 6
+    assert page0["total"] == page1["total"] == 7
     assert len(page0["users"]) == 4
-    assert len(page1["users"]) == 2
+    assert len(page1["users"]) == 3
     ids0 = {u["user_id"] for u in page0["users"]}
     ids1 = {u["user_id"] for u in page1["users"]}
     assert not (ids0 & ids1)
+
+    # Caminho SEM busca (paginação 100% em SQL): filtra por status pra
+    # não depender do resto da base, e as páginas não podem se sobrepor
+    canceled_total = client.get("/admin/api/users?status=canceled").json()["total"]
+    assert canceled_total >= 2
+    sql0 = client.get("/admin/api/users?status=canceled&per_page=1&page=0").json()
+    sql1 = client.get("/admin/api/users?status=canceled&per_page=1&page=1").json()
+    assert sql0["total"] == sql1["total"] == canceled_total
+    assert len(sql0["users"]) == len(sql1["users"]) == 1
+    assert sql0["users"][0]["user_id"] != sql1["users"][0]["user_id"]
 
 
 # ── Drill-down ─────────────────────────────────────────────────────────────

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -18,6 +18,16 @@ from db import ensure_user, get_conn
 NOW = datetime.now(timezone.utc)
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _admin_tables():
+    """system_event_logs não vem do init_db — só do ensure_admin_tables()
+    (startup do app). No CI o banco é fresco e o drill-down consulta essa
+    tabela; mesmo precedente de test_security_alerts."""
+    import asyncio
+
+    asyncio.run(admin_dashboard.ensure_admin_tables())
+
+
 @pytest.fixture(autouse=True)
 def configured_admin(monkeypatch):
     async def _noop_log(*args, **kwargs):


### PR DESCRIPTION
## O que muda

Clicar no card **Usuários** do admin abre um modal com a visão completa da base:

- **Chips de resumo**: total, pagantes, em trial, inadimplentes, cancelados, cortesia, free e WA conectados — cada chip filtra a tabela. Quando o Stripe está configurado, aparecem também **MRR**, **ticket médio** e **MRR em trial**, calculados da API do Stripe (fonte da verdade de preço, com anual normalizado pra base mensal e cache de 5 min). Sem Stripe, degrada com aviso e as contagens vêm do banco.
- **Tabela paginada** (50/página): e-mail, status com badge, plano, expiração, cadastro, última atividade, transações 30d, WhatsApp, link direto pro customer no dashboard do Stripe. Busca por e-mail e ordenação por cadastro/atividade.
- **Drill-down por conta**: perfil (e-mail, nome, telefone), assinatura (status de pagamento, trial, expiração), contagens de uso (transações, caixinhas, investimentos, cartões — **sem conteúdo financeiro**, por minimização LGPD), eventos e logins recentes da conta.

## Backend

- `GET /admin/api/users` — lista paginada com filtros (`q`, `status`, `plan`, `sort`) + agregados + resumo Stripe. Classificação única em `_derive_account_status` (paying/trial/past_due/canceled/granted/free) a partir de `plan` + `last_payment_status`.
- `GET /admin/api/users/{id}` — drill-down.
- Ambos atrás do auth admin existente; decrypts de PII auditados em `pii_access_log` num único batch (purposes `render_admin_users_list` / `render_admin_user_detail`). Sem busca, só as rows da página devolvida são decifradas; com busca, a base filtrada (necessário pro match de substring).

## Como foi verificado

- **1068 passed, 0 failed** na suíte completa local contra Postgres real (baseline antes da mudança: 1053 passed, 0 failed — os 15 novos são de `tests/test_admin_users_panel.py`).
- Testes novos cobrem: exigência de auth (401), classificação de cada status, agregados, filtros por status/plano, status inválido ignorado, paginação sem sobreposição, 404, shape do drill-down, vazamento de colunas `*_enc` (nunca saem no JSON) e a normalização de MRR mensal/anual com um módulo `stripe` fake.
- UI exercitada no navegador contra servidor local + banco de teste com 9 contas seed (uma por status): abrir modal, chips, filtro por chip, busca, drill-down, voltar, Esc, paginação — rede toda 200, console sem erros novos.
- **Não verificado localmente** (sem `STRIPE_SECRET_KEY` local): o caminho vivo do resumo Stripe — coberto por teste com fake e por degradação explícita na UI; confirmação real só no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)