### PR TITLE
feat(admin): origem do cadastro (web/app/google) na conta e no painel

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -935,6 +935,7 @@ async def fetch_admin_users(
                     a.phone_status,
                     a.whatsapp_verified_at,
                     a.deletion_status,
+                    a.signup_source,
                     {_ACCOUNT_STATUS_SQL} AS account_status,
                     EXISTS (
                         SELECT 1 FROM user_identities ui
@@ -979,6 +980,17 @@ async def fetch_admin_users(
                 aggregates[r["account_status"]] = int(r["n"])
                 aggregates["whatsapp_connected"] += int(r["wa"])
             aggregates["total"] = sum(aggregates[s] for s in _USER_STATUSES)
+
+            # Origem do cadastro (base inteira): web × app × google × …
+            # NULL = contas anteriores à coluna → 'desconhecido'.
+            await cur.execute(
+                """
+                SELECT coalesce(signup_source, 'desconhecido') AS src, COUNT(*) AS n
+                FROM auth_accounts
+                GROUP BY 1
+                """
+            )
+            by_source = {r["src"]: int(r["n"]) for r in await cur.fetchall()}
 
             if not q:
                 await cur.execute(
@@ -1042,6 +1054,7 @@ async def fetch_admin_users(
     return {
         "generated_at": now,
         "aggregates": aggregates,
+        "by_source": by_source,
         "billing": await fetch_billing_summary(),
         "users": page_rows,
         "page": page,
@@ -1071,7 +1084,7 @@ async def fetch_admin_user_detail(user_id: int, admin_user: str = "admin") -> di
                     a.created_at, a.last_activity_at,
                     a.phone_status, a.whatsapp_verified_at, a.whatsapp_updates_opt_out,
                     a.engagement_opt_out, a.tip_email_opt_out, a.insight_email_opt_out,
-                    a.deletion_status, a.deletion_requested_at,
+                    a.deletion_status, a.deletion_requested_at, a.signup_source,
                     a.ai_messages_this_month,
                     EXISTS (
                         SELECT 1 FROM user_identities ui

--- a/db/google_auth.py
+++ b/db/google_auth.py
@@ -158,6 +158,7 @@ def consume_pending_google_signup(
     token: str,
     name: str,
     phone_raw: str,
+    source: str = "google",
 ) -> dict:
     """
     Finaliza o cadastro: cria auth_account (sem senha), grava auth_identities
@@ -201,8 +202,8 @@ def consume_pending_google_signup(
                 """
                 insert into auth_accounts
                   (user_id, email, password_hash, phone_e164, display_name, phone_status,
-                   email_hash, email_enc, phone_hash, phone_enc, display_name_enc)
-                values (%s, %s, NULL, %s, %s, 'pending', %s, %s, %s, %s, %s)
+                   email_hash, email_enc, phone_hash, phone_enc, display_name_enc, signup_source)
+                values (%s, %s, NULL, %s, %s, 'pending', %s, %s, %s, %s, %s, %s)
                 on conflict (email) do update
                 set phone_e164 = coalesce(auth_accounts.phone_e164, excluded.phone_e164),
                     display_name = coalesce(auth_accounts.display_name, excluded.display_name),
@@ -210,14 +211,17 @@ def consume_pending_google_signup(
                     email_enc = coalesce(auth_accounts.email_enc, excluded.email_enc),
                     phone_hash = coalesce(auth_accounts.phone_hash, excluded.phone_hash),
                     phone_enc = coalesce(auth_accounts.phone_enc, excluded.phone_enc),
-                    display_name_enc = coalesce(auth_accounts.display_name_enc, excluded.display_name_enc)
+                    display_name_enc = coalesce(auth_accounts.display_name_enc, excluded.display_name_enc),
+                    -- Preserva a origem da 1ª criação em re-registro do mesmo e-mail
+                    signup_source = coalesce(auth_accounts.signup_source, excluded.signup_source)
                 """,
                 (user_id, email, normalized_phone, name,
                  hash_pii_optional(email, kind="email"),
                  encrypt_pii_optional(email),
                  hash_pii_optional(normalized_phone, kind="phone"),
                  encrypt_pii_optional(normalized_phone),
-                 encrypt_pii_optional(name)),
+                 encrypt_pii_optional(name),
+                 source),
             )
             cur.execute(
                 """

--- a/db/reports.py
+++ b/db/reports.py
@@ -192,9 +192,9 @@ def create_email_verification(
     )
 
 
-def confirm_email_verification(email: str, code: str) -> dict:
+def confirm_email_verification(email: str, code: str, source: str = "web") -> dict:
     result = _db_support.confirm_email_verification_impl(
-        get_conn, get_or_create_canonical_user, create_link_code, email, code
+        get_conn, get_or_create_canonical_user, create_link_code, email, code, source
     )
     # Planos v2 (2026-08-06): o trial NÃO nasce mais no cadastro. Ele é uma
     # assinatura Stripe do plano escolhido (com cartão) e só é registrado quando

--- a/db/schema.py
+++ b/db/schema.py
@@ -1613,6 +1613,13 @@ def init_db():
         # avaliado uma vez, sem reescrever a tabela.
         """alter table auth_accounts add column if not exists plan_selected_at timestamptz default now()""",
         """alter table auth_accounts alter column plan_selected_at drop default""",
+        # Origem do cadastro (2026-08-17): de onde a conta nasceu, pra separar
+        # no painel de admin quem se cadastrou pela web (passa pelo gate da
+        # /precos) de quem veio pelo app iOS (isento do gate — diretriz 3.1.1
+        # da Apple). Valores: 'web' | 'app' | 'google' | 'google_app' |
+        # 'whatsapp'. NULL = conta anterior a esta coluna (origem desconhecida);
+        # sem backfill por data chutado — o painel mostra "—" pra elas.
+        """alter table auth_accounts add column if not exists signup_source text""",
         """
         create table if not exists plan_trials (
           phone_hash text primary key,

--- a/db_support.py
+++ b/db_support.py
@@ -731,6 +731,7 @@ def confirm_email_verification_impl(
     create_link_code,
     email: str,
     code: str,
+    source: str = "web",
 ) -> dict:
     email = email.strip().lower()
     now = datetime.now(timezone.utc)
@@ -770,8 +771,8 @@ def confirm_email_verification_impl(
                 """
                 insert into auth_accounts
                   (user_id, email, password_hash, phone_e164, display_name, phone_status,
-                   email_hash, email_enc, phone_hash, phone_enc, display_name_enc)
-                values (%s, %s, %s, %s, %s, 'pending', %s, %s, %s, %s, %s)
+                   email_hash, email_enc, phone_hash, phone_enc, display_name_enc, signup_source)
+                values (%s, %s, %s, %s, %s, 'pending', %s, %s, %s, %s, %s, %s)
                 on conflict (email) do update
                 set user_id = excluded.user_id,
                     password_hash = excluded.password_hash,
@@ -785,14 +786,17 @@ def confirm_email_verification_impl(
                     email_enc = coalesce(auth_accounts.email_enc, excluded.email_enc),
                     phone_hash = coalesce(auth_accounts.phone_hash, excluded.phone_hash),
                     phone_enc = coalesce(auth_accounts.phone_enc, excluded.phone_enc),
-                    display_name_enc = coalesce(auth_accounts.display_name_enc, excluded.display_name_enc)
+                    display_name_enc = coalesce(auth_accounts.display_name_enc, excluded.display_name_enc),
+                    -- Preserva a origem da 1ª criação em re-registro do mesmo e-mail
+                    signup_source = coalesce(auth_accounts.signup_source, excluded.signup_source)
                 """,
                 (user_id, email, password_hash, phone_e164, display_name,
                  hash_pii_optional(email, kind="email"),
                  encrypt_pii_optional(email),
                  hash_pii_optional(phone_e164, kind="phone"),
                  encrypt_pii_optional(phone_e164),
-                 encrypt_pii_optional(display_name)),
+                 encrypt_pii_optional(display_name),
+                 source),
             )
             cur.execute(
                 "update email_verification_codes set used_at = now() where id = %s",

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -619,7 +619,7 @@ button:disabled { opacity: .6; cursor: wait; }
       <table class="table">
         <thead>
           <tr>
-            <th>E-mail</th><th>Status</th><th>Plano</th><th>Expira</th>
+            <th>E-mail</th><th>Status</th><th>Plano</th><th>Origem</th><th>Expira</th>
             <th>Cadastro</th><th>Últ. atividade</th><th>Tx 30d</th><th>WA</th><th>Stripe</th>
           </tr>
         </thead>
@@ -1354,6 +1354,12 @@ function planLabel(p) {
   const k = String(p || 'free').trim().toLowerCase() || 'free';
   return PLAN_LABELS[k] || k;
 }
+// Origem do cadastro (auth_accounts.signup_source). null = conta anterior à coluna.
+const SOURCE_LABELS = { web: 'Web', app: 'App iOS', google: 'Google', google_app: 'Google (app)' };
+function sourceLabel(s) {
+  if (!s) return '—';
+  return SOURCE_LABELS[String(s).toLowerCase()] || s;
+}
 const usersState = { q: '', status: '', page: 0, perPage: 50, sort: 'created_at', open: false };
 let usersSearchDebounce = null;
 let usersController = null;
@@ -1392,7 +1398,7 @@ async function loadUsers() {
     if (res.status === 401) { window.location.href = '/admin/login'; return; }
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    renderUsersChips(data.aggregates, data.billing);
+    renderUsersChips(data.aggregates, data.billing, data.by_source);
     renderUsersTable(data);
     $id('users-loading').textContent = '';
   } catch (e) {
@@ -1403,7 +1409,7 @@ async function loadUsers() {
   }
 }
 
-function renderUsersChips(agg, billing) {
+function renderUsersChips(agg, billing, bySource) {
   const chips = [
     { key: '',         label: 'Total',        val: fInt(agg.total),    chip: '' },
     { key: 'paying',   label: 'Pagantes',     val: fInt(agg.paying),   chip: 'green' },
@@ -1419,6 +1425,18 @@ function renderUsersChips(agg, billing) {
     </div>`).join('');
   html += `
     <div class="user-chip static"><b>${fInt(agg.whatsapp_connected)}</b><span>WA conect.</span></div>`;
+  // Origem do cadastro (só as origens presentes; agrupa google/google_app)
+  if (bySource) {
+    const web = bySource.web || 0;
+    const app = bySource.app || 0;
+    const google = (bySource.google || 0) + (bySource.google_app || 0);
+    const unknown = bySource.desconhecido || 0;
+    const srcChips = [
+      ['Web', web], ['App iOS', app], ['Google', google], ['Origem —', unknown],
+    ].filter(([, n]) => n > 0);
+    html += srcChips.map(([lbl, n]) =>
+      `<div class="user-chip static"><b>${fInt(n)}</b><span>${lbl}</span></div>`).join('');
+  }
   if (billing?.available) {
     html += `
     <div class="user-chip static"><b class="green">${fMoney(billing.mrr)}</b><span>MRR</span></div>
@@ -1442,7 +1460,7 @@ function setUsersStatus(status) {
 function renderUsersTable(data) {
   const body = $id('users-table-body');
   if (!data.users.length) {
-    body.innerHTML = `<tr><td colspan="9" class="empty">Nenhum usuário com esse filtro.</td></tr>`;
+    body.innerHTML = `<tr><td colspan="10" class="empty">Nenhum usuário com esse filtro.</td></tr>`;
   } else {
     body.innerHTML = data.users.map(u => {
       const meta = USER_STATUS_META[u.account_status] || USER_STATUS_META.free;
@@ -1456,6 +1474,7 @@ function renderUsersTable(data) {
         <td title="user_id ${Number(u.user_id)}">${esc(u.email || '(sem e-mail)')}</td>
         <td><span class="badge ${meta.cls}">${meta.label}</span></td>
         <td>${esc(planLabel(u.plan))}</td>
+        <td>${esc(sourceLabel(u.signup_source))}</td>
         <td title="${fDate(u.plan_expires_at)}">${u.plan_expires_at ? fDate(u.plan_expires_at) : '—'}</td>
         <td title="${fDate(u.created_at)}">${fRelTime(u.created_at)}</td>
         <td title="${fDate(u.last_activity_at)}">${fRelTime(u.last_activity_at)}</td>
@@ -1529,6 +1548,7 @@ function renderUserDetail(data) {
       ${item('Nome', esc(p.display_name || '—'))}
       ${item('Telefone', esc(p.phone_e164 || '—'))}
       ${item('Plano', `${esc(planLabel(p.plan))}${p.plan_expires_at ? ` · expira ${fDate(p.plan_expires_at)}` : ''}`)}
+      ${item('Origem do cadastro', esc(sourceLabel(p.signup_source)))}
       ${item('Status pagamento', esc(p.last_payment_status || '—'))}
       ${item('Trial iniciado', p.trial_started_at ? fDate(p.trial_started_at) : '—')}
       ${item('Plano escolhido em', p.plan_selected_at ? fDate(p.plan_selected_at) : '—')}

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2381,8 +2381,11 @@ async def auth_verify_email(request: Request, response: Response, body: VerifyEm
     # do código de 6 dígitos rotacionando IP.
     await _check_auth_rate_limits("verify-email", request, body.email)
 
+    from frontend.routes.shared import signup_source_from_request
     try:
-        result = confirm_email_verification(body.email, body.code)
+        result = confirm_email_verification(
+            body.email, body.code, source=signup_source_from_request(request)
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -3467,10 +3470,12 @@ async def auth_google_complete_signup(
             detail="É necessário aceitar a Política de Privacidade.",
         )
 
+    from frontend.routes.shared import signup_source_from_request
     try:
         result = await asyncio.to_thread(
             consume_pending_google_signup,
             body.token, body.name, body.phone,
+            signup_source_from_request(request, google=True),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -303,6 +303,18 @@ def _is_pigbank_app(request: Request) -> bool:
     return "PigBankApp" in (request.headers.get("user-agent") or "")
 
 
+def signup_source_from_request(request: Request, *, google: bool = False) -> str:
+    """Origem do cadastro, gravada em auth_accounts.signup_source. Distingue web
+    de app iOS (mesmo UA que isenta o gate da /precos) pra o painel de admin
+    separar quem passou pela escolha de plano de quem entrou pelo acesso base.
+
+      web | app | google | google_app"""
+    in_app = _is_pigbank_app(request)
+    if google:
+        return "google_app" if in_app else "google"
+    return "app" if in_app else "web"
+
+
 def _enforce_subscription_gate(request: Request, user_id: int) -> None:
     """Backstop server-side das rotas de dados do dashboard. Além do paywall
     (assinatura ativa/trial), fecha o gate de escolha de plano no cadastro: sem

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -57,7 +57,8 @@ def _admin_client() -> TestClient:
 
 
 def _mk_account(email: str, *, plan: str = "free", pay: str = "inactive",
-                stripe_customer: str | None = None, expires=None) -> int:
+                stripe_customer: str | None = None, expires=None,
+                source: str | None = None) -> int:
     uid = int(uuid.uuid4().int % 10_000_000_000)
     ensure_user(uid)
     with get_conn() as conn:
@@ -66,10 +67,10 @@ def _mk_account(email: str, *, plan: str = "free", pay: str = "inactive",
                 """
                 insert into auth_accounts
                     (user_id, email, password_hash, plan, last_payment_status,
-                     stripe_customer_id, plan_expires_at)
-                values (%s, %s, 'x', %s, %s, %s, %s)
+                     stripe_customer_id, plan_expires_at, signup_source)
+                values (%s, %s, 'x', %s, %s, %s, %s, %s)
                 """,
-                (uid, email, plan, pay, stripe_customer, expires),
+                (uid, email, plan, pay, stripe_customer, expires, source),
             )
         conn.commit()
     return uid
@@ -256,6 +257,34 @@ def test_stripe_billing_cache_faz_backoff_apos_falha(monkeypatch):
 def test_users_endpoint_requires_admin_auth():
     response = TestClient(dashboard.app).get("/admin/api/users")
     assert response.status_code == 401
+
+
+def test_users_list_expoe_signup_source_e_agregado(panel_accounts):
+    tag, _uids = panel_accounts
+    client = _admin_client()
+
+    # Contas com origem explícita, buscáveis pelo prefixo único
+    web = _mk_account(f"srcpanel-{tag}-web@test.local", source="web")
+    app = _mk_account(f"srcpanel-{tag}-app@test.local", source="app")
+    goog = _mk_account(f"srcpanel-{tag}-goog@test.local", source="google")
+    unknown = _mk_account(f"srcpanel-{tag}-unk@test.local")  # signup_source NULL
+    try:
+        data = client.get(f"/admin/api/users?q=srcpanel-{tag}").json()
+        src_by_uid = {u["user_id"]: u["signup_source"] for u in data["users"]}
+        assert src_by_uid == {web: "web", app: "app", goog: "google", unknown: None}
+
+        # Agregado por origem é da base inteira e conta NULL como 'desconhecido'
+        by_source = data["by_source"]
+        assert by_source.get("web", 0) >= 1
+        assert by_source.get("app", 0) >= 1
+        assert by_source.get("google", 0) >= 1
+        assert by_source.get("desconhecido", 0) >= 1
+    finally:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("delete from auth_accounts where user_id = any(%s)",
+                            ([web, app, goog, unknown],))
+            conn.commit()
 
 
 def test_users_list_aggregates_and_statuses(panel_accounts):

--- a/tests/test_db_core.py
+++ b/tests/test_db_core.py
@@ -340,3 +340,68 @@ def test_confirm_email_verification_normaliza_telefone_armazenado_no_codigo():
             row = cur.fetchone()
 
     assert row["phone_e164"] == "5565992741873"
+
+
+def _confirm_and_read_source(email: str, *, source=None):
+    code = create_email_verification(email, "123456", "5565992741873")
+    if source is None:
+        result = confirm_email_verification(email, code)
+    else:
+        result = confirm_email_verification(email, code, source)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select signup_source from auth_accounts where user_id = %s",
+                (result["user_id"],),
+            )
+            row = cur.fetchone()
+    return result["user_id"], row["signup_source"]
+
+
+def test_confirm_email_verification_grava_signup_source():
+    # Default = 'web' quando o caller não informa origem
+    _uid, src = _confirm_and_read_source(f"src-def-{uuid.uuid4().hex[:8]}@example.com")
+    assert src == "web"
+
+    # Origem explícita (app iOS) é persistida
+    _uid, src = _confirm_and_read_source(
+        f"src-app-{uuid.uuid4().hex[:8]}@example.com", source="app"
+    )
+    assert src == "app"
+
+
+def test_confirm_email_preserva_origem_no_re_registro():
+    # O insert usa `on conflict (email) do update ... coalesce(signup_source)`:
+    # se a conta já existe, a origem da 1ª criação é preservada. O guard
+    # anti-duplicata de create_email_verification bloqueia o 2º cadastro pela
+    # API, então semeamos o 2º código direto na tabela (como o teste de
+    # normalização de telefone faz) pra exercitar o caminho on-conflict.
+    email = f"src-recad-{uuid.uuid4().hex[:8]}@example.com"
+    uid1, src1 = _confirm_and_read_source(email, source="app")
+    assert src1 == "app"
+
+    # 2º código pro mesmo e-mail, inserido direto (bypassa o guard)
+    from core.crypto import hash_pii_optional
+    from datetime import datetime, timedelta, timezone
+    code2 = "654321"
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into email_verification_codes
+                    (email, email_hash, code, password_hash, expires_at)
+                values (%s, %s, %s, 'x', %s)
+                """,
+                (email, hash_pii_optional(email, kind="email"), code2,
+                 datetime.now(timezone.utc) + timedelta(minutes=15)),
+            )
+        conn.commit()
+
+    result = confirm_email_verification(email, code2, "web")
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select signup_source from auth_accounts where user_id = %s",
+                        (result["user_id"],))
+            src2 = cur.fetchone()["signup_source"]
+    assert result["user_id"] == uid1
+    assert src2 == "app"  # coalesce preservou a 1ª origem

--- a/tests/test_gate_plan_selection.py
+++ b/tests/test_gate_plan_selection.py
@@ -77,3 +77,21 @@ def test_jti_invalido_cai_no_dashboard_token(monkeypatch):
     _patch(monkeypatch, payload={"type": "auth", "sub": "7", "jti": "x"},
            needs=True, session=None, dashboard_uid=None)
     assert shared.gate_plan_selection(_Req()) is None
+
+
+# ── Detecção da origem do cadastro (signup_source_from_request) ──────────────
+
+def test_signup_source_web_por_padrao():
+    assert shared.signup_source_from_request(_Req(ua="Mozilla/5.0")) == "web"
+
+
+def test_signup_source_app_pela_ua():
+    assert shared.signup_source_from_request(
+        _Req(ua="Mozilla/5.0 PigBankApp/1.2")) == "app"
+
+
+def test_signup_source_google_web_e_app():
+    assert shared.signup_source_from_request(
+        _Req(ua="Mozilla/5.0"), google=True) == "google"
+    assert shared.signup_source_from_request(
+        _Req(ua="PigBankApp/1.0"), google=True) == "google_app"


### PR DESCRIPTION
## Por quê

No painel de usuários (#61), a maioria dos Free tem "últ. atividade —" e alguns aparecem "sem escolha de plano". Investigando, boa parte é **cadastro pelo app iOS**, que é deliberadamente isento do gate da /precos (diretriz 3.1.1 da Apple proíbe empurrar tela de compra) — indistinguível, hoje, de quem abandonou o funil na web. Sem um campo de origem, não dá pra separar drop-off real de fluxo-app esperado.

## O que muda

Nova coluna `auth_accounts.signup_source`, gravada onde a conta nasce:
- **Cadastro e-mail/senha** (`confirm_email_verification`) → `web` ou `app`
- **Cadastro Google** (`consume_pending_google_signup`) → `google` ou `google_app`

A origem vem de `signup_source_from_request()` (frontend/routes/shared.py), que usa o **mesmo** marcador de UA (`PigBankApp`) que já isenta o app do gate — então a classificação é consistente com o comportamento do gate, não uma heurística nova.

No admin (modal de usuários):
- Coluna **Origem** na tabela (Web / App iOS / Google / —)
- Campo **Origem do cadastro** no drill-down
- Chips de agregado por origem (Web · App iOS · Google · Origem —), da base inteira

## Decisões

- **Migração idempotente, sem backfill por data chutado**: `add column if not exists signup_source text` (sem default). Contas anteriores à coluna ficam NULL → "desconhecido" nos chips e "—" na linha. Honesto: não inventa origem pra quem já existia.
- **Re-registro do mesmo e-mail preserva a origem da 1ª criação** (`coalesce(auth_accounts.signup_source, excluded.signup_source)` no `on conflict do update`), tanto no e-mail quanto no Google.
- WhatsApp não cria `auth_accounts` (só lê/vincula), então não há origem 'whatsapp' — verificado no inventário dos 3 pontos de insert.

## Verificação

- **1080 passed, 0 failed** na suíte completa local contra Postgres real (baseline #61: 1074; 6 testes novos).
- Testes novos: grava/default(`web`)/persiste origem explícita no confirm; preserva no re-registro via on-conflict (semeando o 2º código direto, já que o guard anti-duplicata bloqueia a API); detecção `web`/`app`/`google`/`google_app` da UA; `signup_source` por linha e agregado `by_source` no endpoint.
- UI exercitada no navegador (servidor local + banco de teste, contas demo com origens variadas incl. NULL): coluna Origem, chips de origem e campo no drill-down renderizando; console sem erros novos; screenshot conferido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)