### PR TITLE
feat(admin): funil de checkout (iniciados × conversão) no painel

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -887,32 +887,45 @@ async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
 
 
 async def _fetch_checkout_funnel(cur) -> dict[str, int]:
-    """Funil de checkout a partir de system_event_logs: pessoas distintas que
-    ABRIRAM o checkout (billing_checkout_started) × as que CONCLUÍRAM
-    (billing_checkout_completed), em 30d e 7d. Por usuário distinto pra abrir
-    o checkout 2x não contar como 2 — user_id NULL (evento sem conta) é
-    ignorado no distinct. started_30d é 0 antes deste recurso ir pro ar (o
-    evento passou a ser logado agora); a conversão só fica confiável dali pra
-    frente, e o front avisa quando started=0."""
+    """Funil de checkout a partir de system_event_logs, por COORTE de abertura:
+    started = pessoas distintas que ABRIRAM o checkout na janela;
+    completed = as que abriram na janela E TAMBÉM concluíram na janela.
+
+    O completed é subconjunto do started de propósito. Se contássemos toda
+    conclusão (billing_checkout_completed) contra o started novo, a conversão
+    estouraria 100% no 1º mês pós-deploy — billing_checkout_completed já tem
+    histórico de meses, billing_checkout_started nasce agora — e voltaria a
+    furar na borda da janela (quem abriu há 31d e concluiu há 5d). Amarrar o
+    numerador à coorte que abriu na janela mantém a razão em 0–100% e
+    semanticamente correta ('dos que abriram, quantos fecharam').
+
+    Contagem por usuário (abrir 2x não conta 2); user_id NULL é ignorado.
+    Nota: quem abre no fim da janela e conclui já fora dela não entra no
+    completed (subestima levemente, no sentido seguro)."""
     await cur.execute(
         """
         SELECT
-            COUNT(DISTINCT user_id) FILTER (
-                WHERE event_type = 'billing_checkout_started'
-                  AND created_at >= NOW() - INTERVAL '30 days') AS started_30d,
-            COUNT(DISTINCT user_id) FILTER (
-                WHERE event_type = 'billing_checkout_completed'
-                  AND created_at >= NOW() - INTERVAL '30 days') AS completed_30d,
-            COUNT(DISTINCT user_id) FILTER (
-                WHERE event_type = 'billing_checkout_started'
-                  AND created_at >= NOW() - INTERVAL '7 days') AS started_7d,
-            COUNT(DISTINCT user_id) FILTER (
-                WHERE event_type = 'billing_checkout_completed'
-                  AND created_at >= NOW() - INTERVAL '7 days') AS completed_7d
-        FROM system_event_logs
-        WHERE event_type IN ('billing_checkout_started', 'billing_checkout_completed')
-          AND created_at >= NOW() - INTERVAL '30 days'
-          AND user_id IS NOT NULL
+            COUNT(*) FILTER (WHERE started_30d)                     AS started_30d,
+            COUNT(*) FILTER (WHERE started_30d AND completed_30d)   AS completed_30d,
+            COUNT(*) FILTER (WHERE started_7d)                      AS started_7d,
+            COUNT(*) FILTER (WHERE started_7d AND completed_7d)     AS completed_7d
+        FROM (
+            SELECT
+                user_id,
+                bool_or(event_type = 'billing_checkout_started'
+                        AND created_at >= NOW() - INTERVAL '30 days') AS started_30d,
+                bool_or(event_type = 'billing_checkout_completed'
+                        AND created_at >= NOW() - INTERVAL '30 days') AS completed_30d,
+                bool_or(event_type = 'billing_checkout_started'
+                        AND created_at >= NOW() - INTERVAL '7 days')  AS started_7d,
+                bool_or(event_type = 'billing_checkout_completed'
+                        AND created_at >= NOW() - INTERVAL '7 days')  AS completed_7d
+            FROM system_event_logs
+            WHERE event_type IN ('billing_checkout_started', 'billing_checkout_completed')
+              AND created_at >= NOW() - INTERVAL '30 days'
+              AND user_id IS NOT NULL
+            GROUP BY user_id
+        ) per_user
         """
     )
     row = await cur.fetchone()

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -886,6 +886,12 @@ async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
     return _billing_summary_cache["data"]
 
 
+# Telemetria do funil: as duas pontas precisam sobreviver pra a conversão 30d
+# fazer sentido. O "Limpar" do feed (bulk delete até um id) NÃO pode apagá-las
+# — senão uma limpeza de rotina do feed zeraria a métrica silenciosamente.
+_FUNNEL_EVENT_TYPES = ("billing_checkout_started", "billing_checkout_completed")
+
+
 async def _fetch_checkout_funnel(cur) -> dict[str, int]:
     """Funil de checkout a partir de system_event_logs, por COORTE de abertura:
     started = pessoas distintas que ABRIRAM o checkout na janela;
@@ -1522,15 +1528,21 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
           - before_id: deleta eventos com id <= before_id (snapshot do client)
 
         Use sem filtros pra apagar tudo, ou só `before_id` pra "limpar tudo até este momento".
+
+        Exceção sempre aplicada: os eventos do funil de checkout
+        (_FUNNEL_EVENT_TYPES) são preservados — o painel depende deles pra
+        conversão 30d, e o "Limpar" é uma ação de UX do feed de alertas, não
+        um expurgo de telemetria de negócio.
         """
-        clauses, params = [], []
+        clauses = ["event_type <> ALL(%s)"]
+        params: list[Any] = [list(_FUNNEL_EVENT_TYPES)]
         if level in ("error", "warning", "info"):
             clauses.append("level = %s")
             params.append(level)
         if before_id is not None:
             clauses.append("id <= %s")
             params.append(int(before_id))
-        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        where = "WHERE " + " AND ".join(clauses)
 
         async with await db_connect() as conn:
             async with conn.cursor() as cur:

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -886,6 +886,39 @@ async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
     return _billing_summary_cache["data"]
 
 
+async def _fetch_checkout_funnel(cur) -> dict[str, int]:
+    """Funil de checkout a partir de system_event_logs: pessoas distintas que
+    ABRIRAM o checkout (billing_checkout_started) × as que CONCLUÍRAM
+    (billing_checkout_completed), em 30d e 7d. Por usuário distinto pra abrir
+    o checkout 2x não contar como 2 — user_id NULL (evento sem conta) é
+    ignorado no distinct. started_30d é 0 antes deste recurso ir pro ar (o
+    evento passou a ser logado agora); a conversão só fica confiável dali pra
+    frente, e o front avisa quando started=0."""
+    await cur.execute(
+        """
+        SELECT
+            COUNT(DISTINCT user_id) FILTER (
+                WHERE event_type = 'billing_checkout_started'
+                  AND created_at >= NOW() - INTERVAL '30 days') AS started_30d,
+            COUNT(DISTINCT user_id) FILTER (
+                WHERE event_type = 'billing_checkout_completed'
+                  AND created_at >= NOW() - INTERVAL '30 days') AS completed_30d,
+            COUNT(DISTINCT user_id) FILTER (
+                WHERE event_type = 'billing_checkout_started'
+                  AND created_at >= NOW() - INTERVAL '7 days') AS started_7d,
+            COUNT(DISTINCT user_id) FILTER (
+                WHERE event_type = 'billing_checkout_completed'
+                  AND created_at >= NOW() - INTERVAL '7 days') AS completed_7d
+        FROM system_event_logs
+        WHERE event_type IN ('billing_checkout_started', 'billing_checkout_completed')
+          AND created_at >= NOW() - INTERVAL '30 days'
+          AND user_id IS NOT NULL
+        """
+    )
+    row = await cur.fetchone()
+    return {k: int(v or 0) for k, v in dict(row).items()}
+
+
 _ADMIN_USERS_HARD_CAP = 2000
 
 
@@ -980,6 +1013,12 @@ async def fetch_admin_users(
                 aggregates["whatsapp_connected"] += int(r["wa"])
             aggregates["total"] = sum(aggregates[s] for s in _USER_STATUSES)
 
+            # Funil de checkout (system_event_logs): quantas PESSOAS abriram o
+            # checkout × quantas concluíram, em 30d/7d. Contagem por usuário
+            # distinto (não por evento) — abrir 2x não infla o funil. A
+            # conversão é derivada no front (completed / started).
+            checkout_funnel = await _fetch_checkout_funnel(cur)
+
             if not q:
                 await cur.execute(
                     f"SELECT COUNT(*) AS n FROM auth_accounts a {where_sql}",
@@ -1042,6 +1081,7 @@ async def fetch_admin_users(
     return {
         "generated_at": now,
         "aggregates": aggregates,
+        "checkout_funnel": checkout_funnel,
         "billing": await fetch_billing_summary(),
         "users": page_rows,
         "page": page,

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -886,61 +886,47 @@ async def fetch_billing_summary(force: bool = False) -> dict[str, Any]:
     return _billing_summary_cache["data"]
 
 
-# Telemetria do funil: as duas pontas precisam sobreviver pra a conversão 30d
-# fazer sentido. O "Limpar" do feed (bulk delete até um id) NÃO pode apagá-las
-# — senão uma limpeza de rotina do feed zeraria a métrica silenciosamente.
-_FUNNEL_EVENT_TYPES = ("billing_checkout_started", "billing_checkout_completed")
-
-
 async def _fetch_checkout_funnel(cur) -> dict[str, int]:
-    """Funil de checkout a partir de system_event_logs, por COORTE de abertura:
-    started = pessoas distintas que ABRIRAM o checkout na janela;
-    completed = as que abriram na janela E TAMBÉM concluíram na janela.
+    """Funil de checkout a partir da tabela dedicada checkout_funnel_events,
+    correlacionando abertura e conclusão pelo session_id do Stripe (a MESMA
+    tentativa). Devolve, em 30d e 7d:
 
-    O completed é subconjunto do started de propósito. Se contássemos toda
-    conclusão (billing_checkout_completed) contra o started novo, a conversão
-    estouraria 100% no 1º mês pós-deploy — billing_checkout_completed já tem
-    histórico de meses, billing_checkout_started nasce agora — e voltaria a
-    furar na borda da janela (quem abriu há 31d e concluiu há 5d). Amarrar o
-    numerador à coorte que abriu na janela mantém a razão em 0–100% e
-    semanticamente correta ('dos que abriram, quantos fecharam').
+      people_Nd            — pessoas distintas que abriram algum checkout
+      sessions_started_Nd  — sessões (tentativas) abertas
+      sessions_completed_Nd— dessas, as que concluíram (mesmo session_id)
 
-    Contagem por usuário (abrir 2x não conta 2); user_id NULL é ignorado.
+    A conversão (sessions_completed / sessions_started) é por SESSÃO: um
+    ex-assinante que comprou numa sessão e depois reabre e abandona outra tem
+    a 2ª sessão contada como não-convertida — sem a correlação por session_id
+    isso era impossível de separar (era a raiz dos 3 apontamentos anteriores).
+    Viver em tabela própria (não em system_event_logs) também torna a
+    telemetria imune ao 'Limpar'/purge do feed.
 
-    A conclusão precisa vir DEPOIS da abertura da coorte: comparamos
-    max(concluído) >= min(aberto) na janela. Sem isso, um ex-assinante que
-    concluiu antes na janela e depois reabre o checkout (e abandona) seria
-    contado como convertido pela conclusão velha. Efeito colateral aceito:
-    quem abre no fim da janela e conclui já fora dela não entra no completed
-    (subestima levemente, no sentido seguro)."""
+    Uma sessão sem session_id (raro — Stripe sempre devolve) entra em people
+    mas não nas contagens de sessão (COUNT DISTINCT ignora NULL)."""
     await cur.execute(
         """
         SELECT
-            COUNT(*) FILTER (WHERE min_start_30d IS NOT NULL) AS started_30d,
-            COUNT(*) FILTER (
-                WHERE min_start_30d IS NOT NULL
-                  AND max_comp_30d >= min_start_30d) AS completed_30d,
-            COUNT(*) FILTER (WHERE min_start_7d IS NOT NULL) AS started_7d,
-            COUNT(*) FILTER (
-                WHERE min_start_7d IS NOT NULL
-                  AND max_comp_7d >= min_start_7d) AS completed_7d
+            COUNT(DISTINCT user_id)    FILTER (WHERE w30)                AS people_30d,
+            COUNT(DISTINCT session_id) FILTER (WHERE w30)                AS sessions_started_30d,
+            COUNT(DISTINCT session_id) FILTER (WHERE w30 AND converted)  AS sessions_completed_30d,
+            COUNT(DISTINCT user_id)    FILTER (WHERE w7)                 AS people_7d,
+            COUNT(DISTINCT session_id) FILTER (WHERE w7)                 AS sessions_started_7d,
+            COUNT(DISTINCT session_id) FILTER (WHERE w7 AND converted)   AS sessions_completed_7d
         FROM (
             SELECT
-                user_id,
-                MIN(created_at) FILTER (WHERE event_type = 'billing_checkout_started'
-                    AND created_at >= NOW() - INTERVAL '30 days') AS min_start_30d,
-                MAX(created_at) FILTER (WHERE event_type = 'billing_checkout_completed'
-                    AND created_at >= NOW() - INTERVAL '30 days') AS max_comp_30d,
-                MIN(created_at) FILTER (WHERE event_type = 'billing_checkout_started'
-                    AND created_at >= NOW() - INTERVAL '7 days')  AS min_start_7d,
-                MAX(created_at) FILTER (WHERE event_type = 'billing_checkout_completed'
-                    AND created_at >= NOW() - INTERVAL '7 days')  AS max_comp_7d
-            FROM system_event_logs
-            WHERE event_type IN ('billing_checkout_started', 'billing_checkout_completed')
-              AND created_at >= NOW() - INTERVAL '30 days'
-              AND user_id IS NOT NULL
-            GROUP BY user_id
-        ) per_user
+                s.user_id,
+                s.session_id,
+                s.created_at >= NOW() - INTERVAL '30 days' AS w30,
+                s.created_at >= NOW() - INTERVAL '7 days'  AS w7,
+                (s.session_id IS NOT NULL AND EXISTS (
+                    SELECT 1 FROM checkout_funnel_events c
+                    WHERE c.kind = 'completed' AND c.session_id = s.session_id
+                )) AS converted
+            FROM checkout_funnel_events s
+            WHERE s.kind = 'started'
+              AND s.created_at >= NOW() - INTERVAL '30 days'
+        ) per_start
         """
     )
     row = await cur.fetchone()
@@ -1528,21 +1514,15 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
           - before_id: deleta eventos com id <= before_id (snapshot do client)
 
         Use sem filtros pra apagar tudo, ou só `before_id` pra "limpar tudo até este momento".
-
-        Exceção sempre aplicada: os eventos do funil de checkout
-        (_FUNNEL_EVENT_TYPES) são preservados — o painel depende deles pra
-        conversão 30d, e o "Limpar" é uma ação de UX do feed de alertas, não
-        um expurgo de telemetria de negócio.
         """
-        clauses = ["event_type <> ALL(%s)"]
-        params: list[Any] = [list(_FUNNEL_EVENT_TYPES)]
+        clauses, params = [], []
         if level in ("error", "warning", "info"):
             clauses.append("level = %s")
             params.append(level)
         if before_id is not None:
             clauses.append("id <= %s")
             params.append(int(before_id))
-        where = "WHERE " + " AND ".join(clauses)
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
 
         async with await db_connect() as conn:
             async with conn.cursor() as cur:

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -900,26 +900,35 @@ async def _fetch_checkout_funnel(cur) -> dict[str, int]:
     semanticamente correta ('dos que abriram, quantos fecharam').
 
     Contagem por usuário (abrir 2x não conta 2); user_id NULL é ignorado.
-    Nota: quem abre no fim da janela e conclui já fora dela não entra no
-    completed (subestima levemente, no sentido seguro)."""
+
+    A conclusão precisa vir DEPOIS da abertura da coorte: comparamos
+    max(concluído) >= min(aberto) na janela. Sem isso, um ex-assinante que
+    concluiu antes na janela e depois reabre o checkout (e abandona) seria
+    contado como convertido pela conclusão velha. Efeito colateral aceito:
+    quem abre no fim da janela e conclui já fora dela não entra no completed
+    (subestima levemente, no sentido seguro)."""
     await cur.execute(
         """
         SELECT
-            COUNT(*) FILTER (WHERE started_30d)                     AS started_30d,
-            COUNT(*) FILTER (WHERE started_30d AND completed_30d)   AS completed_30d,
-            COUNT(*) FILTER (WHERE started_7d)                      AS started_7d,
-            COUNT(*) FILTER (WHERE started_7d AND completed_7d)     AS completed_7d
+            COUNT(*) FILTER (WHERE min_start_30d IS NOT NULL) AS started_30d,
+            COUNT(*) FILTER (
+                WHERE min_start_30d IS NOT NULL
+                  AND max_comp_30d >= min_start_30d) AS completed_30d,
+            COUNT(*) FILTER (WHERE min_start_7d IS NOT NULL) AS started_7d,
+            COUNT(*) FILTER (
+                WHERE min_start_7d IS NOT NULL
+                  AND max_comp_7d >= min_start_7d) AS completed_7d
         FROM (
             SELECT
                 user_id,
-                bool_or(event_type = 'billing_checkout_started'
-                        AND created_at >= NOW() - INTERVAL '30 days') AS started_30d,
-                bool_or(event_type = 'billing_checkout_completed'
-                        AND created_at >= NOW() - INTERVAL '30 days') AS completed_30d,
-                bool_or(event_type = 'billing_checkout_started'
-                        AND created_at >= NOW() - INTERVAL '7 days')  AS started_7d,
-                bool_or(event_type = 'billing_checkout_completed'
-                        AND created_at >= NOW() - INTERVAL '7 days')  AS completed_7d
+                MIN(created_at) FILTER (WHERE event_type = 'billing_checkout_started'
+                    AND created_at >= NOW() - INTERVAL '30 days') AS min_start_30d,
+                MAX(created_at) FILTER (WHERE event_type = 'billing_checkout_completed'
+                    AND created_at >= NOW() - INTERVAL '30 days') AS max_comp_30d,
+                MIN(created_at) FILTER (WHERE event_type = 'billing_checkout_started'
+                    AND created_at >= NOW() - INTERVAL '7 days')  AS min_start_7d,
+                MAX(created_at) FILTER (WHERE event_type = 'billing_checkout_completed'
+                    AND created_at >= NOW() - INTERVAL '7 days')  AS max_comp_7d
             FROM system_event_logs
             WHERE event_type IN ('billing_checkout_started', 'billing_checkout_completed')
               AND created_at >= NOW() - INTERVAL '30 days'

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -269,6 +269,10 @@ from .agents import (
 )
 
 # ── Relatórios, Auth, Dashboard, Engajamento ──────────────────────────────────
+from .checkout_funnel import (
+    record_checkout_started,
+    record_checkout_completed,
+)
 from .reports import (
     set_daily_report_enabled,
     set_daily_report_hour,
@@ -489,6 +493,7 @@ __all__ = [
     "register_auth_user", "login_auth_user", "get_auth_user", "get_password_changed_at", "auto_link_auth_user",
     "create_dashboard_session", "get_dashboard_session", "consume_dashboard_session",
     "update_user_plan", "mark_plan_selected", "get_user_by_stripe_customer", "set_stripe_customer", "set_payment_status",
+    "record_checkout_started", "record_checkout_completed",
     "create_email_verification", "AccountAlreadyExistsError", "confirm_email_verification", "attempt_whatsapp_phone_link",
     "create_password_reset_token", "consume_password_reset_token",
     "update_last_activity", "get_users_for_engagement", "get_free_users_for_upgrade_nudge",

--- a/db/checkout_funnel.py
+++ b/db/checkout_funnel.py
@@ -1,0 +1,40 @@
+"""db/checkout_funnel.py — telemetria do funil de checkout (tabela dedicada
+checkout_funnel_events, fora do system_event_logs purgável).
+
+Duas pontas: record_checkout_started (no /billing/create-checkout) e
+record_checkout_completed (no webhook checkout.session.completed). O
+session_id (id da Checkout Session do Stripe) liga a abertura à conclusão
+da MESMA tentativa — é o que permite a conversão por sessão no painel.
+
+Falha de gravação nunca propaga: telemetria não pode derrubar o checkout
+nem o processamento do webhook.
+"""
+from __future__ import annotations
+
+import logging
+
+from .connection import get_conn
+
+_log = logging.getLogger(__name__)
+
+
+def _record(user_id: int, session_id: str | None, kind: str) -> None:
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "insert into checkout_funnel_events (user_id, session_id, kind) "
+                    "values (%s, %s, %s)",
+                    (int(user_id), session_id, kind),
+                )
+            conn.commit()
+    except Exception as exc:  # nunca derruba o fluxo principal
+        _log.warning("checkout_funnel %s falhou user=%s: %s", kind, user_id, exc)
+
+
+def record_checkout_started(user_id: int, session_id: str | None) -> None:
+    _record(user_id, session_id, "started")
+
+
+def record_checkout_completed(user_id: int, session_id: str | None) -> None:
+    _record(user_id, session_id, "completed")

--- a/db/schema.py
+++ b/db/schema.py
@@ -1626,6 +1626,35 @@ def init_db():
         """alter table plan_trials add column if not exists model_version smallint not null default 1""",
         """alter table plan_trials alter column model_version set default 2""",
 
+        # ── Funil de checkout (telemetria durável, fora do log operacional) ──
+        # Vive em tabela própria, NÃO em system_event_logs, por dois motivos:
+        # (1) system_event_logs é purgável (o "Limpar" do painel, admin.py
+        #     purge, delete individual) — telemetria de negócio não pode sumir
+        #     numa limpeza de rotina;
+        # (2) session_id (id da Checkout Session do Stripe) correlaciona a
+        #     abertura com a conclusão da MESMA tentativa — sem isso, heurística
+        #     de timestamp conta errado quem comprou, cancelou e reabriu.
+        # kind: 'started' (endpoint /billing/create-checkout) | 'completed'
+        # (webhook checkout.session.completed). user_id SET NULL na exclusão
+        # da conta: o evento sobrevive (contamos sessões, não só pessoas vivas).
+        """
+        create table if not exists checkout_funnel_events (
+          id bigserial primary key,
+          user_id bigint references users(id) on delete set null,
+          session_id text,
+          kind text not null check (kind in ('started', 'completed')),
+          created_at timestamptz not null default now()
+        )
+        """,
+        """
+        create index if not exists idx_checkout_funnel_kind_created
+          on checkout_funnel_events (kind, created_at desc)
+        """,
+        """
+        create index if not exists idx_checkout_funnel_session
+          on checkout_funnel_events (session_id)
+        """,
+
         # ── Agentes do Piggy (prateleira de jobs proativos) ──────────────────
         # Um agente por kind por usuário (custom multiplica no futuro via
         # config, não via linhas). status: 'active' | 'paused'.

--- a/db/schema_repairs.py
+++ b/db/schema_repairs.py
@@ -23,6 +23,10 @@ logger = logging.getLogger(__name__)
 # manter eventos com user_id nulo para investigação de incidentes).
 _USER_FK_SET_NULL_TABLES: frozenset[str] = frozenset({
     "auth_login_events",
+    # Telemetria do funil de checkout: contamos sessões (session_id), não só
+    # pessoas vivas — a conversão histórica não pode encolher quando uma conta
+    # é excluída. O evento sobrevive anonimizado (user_id nulo).
+    "checkout_funnel_events",
 })
 
 

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1392,7 +1392,7 @@ async function loadUsers() {
     if (res.status === 401) { window.location.href = '/admin/login'; return; }
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    renderUsersChips(data.aggregates, data.billing);
+    renderUsersChips(data.aggregates, data.billing, data.checkout_funnel);
     renderUsersTable(data);
     $id('users-loading').textContent = '';
   } catch (e) {
@@ -1403,7 +1403,7 @@ async function loadUsers() {
   }
 }
 
-function renderUsersChips(agg, billing) {
+function renderUsersChips(agg, billing, funnel) {
   const chips = [
     { key: '',         label: 'Total',        val: fInt(agg.total),    chip: '' },
     { key: 'paying',   label: 'Pagantes',     val: fInt(agg.paying),   chip: 'green' },
@@ -1419,6 +1419,15 @@ function renderUsersChips(agg, billing) {
     </div>`).join('');
   html += `
     <div class="user-chip static"><b>${fInt(agg.whatsapp_connected)}</b><span>WA conect.</span></div>`;
+  // Funil de checkout 30d: abriram × conversão (concluíram / abriram).
+  if (funnel) {
+    const started = funnel.started_30d || 0;
+    const completed = funnel.completed_30d || 0;
+    const conv = started > 0 ? Math.round((completed / started) * 100) : null;
+    html += `
+    <div class="user-chip static"><b>${fInt(started)}</b><span>Checkout 30d</span></div>
+    <div class="user-chip static"><b class="${conv !== null && conv >= 50 ? 'green' : ''}">${conv !== null ? conv + '%' : '—'}</b><span>Conversão 30d</span></div>`;
+  }
   if (billing?.available) {
     html += `
     <div class="user-chip static"><b class="green">${fMoney(billing.mrr)}</b><span>MRR</span></div>

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1419,13 +1419,15 @@ function renderUsersChips(agg, billing, funnel) {
     </div>`).join('');
   html += `
     <div class="user-chip static"><b>${fInt(agg.whatsapp_connected)}</b><span>WA conect.</span></div>`;
-  // Funil de checkout 30d: abriram × conversão (concluíram / abriram).
+  // Funil de checkout 30d: pessoas que abriram + conversão POR SESSÃO
+  // (sessões concluídas / sessões abertas, correlação por session_id).
   if (funnel) {
-    const started = funnel.started_30d || 0;
-    const completed = funnel.completed_30d || 0;
-    const conv = started > 0 ? Math.round((completed / started) * 100) : null;
+    const people = funnel.people_30d || 0;
+    const sStarted = funnel.sessions_started_30d || 0;
+    const sCompleted = funnel.sessions_completed_30d || 0;
+    const conv = sStarted > 0 ? Math.round((sCompleted / sStarted) * 100) : null;
     html += `
-    <div class="user-chip static"><b>${fInt(started)}</b><span>Checkout 30d</span></div>
+    <div class="user-chip static"><b>${fInt(people)}</b><span>Checkout 30d</span></div>
     <div class="user-chip static"><b class="${conv !== null && conv >= 50 ? 'green' : ''}">${conv !== null ? conv + '%' : '—'}</b><span>Conversão 30d</span></div>`;
   }
   if (billing?.available) {

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3743,7 +3743,10 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
         logging.getLogger(__name__).error("billing_checkout_stripe_error: %s", exc)
         raise HTTPException(status_code=502, detail="Erro no Stripe ao iniciar o checkout.")
 
-    return {"checkout_url": session.url, "interval": interval, "plan": plan}
+    return {
+        "checkout_url": session.url, "interval": interval, "plan": plan,
+        "session_id": getattr(session, "id", None),
+    }
 
 
 @app.get("/billing/plans-config")
@@ -3789,17 +3792,13 @@ async def billing_create_checkout(
         async with _billing_user_lock(user_id):
             result = await _billing_checkout_for_user(
                 stripe, user_id, plan, interval, price_id)
-        # Funil de checkout: registra a ABERTURA (par do billing_checkout_completed
-        # logado no webhook). started × completed dá a conversão no painel de
-        # admin. Só depois da sessão nascer de fato — sessão que falhou não conta.
-        await log_system_event(
-            "info",
-            "billing_checkout_started",
-            f"Checkout iniciado; plano {plan} ({interval}).",
-            source="billing",
-            user_id=user_id,
-            details={"plan": plan, "interval": interval},
-        )
+        # Funil de checkout: registra a ABERTURA na tabela dedicada, com o
+        # session_id do Stripe (par do record_checkout_completed no webhook —
+        # correlaciona a mesma tentativa). Só depois da sessão nascer de fato.
+        # session_id sai do payload do cliente (é interno do funil).
+        from db import record_checkout_started
+        _session_id = result.pop("session_id", None)
+        await asyncio.to_thread(record_checkout_started, user_id, _session_id)
         # Abrir o checkout já é "escolha de plano" no cadastro: fecha o gate da
         # /precos agora (idempotente) pra que, ao voltar do Stripe com
         # ?upgrade=success, o /home não bata no backstop 402 antes do webhook
@@ -4192,6 +4191,13 @@ async def billing_webhook(request: Request):
         session = event["data"]["object"]
         user_id = _resolve_user(session)
         sub_id  = _g(session, "subscription")
+        # Funil: registra a CONCLUSÃO na tabela dedicada, com o session_id
+        # (correlaciona com o record_checkout_started da mesma tentativa).
+        # Vale pra trial e compra imediata — os dois disparam este evento.
+        if user_id:
+            from db import record_checkout_completed
+            await asyncio.to_thread(
+                record_checkout_completed, user_id, _g(session, "id"))
         # Trial 30d: subscription nasce status=trialing, sem invoice paga.
         # Promover ja agora pra user nao ficar Free durante o trial.
         if user_id and sub_id:

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3668,7 +3668,13 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             )
 
     if reusable is not None:
-        return {"checkout_url": _sg(reusable, "url"), "interval": interval, "plan": plan}
+        # session_id da sessão REAPROVEITADA: sem ele, o started iria com NULL
+        # e a sessão nunca correlacionaria a conclusão no funil (só entraria
+        # people, não sessions). Mesma chave que o caminho de sessão nova.
+        return {
+            "checkout_url": _sg(reusable, "url"), "interval": interval, "plan": plan,
+            "session_id": _sg(reusable, "id"),
+        }
 
     # A sessão pode ter sido concluída entre a primeira consulta e a listagem.
     # Confere de novo imediatamente antes da criação para fechar essa corrida

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3789,6 +3789,17 @@ async def billing_create_checkout(
         async with _billing_user_lock(user_id):
             result = await _billing_checkout_for_user(
                 stripe, user_id, plan, interval, price_id)
+        # Funil de checkout: registra a ABERTURA (par do billing_checkout_completed
+        # logado no webhook). started × completed dá a conversão no painel de
+        # admin. Só depois da sessão nascer de fato — sessão que falhou não conta.
+        await log_system_event(
+            "info",
+            "billing_checkout_started",
+            f"Checkout iniciado; plano {plan} ({interval}).",
+            source="billing",
+            user_id=user_id,
+            details={"plan": plan, "interval": interval},
+        )
         # Abrir o checkout já é "escolha de plano" no cadastro: fecha o gate da
         # /precos agora (idempotente) pra que, ao voltar do Stripe com
         # ?upgrade=success, o /home não bata no backstop 402 antes do webhook

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -266,17 +266,57 @@ def test_users_endpoint_requires_admin_auth():
     assert response.status_code == 401
 
 
-def _log_event(uid, event_type, *, days_ago=0):
+def test_limpar_feed_preserva_eventos_do_funil(panel_accounts):
+    """Guard do P2: o 'Limpar' (DELETE /admin/api/events?before_id=...) apaga o
+    feed mas NÃO pode zerar o funil — os eventos billing_checkout_* sobrevivem
+    ao expurgo, senão a conversão 30d some numa limpeza de rotina."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+
+    # 1 evento comum (deve ser apagado) + os 2 do funil (devem sobreviver)
+    common_id = _log_event(uids["free"], "whatsapp_webhook_received", level="info")
+    start_id = _log_event(uids["paying"], "billing_checkout_started")
+    comp_id = _log_event(uids["paying"], "billing_checkout_completed")
+    before = max(common_id, start_id, comp_id)
+
+    base_funnel = client.get("/admin/api/users").json()["checkout_funnel"]
+
+    # "Limpar tudo até este momento" (DELETE exige o header CSRF)
+    resp = client.request(
+        "DELETE", f"/admin/api/events?before_id={before}",
+        headers={dashboard.CSRF_HEADER_NAME: "test-admin-csrf"},
+    )
+    assert resp.status_code == 200
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select count(*) n from system_event_logs where id = %s", (common_id,))
+            assert cur.fetchone()["n"] == 0, "evento comum devia ter sido apagado"
+            cur.execute(
+                "select count(*) n from system_event_logs where id = any(%s)",
+                ([start_id, comp_id],),
+            )
+            assert cur.fetchone()["n"] == 2, "eventos do funil NÃO podem ser apagados"
+
+    # E o funil continua contando a coorte
+    after_funnel = client.get("/admin/api/users").json()["checkout_funnel"]
+    assert after_funnel["started_30d"] == base_funnel["started_30d"]
+    assert after_funnel["completed_30d"] == base_funnel["completed_30d"]
+
+
+def _log_event(uid, event_type, *, days_ago=0, level="info"):
     from datetime import datetime, timedelta, timezone
     ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 "insert into system_event_logs (level, event_type, message, source, user_id, details, created_at) "
-                "values ('info', %s, 'x', 'billing', %s, '{}'::jsonb, %s)",
-                (event_type, uid, ts),
+                "values (%s, %s, 'x', 'billing', %s, '{}'::jsonb, %s) returning id",
+                (level, event_type, uid, ts),
             )
+            new_id = cur.fetchone()["id"]
         conn.commit()
+    return new_id
 
 
 def test_checkout_funnel_conta_pessoas_distintas(panel_accounts):

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -266,125 +266,103 @@ def test_users_endpoint_requires_admin_auth():
     assert response.status_code == 401
 
 
-def test_limpar_feed_preserva_eventos_do_funil(panel_accounts):
-    """Guard do P2: o 'Limpar' (DELETE /admin/api/events?before_id=...) apaga o
-    feed mas NÃO pode zerar o funil — os eventos billing_checkout_* sobrevivem
-    ao expurgo, senão a conversão 30d some numa limpeza de rotina."""
-    _tag, uids = panel_accounts
-    client = _admin_client()
-
-    # 1 evento comum (deve ser apagado) + os 2 do funil (devem sobreviver)
-    common_id = _log_event(uids["free"], "whatsapp_webhook_received", level="info")
-    start_id = _log_event(uids["paying"], "billing_checkout_started")
-    comp_id = _log_event(uids["paying"], "billing_checkout_completed")
-    before = max(common_id, start_id, comp_id)
-
-    base_funnel = client.get("/admin/api/users").json()["checkout_funnel"]
-
-    # "Limpar tudo até este momento" (DELETE exige o header CSRF)
-    resp = client.request(
-        "DELETE", f"/admin/api/events?before_id={before}",
-        headers={dashboard.CSRF_HEADER_NAME: "test-admin-csrf"},
-    )
-    assert resp.status_code == 200
-
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute("select count(*) n from system_event_logs where id = %s", (common_id,))
-            assert cur.fetchone()["n"] == 0, "evento comum devia ter sido apagado"
-            cur.execute(
-                "select count(*) n from system_event_logs where id = any(%s)",
-                ([start_id, comp_id],),
-            )
-            assert cur.fetchone()["n"] == 2, "eventos do funil NÃO podem ser apagados"
-
-    # E o funil continua contando a coorte
-    after_funnel = client.get("/admin/api/users").json()["checkout_funnel"]
-    assert after_funnel["started_30d"] == base_funnel["started_30d"]
-    assert after_funnel["completed_30d"] == base_funnel["completed_30d"]
-
-
-def _log_event(uid, event_type, *, days_ago=0, level="info"):
+def _funnel_event(uid, kind, session_id, *, days_ago=0):
+    """Insere um evento na tabela dedicada checkout_funnel_events."""
     from datetime import datetime, timedelta, timezone
     ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "insert into system_event_logs (level, event_type, message, source, user_id, details, created_at) "
-                "values (%s, %s, 'x', 'billing', %s, '{}'::jsonb, %s) returning id",
-                (level, event_type, uid, ts),
+                "insert into checkout_funnel_events (user_id, session_id, kind, created_at) "
+                "values (%s, %s, %s, %s)",
+                (uid, session_id, kind, ts),
             )
-            new_id = cur.fetchone()["id"]
         conn.commit()
-    return new_id
 
 
-def test_checkout_funnel_conta_pessoas_distintas(panel_accounts):
-    """checkout_funnel conta USUÁRIOS distintos: abrir 2x não vira 2 no
-    started; completed = quem abriu E concluiu na janela."""
-    _tag, uids = panel_accounts
-    client = _admin_client()
-
-    base = client.get("/admin/api/users").json()["checkout_funnel"]
-    b_started, b_completed = base["started_30d"], base["completed_30d"]
-
-    # 2 pessoas abrem o checkout; uma delas abre 2x (não deve inflar); 1 conclui
-    _log_event(uids["paying"], "billing_checkout_started")
-    _log_event(uids["paying"], "billing_checkout_started")  # 2ª abertura, mesmo user
-    _log_event(uids["trial"], "billing_checkout_started")
-    _log_event(uids["paying"], "billing_checkout_completed")
-
-    funnel = client.get("/admin/api/users").json()["checkout_funnel"]
-    assert funnel["started_30d"] == b_started + 2      # 2 pessoas, não 3 eventos
-    assert funnel["completed_30d"] == b_completed + 1  # só paying (abriu E fechou)
-
-
-def test_checkout_funnel_conversao_nunca_passa_de_100pct(panel_accounts):
-    """Guard do P1: conclusão SEM abertura na coorte (histórico anterior ao
-    recurso, ou início fora da janela) não entra no numerador — a conversão
-    fica sempre <= 100%."""
-    _tag, uids = panel_accounts
+def test_checkout_funnel_conta_pessoas_e_sessoes(panel_accounts):
+    """people conta usuários distintos; sessions_started conta sessões
+    distintas; sessions_completed liga início e fim pelo MESMO session_id."""
+    tag, uids = panel_accounts
     client = _admin_client()
 
     base = client.get("/admin/api/users").json()["checkout_funnel"]
 
-    # Conclusão histórica sem started correspondente na janela (caso do deploy)
-    _log_event(uids["canceled"], "billing_checkout_completed")
-    # Abertura antiga (fora da janela de 30d) + conclusão recente: não é coorte
-    _log_event(uids["granted"], "billing_checkout_started", days_ago=40)
-    _log_event(uids["granted"], "billing_checkout_completed")
-    # Uma coorte legítima na janela
-    _log_event(uids["paying"], "billing_checkout_started")
-    _log_event(uids["paying"], "billing_checkout_completed")
+    # paying abre 2 sessões (A e B); só A conclui. trial abre 1 sessão (C) sem concluir.
+    _funnel_event(uids["paying"], "started", f"sess_A_{tag}")
+    _funnel_event(uids["paying"], "completed", f"sess_A_{tag}")
+    _funnel_event(uids["paying"], "started", f"sess_B_{tag}")   # abandonada
+    _funnel_event(uids["trial"], "started", f"sess_C_{tag}")    # abandonada
 
-    funnel = client.get("/admin/api/users").json()["checkout_funnel"]
-    # started só ganhou o paying (o granted abriu fora da janela)
-    assert funnel["started_30d"] == base["started_30d"] + 1
-    # completed só ganhou o paying — as duas conclusões sem coorte não contam
-    assert funnel["completed_30d"] == base["completed_30d"] + 1
-    # E a razão respeita o teto
-    assert funnel["completed_30d"] <= funnel["started_30d"]
+    f = client.get("/admin/api/users").json()["checkout_funnel"]
+    assert f["people_30d"] == base["people_30d"] + 2            # paying + trial
+    assert f["sessions_started_30d"] == base["sessions_started_30d"] + 3  # A, B, C
+    assert f["sessions_completed_30d"] == base["sessions_completed_30d"] + 1  # só A
 
 
-def test_checkout_funnel_conclusao_precisa_vir_depois_da_abertura(panel_accounts):
-    """Guard do P2: ex-assinante que concluiu ANTES na janela e depois reabre
-    o checkout (e abandona) não é convertido — a conclusão velha não conta pra
-    coorte nova. Exige max(concluído) >= min(aberto)."""
-    _tag, uids = panel_accounts
+def test_checkout_funnel_conversao_por_sessao_resolve_recompra(panel_accounts):
+    """P2 (388): comprou numa sessão, cancelou, reabre outra e abandona. A
+    correlação por session_id conta a 2ª sessão como NÃO convertida — a
+    conversão por sessão nunca fica inflada pela compra velha."""
+    tag, uids = panel_accounts
     client = _admin_client()
 
     base = client.get("/admin/api/users").json()["checkout_funnel"]
 
-    # Ex-assinante: concluiu há 20d (compra antiga), reabre há 2d e abandona
-    # (sem conclusão posterior). Abriu na janela → conta no started; mas a
-    # única conclusão é ANTERIOR à reabertura → NÃO conta no completed.
-    _log_event(uids["canceled"], "billing_checkout_completed", days_ago=20)
-    _log_event(uids["canceled"], "billing_checkout_started", days_ago=2)
+    # sessão A: comprou há 20d (started+completed, mesmo id). sessão B: reabre
+    # há 2d e abandona (started sem completed).
+    _funnel_event(uids["canceled"], "started", f"sess_old_{tag}", days_ago=20)
+    _funnel_event(uids["canceled"], "completed", f"sess_old_{tag}", days_ago=20)
+    _funnel_event(uids["canceled"], "started", f"sess_new_{tag}", days_ago=2)
 
-    funnel = client.get("/admin/api/users").json()["checkout_funnel"]
-    assert funnel["started_30d"] == base["started_30d"] + 1
-    assert funnel["completed_30d"] == base["completed_30d"]  # conclusão velha não conta
-    assert funnel["completed_30d"] <= funnel["started_30d"]
+    f = client.get("/admin/api/users").json()["checkout_funnel"]
+    assert f["sessions_started_30d"] == base["sessions_started_30d"] + 2   # old + new
+    assert f["sessions_completed_30d"] == base["sessions_completed_30d"] + 1  # só a old
+    # a razão respeita o teto e a sessão nova (abandonada) não é convertida
+    assert f["sessions_completed_30d"] <= f["sessions_started_30d"]
+
+
+def test_checkout_funnel_conclusao_sem_abertura_nao_conta(panel_accounts):
+    """P1: conclusão cujo session_id nunca teve um 'started' (histórico órfão,
+    ou completed sem session_id) não infla o completed — só sessões abertas
+    entram no started, e completed é subconjunto delas."""
+    tag, uids = panel_accounts
+    client = _admin_client()
+
+    base = client.get("/admin/api/users").json()["checkout_funnel"]
+
+    # completed órfão (nenhum started com esse session_id)
+    _funnel_event(uids["free"], "completed", f"sess_orphan_{tag}")
+    # completed sem session_id
+    _funnel_event(uids["free"], "completed", None)
+
+    f = client.get("/admin/api/users").json()["checkout_funnel"]
+    # nenhuma sessão ABERTA nova → started e completed inalterados
+    assert f["sessions_started_30d"] == base["sessions_started_30d"]
+    assert f["sessions_completed_30d"] == base["sessions_completed_30d"]
+
+
+def test_checkout_funnel_imune_ao_purge_do_feed(panel_accounts):
+    """O funil vive em tabela própria (checkout_funnel_events), NÃO em
+    system_event_logs — então o 'Limpar' do feed não pode zerá-lo. Aqui isso
+    é estrutural (tabelas diferentes), mas o teste trava a garantia."""
+    tag, uids = panel_accounts
+    client = _admin_client()
+
+    _funnel_event(uids["paying"], "started", f"sess_P_{tag}")
+    _funnel_event(uids["paying"], "completed", f"sess_P_{tag}")
+    base = client.get("/admin/api/users").json()["checkout_funnel"]
+
+    # Apaga TUDO de system_event_logs
+    resp = client.request(
+        "DELETE", "/admin/api/events",
+        headers={dashboard.CSRF_HEADER_NAME: "test-admin-csrf"},
+    )
+    assert resp.status_code == 200
+
+    after = client.get("/admin/api/users").json()["checkout_funnel"]
+    assert after["sessions_started_30d"] == base["sessions_started_30d"]
+    assert after["sessions_completed_30d"] == base["sessions_completed_30d"]
 
 
 def test_users_list_aggregates_and_statuses(panel_accounts):

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -258,6 +258,36 @@ def test_users_endpoint_requires_admin_auth():
     assert response.status_code == 401
 
 
+def test_checkout_funnel_conta_pessoas_distintas(panel_accounts):
+    """checkout_funnel conta USUÁRIOS distintos: abrir 2x não vira 2 no
+    started; started conta quem abriu, completed quem concluiu."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+
+    def _log(uid, event_type):
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "insert into system_event_logs (level, event_type, message, source, user_id, details) "
+                    "values ('info', %s, 'x', 'billing', %s, '{}'::jsonb)",
+                    (event_type, uid),
+                )
+            conn.commit()
+
+    base = client.get("/admin/api/users").json()["checkout_funnel"]
+    b_started, b_completed = base["started_30d"], base["completed_30d"]
+
+    # 2 pessoas abrem o checkout; uma delas abre 2x (não deve inflar); 1 conclui
+    _log(uids["paying"], "billing_checkout_started")
+    _log(uids["paying"], "billing_checkout_started")  # 2ª abertura, mesmo user
+    _log(uids["trial"], "billing_checkout_started")
+    _log(uids["paying"], "billing_checkout_completed")
+
+    funnel = client.get("/admin/api/users").json()["checkout_funnel"]
+    assert funnel["started_30d"] == b_started + 2      # 2 pessoas, não 3 eventos
+    assert funnel["completed_30d"] == b_completed + 1
+
+
 def test_users_list_aggregates_and_statuses(panel_accounts):
     tag, uids = panel_accounts
     client = _admin_client()

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -258,34 +258,64 @@ def test_users_endpoint_requires_admin_auth():
     assert response.status_code == 401
 
 
+def _log_event(uid, event_type, *, days_ago=0):
+    from datetime import datetime, timedelta, timezone
+    ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "insert into system_event_logs (level, event_type, message, source, user_id, details, created_at) "
+                "values ('info', %s, 'x', 'billing', %s, '{}'::jsonb, %s)",
+                (event_type, uid, ts),
+            )
+        conn.commit()
+
+
 def test_checkout_funnel_conta_pessoas_distintas(panel_accounts):
     """checkout_funnel conta USUÁRIOS distintos: abrir 2x não vira 2 no
-    started; started conta quem abriu, completed quem concluiu."""
+    started; completed = quem abriu E concluiu na janela."""
     _tag, uids = panel_accounts
     client = _admin_client()
-
-    def _log(uid, event_type):
-        with get_conn() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "insert into system_event_logs (level, event_type, message, source, user_id, details) "
-                    "values ('info', %s, 'x', 'billing', %s, '{}'::jsonb)",
-                    (event_type, uid),
-                )
-            conn.commit()
 
     base = client.get("/admin/api/users").json()["checkout_funnel"]
     b_started, b_completed = base["started_30d"], base["completed_30d"]
 
     # 2 pessoas abrem o checkout; uma delas abre 2x (não deve inflar); 1 conclui
-    _log(uids["paying"], "billing_checkout_started")
-    _log(uids["paying"], "billing_checkout_started")  # 2ª abertura, mesmo user
-    _log(uids["trial"], "billing_checkout_started")
-    _log(uids["paying"], "billing_checkout_completed")
+    _log_event(uids["paying"], "billing_checkout_started")
+    _log_event(uids["paying"], "billing_checkout_started")  # 2ª abertura, mesmo user
+    _log_event(uids["trial"], "billing_checkout_started")
+    _log_event(uids["paying"], "billing_checkout_completed")
 
     funnel = client.get("/admin/api/users").json()["checkout_funnel"]
     assert funnel["started_30d"] == b_started + 2      # 2 pessoas, não 3 eventos
-    assert funnel["completed_30d"] == b_completed + 1
+    assert funnel["completed_30d"] == b_completed + 1  # só paying (abriu E fechou)
+
+
+def test_checkout_funnel_conversao_nunca_passa_de_100pct(panel_accounts):
+    """Guard do P1: conclusão SEM abertura na coorte (histórico anterior ao
+    recurso, ou início fora da janela) não entra no numerador — a conversão
+    fica sempre <= 100%."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+
+    base = client.get("/admin/api/users").json()["checkout_funnel"]
+
+    # Conclusão histórica sem started correspondente na janela (caso do deploy)
+    _log_event(uids["canceled"], "billing_checkout_completed")
+    # Abertura antiga (fora da janela de 30d) + conclusão recente: não é coorte
+    _log_event(uids["granted"], "billing_checkout_started", days_ago=40)
+    _log_event(uids["granted"], "billing_checkout_completed")
+    # Uma coorte legítima na janela
+    _log_event(uids["paying"], "billing_checkout_started")
+    _log_event(uids["paying"], "billing_checkout_completed")
+
+    funnel = client.get("/admin/api/users").json()["checkout_funnel"]
+    # started só ganhou o paying (o granted abriu fora da janela)
+    assert funnel["started_30d"] == base["started_30d"] + 1
+    # completed só ganhou o paying — as duas conclusões sem coorte não contam
+    assert funnel["completed_30d"] == base["completed_30d"] + 1
+    # E a razão respeita o teto
+    assert funnel["completed_30d"] <= funnel["started_30d"]
 
 
 def test_users_list_aggregates_and_statuses(panel_accounts):

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -41,6 +41,14 @@ def configured_admin(monkeypatch):
     monkeypatch.setattr(
         admin_dashboard, "_billing_summary_cache", {"fetched_at": None, "data": None}
     )
+    # /admin/auth/login tem rate limit de 10/min (slowapi, storage em memória
+    # compartilhado entre testes). Cada _admin_client() loga; num arquivo com
+    # muitos testes isso estoura o teto e derruba o último com 429. Zera o
+    # storage por teste — não afrouxa o limite em produção.
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:
+        pass
 
 
 def _admin_client() -> TestClient:
@@ -315,6 +323,27 @@ def test_checkout_funnel_conversao_nunca_passa_de_100pct(panel_accounts):
     # completed só ganhou o paying — as duas conclusões sem coorte não contam
     assert funnel["completed_30d"] == base["completed_30d"] + 1
     # E a razão respeita o teto
+    assert funnel["completed_30d"] <= funnel["started_30d"]
+
+
+def test_checkout_funnel_conclusao_precisa_vir_depois_da_abertura(panel_accounts):
+    """Guard do P2: ex-assinante que concluiu ANTES na janela e depois reabre
+    o checkout (e abandona) não é convertido — a conclusão velha não conta pra
+    coorte nova. Exige max(concluído) >= min(aberto)."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+
+    base = client.get("/admin/api/users").json()["checkout_funnel"]
+
+    # Ex-assinante: concluiu há 20d (compra antiga), reabre há 2d e abandona
+    # (sem conclusão posterior). Abriu na janela → conta no started; mas a
+    # única conclusão é ANTERIOR à reabertura → NÃO conta no completed.
+    _log_event(uids["canceled"], "billing_checkout_completed", days_ago=20)
+    _log_event(uids["canceled"], "billing_checkout_started", days_ago=2)
+
+    funnel = client.get("/admin/api/users").json()["checkout_funnel"]
+    assert funnel["started_30d"] == base["started_30d"] + 1
+    assert funnel["completed_30d"] == base["completed_30d"]  # conclusão velha não conta
     assert funnel["completed_30d"] <= funnel["started_30d"]
 
 

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -15,6 +15,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
+import pytest
 from cryptography.fernet import Fernet
 from fastapi.testclient import TestClient
 
@@ -25,6 +26,19 @@ import frontend.finance_bot_websocket_custom as dashboard
 
 
 _CSRF_TOKEN = "test-csrf-token-billing"
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """/billing/create-checkout tem rate limit de 20/hora (slowapi, storage em
+    memória compartilhado entre testes). Com muitos testes no arquivo, cada um
+    fazendo 1-2 POSTs, o teto estoura e o último cai com 429. Zera o storage
+    por teste — não afrouxa o limite em produção."""
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:
+        pass
+    yield
 
 
 def _auth_user_setup(suffix: str) -> tuple[int, str, TestClient]:
@@ -494,3 +508,35 @@ def test_checkout_falho_nao_grava_started(user_id, monkeypatch):
             )
             n = cur.fetchone()["n"]
     assert n == 0
+
+
+def test_checkout_reaproveitado_propaga_session_id_no_funil(user_id, monkeypatch):
+    """P2: quando o checkout REAPROVEITA uma sessão aberta, o 'started' precisa
+    carregar o session_id da sessão reusada — senão iria NULL e a conclusão
+    dessa sessão nunca correlacionaria no funil."""
+    from db import get_conn
+
+    uid, _, client = _auth_user_setup(f"reuse-funnel-{user_id}")
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+    fake = _patch_stripe(monkeypatch)
+
+    r1 = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    r2 = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    assert r1.status_code == 200 and r2.status_code == 200
+    # 2ª chamada reaproveitou a sessão da 1ª (não criou nova)
+    assert fake.session_create_calls == 1
+    assert r1.json()["checkout_url"] == r2.json()["checkout_url"]
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select session_id from checkout_funnel_events "
+                "where user_id = %s and kind = 'started' order by id",
+                (uid,),
+            )
+            sids = [row["session_id"] for row in cur.fetchall()]
+    # dois 'started' (criação + reuso), AMBOS com o mesmo session_id não-nulo
+    assert len(sids) == 2
+    assert all(s and s.startswith("cs_test_") for s in sids), sids
+    assert sids[0] == sids[1]

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -442,3 +442,56 @@ def test_checkout_novo_plano_expira_sessao_aberta_incompativel(user_id, monkeypa
     assert first.json()["checkout_url"] != second.json()["checkout_url"]
     assert fake.session_create_calls == 2
     assert fake.session_expire_calls == 1
+
+
+def test_checkout_loga_evento_started_no_funil(user_id, monkeypatch):
+    """Abrir o checkout com sucesso registra billing_checkout_started em
+    system_event_logs (par do billing_checkout_completed do webhook) — é o que
+    alimenta o funil de conversão no painel de admin."""
+    from db import get_conn
+
+    uid, _, client = _auth_user_setup(f"funnel-{user_id}")
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+    _patch_stripe(monkeypatch)
+
+    resp = client.post(
+        "/billing/create-checkout", json={"interval": "monthly"}, headers=_CSRF_HEADERS
+    )
+    assert resp.status_code == 200, resp.text
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select details from system_event_logs
+                where event_type = 'billing_checkout_started' and user_id = %s
+                order by created_at desc limit 1
+                """,
+                (uid,),
+            )
+            row = cur.fetchone()
+    assert row is not None, "evento billing_checkout_started não foi logado"
+    assert row["details"]["interval"] == "monthly"
+
+
+def test_checkout_falho_nao_loga_started(user_id, monkeypatch):
+    """Sessão que não nasce (Stripe não configurado) não polui o funil."""
+    from db import get_conn
+
+    uid, _, client = _auth_user_setup(f"nofunnel-{user_id}")
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "")  # 503: pagamentos off
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+
+    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    assert resp.status_code == 503
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select count(*) as n from system_event_logs "
+                "where event_type = 'billing_checkout_started' and user_id = %s",
+                (uid,),
+            )
+            n = cur.fetchone()["n"]
+    assert n == 0

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -444,10 +444,11 @@ def test_checkout_novo_plano_expira_sessao_aberta_incompativel(user_id, monkeypa
     assert fake.session_expire_calls == 1
 
 
-def test_checkout_loga_evento_started_no_funil(user_id, monkeypatch):
-    """Abrir o checkout com sucesso registra billing_checkout_started em
-    system_event_logs (par do billing_checkout_completed do webhook) — é o que
-    alimenta o funil de conversão no painel de admin."""
+def test_checkout_grava_started_no_funil_com_session_id(user_id, monkeypatch):
+    """Abrir o checkout com sucesso grava um 'started' na tabela dedicada
+    checkout_funnel_events, com o session_id do Stripe (o que permite
+    correlacionar com o 'completed' do webhook). O session_id NÃO vaza no
+    payload devolvido ao cliente."""
     from db import get_conn
 
     uid, _, client = _auth_user_setup(f"funnel-{user_id}")
@@ -459,23 +460,21 @@ def test_checkout_loga_evento_started_no_funil(user_id, monkeypatch):
         "/billing/create-checkout", json={"interval": "monthly"}, headers=_CSRF_HEADERS
     )
     assert resp.status_code == 200, resp.text
+    assert "session_id" not in resp.json(), "session_id não pode vazar pro cliente"
 
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
-                select details from system_event_logs
-                where event_type = 'billing_checkout_started' and user_id = %s
-                order by created_at desc limit 1
-                """,
+                "select session_id, kind from checkout_funnel_events "
+                "where user_id = %s and kind = 'started' order by id desc limit 1",
                 (uid,),
             )
             row = cur.fetchone()
-    assert row is not None, "evento billing_checkout_started não foi logado"
-    assert row["details"]["interval"] == "monthly"
+    assert row is not None, "'started' não foi gravado na tabela do funil"
+    assert row["session_id"] and row["session_id"].startswith("cs_test_")
 
 
-def test_checkout_falho_nao_loga_started(user_id, monkeypatch):
+def test_checkout_falho_nao_grava_started(user_id, monkeypatch):
     """Sessão que não nasce (Stripe não configurado) não polui o funil."""
     from db import get_conn
 
@@ -489,8 +488,8 @@ def test_checkout_falho_nao_loga_started(user_id, monkeypatch):
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "select count(*) as n from system_event_logs "
-                "where event_type = 'billing_checkout_started' and user_id = %s",
+                "select count(*) as n from checkout_funnel_events "
+                "where user_id = %s and kind = 'started'",
                 (uid,),
             )
             n = cur.fetchone()["n"]

--- a/tests/test_billing_webhook_lifecycle.py
+++ b/tests/test_billing_webhook_lifecycle.py
@@ -208,3 +208,37 @@ def test_assinatura_invalida_da_400(user_id, monkeypatch):
     r = client.post("/billing/webhook", content=b"{}",
                     headers={"stripe-signature": "bad"})
     assert r.status_code == 400
+
+
+def test_checkout_completed_grava_funil(user_id, monkeypatch):
+    """checkout.session.completed grava um 'completed' na tabela do funil, com
+    o session_id do evento — é o par do 'started' do endpoint, correlacionado
+    pelo mesmo id, que dá a conversão por sessão no painel."""
+    uid, client, fake = _setup(monkeypatch, f"funnel-{user_id}")
+    try:
+        r = _post(
+            client, fake,
+            {"type": "checkout.session.completed",
+             "data": {"object": {"id": "cs_test_funnel",
+                                  "metadata": {"finbot_user_id": str(uid)},
+                                  "subscription": "sub_fun"}}},
+            subs={"sub_fun": _fake_sub("trialing")},
+        )
+        assert r.status_code == 200, r.text
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "select session_id from checkout_funnel_events "
+                    "where user_id = %s and kind = 'completed' order by id desc limit 1",
+                    (uid,),
+                )
+                row = cur.fetchone()
+        assert row is not None, "'completed' não foi gravado no funil"
+        assert row["session_id"] == "cs_test_funnel"
+    finally:
+        _cleanup_trial(uid)
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("delete from checkout_funnel_events where user_id = %s", (uid,))
+            conn.commit()


### PR DESCRIPTION
## Por quê

Investigando o excesso de Free no painel (#61), você perguntou quantas pessoas passam pelo checkout. Hoje só registramos `billing_checkout_completed` (no webhook, só quem concluiu), então não dá pra calcular conversão. Este é o **item #1** da conversa sobre a corrida do 402: **medição pura, desacoplada do redesenho do fluxo de pagamento** (item #2, que ficou pra um PR próprio com plano escrito).

## O que muda

- **Loga `billing_checkout_started`** em `/billing/create-checkout`, logo após a sessão Stripe nascer de fato (sessão que falhou / 503 não conta). É o par do `billing_checkout_completed` que o webhook já registra.
- **Dois chips no painel de usuários**: "Checkout 30d" (pessoas distintas que abriram) e "Conversão 30d" (concluíram / abriram, %).
- Contagem por **usuário distinto**, não por evento: abrir o checkout 2x não infla o funil.

## Decisões

- **Só telemetria** — não toca no fluxo de pagamento nem no gate. Zero risco pro caminho sensível.
- **Sem backfill**: `started_30d` começa em 0 e acumula a partir do deploy (o evento passa a existir agora). Enquanto `started=0`, o chip de conversão mostra "—" em vez de dividir por zero.
- `user_id NULL` (evento sem conta) é ignorado no distinct.

## Verificação

- **1077 passed, 0 failed** na suíte completa local contra Postgres real (baseline #61: 1074; 3 testes novos).
- Testes: evento logado no checkout com sucesso e com o `interval` certo; sessão falha (503) **não** loga; agregado conta pessoas distintas (2 aberturas do mesmo user contam como 1).
- UI exercitada no navegador (banco de teste com 5 aberturas / 2 conclusões): endpoint retorna `started_30d:5, completed_30d:2`; chips renderizam "5 Checkout 30d" e "40% Conversão 30d"; screenshot conferido; console sem erros novos.

## Depende de

Baseado na `main` (tem #61). Independente do #62 (origem do cadastro) — tocam pontos diferentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)