### PR TITLE
ci: reduz consumo de minutos do Actions (sem run duplicado + cache)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,18 @@
 name: Tests
 
+# push só na main (pega merge/commit direto); o trabalho de branch é coberto
+# pelo pull_request. Antes, `push` + `pull_request` sem filtro rodava o CI DUAS
+# vezes a cada push numa branch com PR aberto — dobrava o consumo de minutos.
 on:
   push:
+    branches: [main]
   pull_request:
+
+# Cancela runs anteriores do mesmo ref quando um novo push chega — vários
+# commits seguidos numa branch deixam de acumular runs paralelos até o fim.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pytest:
@@ -35,6 +45,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install dependencies
         run: |
@@ -66,6 +78,8 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: pip-audit (informativo, nao bloqueia)
         run: |


### PR DESCRIPTION
## Por quê

O repo é privado (cota mensal de minutos do GitHub Actions). O workflow atual gasta o dobro do necessário: `on: push` **e** `on: pull_request` sem filtro faz **todo push numa branch com PR aberto rodar o CI duas vezes** — uma pelo evento `push`, outra pelo `pull_request`.

## O que muda em `.github/workflows/tests.yml`

- **`push` só na `main`** (`branches: [main]`) — pega merge/commit direto na main; o trabalho de branch continua coberto pelo `pull_request`. Fim do run duplicado.
- **`concurrency` com `cancel-in-progress`** — vários commits seguidos numa branch cancelam o run anterior em vez de acumular runs paralelos até o fim.
- **`cache: pip`** no `setup-python` (ambos os jobs) — o install fica mais rápido, menos minutos por run.

## Sem perda de sinal

Todo PR continua rodando **pytest** (bloqueante) + **audit** (informativo); a main roda no push pós-merge. A única mudança de cobertura é não rodar mais em push de branch **sem** PR — cenário sem valor de revisão.

## Estimativa

Só o fim do run duplicado já corta ~metade dos minutos em fluxo de PR; o cancel-in-progress e o cache de pip reduzem o resto.

## Verificação

- YAML validado (`yaml.safe_load`).
- Não altera a lógica dos testes — o job `pytest` roda exatamente o mesmo `PYTHONPATH=. pytest -q` com o mesmo Postgres 16.
- **Não verificável no CI agora**: o Actions da conta está bloqueado por cobrança (os jobs não iniciam até regularizar Billing & plans). Este PR é justamente para reduzir esse consumo daqui pra frente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)