### PR TITLE
feat(landing): preview de redesign da landing (index-redesign)

### DIFF
--- a/frontend/index-redesign.html
+++ b/frontend/index-redesign.html
@@ -1,0 +1,542 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PigBank — Seu assistente financeiro no WhatsApp</title>
+<meta name="description" content="Controle seu dinheiro direto no WhatsApp. Registre gastos, consulte saldo e acompanhe cartões em segundos com a IA da PigBank." />
+<link rel="icon" type="image/png" href="/favicon.png?v=3" />
+<link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
+<meta name="theme-color" content="#0c0c0d" />
+<meta property="og:type" content="website" />
+<script>
+/* PWA instalada (start_url antiga "/"): entra pelo app, não pela landing —
+   /login pula direto pro /home quando a sessão está viva.
+   Exceção: ?site=1 é o usuário PEDINDO o site pelo menu da conta ("Ir para o
+   site"). Sem essa saída, o atalho virava um pulo de volta pro /home. */
+if (!/[?&]site=1(&|$)/.test(location.search) &&
+    ((window.matchMedia && matchMedia("(display-mode: standalone)").matches) || navigator.standalone === true)) {
+  location.replace("/login");
+}
+</script>
+<link rel="stylesheet" href="/brand.css?v=4" />
+<link rel="stylesheet" href="/phosphor.css?v=1" />
+<link rel="stylesheet" href="/site.css?v=5" />
+<link rel="stylesheet" href="/site-redesign.css?v=1" />
+<style>
+  /* Planos: card único de entrada (R$ 9,90) — leva pra /precos escolher ciclo */
+  .plan-solo-wrap { display: flex; justify-content: center; padding: 10px 0 30px; }
+  .plan-solo {
+    position: relative; width: 100%; max-width: 480px;
+    background: linear-gradient(180deg, rgba(255,45,142,.12), var(--card));
+    border: 1px solid rgba(255,45,142,.4);
+    border-radius: var(--radius);
+    box-shadow: 0 24px 60px rgba(255,45,142,.16);
+    padding: 40px 34px 34px; text-align: center;
+    display: flex; flex-direction: column; align-items: center;
+  }
+  .plan-solo-trial {
+    background: var(--neon); color: var(--neon-ink);
+    font-size: .62rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase;
+    padding: 5px 12px; border-radius: 999px; margin-bottom: 14px;
+  }
+  .plan-solo-from { color: var(--ink-2); font-size: 1rem; font-weight: 600; }
+  .plan-solo-amount { font-size: 3.2rem; font-weight: 850; letter-spacing: -.03em; line-height: 1.05; margin: 4px 0 2px; }
+  .plan-solo-amount span { font-size: 1.05rem; color: var(--ink-2); font-weight: 600; }
+  .plan-solo-feats { list-style: none; display: grid; gap: 11px; margin: 22px 0 24px; text-align: left; width: 100%; max-width: 330px; }
+  .plan-solo-feats li { display: flex; align-items: flex-start; gap: 10px; color: var(--ink-2); font-size: .9rem; line-height: 1.4; }
+  .plan-solo-feats li .tick { width: 20px; height: 20px; font-size: .7rem; margin-top: 1px; }
+  .plan-solo .btn-block { width: 100%; max-width: 330px; }
+  .plan-solo-choose { color: var(--ink-3); font-size: .82rem; margin-top: 14px; }
+  .plan-solo-choose b { color: var(--ink-2); font-weight: 700; }
+  @media (max-width: 560px) {
+    .plan-solo { padding: 32px 22px 26px; }
+    .plan-solo-amount { font-size: 2.6rem; }
+  }
+</style>
+<script src="/safe-area.js?v=1"></script>
+</head>
+<body class="rd">
+<div class="glow"></div>
+<div class="rd-grain" aria-hidden="true"></div>
+
+  <!-- ─── Nav ─────────────────────────────────────────────────────── -->
+  <nav class="nav">
+    <a class="nav-logo" href="/"><img class="logo-full" src="/brand/logo.png?v=1" alt="PigBank" /></a>
+    <div class="nav-links">
+      <a href="#funcionalidades">Funcionalidades</a>
+      <a href="#como-funciona">Como funciona</a>
+      <a href="/precos">Planos</a>
+      <a href="/whatsapp">WhatsApp</a>
+      <a href="/agents">Agentes</a>
+      
+    </div>
+    <div class="nav-right">
+      <a class="link-entrar" href="/login">Entrar</a>
+      <a class="btn btn-primary" href="/cadastro">Começar agora</a>
+    </div>
+  </nav>
+
+  <div class="wrap">
+
+    <!-- ─── Hero ──────────────────────────────────────────────────── -->
+    <section class="hero-grid">
+      <div class="hero-copy">
+        <div class="pill"><span class="tag-novo">NOVO</span> Seu assistente financeiro com IA no WhatsApp</div>
+        <h1 class="hero-title">A sua vida financeira,<br><span class="grad">resolvida no WhatsApp.</span></h1>
+        <p class="hero-sub">Registre gastos, acompanhe seu saldo e entenda sua vida financeira conversando com a IA da PigBank — sem planilha, sem app pra baixar.</p>
+        <div class="hero-cta">
+          <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
+          <a class="btn btn-outline btn-lg" href="#como-funciona">Ver como funciona</a>
+        </div>
+        <div class="trust">
+          <span><i class="dot"></i> Seguro e confiável</span>
+          <span><i class="dot"></i> Rápido e prático</span>
+          <span><i class="dot"></i> Privacidade garantida</span>
+        </div>
+      </div>
+
+      <!-- Visual: chat + resumo + mascote -->
+      <div class="hero-visual">
+        <img class="hero-mascot" src="/brand/mascot.webp" alt="Piggy" />
+
+        <div class="chat-card">
+          <div class="chat-head">
+            <img src="/brand/icon.png?v=1" alt="" /> <strong>PigBank</strong>
+            <span class="online"><i></i> online</span>
+          </div>
+          <div class="bubble user">Gastei R$ 50 no mercado</div>
+          <div class="bubble bot">
+            Entendi!<br>
+            Categoria: <b>Alimentação</b><br>
+            Total hoje: <b>R$ 50,00</b><br>
+            Saldo atual: <b>R$ 1.250,00</b><br>
+            Ótimo controle!
+          </div>
+        </div>
+
+        <div class="summary-card">
+          <div class="sum-head">
+            <span>Resumo do mês</span>
+            <span class="delta-up">+12% <small>vs mês passado</small></span>
+          </div>
+          <div class="sum-balance">Saldo atual<b>R$ 3.420,50</b></div>
+          <div class="sum-body">
+            <div class="donut-wrap">
+              <svg viewBox="0 0 100 100" width="112" height="112" aria-hidden="true">
+                <g transform="rotate(-90 50 50)" fill="none" stroke-width="15">
+                  <circle cx="50" cy="50" r="42" stroke="#FF2D8E" stroke-dasharray="109 155" stroke-dashoffset="0"></circle>
+                  <circle cx="50" cy="50" r="42" stroke="#2E7FE0" stroke-dasharray="64 200" stroke-dashoffset="-111"></circle>
+                  <circle cx="50" cy="50" r="42" stroke="#C6F11A" stroke-dasharray="40 224" stroke-dashoffset="-177"></circle>
+                  <circle cx="50" cy="50" r="42" stroke="#5a5a62" stroke-dasharray="43 221" stroke-dashoffset="-219"></circle>
+                </g>
+              </svg>
+            </div>
+            <ul class="donut-legend">
+              <li><i style="background:#FF2D8E"></i>Alimentação <b>42%</b></li>
+              <li><i style="background:#2E7FE0"></i>Transporte <b>25%</b></li>
+              <li><i style="background:#C6F11A"></i>Lazer <b>16%</b></li>
+              <li><i style="background:#5a5a62"></i>Outros <b>17%</b></li>
+            </ul>
+          </div>
+          <div class="sum-chart">
+            <svg viewBox="0 0 260 70" preserveAspectRatio="none" width="100%" height="64" aria-hidden="true">
+              <defs><linearGradient id="lg" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0" stop-color="rgba(255,45,142,.35)"/><stop offset="1" stop-color="rgba(255,45,142,0)"/>
+              </linearGradient></defs>
+              <path d="M0,54 L40,48 L80,50 L120,38 L160,40 L200,24 L260,14 L260,70 L0,70 Z" fill="url(#lg)"/>
+              <path d="M0,54 L40,48 L80,50 L120,38 L160,40 L200,24 L260,14" fill="none" stroke="#FF2D8E" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="chart-badge">+18%</span>
+            <div class="chart-months"><span>Jan</span><span>Fev</span><span>Mar</span><span>Abr</span><span>Mai</span><span>Jun</span><span>Jul</span></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── Faixa de valor ────────────────────────────────────────── -->
+    <div class="value-strip" data-reveal>
+      <span class="value-chip"><i></i> Sem planilha</span>
+      <span class="value-chip"><i></i> Sem app pra baixar</span>
+      <span class="value-chip"><i></i> Registra em segundos</span>
+      <span class="value-chip"><i></i> Dados cifrados</span>
+      <span class="value-chip"><i></i> Cancela quando quiser</span>
+    </div>
+
+    <!-- ─── Funcionalidades ───────────────────────────────────────── -->
+    <section class="section" id="funcionalidades">
+      <div class="section-head" data-reveal>
+        <div class="eyebrow">Funcionalidades</div>
+        <h2>Recursos que fazem<br>a <span class="grad">diferença</span></h2>
+        <p>Tudo que você precisa pra organizar sua vida financeira — sem planilha, sem app pra baixar, direto no WhatsApp.</p>
+      </div>
+
+      <div class="grid-3" data-reveal>
+        <div class="card feature-card">
+          <div class="icon-box"><i class="ph ph-chat-circle" aria-hidden="true"></i></div>
+          <h3>Registro por conversa</h3>
+          <p>Fale como você fala. A IA entende, categoriza e registra o gasto na hora — em segundos.</p>
+        </div>
+        <div class="card feature-card">
+          <div class="icon-box neon"><i class="ph ph-tag" aria-hidden="true"></i></div>
+          <h3>Categorização automática</h3>
+          <p>Cada gasto cai na categoria certa sozinho. Você não precisa marcar nada manualmente.</p>
+        </div>
+        <div class="card feature-card">
+          <div class="icon-box"><i class="ph ph-piggy-bank" aria-hidden="true"></i></div>
+          <h3>Caixinhas &amp; metas</h3>
+          <p>Separe dinheiro por objetivo e acompanhe o progresso de cada meta que você criar.</p>
+        </div>
+        <div class="card feature-card">
+          <div class="icon-box neon"><i class="ph ph-credit-card" aria-hidden="true"></i></div>
+          <h3>Cartões &amp; faturas</h3>
+          <p>Limite, fatura aberta e parcelamentos de todos os seus cartões num lugar só.</p>
+        </div>
+        <div class="card feature-card">
+          <div class="icon-box"><i class="ph ph-bell" aria-hidden="true"></i></div>
+          <h3>Alertas inteligentes</h3>
+          <p>A Piggy te avisa quando um gasto foge do padrão ou o orçamento começa a apertar.</p>
+        </div>
+        <div class="card feature-card">
+          <div class="icon-box neon"><i class="ph ph-lock" aria-hidden="true"></i></div>
+          <h3>Segurança &amp; privacidade</h3>
+          <p>Seus dados sensíveis são cifrados. Você fica no controle das suas informações, sempre.</p>
+        </div>
+      </div>
+    </section>
+
+    <div class="sec-sep"></div>
+
+    <!-- ─── Como funciona ─────────────────────────────────────────── -->
+    <section class="section" id="como-funciona">
+      <div class="section-head" data-reveal>
+        <div class="eyebrow">Como funciona</div>
+        <h2>Simples, rápido e<br>no seu <span class="grad">WhatsApp</span></h2>
+        <p>Em poucos minutos você já está no controle do seu dinheiro — sem planilha, sem app pra baixar.</p>
+      </div>
+
+      <div class="how-grid">
+        <div class="steps" data-reveal>
+          <div class="step">
+            <div class="step-num">1</div>
+            <div><h3>Crie sua conta</h3><p>Grátis e em segundos, entrando com o Google. Sem cadastro chato.</p></div>
+          </div>
+          <div class="step">
+            <div class="step-num">2</div>
+            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece — nada pra instalar.</p></div>
+          </div>
+          <div class="step">
+            <div class="step-num">3</div>
+            <div><h3>Registre falando</h3><p>"Gastei R$ 50 no mercado" e pronto: a IA entende, categoriza e salva na hora.</p></div>
+          </div>
+          <div class="step">
+            <div class="step-num">4</div>
+            <div><h3>Acompanhe tudo</h3><p>Saldo, gastos, caixinhas e metas no dashboard, atualizados em tempo real.</p></div>
+          </div>
+        </div>
+
+        <div class="phone" data-reveal>
+          <div class="phone-notch"></div>
+          <div class="chat-head">
+            <img src="/brand/icon.png?v=1" alt="" /> <strong>PigBank</strong>
+            <span class="online"><i></i> online</span>
+          </div>
+          <div class="bubble user">Gastei 32 no uber</div>
+          <div class="bubble bot">Anotado!<br>Categoria: <b>Transporte</b><br>Saldo atual: <b>R$ 1.218,00</b></div>
+          <div class="bubble user">quanto sobrou esse mês?</div>
+          <div class="bubble bot">Você tem <b>R$ 1.218,00</b><br>Já guardou <b>R$ 300</b> na caixinha "Viagem". Bora?</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── IA / Tecnologia ───────────────────────────────────────── -->
+    <section class="tech-split">
+      <div class="tech-copy" data-reveal>
+        <div class="eyebrow">Tecnologia</div>
+        <h2>A inteligência que<br><span class="grad">facilita sua vida</span></h2>
+        <ul class="tech-list">
+          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> IA que entende português do dia a dia</li>
+          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização que aprende com você</li>
+          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard atualizado em tempo real</li>
+          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp — zero apps pra baixar</li>
+        </ul>
+        <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
+      </div>
+      <div class="tech-visual" data-reveal>
+        <div class="hologram" aria-label="Cubo AI holográfico em wireframe">
+          <div class="floating">
+            <svg viewBox="0 0 800 800" role="img" aria-labelledby="holoTitle holoDesc">
+              <title id="holoTitle">Cubo AI holográfico com texto em relevo</title>
+              <desc id="holoDesc">Cubo isométrico em wireframe rosa neon, com letras AI em perspectiva e extrusão tridimensional sobre a face superior.</desc>
+
+              <defs>
+                <linearGradient id="edgeGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stop-color="#ff2d75" /><stop offset="52%" stop-color="#ec1758" /><stop offset="100%" stop-color="#b10c42" />
+                </linearGradient>
+                <linearGradient id="hotGradient" x1="0" y1="0" x2="1" y2="1">
+                  <stop offset="0%" stop-color="#ff86b1" /><stop offset="28%" stop-color="#ff2d75" /><stop offset="100%" stop-color="#ec1758" />
+                </linearGradient>
+                <linearGradient id="aiGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stop-color="#ff79aa" /><stop offset="38%" stop-color="#ff2d75" /><stop offset="100%" stop-color="#e31455" />
+                </linearGradient>
+                <filter id="neonGlow" x="-100%" y="-100%" width="300%" height="300%">
+                  <feGaussianBlur stdDeviation="3.5" result="a" /><feGaussianBlur stdDeviation="8.5" result="b" />
+                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
+                </filter>
+                <filter id="softGlow" x="-100%" y="-100%" width="300%" height="300%">
+                  <feGaussianBlur stdDeviation="2.5" result="a" /><feMerge><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
+                </filter>
+                <filter id="nodeGlow" x="-200%" y="-200%" width="500%" height="500%">
+                  <feGaussianBlur stdDeviation="4" result="a" /><feGaussianBlur stdDeviation="8" result="b" />
+                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
+                </filter>
+                <filter id="textGlow" x="-100%" y="-100%" width="300%" height="300%">
+                  <feGaussianBlur stdDeviation="4" result="a" /><feGaussianBlur stdDeviation="12" result="b" />
+                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
+                </filter>
+                <filter id="particleGlow" x="-250%" y="-250%" width="600%" height="600%">
+                  <feGaussianBlur stdDeviation="2.2" result="a" /><feMerge><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
+                </filter>
+                <clipPath id="topClip"><polygon points="400,148 648,292 400,436 152,292" /></clipPath>
+              </defs>
+
+              <g aria-hidden="true">
+                <path class="circuit" d="M66 332 H165 L212 379 H276" /><path class="circuit" d="M70 546 H170 L222 494 H282" />
+                <path class="circuit" d="M734 332 H635 L588 379 H524" /><path class="circuit" d="M730 546 H630 L578 494 H518" />
+                <path class="circuit" d="M400 58 V118 L366 152" /><path class="circuit" d="M400 744 V684 L435 649" />
+                <path class="circuit" d="M116 228 H186 L221 263" /><path class="circuit" d="M684 228 H614 L579 263" />
+                <path class="circuit" d="M95 642 H176 L226 592" /><path class="circuit" d="M705 642 H624 L574 592" />
+                <circle class="circuit-dot" cx="66" cy="332" r="2.2"/><circle class="circuit-dot" cx="70" cy="546" r="2.2"/>
+                <circle class="circuit-dot" cx="734" cy="332" r="2.2"/><circle class="circuit-dot" cx="730" cy="546" r="2.2"/>
+                <circle class="circuit-dot" cx="400" cy="58" r="2.2"/><circle class="circuit-dot" cx="400" cy="744" r="2.2"/>
+              </g>
+
+              <g aria-hidden="true">
+                <circle class="particle" cx="126" cy="275" r="2.2" style="--duration:5.4s;--delay:-1.1s"/>
+                <circle class="particle soft" cx="174" cy="421" r="1.7" style="--duration:6.2s;--delay:-3.5s"/>
+                <circle class="particle dim" cx="124" cy="554" r="2.8" style="--duration:7s;--delay:-2.4s"/>
+                <circle class="particle" cx="235" cy="655" r="1.9" style="--duration:5s;--delay:-.8s"/>
+                <circle class="particle soft" cx="340" cy="706" r="2.2" style="--duration:5.8s;--delay:-4.1s"/>
+                <circle class="particle dim" cx="478" cy="691" r="2.5" style="--duration:6.8s;--delay:-1.8s"/>
+                <circle class="particle soft" cx="588" cy="626" r="1.8" style="--duration:5.1s;--delay:-2.3s"/>
+                <circle class="particle" cx="684" cy="518" r="2.5" style="--duration:6.4s;--delay:-4.7s"/>
+                <circle class="particle dim" cx="692" cy="363" r="2.7" style="--duration:7.2s;--delay:-3s"/>
+                <circle class="particle" cx="637" cy="218" r="1.8" style="--duration:5.7s;--delay:-1.5s"/>
+                <circle class="particle soft" cx="530" cy="115" r="2.2" style="--duration:6.5s;--delay:-4.4s"/>
+                <circle class="particle dim" cx="365" cy="82" r="2.5" style="--duration:7.3s;--delay:-2.9s"/>
+                <circle class="particle soft" cx="247" cy="125" r="1.8" style="--duration:5.3s;--delay:-.5s"/>
+              </g>
+
+              <g class="cube">
+                <g class="face-grid top-grid">
+                  <path d="M214 256 L462 400"/><path d="M276 220 L524 364"/><path d="M338 184 L586 328"/>
+                  <path d="M586 256 L338 400"/><path d="M524 220 L276 364"/><path d="M462 184 L214 328"/>
+                </g>
+                <g class="face-grid">
+                  <path d="M214 328 L400 436 L400 690"/><path d="M276 364 L400 436"/><path d="M338 400 L400 436"/>
+                  <path d="M152 356 L400 500"/><path d="M152 420 L400 564"/><path d="M152 484 L400 628"/>
+                  <path d="M586 328 L400 436 L400 690"/><path d="M524 364 L400 436"/><path d="M462 400 L400 436"/>
+                  <path d="M648 356 L400 500"/><path d="M648 420 L400 564"/><path d="M648 484 L400 628"/>
+                </g>
+
+                <path class="inner" d="M400 148 L400 436 L400 690"/>
+                <path class="inner" d="M152 292 L400 436 L648 292"/>
+                <path class="inner" d="M152 548 L400 436 L648 548"/>
+                <path class="inner" d="M276 364 L276 620"/><path class="inner" d="M524 364 L524 620"/>
+
+                <path class="edge back" d="M400 148 L152 292"/><path class="edge back" d="M400 148 L648 292"/><path class="edge back" d="M400 148 L400 436"/>
+                <path class="edge strong" d="M400 148 L648 292 L400 436 L152 292 Z"/>
+                <path class="edge" d="M152 292 L400 436 L400 690 L152 548 Z"/>
+                <path class="edge strong" d="M648 292 L400 436 L400 690 L648 548 Z"/>
+                <path class="edge" d="M152 548 L400 690 L648 548"/>
+                <path class="edge" d="M152 292 L152 548"/><path class="edge strong" d="M400 436 L400 690"/><path class="edge strong" d="M648 292 L648 548"/>
+
+                <g clip-path="url(#topClip)" aria-label="AI">
+                  <g transform="translate(0 18)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-deep" x="-36" y="0">A</text><text class="ai-text ai-depth-deep" x="36" y="0">I</text></g></g>
+                  <g transform="translate(0 12)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-mid" x="-36" y="0">A</text><text class="ai-text ai-depth-mid" x="36" y="0">I</text></g></g>
+                  <g transform="translate(0 6)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-mid" x="-36" y="0">A</text><text class="ai-text ai-depth-mid" x="36" y="0">I</text></g></g>
+                  <g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-letter-top" x="-36" y="0">A</text><text class="ai-text ai-letter-top" x="36" y="0">I</text></g>
+                </g>
+
+                <path class="scan" d="M232 363 L400 460 L568 363"/>
+
+                <circle class="node" cx="400" cy="148" r="4.2"/><circle class="node" cx="152" cy="292" r="4.2"/><circle class="node" cx="648" cy="292" r="4.2"/>
+                <circle class="node" cx="400" cy="436" r="4.8"/><circle class="node" cx="152" cy="548" r="4.1"/><circle class="node" cx="648" cy="548" r="4.1"/>
+                <circle class="node" cx="400" cy="690" r="4.8"/>
+                <circle class="node small" cx="276" cy="220" r="2.2"/><circle class="node small" cx="524" cy="220" r="2.2"/>
+                <circle class="node small" cx="276" cy="364" r="2.2"/><circle class="node small" cx="524" cy="364" r="2.2"/>
+                <circle class="node small" cx="152" cy="420" r="2.1"/><circle class="node small" cx="648" cy="420" r="2.1"/>
+                <circle class="node small" cx="400" cy="564" r="2.3"/><circle class="node small" cx="276" cy="620" r="2.1"/><circle class="node small" cx="524" cy="620" r="2.1"/>
+
+                <circle class="particle" cx="330" cy="340" r="1.8" style="--duration:4.7s;--delay:-1.1s"/>
+                <circle class="particle soft" cx="474" cy="350" r="2" style="--duration:5.7s;--delay:-3.4s"/>
+                <circle class="particle dim" cx="316" cy="468" r="2.3" style="--duration:6.5s;--delay:-2.1s"/>
+                <circle class="particle" cx="484" cy="494" r="1.7" style="--duration:5.1s;--delay:-4.1s"/>
+                <circle class="particle soft" cx="365" cy="575" r="2" style="--duration:6s;--delay:-.9s"/>
+                <circle class="particle" cx="442" cy="610" r="1.8" style="--duration:4.8s;--delay:-2.8s"/>
+              </g>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="sec-sep"></div>
+
+    <!-- ─── Preços ────────────────────────────────────────────────── -->
+    <section class="section" id="precos">
+      <div class="section-head" data-reveal>
+        <div class="eyebrow">Planos</div>
+        <h2>Escolha seu <span class="grad">PigBank+</span></h2>
+        <p>30 dias grátis pra testar. Cancele quando quiser, sem letras miúdas.</p>
+      </div>
+
+      <div class="plan-solo-wrap" data-reveal>
+        <article class="plan-solo">
+          <span class="plan-solo-trial">30 dias grátis</span>
+          <div class="plan-solo-from">Acesse o PigBank por apenas</div>
+          <div class="plan-solo-amount">R$ 9,90<span>/mês</span></div>
+          <ul class="plan-solo-feats">
+            <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Caixinhas, metas e cartões ilimitados</li>
+            <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização automática por IA</li>
+            <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard em tempo real</li>
+            <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA — converse sobre suas finanças</li>
+          </ul>
+          <a class="btn btn-primary btn-lg btn-block" href="/precos">Ver planos <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
+          <p class="plan-solo-choose">Escolha <b>mensal</b> ou <b>anual</b> na próxima tela.</p>
+        </article>
+      </div>
+
+      <p class="plans-note"><i class="ph ph-confetti" aria-hidden="true"></i> 30 dias grátis com cartão; a primeira cobrança só acontece depois do trial. Cancele quando quiser pelo dashboard antes do fim do trial, sem ser cobrado. Pagamentos processados pela Stripe — a PigBank nunca vê os dados do seu cartão.</p>
+    </section>
+
+    <div class="sec-sep"></div>
+
+    <!-- ─── FAQ ───────────────────────────────────────────────────── -->
+    <section class="section" id="faq">
+      <div class="section-head" data-reveal>
+        <div class="eyebrow">Dúvidas</div>
+        <h2>Perguntas <span class="grad">frequentes</span></h2>
+        <p>O que a galera mais quer saber antes de começar com a Piggy.</p>
+      </div>
+
+      <div class="faq" data-reveal>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">Preciso baixar algum aplicativo? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Não. Tudo acontece no seu WhatsApp — é só conversar com a Piggy. O dashboard abre no navegador, sem instalar nada.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">Como eu registro um gasto? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Você só fala como falaria com um amigo: "gastei 50 no mercado". A IA entende, categoriza e salva na hora — em segundos.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">Meus dados estão seguros? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Sim. Seus dados sensíveis são cifrados e você fica no controle das suas informações, sempre. Nada é vendido nem compartilhado.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">A PigBank mexe no meu dinheiro ou tem a senha do meu banco? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Não. A PigBank não é banco nem corretora — <strong>nunca movimenta, transfere ou guarda</strong> o seu dinheiro. Se você conectar um banco, é via Open Finance oficial, <strong>só de leitura</strong> e autorizado por você: a gente nunca pede sua senha, e você revoga o acesso quando quiser.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">Tem período grátis? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Tem 30 dias grátis pra testar tudo. A primeira cobrança só acontece depois do trial, e você pode cancelar antes sem pagar nada.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">Como funciona o pagamento? <span class="chev">+</span></button>
+          <div class="faq-a"><p>O pagamento é processado <strong>100% pela Stripe</strong>, a mesma usada por gigantes do mundo todo. A PigBank <strong>nunca vê nem armazena os dados do seu cartão</strong>.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">Posso cancelar quando quiser? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Pode, pelo próprio dashboard, sem letra miúda e sem falar com ninguém. Cancelou, não é mais cobrado.</p></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" type="button" aria-expanded="false">A Piggy entende português do dia a dia? <span class="chev">+</span></button>
+          <div class="faq-a"><p>Entende. Você não precisa decorar comando nenhum — fala do seu jeito e a IA faz o resto.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ─── CTA final ─────────────────────────────────────────────── -->
+    <div class="cta-band" data-reveal>
+      <h2>Pronto para começar?</h2>
+      <p>Sua vida financeira resolvida no WhatsApp, a partir de agora.</p>
+      <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
+    </div>
+
+  </div>
+
+  <!-- ─── Footer ──────────────────────────────────────────────────── -->
+  <footer class="footer">
+    <div class="wrap footer-inner">
+      <div class="footer-brand">
+        <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
+        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+      </div>
+      <div class="footer-cols">
+        <div class="footer-col"><span class="footer-title">Navegue</span>
+          <a href="#funcionalidades">Funcionalidades</a>
+          <a href="#como-funciona">Como funciona</a>
+          <a href="/precos">Planos</a>
+          <a href="/agents">Agentes</a>
+          
+        </div>
+        <div class="footer-col"><span class="footer-title">Produto</span>
+          <a href="/whatsapp">WhatsApp</a>
+          <a href="/comandos">O que pedir</a>
+          <a href="/suporte">Suporte</a>
+        </div>
+        <div class="footer-col"><span class="footer-title">Institucional</span>
+          <a href="/termos">Termos de Uso</a>
+          <a href="/privacy">Privacidade</a>
+          <a href="mailto:contato@pigbankai.com">Contato</a>
+        </div>
+      </div>
+    </div>
+    <p class="footer-copy">© 2026 PigBank · Feito com <i class="ph ph-piggy-bank" aria-hidden="true"></i></p>
+  </footer>
+
+  <!-- Reveal on scroll + FAQ acordeão (progressive enhancement) -->
+  <script>
+  (function () {
+    // FAQ acordeão
+    document.querySelectorAll(".faq-q").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var item = btn.closest(".faq-item");
+        var a = item.querySelector(".faq-a");
+        var open = item.classList.toggle("open");
+        a.style.maxHeight = open ? a.scrollHeight + "px" : "0";
+        btn.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+    });
+
+    // Reveal on scroll — só ativa se houver suporte e sem reduced-motion.
+    var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    var els = document.querySelectorAll("[data-reveal]");
+    if (!("IntersectionObserver" in window) || reduce) return;  // sem JS/observer: conteúdo já visível
+    els.forEach(function (el) { el.classList.add("reveal"); });
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add("in"); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.12, rootMargin: "0px 0px -8% 0px" });
+    els.forEach(function (el) { io.observe(el); });
+  })();
+  </script>
+  <!-- Redesign preview: borda-holofote que segue o cursor nos cards -->
+  <script>
+  (function () {
+    var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) return;
+    var cards = document.querySelectorAll(".rd .card, .rd .plan-solo, .rd .phone, .rd .step");
+    cards.forEach(function (c) {
+      c.addEventListener("pointermove", function (e) {
+        var r = c.getBoundingClientRect();
+        c.style.setProperty("--mx", (e.clientX - r.left) + "px");
+        c.style.setProperty("--my", (e.clientY - r.top) + "px");
+      });
+    });
+  })();
+  </script>
+  <script src="/nav-auth.js?v=7" defer></script>
+</body>
+</html>

--- a/frontend/index-redesign.html
+++ b/frontend/index-redesign.html
@@ -3,6 +3,8 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<!-- Preview de redesign: não indexar (evita competir com / e vazar página de avaliação) -->
+<meta name="robots" content="noindex, nofollow" />
 <title>PigBank — Seu assistente financeiro no WhatsApp</title>
 <meta name="description" content="Controle seu dinheiro direto no WhatsApp. Registre gastos, consulte saldo e acompanhe cartões em segundos com a IA da PigBank." />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -37,6 +37,14 @@ async def serve_landing():
     return html_file(FRONTEND_DIR / "index.html")
 
 
+@router.get("/index-redesign.html")
+async def serve_landing_redesign():
+    """Preview do redesign da landing (avaliação visual, não-destrutivo).
+    Carrega site.css + a camada site-redesign.css. pixel=False: página de
+    avaliação não deve disparar o Meta Pixel nem poluir conversão."""
+    return html_file(FRONTEND_DIR / "index-redesign.html", pixel=False)
+
+
 @router.get("/app")
 async def serve_dashboard(request: Request):
     # Gate server-side: cadastro sem plano escolhido é mandado pra /precos antes
@@ -472,6 +480,17 @@ async def serve_site_css():
     ativa, então mudanças de CSS precisam aparecer na hora."""
     return FileResponse(
         FRONTEND_DIR / "site.css",
+        media_type="text/css",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+@router.get("/site-redesign.css")
+async def serve_site_redesign_css():
+    """Camada de refino do preview de redesign (só usada por index-redesign.html).
+    no-cache como o /site.css: está em iteração ativa."""
+    return FileResponse(
+        FRONTEND_DIR / "site-redesign.css",
         media_type="text/css",
         headers={"Cache-Control": "no-cache"},
     )

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -41,8 +41,12 @@ async def serve_landing():
 async def serve_landing_redesign():
     """Preview do redesign da landing (avaliação visual, não-destrutivo).
     Carrega site.css + a camada site-redesign.css. pixel=False: página de
-    avaliação não deve disparar o Meta Pixel nem poluir conversão."""
-    return html_file(FRONTEND_DIR / "index-redesign.html", pixel=False)
+    avaliação não deve disparar o Meta Pixel nem poluir conversão.
+    X-Robots-Tag noindex: página pública mas não deve ser indexada nem
+    competir com / (a meta robots no HTML reforça, defesa em profundidade)."""
+    resp = html_file(FRONTEND_DIR / "index-redesign.html", pixel=False)
+    resp.headers["X-Robots-Tag"] = "noindex, nofollow"
+    return resp
 
 
 @router.get("/app")

--- a/frontend/site-redesign.css
+++ b/frontend/site-redesign.css
@@ -1,0 +1,165 @@
+/* ==========================================================================
+   site-redesign.css — PREVIEW de redesign da landing (index-redesign.html).
+   Camada de refino "premium" sobre site.css. TUDO escopado em `body.rd`
+   para não afetar index.html nem as outras páginas que consomem site.css.
+   Paleta/tokens reaproveitados do :root de site.css (--pink, --neon, etc.).
+   ========================================================================== */
+
+/* ─── 1. Textura: grão sutil sobre a página (quebra o flat digital) ────── */
+.rd .rd-grain {
+  position: fixed; inset: 0; z-index: 2; pointer-events: none; opacity: .05;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* Glow ambiente um pouco mais rico: segunda fonte neon fria ao fundo */
+.rd .glow::after { opacity: .28; }
+.rd .glow { --_x: 0; }
+
+/* ─── 2. Tipografia: mais presença, sem trocar a fonte (Inter self-host) ─ */
+.rd .hero-title {
+  font-size: clamp(2.6rem, 5.6vw, 4.4rem);
+  letter-spacing: -.035em;
+  line-height: .98;
+  text-wrap: balance;
+}
+.rd .hero-sub { font-size: 1.12rem; line-height: 1.6; max-width: 500px; text-wrap: pretty; }
+.rd .section-head h2,
+.rd .tech-copy h2,
+.rd .cta-band h2 { letter-spacing: -.03em; text-wrap: balance; }
+.rd .section-head { max-width: 680px; margin-bottom: 60px; }
+.rd .section-head p { font-size: 1.06rem; text-wrap: pretty; }
+
+/* Headline com gradiente vivo (rosa → neon → rosa), respiração lenta */
+.rd .grad {
+  background: linear-gradient(100deg, var(--pink) 0%, #FF7AB8 40%, var(--pink) 80%);
+  background-size: 220% 100%;
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: rdGrad 9s ease-in-out infinite;
+}
+@keyframes rdGrad { 0%,100% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } }
+@media (prefers-reduced-motion: reduce) { .rd .grad { animation: none; } }
+
+/* ─── 3. Nav: vidro mais refinado + borda superior de luz ──────────────── */
+.rd .nav {
+  background: rgba(18,18,20,.66);
+  border: 1px solid rgba(255,255,255,.10);
+  box-shadow: 0 10px 40px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.06);
+}
+.rd .nav-links a { position: relative; }
+.rd .nav-links a::after {
+  content: ""; position: absolute; left: 0; right: 100%; bottom: -6px; height: 2px;
+  background: linear-gradient(90deg, var(--pink), var(--neon));
+  border-radius: 2px; transition: right .25s ease;
+}
+.rd .nav-links a:hover::after { right: 0; }
+
+/* ─── 4. Botão primário: brilho que atravessa no hover ─────────────────── */
+.rd .btn-primary { position: relative; overflow: hidden; }
+.rd .btn-primary::before {
+  content: ""; position: absolute; inset: 0; transform: translateX(-120%);
+  background: linear-gradient(105deg, transparent 30%, rgba(255,255,255,.35) 50%, transparent 70%);
+  transition: transform .6s ease;
+}
+.rd .btn-primary:hover::before { transform: translateX(120%); }
+.rd .btn-lg { padding: 15px 30px; }
+
+/* ─── 5. Cards com profundidade + borda-holofote sob o cursor ──────────── */
+.rd .card,
+.rd .plan-solo,
+.rd .phone,
+.rd .step {
+  position: relative;
+  transition: transform .22s ease, border-color .22s ease, box-shadow .22s ease;
+}
+/* halo radial que segue o mouse (--mx/--my vêm do JS) */
+.rd .card::before,
+.rd .plan-solo::before {
+  content: ""; position: absolute; inset: 0; border-radius: inherit; pointer-events: none;
+  opacity: 0; transition: opacity .25s ease;
+  background: radial-gradient(220px circle at var(--mx, 50%) var(--my, 0),
+              rgba(255,45,142,.16), transparent 60%);
+}
+.rd .card:hover::before,
+.rd .plan-solo:hover::before { opacity: 1; }
+
+.rd .feature-card {
+  background: linear-gradient(180deg, rgba(255,255,255,.03), transparent), var(--card);
+  padding: 28px 26px 30px;
+}
+.rd .feature-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255,45,142,.35);
+  box-shadow: 0 24px 50px rgba(255,45,142,.12), 0 8px 20px rgba(0,0,0,.4);
+}
+.rd .feature-card h3 { font-size: 1.12rem; letter-spacing: -.01em; }
+
+/* Ícones: caixa em gradiente, mais “produto” e menos flat */
+.rd .icon-box {
+  width: 50px; height: 50px; border-radius: 14px; font-size: 1.35rem;
+  background: linear-gradient(135deg, rgba(255,45,142,.22), rgba(255,45,142,.06));
+  border: 1px solid rgba(255,45,142,.32);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.08);
+}
+.rd .icon-box.neon {
+  background: linear-gradient(135deg, rgba(198,241,26,.20), rgba(198,241,26,.05));
+  border-color: rgba(198,241,26,.34);
+}
+
+/* ─── 6. Faixa de valor: chips com vidro e brilho no marcador ──────────── */
+.rd .value-strip { gap: 12px; margin: 8px 0 12px; }
+.rd .value-chip {
+  background: rgba(255,255,255,.04);
+  border: 1px solid rgba(255,255,255,.10);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+  transition: border-color .2s ease, transform .2s ease;
+}
+.rd .value-chip:hover { border-color: rgba(198,241,26,.4); transform: translateY(-2px); }
+
+/* ─── 7. Steps: numeração com anel e trilho conectando ────────────────── */
+.rd .step { padding: 4px 0; }
+.rd .step-num { box-shadow: 0 8px 22px rgba(255,45,142,.35), inset 0 1px 0 rgba(255,255,255,.25); }
+
+/* ─── 8. Chat / summary / phone: elevação com sombra tingida ───────────── */
+.rd .chat-card,
+.rd .summary-card,
+.rd .phone {
+  box-shadow: 0 30px 70px rgba(0,0,0,.55), 0 0 0 1px rgba(255,45,142,.06),
+              0 12px 40px rgba(255,45,142,.08);
+}
+
+/* ─── 9. Plano: card com mais respiro e destaque de preço ──────────────── */
+.rd .plan-solo {
+  box-shadow: 0 30px 80px rgba(255,45,142,.18), inset 0 1px 0 rgba(255,255,255,.06);
+}
+.rd .plan-solo-amount { font-size: 3.6rem; letter-spacing: -.04em; }
+
+/* ─── 10. Ritmo vertical: seções respiram mais ─────────────────────────── */
+.rd .section { padding: 108px 0; }
+.rd .sec-sep {
+  height: 1px; margin: 0 auto; max-width: 1200px;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,.12), transparent);
+}
+.rd .cta-band {
+  padding: 68px 30px;
+  background:
+    radial-gradient(600px circle at 50% 0, rgba(255,45,142,.18), transparent 70%),
+    linear-gradient(180deg, rgba(255,45,142,.08), rgba(255,255,255,.02));
+  box-shadow: 0 30px 80px rgba(255,45,142,.12);
+}
+
+/* ─── 11. FAQ: item com hover mais claro e chevron animado ─────────────── */
+.rd .faq-item { transition: border-color .2s ease, background .2s ease; }
+.rd .faq-item:hover { border-color: rgba(255,255,255,.18); }
+.rd .faq-q .chev { transition: transform .2s ease; }
+.rd .faq-item.open .chev { transform: rotate(45deg); }
+
+/* ─── 12. Mobile: mantém o respiro sem estourar ────────────────────────── */
+@media (max-width: 900px) {
+  .rd .section { padding: 72px 0; }
+}
+@media (max-width: 560px) {
+  .rd .hero-title { font-size: clamp(2.2rem, 9vw, 3rem); }
+  .rd .plan-solo-amount { font-size: 3rem; }
+}


### PR DESCRIPTION
## O que é

Preview **não-destrutivo** de um redesign da landing, para avaliação visual antes de decidir promover para produção. Acessível em `/index-redesign.html`.

Não altera `index.html`, `site.css` nem `brand.css` — logo, **zero impacto** nas ~25 páginas que compartilham o design system. Tudo escopado em `body.rd`.

## Arquivos

- `frontend/index-redesign.html` — cópia fiel do conteúdo de `index.html`, carregando `site.css` + a nova camada `site-redesign.css` e um pequeno JS para o spotlight que segue o cursor.
- `frontend/site-redesign.css` — camada de refino sobre `site.css`.

## Mudanças visuais (medidas a 1280px)

| | Original | Redesign |
|---|---|---|
| Título do hero | 62,4px | **70,4px** (+12,8%) |
| Letter-spacing hero | −1,25px | **−2,46px** |
| Line-height hero | 1,03 | **0,98** |
| Caixa de ícone | rosa chapado | **gradiente** |
| Padding de seção | 92px | **108px** |
| Grão/textura | ausente | **overlay 5%** |

Também: borda-holofote nos cards sob o cursor, brilho atravessando o botão primário, sublinhado animado no nav, gradiente vivo na headline, sombras tingidas mais fundas.

## Verificação

- Renderização confirmada no Chromium (DOM + computed styles) para hero, funcionalidades e planos; `site-redesign.css`, fontes e assets carregam com HTTP 200.
- **Não verificado:** comportamento no app iOS / área segura — este é um arquivo de preview não alcançável pelo app, e `env(safe-area-inset-*)` vale 0 em headless. Fica para a etapa de promoção.

## Próximo passo (fora deste PR)

Se aprovado o visual, portar os overlays para `index.html`/`site.css` **com** tratamento de área segura e cuidado com as páginas que compartilham `site.css`, em PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)