### PR TITLE
chore(site): remove em-dashes do texto visível

### DIFF
--- a/frontend/agents.html
+++ b/frontend/agents.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Agentes do Piggy — PigBank</title>
+<title>Agentes do Piggy · PigBank</title>
 <meta name="description" content="Conheça os Agentes do Piggy: pequenos assistentes que vigiam seus gastos, avisam sobre boletos, caçam assinaturas esquecidas e cuidam do seu dinheiro sozinhos." />
 <link rel="canonical" href="https://pigbankai.com/agents" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
@@ -109,7 +109,7 @@
       <div class="section-head">
         <div class="pill" style="margin:0 auto 18px"><span class="tag-novo">NOVO</span> Sua equipe financeira no automático</div>
         <h2>Os <span class="grad">Agentes</span><br>do Piggy</h2>
-        <p>Pequenos assistentes que trabalham por você nos bastidores. Cada um cuida de uma parte do seu dinheiro — vigiando gastos, avisando de boletos e caçando desperdício — sem você precisar pedir.</p>
+        <p>Pequenos assistentes que trabalham por você nos bastidores. Cada um cuida de uma parte do seu dinheiro, vigiando gastos, avisando de boletos e caçando desperdício, sem você precisar pedir.</p>
       </div>
 
       <div class="agents-grid">
@@ -121,7 +121,7 @@
             <div class="agent-name">Xerife</div>
           </div>
           <div class="agent-body">
-            <p class="agent-desc">Fica de olho no seu padrão de gastos e dá o alerta quando algo foge da curva — ou quando uma categoria estoura o limite que você definiu.</p>
+            <p class="agent-desc">Fica de olho no seu padrão de gastos e dá o alerta quando algo foge da curva, ou quando uma categoria estoura o limite que você definiu.</p>
           </div>
         </article>
 
@@ -132,7 +132,7 @@
             <div class="agent-name">Repórter</div>
           </div>
           <div class="agent-body">
-            <p class="agent-desc">Traz a manchete do seu mês: quanto entrou, quanto saiu e quanto sobrou — o resumo direto ao ponto, sem você abrir planilha nenhuma.</p>
+            <p class="agent-desc">Traz a manchete do seu mês: quanto entrou, quanto saiu e quanto sobrou: o resumo direto ao ponto, sem você abrir planilha nenhuma.</p>
           </div>
         </article>
 
@@ -154,7 +154,7 @@
             <div class="agent-name">Detetive</div>
           </div>
           <div class="agent-body">
-            <p class="agent-desc">Fareja cobranças repetidas que parecem aquela assinatura esquecida — a que você paga todo mês e nem lembra mais que existe.</p>
+            <p class="agent-desc">Fareja cobranças repetidas que parecem aquela assinatura esquecida, a que você paga todo mês e nem lembra mais que existe.</p>
           </div>
         </article>
 
@@ -187,7 +187,7 @@
             <div class="agent-name">Faria Limer</div>
           </div>
           <div class="agent-body">
-            <p class="agent-desc">Fica de olho na sua renda variável (ações e FIIs) pela sua corretora: todo mês te entrega o retrato da carteira — valor, resultado e concentração. Só fatos, nunca recomendação: a decisão é sempre sua.</p>
+            <p class="agent-desc">Fica de olho na sua renda variável (ações e FIIs) pela sua corretora: todo mês te entrega o retrato da carteira: valor, resultado e concentração. Só fatos, nunca recomendação: a decisão é sempre sua.</p>
           </div>
         </article>
 
@@ -199,14 +199,14 @@
             <div class="agent-name">Aviador</div>
           </div>
           <div class="agent-body">
-            <p class="agent-desc">Vai caçar passagem em promoção pros destinos que você marcar — e avisar na hora que o preço cair. Ainda tá aquecendo as turbinas.</p>
+            <p class="agent-desc">Vai caçar passagem em promoção pros destinos que você marcar, e avisar na hora que o preço cair. Ainda tá aquecendo as turbinas.</p>
           </div>
         </article>
 
       </div>
 
       <p class="agents-note">
-        Os Agentes são ativados no seu painel, quando e como você quiser — cada um trabalha em silêncio e só te chama quando tem algo que vale a pena saber.
+        Os Agentes são ativados no seu painel, quando e como você quiser: cada um trabalha em silêncio e só te chama quando tem algo que vale a pena saber.
       </p>
 
       <div class="agents-cta">
@@ -223,7 +223,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/blog-article.html
+++ b/frontend/blog-article.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>{{TITLE}} — PigBank</title>
+<title>{{TITLE}} · PigBank</title>
 <meta name="description" content="{{DESCRIPTION}}" />
 <link rel="canonical" href="{{CANONICAL}}" />
 <meta property="og:type" content="article" />
@@ -81,7 +81,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Criar conta — PigBank</title>
+<title>Criar conta · PigBank</title>
 <meta name="description" content="Crie sua conta PigBank e comece a organizar sua vida financeira no WhatsApp." />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Notícias — PigBank</title>
-<meta name="description" content="Notícias e resumos do mercado financeiro pela Piggy — exclusivo pra assinantes do PigBank+." />
+<title>Notícias · PigBank</title>
+<meta name="description" content="Notícias e resumos do mercado financeiro pela Piggy, exclusivo pra assinantes do PigBank+." />
 <link rel="canonical" href="https://pigbankai.com/changelog" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -50,7 +50,7 @@
 
       <!-- Estado vazio: some assim que o blog-news.js revela #news-section -->
       <p id="news-empty" class="plans-note" style="margin-top:20px">
-        Nenhuma notícia por aqui ainda — a Piggy publica os resumos ao longo do dia.<br>
+        Nenhuma notícia por aqui ainda. A Piggy publica os resumos ao longo do dia.<br>
         Procurando os guias e dicas? Agora eles ficam no <a href="/suporte" style="color:var(--pink);font-weight:700">Suporte</a>.
       </p>
     </section>
@@ -61,7 +61,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-<title>O que pedir — PigBank</title>
+<title>O que pedir · PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
 <meta name="theme-color" content="#111111" />
@@ -106,7 +106,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
     <section class="hero">
       <div class="eyebrow" id="hero-eyebrow">O que pedir</div>
       <h2 id="hero-title">Pergunta do jeito que <span class="grad">sair na cabeça</span></h2>
-      <p id="hero-sub">Toca numa categoria pra ver os comandos prontos. Clica num comando pra copiar — funciona aqui e no <strong>WhatsApp</strong>.</p>
+      <p id="hero-sub">Toca numa categoria pra ver os comandos prontos. Clica num comando pra copiar: funciona aqui e no <strong>WhatsApp</strong>.</p>
     </section>
 
     <section class="section-list" id="cats-grid">

--- a/frontend/comandos.html
+++ b/frontend/comandos.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>O que pedir — PigBank</title>
-<meta name="description" content="Exemplos do que você pode pedir pra Piggy no WhatsApp — em português corrido, sem comando decorado." />
+<title>O que pedir · PigBank</title>
+<meta name="description" content="Exemplos do que você pode pedir pra Piggy no WhatsApp, em português corrido, sem comando decorado." />
 <link rel="canonical" href="https://pigbankai.com/comandos" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -38,7 +38,7 @@
     <section class="hero">
       <div class="eyebrow">O que pedir</div>
       <h1>Pergunta do jeito que <span class="grad">sair na cabeça</span></h1>
-      <p>O Piggy não tem comando decorado — você fala português corrido e ele entende. Aqui em baixo tem algumas das coisas que dá pra pedir, pra você ter ideia. Clica em qualquer exemplo pra copiar.</p>
+      <p>O Piggy não tem comando decorado: você fala português corrido e ele entende. Aqui em baixo tem algumas das coisas que dá pra pedir, pra você ter ideia. Clica em qualquer exemplo pra copiar.</p>
     </section>
 
     <section class="section-list">
@@ -56,7 +56,7 @@
 
       <article class="cat">
         <div class="cat-head"><div class="cat-icon"><i class="ph ph-coins" aria-hidden="true"></i></div><h2>Saldo e lançamentos</h2></div>
-        <p class="cat-desc">O básico — quanto tem, o que entrou, o que saiu.</p>
+        <p class="cat-desc">O básico: quanto tem, o que entrou, o que saiu.</p>
         <div class="cmds">
           <div class="cmd">saldo<span class="copied">copiado</span></div>
           <div class="cmd">gastei 50 no mercado<span class="copied">copiado</span></div>
@@ -69,7 +69,7 @@
 
       <article class="cat">
         <div class="cat-head"><div class="cat-icon"><i class="ph ph-credit-card" aria-hidden="true"></i></div><h2>Cartão de crédito</h2></div>
-        <p class="cat-desc">Compras, faturas, limite e pagamento — o cartão sem mistério.</p>
+        <p class="cat-desc">Compras, faturas, limite e pagamento: o cartão sem mistério.</p>
         <div class="cmds">
           <div class="cmd">gastei 200 no Nubank<span class="copied">copiado</span></div>
           <div class="cmd">parcelei 1200 em 6x no Nubank<span class="copied">copiado</span></div>
@@ -103,7 +103,7 @@
 
       <article class="cat">
         <div class="cat-head"><div class="cat-icon"><i class="ph ph-bank" aria-hidden="true"></i></div><h2>Caixinhas</h2></div>
-        <p class="cat-desc">Reservas separadas — viagem, emergência, reforma. Dinheiro que não tá no saldo principal.</p>
+        <p class="cat-desc">Reservas separadas: viagem, emergência, reforma. Dinheiro que não tá no saldo principal.</p>
         <div class="cmds">
           <div class="cmd">cria caixinha viagem<span class="copied">copiado</span></div>
           <div class="cmd">deposita 200 na caixinha viagem<span class="copied">copiado</span></div>
@@ -115,7 +115,7 @@
 
       <article class="cat">
         <div class="cat-head"><div class="cat-icon"><i class="ph ph-trend-up" aria-hidden="true"></i></div><h2>Investimentos</h2></div>
-        <p class="cat-desc">CDB, Tesouro, LCI — cadastro, aporta, resgata. Calcula IR/IOF no resgate sozinho.</p>
+        <p class="cat-desc">CDB, Tesouro, LCI: cadastro, aporta, resgata. Calcula IR/IOF no resgate sozinho.</p>
         <div class="cmds">
           <div class="cmd">cria investimento Tesouro Selic 13.75 anual<span class="cmd-note">nome, taxa (% anual), periodicidade</span><span class="copied">copiado</span></div>
           <div class="cmd">aporta 500 no Tesouro Selic<span class="copied">copiado</span></div>
@@ -160,7 +160,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/como-funciona.html
+++ b/frontend/como-funciona.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Como funciona — PigBank</title>
+<title>Como funciona · PigBank</title>
 <meta name="description" content="Em poucos minutos você está no controle: crie a conta, conecte o WhatsApp, registre gastos falando e acompanhe tudo no dashboard." />
 <link rel="canonical" href="https://pigbankai.com/como-funciona" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
@@ -38,7 +38,7 @@
     <section class="section">
       <div class="section-head">
         <h2>Simples, rápido e<br>no seu <span class="grad">WhatsApp</span></h2>
-        <p>Em poucos minutos você já está no controle do seu dinheiro — sem planilha, sem app pra baixar.</p>
+        <p>Em poucos minutos você já está no controle do seu dinheiro, sem planilha, sem app pra baixar.</p>
       </div>
 
       <div class="how-grid">
@@ -49,7 +49,7 @@
           </div>
           <div class="step">
             <div class="step-num">2</div>
-            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece — nada pra instalar.</p></div>
+            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece. Nada pra instalar.</p></div>
           </div>
           <div class="step">
             <div class="step-num">3</div>
@@ -87,7 +87,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -234,7 +234,7 @@
   <p class="section-title" id="history-title" style="display:none">Histórico Mensal</p>
   <div id="history-wrap" style="display:none">
     <div class="card">
-      <h2 id="history-card-title">Receita vs Despesa — Últimos 6 Meses</h2>
+      <h2 id="history-card-title">Receita vs Despesa (Últimos 6 Meses)</h2>
       <div class="chart-wrap" style="height:230px"><canvas id="chart-history"></canvas></div>
     </div>
   </div>
@@ -650,7 +650,7 @@
       <p class="section-title" style="margin:0">Agentes</p>
       <div id="agentes-counters" class="ag-counters"></div>
     </div>
-    <p class="ag-sub">Sua equipe de porquinhos trabalhando 24h nos seus dados — cada um vigia uma coisa e só fala quando vale a pena.</p>
+    <p class="ag-sub">Sua equipe de porquinhos trabalhando 24h nos seus dados: cada um vigia uma coisa e só fala quando vale a pena.</p>
 
     <div id="agentes-shelf" class="ag-shelf"></div>
 
@@ -839,7 +839,7 @@
     <h3 id="upg-title">Disponível nos planos PigBank</h3>
     <p class="upg-feat" id="upg-feat-msg">Essa feature faz parte dos planos pagos do PigBank. Escolha o que faz mais sentido pra você.</p>
     <div class="upg-perks">
-      <div class="upg-perk">Piggy IA — converse sobre suas finanças</div>
+      <div class="upg-perk">Piggy IA: converse sobre suas finanças</div>
       <div class="upg-perk">Caixinhas e cartões ilimitados</div>
       <div class="upg-perk">Investimentos com acompanhamento automático</div>
       <div class="upg-perk">Histórico completo + exportar CSV</div>
@@ -1199,7 +1199,7 @@
           <input class="modal-inp" id="pocket-interest-rate" type="number" min="1" max="300" step="0.01" value="100" inputmode="decimal" style="width:112px;flex:0 0 112px" />
           <span style="color:var(--text-2);font-size:.86rem;white-space:nowrap">% do CDI</span>
         </div>
-        <div style="color:var(--text-3);font-size:.78rem;margin-top:8px;line-height:1.35"><i class="ph ph-lightbulb" aria-hidden="true"></i> Valor simulado — o PigBank não custodia seu dinheiro. Use a taxa do banco onde o saldo realmente está aplicado.</div>
+        <div style="color:var(--text-3);font-size:.78rem;margin-top:8px;line-height:1.35"><i class="ph ph-lightbulb" aria-hidden="true"></i> Valor simulado: o PigBank não custodia seu dinheiro. Use a taxa do banco onde o saldo realmente está aplicado.</div>
       </div>
     </div>
 
@@ -1327,7 +1327,7 @@
 <div class="overlay" id="adjust-wallet-overlay" onclick="if(event.target===this) closeAdjustWalletModal()">
   <div class="modal">
     <h3>Ajustar carteira</h3>
-    <p class="msub">A <b>Carteira</b> é o dinheiro <b>fora</b> dos bancos conectados — espécie e contas que você não ligou no Open Finance. O saldo dos bancos conectados entra sozinho; não digite ele aqui.</p>
+    <p class="msub">A <b>Carteira</b> é o dinheiro <b>fora</b> dos bancos conectados: espécie e contas que você não ligou no Open Finance. O saldo dos bancos conectados entra sozinho; não digite ele aqui.</p>
 
     <div class="bill-balance-line">
       <span class="lbl-k"><i class="ph ph-bank" aria-hidden="true"></i> Nos bancos conectados</span>
@@ -1371,7 +1371,7 @@
 <div class="overlay" id="card-edit-overlay">
   <div class="modal wide">
     <h3 id="card-edit-title">Novo cartão</h3>
-    <p class="msub">Apelido obrigatório. Demais campos são opcionais — só preencha o que ajudar você a identificar este cartão.</p>
+    <p class="msub">Apelido obrigatório. Demais campos são opcionais. Só preencha o que ajudar você a identificar este cartão.</p>
     <form id="card-edit-form" onsubmit="event.preventDefault(); saveCard();" novalidate>
       <input type="hidden" id="card-edit-id" />
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1467,9 +1467,9 @@ async function openInstDeleteModal(group_id, name) {
     if (hasPaid) {
       body.innerHTML = `
         Excluir <b>${escapeHtmlSafe(name)}</b>?<br><br>
-        • <b>${imp.future_count}</b> parcela${futOne ? "" : "s"} futura${futOne ? "" : "s"} (${_fmtBRL(imp.future_total)}) ${futOne ? "será removida" : "serão removidas"} das faturas abertas — saldo do mês volta.<br>
+        • <b>${imp.future_count}</b> parcela${futOne ? "" : "s"} futura${futOne ? "" : "s"} (${_fmtBRL(imp.future_total)}) ${futOne ? "será removida" : "serão removidas"} das faturas abertas. Saldo do mês volta.<br>
         • <b>${imp.paid_count}</b> parcela${paidOne ? "" : "s"} já paga${paidOne ? "" : "s"} (${_fmtBRL(imp.paid_total)}) ${paidOne ? "fica" : "ficam"} no histórico (faturas pagas intactas).<br><br>
-        <span style="color:var(--red);font-weight:600">R$ ${imp.paid_total.toFixed(2).replace(".", ",")} já pago${paidOne ? "" : "s"} NÃO ${paidOne ? "volta" : "voltam"} pra conta</span> — dinheiro já saiu via fatura. Se precisar corrigir, crie um lançamento manual.
+        <span style="color:var(--red);font-weight:600">R$ ${imp.paid_total.toFixed(2).replace(".", ",")} já pago${paidOne ? "" : "s"} NÃO ${paidOne ? "volta" : "voltam"} pra conta</span>. Dinheiro já saiu via fatura. Se precisar corrigir, crie um lançamento manual.
       `;
     } else {
       body.innerHTML = `
@@ -2073,11 +2073,11 @@ function _renderBudgetRow(b, idx = 0) {
   const widthPct = Math.min(100, pct);
   const subColor = b.status === "vermelho" ? "color:#FF2D2D" : "";
   const dotEmoji = `<span style="display:inline-block;width:9px;height:9px;border-radius:50%;vertical-align:middle;margin-right:5px;background:${b.status === "vermelho" ? "#ef4444" : (b.status === "amarelo" ? "#fbbf24" : "#22c55e")}"></span>`;
-  let subText = `${pct.toFixed(0)}% — ${_fmtBRL(b.remaining)} restantes`;
+  let subText = `${pct.toFixed(0)}%, ${_fmtBRL(b.remaining)} restantes`;
   if (b.status === "vermelho") {
-    subText = `<i class="ph ph-warning" aria-hidden="true"></i> ${pct.toFixed(0)}% — estourou ${_fmtBRL(-b.remaining)}`;
+    subText = `<i class="ph ph-warning" aria-hidden="true"></i> ${pct.toFixed(0)}%, estourou ${_fmtBRL(-b.remaining)}`;
   } else if (b.status === "amarelo") {
-    subText = `${pct.toFixed(0)}% — ${_fmtBRL(b.remaining)} restantes. Piggy te avisa via WhatsApp.`;
+    subText = `${pct.toFixed(0)}%, ${_fmtBRL(b.remaining)} restantes. Piggy te avisa via WhatsApp.`;
   }
   const safeCatJson = JSON.stringify(b).replace(/'/g, "&apos;");
   const delay = 240 + idx * 60;
@@ -2450,9 +2450,9 @@ function _renderPocketOnlyCard(p, idx = 0) {
   const color = p.color || "#FF2D8E";
   const ofPocket = _isOfPocket(p);
   const ofStale = _isOfStale(p);
-  const line1 = ofStale ? "<i class='ph ph-lock' aria-hidden='true'></i> Banco desconectado — reative pra atualizar"
+  const line1 = ofStale ? "<i class='ph ph-lock' aria-hidden='true'></i> Banco desconectado. Reative pra atualizar"
               : ofPocket ? "Sincronizada com seu banco"
-              : "Caixinha sem meta — depósitos livres";
+              : "Caixinha sem meta: depósitos livres";
   const line2 = ofStale ? "Reative seu banco (plano pago) pra o saldo voltar a atualizar"
               : ofPocket ? "Saldo atualizado pela corretora/banco"
               : (p.interest_enabled === false ? "Sem rendimento" : _formatCdiRate(p.interest_rate));
@@ -2502,11 +2502,11 @@ function _renderGoalCard(g, idx = 0) {
     const today = new Date();
     const proj = new Date(today.getFullYear(), today.getMonth() + Math.ceil(g.projected_months), 1);
     const projStr = proj.toLocaleDateString("pt-BR", { month: "short", year: "numeric" });
-    alertText = `<div class="goal-deadline" style="color:#FF2D2D"><i class="ph ph-warning" aria-hidden="true"></i> Ritmo atual chega só em ${projStr}${g.target_date ? " — prazo era " + deadlineText.replace("Prazo: ", "") : ""}</div>`;
+    alertText = `<div class="goal-deadline" style="color:#FF2D2D"><i class="ph ph-warning" aria-hidden="true"></i> Ritmo atual chega só em ${projStr}${g.target_date ? ", prazo era " + deadlineText.replace("Prazo: ", "") : ""}</div>`;
   } else if (g.indicator === "tight") {
-    alertText = `<div class="goal-deadline" style="color:#fbbf24">Ritmo apertado — pode atrasar</div>`;
+    alertText = `<div class="goal-deadline" style="color:#fbbf24">Ritmo apertado, pode atrasar</div>`;
   } else if (g.indicator === "ahead") {
-    alertText = `<div class="goal-deadline" style="color:#00F078"><i class="ph ph-rocket-launch" aria-hidden="true"></i> Adiantado — no melhor caminho</div>`;
+    alertText = `<div class="goal-deadline" style="color:#00F078"><i class="ph ph-rocket-launch" aria-hidden="true"></i> Adiantado, no melhor caminho</div>`;
   } else if (g.indicator === "on_track") {
     alertText = `<div class="goal-deadline" style="color:#00F078">No prazo</div>`;
   } else if (g.indicator === "achieved") {
@@ -2598,7 +2598,7 @@ function _ensureGoalModal() {
                   <input type="number" id="goal-interest-rate" min="1" max="300" step="0.01" value="100" inputmode="decimal" style="width:112px;flex:0 0 112px" />
                   <span style="color:var(--text-2);font-size:.86rem;white-space:nowrap">% do CDI</span>
                 </div>
-                <div style="color:var(--text-3);font-size:.78rem;margin-top:8px;line-height:1.35"><i class="ph ph-lightbulb" aria-hidden="true"></i> Valor simulado — o PigBank não custodia seu dinheiro. Use a taxa do banco onde o saldo realmente está aplicado.</div>
+                <div style="color:var(--text-3);font-size:.78rem;margin-top:8px;line-height:1.35"><i class="ph ph-lightbulb" aria-hidden="true"></i> Valor simulado: o PigBank não custodia seu dinheiro. Use a taxa do banco onde o saldo realmente está aplicado.</div>
               </div>
             </div>
           </div>
@@ -3512,7 +3512,7 @@ function _toggleRecurringModeHint() {
   const amount = document.getElementById("recurring-amount");
   const name = document.getElementById("recurring-name");
   if (mode === "manual") {
-    if (hint) hint.innerHTML = "<i class='ph ph-receipt' aria-hidden='true'></i> <strong>Conta a pagar:</strong> a Piggy te <strong>lembra</strong> do vencimento e <strong>nada sai da conta</strong> até você confirmar. O valor é sempre uma <strong>estimativa</strong> — você informa o valor real ao marcar como paga.";
+    if (hint) hint.innerHTML = "<i class='ph ph-receipt' aria-hidden='true'></i> <strong>Conta a pagar:</strong> a Piggy te <strong>lembra</strong> do vencimento e <strong>nada sai da conta</strong> até você confirmar. O valor é sempre uma <strong>estimativa</strong>. Você informa o valor real ao marcar como paga.";
     if (title && !isEdit) title.textContent = "Nova conta a pagar";
     // Conta a pagar nunca é débito automático — o user sempre confirma na mão.
     // A "forma de pagamento" (autopay/cartão) não se aplica: esconde e fixa account.
@@ -3659,7 +3659,7 @@ async function saveRecurring() {
 async function deleteRecurringFromModal() {
   if (!_recurringEditState.id) return;
   const ok = await confirmModal(
-    "Excluir este gasto fixo? Lançamentos passados ficam preservados — só não vai mais cobrar automaticamente.",
+    "Excluir este gasto fixo? Lançamentos passados ficam preservados. Só não vai mais cobrar automaticamente.",
     { title: "Excluir gasto fixo", okText: "Excluir", danger: true },
   );
   if (!ok) return;
@@ -3793,7 +3793,7 @@ async function loadRecurringOverview({ background = false } = {}) {
   const head = `
     <div style="margin-bottom:14px">
       <h2 style="margin:0 0 2px;font-size:1.5rem">Previsão mensal</h2>
-      <div style="font-size:.86rem;color:var(--text-3)">Veja rapidamente o que entra, o que sai e o que vence primeiro — só do que é recorrente.</div>
+      <div style="font-size:.86rem;color:var(--text-3)">Veja rapidamente o que entra, o que sai e o que vence primeiro, só do que é recorrente.</div>
     </div>`;
 
   // ── Alerta (déficit ou no azul) ──
@@ -3801,7 +3801,7 @@ async function loadRecurringOverview({ background = false } = {}) {
     ? `<div class="mock-card" style="border:1px solid rgba(34,197,94,.35);margin-bottom:14px;display:flex;align-items:center;gap:14px;flex-wrap:wrap">
         <div style="font-size:1.5rem"><i class="ph ph-check-circle" aria-hidden="true"></i></div>
         <div style="flex:1;min-width:220px">
-          <div style="font-weight:700">Suas entradas cobrem os compromissos — sobra <span style="color:#22c55e">${_fmtBRL(resultado)}</span>.</div>
+          <div style="font-weight:700">Suas entradas cobrem os compromissos. Sobra <span style="color:#22c55e">${_fmtBRL(resultado)}</span>.</div>
           <div style="font-size:.82rem;color:var(--text-3)">Mês recorrente equilibrado. Bom trabalho! <i class="ph ph-piggy-bank" aria-hidden="true"></i></div>
         </div>
       </div>`
@@ -4187,8 +4187,8 @@ function _renderProjection(p) {
   const accent = ok ? "#22c55e" : "#FF2D2D";
   const alvo = new Date(p.target + "T00:00:00").toLocaleDateString("pt-BR", { day: "2-digit", month: "long" });
   const header = ok
-    ? `<i class="ph ph-smiley" aria-hidden="true"></i> Tranquilo até ${alvo} — sobra ${_fmtBRL(p.projetado)}`
-    : `<i class="ph ph-warning" aria-hidden="true"></i> Aperta até ${alvo} — falta ${_fmtBRL(Math.abs(p.projetado))}`;
+    ? `<i class="ph ph-smiley" aria-hidden="true"></i> Tranquilo até ${alvo}, sobra ${_fmtBRL(p.projetado)}`
+    : `<i class="ph ph-warning" aria-hidden="true"></i> Aperta até ${alvo}, falta ${_fmtBRL(Math.abs(p.projetado))}`;
   const line = (label, val, positive) => `
     <div style="display:flex;justify-content:space-between;font-size:.82rem;padding:2px 0">
       <span style="color:var(--text-2)">${label}</span>
@@ -4450,7 +4450,7 @@ function _ensureRecurringIncomeModal() {
       <div class="modal wide">
         <h3 id="recurring-income-edit-title">Nova receita fixa</h3>
         <p class="msub" style="background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.3);border-radius:8px;padding:10px 12px;margin-bottom:14px;font-size:.78rem">
-          <i class="ph ph-coins" aria-hidden="true"></i> <strong>Importante:</strong> essa receita será <strong>lançada automaticamente</strong> todo mês no dia escolhido. Se o valor variar, é só editar aqui — o Piggy registra o reajuste.
+          <i class="ph ph-coins" aria-hidden="true"></i> <strong>Importante:</strong> essa receita será <strong>lançada automaticamente</strong> todo mês no dia escolhido. Se o valor variar, é só editar aqui: o Piggy registra o reajuste.
         </p>
         <form id="recurring-income-edit-form" onsubmit="event.preventDefault(); saveRecurringIncome();">
           <div class="invest-form">
@@ -4617,7 +4617,7 @@ async function saveRecurringIncome() {
 async function deleteRecurringIncomeFromModal() {
   if (!_recurringIncomeEditState.id) return;
   const ok = await confirmModal(
-    "Excluir esta receita fixa? Lançamentos passados ficam preservados — só não vai mais lançar automaticamente.",
+    "Excluir esta receita fixa? Lançamentos passados ficam preservados. Só não vai mais lançar automaticamente.",
     { title: "Excluir receita fixa", okText: "Excluir", danger: true },
   );
   if (!ok) return;
@@ -5254,7 +5254,7 @@ function renderAnalyticsPatterns(patterns) {
       <div class="empty" style="padding:24px 16px;text-align:center;color:var(--text-3);font-size:.85rem">
         <div style="font-size:2rem;margin-bottom:6px"><i class="ph ph-piggy-bank" aria-hidden="true"></i></div>
         <div style="font-weight:600;color:var(--text-2);margin-bottom:4px">Sem padrões ainda</div>
-        <div>A IA precisa de mais histórico pra detectar padrões. Continue lançando — vai aparecer aqui em breve.</div>
+        <div>A IA precisa de mais histórico pra detectar padrões. Continue lançando, vai aparecer aqui em breve.</div>
       </div>`;
     return;
   }
@@ -5691,13 +5691,13 @@ function isProUser() {
 const UPGRADE_MESSAGES = {
   investments: "Acompanhe sua carteira de investimentos com cálculo automático de rendimento, IR e IOF. Disponível nos planos pagos.",
   export: "Exportar seus lançamentos (PDF, planilha) por email faz parte dos planos pagos.",
-  pockets_unlimited: "No Grátis você cria 1 caixinha. Com um plano pago fica ilimitado — separe sua reserva, viagens, presentes…",
-  cards_unlimited: "No Grátis você cadastra 1 cartão. Com um plano pago fica ilimitado — controle todos os seus cartões em um lugar.",
+  pockets_unlimited: "No Grátis você cria 1 caixinha. Com um plano pago fica ilimitado: separe sua reserva, viagens, presentes…",
+  cards_unlimited: "No Grátis você cadastra 1 cartão. Com um plano pago fica ilimitado: controle todos os seus cartões em um lugar.",
   ofx_import: "Importar extrato bancário e fatura de cartão por OFX faz parte dos planos pagos.",
   history_unlimited: "Histórico além de 30 dias faz parte dos planos pagos.",
   changelog: "As notícias e resumos do mercado feitos pela Piggy fazem parte dos planos Plus e Pro. Assine pra desbloquear.",
   recurring_expenses: "A agenda de boletos e os gastos fixos fazem parte dos planos pagos. Cadastre suas contas a pagar e nunca mais perca um vencimento.",
-  agents: "Seu plano atual não ativa mais agentes. Fazendo upgrade, a equipe de porquinhos trabalha pra você — Xerife, Repórter, Carteiro e os próximos que chegarem.",
+  agents: "Seu plano atual não ativa mais agentes. Fazendo upgrade, a equipe de porquinhos trabalha pra você: Xerife, Repórter, Carteiro e os próximos que chegarem.",
   generic: "Essa feature faz parte dos planos pagos do PigBank. Escolha o que faz mais sentido pra você."
 };
 
@@ -5764,7 +5764,7 @@ function applyProGates() {
     } else {
       el.classList.add("pro-locked");
       el.setAttribute("aria-disabled", "true");
-      el.setAttribute("title", "Funcionalidade de um plano pago — clica pra ver os planos");
+      el.setAttribute("title", "Funcionalidade de um plano pago: clica pra ver os planos");
       if (!el.querySelector(":scope > .pro-badge")) {
         const b = document.createElement("span");
         b.className = "pro-badge";
@@ -5778,8 +5778,8 @@ function applyProGates() {
   const histTitle = document.getElementById("history-card-title");
   if (histTitle) {
     histTitle.textContent = isProUser()
-      ? "Receita vs Despesa — Últimos 6 Meses"
-      : "Receita vs Despesa — Últimos 30 dias";
+      ? "Receita vs Despesa (Últimos 6 Meses)"
+      : "Receita vs Despesa (Últimos 30 dias)";
   }
 }
 
@@ -7214,16 +7214,16 @@ function openSobrouDetail() {
   // do número (fluxo daquele mês).
   let note;
   if (s.hist) {
-    note = "Este é o fluxo de " + monthLbl + " — só receitas, gastos e aportes daquele mês. " +
+    note = "Este é o fluxo de " + monthLbl + ": só receitas, gastos e aportes daquele mês. " +
       "Não é um saldo: o saldo é acumulado e reflete o momento atual, não o fim de um mês passado.";
   } else if (s.saldoAtual < 0) {
     note = "Seu <b>saldo</b> está negativo (" + fmt(s.saldoAtual) + "), mas ainda assim " +
       (deficit ? "o mês fechou como está acima" : "sobrou dinheiro <b>neste mês</b>") + ". " +
-      "Não é contradição: o saldo é acumulado — arrasta meses anteriores, ajustes e movimentações entre contas —, " +
+      "Não é contradição: o saldo é acumulado, arrasta meses anteriores, ajustes e movimentações entre contas, " +
       "enquanto este valor olha só receitas, gastos e aportes de " + monthLbl + ".";
   } else {
     note = "O <b>saldo</b> é acumulado (arrasta meses anteriores, ajustes e movimentações entre contas). " +
-      "Este valor considera só receitas, gastos e aportes de " + monthLbl + " — por isso os dois podem divergir.";
+      "Este valor considera só receitas, gastos e aportes de " + monthLbl + ". Por isso os dois podem divergir.";
   }
   if (s.apt > 0) {
     note += " Aportes não são gasto: viram patrimônio seu (investimentos e caixinhas), mas saem do que “sobra livre” no mês.";
@@ -7677,9 +7677,9 @@ async function confirmDeleteLaunch(launchId, descricao, valor, isCredit = false,
   const isInstallment = isCredit && installmentsTotal && installmentsTotal > 1;
   const body = isCredit
     ? (isInstallment
-        ? `${desc}${valFmt ? ` — ${valFmt}` : ""}\n\nEsta compra faz parte de um parcelamento em ${installmentsTotal}x. **TODAS as ${installmentsTotal} parcelas** serão apagadas. Essa ação não pode ser desfeita.`
-        : `${desc}${valFmt ? ` — ${valFmt}` : ""}\n\nA compra será removida da fatura. Essa ação não pode ser desfeita.`)
-    : `${desc}${valFmt ? ` — ${valFmt}` : ""}\n\nO efeito no saldo (e em caixinhas/investimentos, se houver) será revertido. Essa ação não pode ser desfeita.`;
+        ? `${desc}${valFmt ? ` · ${valFmt}` : ""}\n\nEsta compra faz parte de um parcelamento em ${installmentsTotal}x. **TODAS as ${installmentsTotal} parcelas** serão apagadas. Essa ação não pode ser desfeita.`
+        : `${desc}${valFmt ? ` · ${valFmt}` : ""}\n\nA compra será removida da fatura. Essa ação não pode ser desfeita.`)
+    : `${desc}${valFmt ? ` · ${valFmt}` : ""}\n\nO efeito no saldo (e em caixinhas/investimentos, se houver) será revertido. Essa ação não pode ser desfeita.`;
 
   const ok = await confirmModal(body, {
     title: isCredit ? "Apagar compra no crédito" : "Apagar lançamento",
@@ -7826,7 +7826,7 @@ async function submitLaunch() {
                     : launchTipo === "credito" ? "Compra no crédito"
                     : "Despesa";
     const idLabel = data.launch_id ? `#${data.launch_id}` : "";
-    showLaunchSuccessToast(`✓ ${tipoLabel} registrada${idLabel ? " — " + idLabel : ""}`);
+    showLaunchSuccessToast(`✓ ${tipoLabel} registrada${idLabel ? " · " + idLabel : ""}`);
     sendRefresh();
   } catch (err) {
     showLaunchError(err.message || "Erro ao registrar lançamento.");
@@ -8066,7 +8066,7 @@ async function openPocketHistory(pocketName) {
   _currentPocketName = pocketName;
   _currentPocketForEdit = null;
   closePocketMove();
-  titleEl.textContent = `Histórico — ${pocketName}`;
+  titleEl.textContent = `Histórico: ${pocketName}`;
   subEl.textContent   = "Depósitos e saques desta caixinha.";
   sumEl.style.display = "none";
   if (actionsEl) actionsEl.style.display = "none";
@@ -8085,7 +8085,7 @@ async function openPocketHistory(pocketName) {
     const p = data.pocket || {};
     const t = data.totals || {};
     _currentPocketForEdit = p;
-    titleEl.textContent = `Histórico — ${p.name || pocketName}`;
+    titleEl.textContent = `Histórico: ${p.name || pocketName}`;
     const interestTxt = p.interest_enabled === false ? "Sem rendimento" : _formatCdiRate(p.interest_rate);
     subEl.textContent = p.description ? `${p.description} · ${interestTxt}` : interestTxt;
 
@@ -9440,7 +9440,7 @@ function render(d) {
           </div>
           ${mkBlock("Investimentos", inv, "var(--blue)")}
           ${mkBlock("Caixinhas",     pkt, "var(--purple)")}
-          <div class="aporte-foot">Não conta como despesa — é alocação de patrimônio.</div>
+          <div class="aporte-foot">Não conta como despesa: é alocação de patrimônio.</div>
         `;
       })()}
     </div>
@@ -9625,7 +9625,7 @@ function _renderAffiliateView(data) {
           style="flex:1;min-width:0;padding:10px 12px;border-radius:10px;border:1px solid var(--glass-border);background:var(--glass-bg);color:var(--text);font-size:.82rem">
         <button class="mock-cta" type="button" onclick="copyAffiliateLink()">Copiar</button>
       </div>
-      ${data.status !== "active" ? '<p style="font-size:.75rem;color:var(--red);margin:10px 0 0">Seu cadastro de afiliado está desativado — o link não gera novas comissões.</p>' : ""}
+      ${data.status !== "active" ? '<p style="font-size:.75rem;color:var(--red);margin:10px 0 0">Seu cadastro de afiliado está desativado. O link não gera novas comissões.</p>' : ""}
 
       <h3 style="margin:18px 0 6px">Solicitar saque</h3>
       <p style="font-size:.78rem;color:var(--text-3);margin:0 0 10px">
@@ -9642,7 +9642,7 @@ function _renderAffiliateView(data) {
 
     <div class="mock-card">
       <h3 style="margin:0 0 10px">Comissões</h3>
-      <div class="tx-list">${commissionRows || '<div style="padding:16px 0;color:var(--text-3);font-size:.8rem">Nenhuma comissão ainda — divulgue seu link! <i class="ph ph-piggy-bank" aria-hidden="true"></i></div>'}</div>
+      <div class="tx-list">${commissionRows || '<div style="padding:16px 0;color:var(--text-3);font-size:.8rem">Nenhuma comissão ainda. Divulgue seu link! <i class="ph ph-piggy-bank" aria-hidden="true"></i></div>'}</div>
       <h3 style="margin:18px 0 10px">Saques</h3>
       <div class="tx-list">${payoutRows || '<div style="padding:16px 0;color:var(--text-3);font-size:.8rem">Nenhum saque solicitado.</div>'}</div>
     </div>

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4788,7 +4788,7 @@ async def unsubscribe(uid: int, token: str):
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
   <script src="/safe-area.js?v=1"></script>
-  <title>Descadastro — PigBank</title>
+  <title>Descadastro · PigBank</title>
   <style>
     body{margin:0;padding:0;background:#0a0d18;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
          color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh}

--- a/frontend/funcionalidades.html
+++ b/frontend/funcionalidades.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Funcionalidades — PigBank</title>
-<meta name="description" content="Conheça os recursos do PigBank: registro por conversa, categorização automática, caixinhas, cartões, alertas e segurança — tudo no WhatsApp." />
+<title>Funcionalidades · PigBank</title>
+<meta name="description" content="Conheça os recursos do PigBank: registro por conversa, categorização automática, caixinhas, cartões, alertas e segurança, tudo no WhatsApp." />
 <link rel="canonical" href="https://pigbankai.com/funcionalidades" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -38,14 +38,14 @@
     <section class="section">
       <div class="section-head">
         <h2>Recursos que fazem<br>a <span class="grad">diferença</span></h2>
-        <p>Tudo que você precisa pra organizar sua vida financeira — sem planilha, sem app pra baixar, direto no WhatsApp.</p>
+        <p>Tudo que você precisa pra organizar sua vida financeira, sem planilha, sem app pra baixar, direto no WhatsApp.</p>
       </div>
 
       <div class="grid-3">
         <div class="card feature-card">
           <div class="icon-box"><i class="ph ph-chat-circle" aria-hidden="true"></i></div>
           <h3>Registro por conversa</h3>
-          <p>Fale como você fala. A IA entende, categoriza e registra o gasto na hora — em segundos.</p>
+          <p>Fale como você fala. A IA entende, categoriza e registra o gasto na hora, em segundos.</p>
         </div>
         <div class="card feature-card">
           <div class="icon-box neon"><i class="ph ph-tag" aria-hidden="true"></i></div>
@@ -83,7 +83,7 @@
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> IA que entende português do dia a dia</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização que aprende com você</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard atualizado em tempo real</li>
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp — zero apps pra baixar</li>
+          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp, zero apps pra baixar</li>
         </ul>
         <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora →</a>
       </div>
@@ -212,7 +212,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -437,7 +437,7 @@ footer a:hover { color:var(--text); }
     <div class="free-banner" id="free-banner">
       <div class="fb-text">
         <span class="fb-emoji"><i class="ph ph-piggy-bank" aria-hidden="true"></i></span>
-        <span>Você está no <b>Free</b>. Suba pro <b>PigBank+</b> e libere <b>conversar com a IA</b>, OFX, investimentos, export e caixinhas ilimitadas — 30 dias grátis.</span>
+        <span>Você está no <b>Free</b>. Suba pro <b>PigBank+</b> e libere <b>conversar com a IA</b>, OFX, investimentos, export e caixinhas ilimitadas. 30 dias grátis.</span>
       </div>
       <a class="fb-cta" href="/precos">Fazer upgrade</a>
     </div>
@@ -828,7 +828,7 @@ function renderAlerts(snapshot) {
     <div class="alert-body">
       <div class="alert-icon">${isOverdue ? '<i class="ph ph-warning-circle" aria-hidden="true"></i>' : '<i class="ph ph-warning" aria-hidden="true"></i>'}</div>
       <div class="alert-text">
-        Fatura <strong>${escapeHtml(c.name)}</strong> de ${monthName} ${dueLabel} — ${fmtBRL(c.due_amount || 0)} em aberto
+        Fatura <strong>${escapeHtml(c.name)}</strong> de ${monthName} ${dueLabel}, ${fmtBRL(c.due_amount || 0)} em aberto
       </div>
     </div>
     <div class="alert-actions">
@@ -1319,14 +1319,14 @@ async function mfaOnboardingDismiss() {
   <div class="welcome-pro-card">
     <div class="welcome-pro-emoji"><i class="ph ph-piggy-bank" aria-hidden="true"></i></div>
     <h2>Tá dentro do PigBank+!</h2>
-    <p class="welcome-pro-sub">Bora ver o que tu desbloqueou, parceiro?<br/>Os 30 dias grátis começam agora — só tem cobrança depois.</p>
+    <p class="welcome-pro-sub">Bora ver o que tu desbloqueou, parceiro?<br/>Os 30 dias grátis começam agora, só tem cobrança depois.</p>
     <div class="center"><div class="welcome-pro-trial"><i class="ph ph-confetti" aria-hidden="true"></i> 30 dias grátis</div></div>
     <div class="welcome-pro-feats">
       <div class="welcome-pro-feat">Caixinhas e cartões sem limite</div>
       <div class="welcome-pro-feat">Investimentos com IR e IOF no automático</div>
       <div class="welcome-pro-feat">Histórico completo + exportar CSV</div>
       <div class="welcome-pro-feat">Importar extrato e fatura por OFX</div>
-      <div class="welcome-pro-feat">Piggy IA — converse sobre suas finanças</div>
+      <div class="welcome-pro-feat">Piggy IA: converse sobre suas finanças</div>
     </div>
     <div class="welcome-pro-actions">
       <button class="welcome-pro-btn-primary" type="button" onclick="goExplorePro()">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>PigBank — Seu assistente financeiro no WhatsApp</title>
+<title>PigBank · Seu assistente financeiro no WhatsApp</title>
 <meta name="description" content="Controle seu dinheiro direto no WhatsApp. Registre gastos, consulte saldo e acompanhe cartões em segundos com a IA da PigBank." />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -84,7 +84,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       <div class="hero-copy">
         <div class="pill"><span class="tag-novo">NOVO</span> Seu assistente financeiro com IA no WhatsApp</div>
         <h1 class="hero-title">A sua vida financeira,<br><span class="grad">resolvida no WhatsApp.</span></h1>
-        <p class="hero-sub">Registre gastos, acompanhe seu saldo e entenda sua vida financeira conversando com a IA da PigBank — sem planilha, sem app pra baixar.</p>
+        <p class="hero-sub">Registre gastos, acompanhe seu saldo e entenda sua vida financeira conversando com a IA da PigBank. Sem planilha, sem app pra baixar.</p>
         <div class="hero-cta">
           <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
           <a class="btn btn-outline btn-lg" href="#como-funciona">Ver como funciona</a>
@@ -168,14 +168,14 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       <div class="section-head" data-reveal>
         <div class="eyebrow">Funcionalidades</div>
         <h2>Recursos que fazem<br>a <span class="grad">diferença</span></h2>
-        <p>Tudo que você precisa pra organizar sua vida financeira — sem planilha, sem app pra baixar, direto no WhatsApp.</p>
+        <p>Tudo que você precisa pra organizar sua vida financeira, sem planilha, sem app pra baixar, direto no WhatsApp.</p>
       </div>
 
       <div class="grid-3" data-reveal>
         <div class="card feature-card">
           <div class="icon-box"><i class="ph ph-chat-circle" aria-hidden="true"></i></div>
           <h3>Registro por conversa</h3>
-          <p>Fale como você fala. A IA entende, categoriza e registra o gasto na hora — em segundos.</p>
+          <p>Fale como você fala. A IA entende, categoriza e registra o gasto na hora, em segundos.</p>
         </div>
         <div class="card feature-card">
           <div class="icon-box neon"><i class="ph ph-tag" aria-hidden="true"></i></div>
@@ -212,7 +212,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       <div class="section-head" data-reveal>
         <div class="eyebrow">Como funciona</div>
         <h2>Simples, rápido e<br>no seu <span class="grad">WhatsApp</span></h2>
-        <p>Em poucos minutos você já está no controle do seu dinheiro — sem planilha, sem app pra baixar.</p>
+        <p>Em poucos minutos você já está no controle do seu dinheiro, sem planilha, sem app pra baixar.</p>
       </div>
 
       <div class="how-grid">
@@ -223,7 +223,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
           </div>
           <div class="step">
             <div class="step-num">2</div>
-            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece — nada pra instalar.</p></div>
+            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece. Nada pra instalar.</p></div>
           </div>
           <div class="step">
             <div class="step-num">3</div>
@@ -258,7 +258,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> IA que entende português do dia a dia</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização que aprende com você</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard atualizado em tempo real</li>
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp — zero apps pra baixar</li>
+          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp, zero apps pra baixar</li>
         </ul>
         <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
@@ -400,14 +400,14 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
             <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Caixinhas, metas e cartões ilimitados</li>
             <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização automática por IA</li>
             <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard em tempo real</li>
-            <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA — converse sobre suas finanças</li>
+            <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA: converse sobre suas finanças</li>
           </ul>
           <a class="btn btn-primary btn-lg btn-block" href="/precos">Ver planos <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
           <p class="plan-solo-choose">Escolha <b>mensal</b> ou <b>anual</b> na próxima tela.</p>
         </article>
       </div>
 
-      <p class="plans-note"><i class="ph ph-confetti" aria-hidden="true"></i> 30 dias grátis com cartão; a primeira cobrança só acontece depois do trial. Cancele quando quiser pelo dashboard antes do fim do trial, sem ser cobrado. Pagamentos processados pela Stripe — a PigBank nunca vê os dados do seu cartão.</p>
+      <p class="plans-note"><i class="ph ph-confetti" aria-hidden="true"></i> 30 dias grátis com cartão; a primeira cobrança só acontece depois do trial. Cancele quando quiser pelo dashboard antes do fim do trial, sem ser cobrado. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
     </section>
 
     <div class="sec-sep"></div>
@@ -423,11 +423,11 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       <div class="faq" data-reveal>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">Preciso baixar algum aplicativo? <span class="chev">+</span></button>
-          <div class="faq-a"><p>Não. Tudo acontece no seu WhatsApp — é só conversar com a Piggy. O dashboard abre no navegador, sem instalar nada.</p></div>
+          <div class="faq-a"><p>Não. Tudo acontece no seu WhatsApp: é só conversar com a Piggy. O dashboard abre no navegador, sem instalar nada.</p></div>
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">Como eu registro um gasto? <span class="chev">+</span></button>
-          <div class="faq-a"><p>Você só fala como falaria com um amigo: "gastei 50 no mercado". A IA entende, categoriza e salva na hora — em segundos.</p></div>
+          <div class="faq-a"><p>Você só fala como falaria com um amigo: "gastei 50 no mercado". A IA entende, categoriza e salva na hora, em segundos.</p></div>
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">Meus dados estão seguros? <span class="chev">+</span></button>
@@ -435,7 +435,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">A PigBank mexe no meu dinheiro ou tem a senha do meu banco? <span class="chev">+</span></button>
-          <div class="faq-a"><p>Não. A PigBank não é banco nem corretora — <strong>nunca movimenta, transfere ou guarda</strong> o seu dinheiro. Se você conectar um banco, é via Open Finance oficial, <strong>só de leitura</strong> e autorizado por você: a gente nunca pede sua senha, e você revoga o acesso quando quiser.</p></div>
+          <div class="faq-a"><p>Não. A PigBank não é banco nem corretora: <strong>nunca movimenta, transfere ou guarda</strong> o seu dinheiro. Se você conectar um banco, é via Open Finance oficial, <strong>só de leitura</strong> e autorizado por você: a gente nunca pede sua senha, e você revoga o acesso quando quiser.</p></div>
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">Tem período grátis? <span class="chev">+</span></button>
@@ -451,7 +451,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">A Piggy entende português do dia a dia? <span class="chev">+</span></button>
-          <div class="faq-a"><p>Entende. Você não precisa decorar comando nenhum — fala do seu jeito e a IA faz o resto.</p></div>
+          <div class="faq-a"><p>Entende. Você não precisa decorar comando nenhum: fala do seu jeito e a IA faz o resto.</p></div>
         </div>
       </div>
     </section>
@@ -470,7 +470,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Entrar — PigBank</title>
+<title>Entrar · PigBank</title>
 <meta name="description" content="Entre na sua conta PigBank e acompanhe sua vida financeira." />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />

--- a/frontend/onboarding.html
+++ b/frontend/onboarding.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Finalize seu cadastro — PigBank</title>
+<title>Finalize seu cadastro · PigBank</title>
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Planos — PigBank</title>
+<title>Planos · PigBank</title>
 <meta name="description" content="Planos PigBank: Grátis, Essencial R$ 9,90, Plus R$ 19,90 e Pro R$ 49,90. 30 dias grátis pra testar o plano que você escolher." />
 <link rel="canonical" href="https://pigbankai.com/precos" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
@@ -97,7 +97,7 @@
             <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;19,90</span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;199</span></div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>2&nbsp;bancos conectados</strong> (Open&nbsp;Finance)</span></li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Agentes</strong>: energia pra até 3 — você escolhe quais</span></li>
+              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Agentes</strong>: energia pra até 3, você escolhe quais</span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA sem limites</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Alertas de gastos fora do padrão</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Histórico de 12 meses + tudo do Essencial</li>
@@ -136,9 +136,9 @@
           </article>
         </div>
 
-        <p class="plans-note"><i class="ph ph-piggy-bank" aria-hidden="true"></i> <strong>Preço de fundador:</strong> assinando agora, seu valor fica congelado pra sempre — enquanto a assinatura estiver ativa, ele nunca sobe.</p>
+        <p class="plans-note"><i class="ph ph-piggy-bank" aria-hidden="true"></i> <strong>Preço de fundador:</strong> assinando agora, seu valor fica congelado pra sempre: enquanto a assinatura estiver ativa, ele nunca sobe.</p>
       </div>
-      <p class="plans-note" id="plans-note-v2"><i class="ph ph-confetti" aria-hidden="true"></i> Todo plano vem com <strong>30 dias grátis pra testar</strong> (um teste por número). A primeira cobrança só acontece depois do trial — cancele antes pelo dashboard e não paga nada. Pagamentos processados pela Stripe — a PigBank nunca vê os dados do seu cartão.</p>
+      <p class="plans-note" id="plans-note-v2"><i class="ph ph-confetti" aria-hidden="true"></i> Todo plano vem com <strong>30 dias grátis pra testar</strong> (um teste por número). A primeira cobrança só acontece depois do trial. Cancele antes pelo dashboard e não paga nada. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
     </section>
 
   </div>
@@ -147,7 +147,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>
@@ -318,7 +318,7 @@ function openChangeModal(plan) {
         return;
       }
       closeChangeModal();
-      showToast(`✓ Troca agendada pra ${fmtBrDate(data2.effective_at)} — te mandei um e-mail de confirmação.`);
+      showToast(`✓ Troca agendada pra ${fmtBrDate(data2.effective_at)}. Te mandei um e-mail de confirmação.`);
       await loadSubscription();
       refreshPlanButtons();
     } catch {
@@ -343,7 +343,7 @@ async function cancelChange(btn) {
       btn.disabled = false;
       return;
     }
-    showToast("Troca desfeita — seu plano continua como está.");
+    showToast("Troca desfeita. Seu plano continua como está.");
     await loadSubscription();
     refreshPlanButtons();
   } catch {
@@ -368,7 +368,7 @@ async function applyOnboardingChoice() {
   if (me && me.needs_plan_selection) {
     // Guia visual: deixa claro que precisa escolher um plano pra começar.
     const sub = document.getElementById("precos-sub");
-    if (sub) sub.textContent = "Escolha um plano pra começar — dá pra seguir no Grátis ou testar um plano pago 30 dias de graça.";
+    if (sub) sub.textContent = "Escolha um plano pra começar: dá pra seguir no Grátis ou testar um plano pago 30 dias de graça.";
     if (cta) {
       cta.removeAttribute("href");
       cta.style.cursor = "pointer";

--- a/frontend/preview_agentes.html
+++ b/frontend/preview_agentes.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Preview — Agentes</title>
+<title>Preview · Agentes</title>
 <link rel="stylesheet" href="/dashboard.css"/>
 <style>
   body{background:#0a0d18;margin:0;padding:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
@@ -15,7 +15,7 @@
 <div class="wrap" id="agentes-view">
   <h1 class="ag-title">🐷 Seus agentes</h1>
   <div id="agentes-counters" class="ag-counters"></div>
-  <p class="ag-sub">Sua equipe de porquinhos trabalhando 24h nos seus dados — cada um vigia uma coisa e só fala quando vale a pena.</p>
+  <p class="ag-sub">Sua equipe de porquinhos trabalhando 24h nos seus dados: cada um vigia uma coisa e só fala quando vale a pena.</p>
   <div id="agentes-shelf" class="ag-shelf"></div>
   <p class="section-title ag-feed-title">Últimos disparos</p>
   <div id="agentes-feed" class="ag-feed"></div>
@@ -35,7 +35,7 @@ const catalog = [
   {kind:"detetive",nome:"Detetive",freq:"Semanal",desc:"Fareja cobranças repetidas que parecem assinatura esquecida",disponivel:false,status:"inactive"},
   {kind:"cofre",nome:"Banqueiro",freq:"Dia do salário",desc:"Acompanha suas caixinhas e sugere o aporte que adianta a meta",disponivel:false,status:"inactive"},
   {kind:"barao",nome:"Barão",freq:"Diário · Open Finance",desc:"Fareja dinheiro parado rendendo nada e acompanha seus investimentos",disponivel:false,status:"inactive"},
-  {kind:"faria_limer",nome:"Faria Limer",freq:"Mensal · Open Finance",desc:"Acompanha sua renda variável (ações e FIIs): o retrato do mês e a concentração da carteira — só fatos",disponivel:false,status:"inactive"},
+  {kind:"faria_limer",nome:"Faria Limer",freq:"Mensal · Open Finance",desc:"Acompanha sua renda variável (ações e FIIs): o retrato do mês e a concentração da carteira, só fatos",disponivel:false,status:"inactive"},
 ];
 const fmtShort = v => "R$ " + v;
 document.getElementById("agentes-counters").innerHTML = `

--- a/frontend/privacy.html
+++ b/frontend/privacy.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Política de Privacidade — PigBank</title>
+<title>Política de Privacidade · PigBank</title>
 <meta name="description" content="Como o PigBank coleta, usa e protege seus dados pessoais." />
 <link rel="canonical" href="https://pigbankai.com/privacy" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
@@ -207,7 +207,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/reset-password.html
+++ b/frontend/reset-password.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Redefinir senha — PigBank</title>
+<title>Redefinir senha · PigBank</title>
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-<title>Configurações — PigBank</title>
+<title>Configurações · PigBank</title>
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <meta name="theme-color" content="#111111" />
 <!-- Widget da Pluggy: só é instanciado quando o usuário abre "conectar banco"
@@ -1155,7 +1155,7 @@ a { color: inherit; text-decoration: none; }
     </div>
     <h1 class="page-title">Conexões bancárias</h1>
     <p class="page-sub">
-      Conecte seus bancos via Open Finance para sincronizar saldos e transações automaticamente — sem precisar lançar nada no chat.
+      Conecte seus bancos via Open Finance para sincronizar saldos e transações automaticamente, sem precisar lançar nada no chat.
     </p>
   </header>
 
@@ -1324,7 +1324,7 @@ a { color: inherit; text-decoration: none; }
       <div class="info-banner">
         <span class="info-banner-icon"><i class="ph ph-lightbulb" aria-hidden="true"></i></span>
         <span>
-          <strong>Como funciona o Open Finance?</strong> Você autoriza o acesso dentro do ambiente seguro do banco, via Pluggy — a gente nunca vê sua senha e você pode revogar o acesso quando quiser.
+          <strong>Como funciona o Open Finance?</strong> Você autoriza o acesso dentro do ambiente seguro do banco, via Pluggy: a gente nunca vê sua senha e você pode revogar o acesso quando quiser.
         </span>
       </div>
 
@@ -1812,7 +1812,7 @@ let notificationSettingsLoaded = false;
 const SECTION_COPY = {
   "open-finance": {
     title: "Conexões bancárias",
-    sub: "Conecte seus bancos via Open Finance para sincronizar saldos e transações automaticamente — sem precisar lançar nada no chat.",
+    sub: "Conecte seus bancos via Open Finance para sincronizar saldos e transações automaticamente, sem precisar lançar nada no chat.",
   },
   security: {
     title: "Segurança",
@@ -1949,7 +1949,7 @@ function applySecuritySettings(data) {
     }
   }
   document.getElementById("security-plan-note").textContent = isPro
-    ? (data.plan_expires_at ? `Renova em ${fmtDate(data.plan_expires_at)}.` : "Acesso vitalício — sem cobrança.")
+    ? (data.plan_expires_at ? `Renova em ${fmtDate(data.plan_expires_at)}.` : "Acesso vitalício, sem cobrança.")
     : "Assine o Pro para desbloquear todos os recursos.";
   document.getElementById("security-session-value").textContent = formatSessionExpiry();
   document.getElementById("security-reset-btn").disabled = !hasEmail;
@@ -1961,7 +1961,7 @@ function applySecuritySettings(data) {
 async function loadSecuritySettings() {
   if (!USER_ID) {
     applySecuritySettings({});
-    showToast("Sessão inválida — faça login novamente", "error");
+    showToast("Sessão inválida. Faça login novamente", "error");
     return;
   }
   try {
@@ -2247,7 +2247,7 @@ function applyNotificationSettings(data) {
 
 async function loadNotificationSettings() {
   if (!USER_ID) {
-    showToast("Sessão inválida — faça login novamente", "error");
+    showToast("Sessão inválida. Faça login novamente", "error");
     return;
   }
   setNotificationControlsDisabled(true);
@@ -2782,7 +2782,7 @@ async function bindCaixinha(ofInvestmentId, newPocketVal, currentPocketId) {
    banco (PATCH /items), espera concluir e sincroniza — puxa transação nova, marca
    a conexão ATIVA e limpa "Pendente". */
 async function refreshOpenFinance() {
-  if (!USER_ID) { showToast("Sessão inválida — faça login novamente", "error"); return; }
+  if (!USER_ID) { showToast("Sessão inválida. Faça login novamente", "error"); return; }
   const btn = document.getElementById("of-refresh-btn");
   const orig = btn ? btn.textContent : "";
   if (btn) { btn.disabled = true; btn.textContent = "↻ Atualizando…"; }
@@ -2898,7 +2898,7 @@ async function openPluggyConnect() {
 }
 
 async function connectOpenFinance() {
-  if (!USER_ID) { showToast("Sessão inválida — faça login novamente", "error"); return; }
+  if (!USER_ID) { showToast("Sessão inválida. Faça login novamente", "error"); return; }
   // Free (limite 0): não abre o widget — o /pluggy-item recusaria. Leva pro upgrade.
   if (OF_BANKS_MAX === 0) { window.location.href = "/precos"; return; }
   const btn = document.getElementById("connect-btn");
@@ -3401,7 +3401,7 @@ initSettings();
 <div class="mfa-overlay" id="activity-modal-overlay" onclick="if (event.target === this) closeActivityModal()">
   <div class="mfa-modal">
     <h3>Atividade recente da conta</h3>
-    <p class="sub">Últimas ações sensíveis registradas — login de novos dispositivos, alterações de e-mail, MFA e Open Finance.</p>
+    <p class="sub">Últimas ações sensíveis registradas: login de novos dispositivos, alterações de e-mail, MFA e Open Finance.</p>
     <div id="activity-modal-list" class="activity-list"></div>
     <div class="mfa-actions">
       <button class="btn-cancel" type="button" onclick="closeActivityModal()">Fechar</button>

--- a/frontend/suporte.html
+++ b/frontend/suporte.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Contato & Suporte — PigBank</title>
+<title>Contato & Suporte · PigBank</title>
 <meta name="description" content="Fale com o time do PigBank. Tire dúvidas, peça ajuda com acesso, WhatsApp ou dashboard." />
 <link rel="canonical" href="https://pigbankai.com/suporte" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
@@ -110,7 +110,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Termos de Uso — PigBank</title>
-<meta name="description" content="Termos de Uso do PigBank — regras de acesso e uso do serviço." />
+<title>Termos de Uso · PigBank</title>
+<meta name="description" content="Termos de Uso do PigBank: regras de acesso e uso do serviço." />
 <link rel="canonical" href="https://pigbankai.com/termos" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -104,8 +104,8 @@
         </p>
         <p>
           Você pode cancelar a qualquer momento durante o trial pelo
-          <a href="/conta">Portal de assinatura</a> ou pelos comandos do bot (Discord/WhatsApp) —
-          nesse caso, nenhuma cobrança será feita. Se não cancelar antes do fim do prazo, a
+          <a href="/conta">Portal de assinatura</a> ou pelos comandos do bot (Discord/WhatsApp).
+          Nesse caso, nenhuma cobrança será feita. Se não cancelar antes do fim do prazo, a
           cobrança da mensalidade ou anuidade é feita automaticamente no 31º dia, no mesmo cartão
           informado.
         </p>
@@ -135,7 +135,7 @@
         </ul>
         <p>
           Ao cancelar, você mantém acesso aos recursos Pro até o fim do ciclo já pago. Após esse
-          prazo, a conta volta automaticamente para o plano Free — os dados são preservados (você
+          prazo, a conta volta automaticamente para o plano Free. Os dados são preservados (você
           não perde lançamentos, histórico ou conta).
         </p>
       </section>
@@ -153,7 +153,7 @@
           o início do primeiro ciclo cobrado</strong>, desde que entre em contato pelo
           <a href="mailto:suporte@pigbankai.com">suporte@pigbankai.com</a> dentro desse prazo.
           Reembolsos solicitados fora dessa janela não são garantidos, e cancelamentos não geram
-          reembolso proporcional do ciclo em curso — o acesso permanece ativo até o fim do período
+          reembolso proporcional do ciclo em curso. O acesso permanece ativo até o fim do período
           já pago.
         </p>
         <p>
@@ -197,11 +197,11 @@
       <section>
         <h2>10. Limitações de responsabilidade</h2>
         <p>
-          O PigBank é uma ferramenta de organização e análise financeira pessoal —
-          <strong>não somos instituição financeira</strong>, não custodiamos dinheiro, não emitimos
+          O PigBank é uma ferramenta de organização e análise financeira pessoal.
+          <strong>Não somos instituição financeira</strong>, não custodiamos dinheiro, não emitimos
           empréstimos, não somos consultoria de investimentos. Os rendimentos exibidos para
           caixinhas e investimentos são <strong>simulações educacionais</strong> baseadas em taxas
-          de referência públicas (CDI/Selic/IPCA) — você é responsável por verificar valores reais
+          de referência públicas (CDI/Selic/IPCA). Você é responsável por verificar valores reais
           com seu banco ou corretora.
         </p>
         <p>
@@ -261,7 +261,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>

--- a/frontend/whatsapp.html
+++ b/frontend/whatsapp.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>WhatsApp — PigBank</title>
+<title>WhatsApp · PigBank</title>
 <meta name="description" content="Controle seu dinheiro mandando mensagem no WhatsApp. Registre gastos, cartões e veja seu saldo conversando com a Piggy." />
 <link rel="canonical" href="https://pigbankai.com/whatsapp" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
@@ -52,7 +52,7 @@
       <div class="section-head" style="margin-bottom:30px">
         <div class="eyebrow">Como conectar</div>
         <h2>Comece em <span class="grad">3 passos</span></h2>
-        <p>Leva menos de um minuto. O segredo é usar o <b>mesmo número</b> de WhatsApp no cadastro — é ele que liga a conversa à sua conta.</p>
+        <p>Leva menos de um minuto. O segredo é usar o <b>mesmo número</b> de WhatsApp no cadastro: é ele que liga a conversa à sua conta.</p>
       </div>
 
       <div class="steps" style="max-width:620px;margin:0 auto 30px">
@@ -120,7 +120,7 @@
     <div class="wrap footer-inner">
       <div class="footer-brand">
         <a class="nav-logo" href="/"><img class="logo-icon" src="/brand/icon.png?v=1" alt="" /> <span>PigBank</span></a>
-        <p>Seu dinheiro, suas regras — direto no WhatsApp, com a IA da Piggy.</p>
+        <p>Seu dinheiro, suas regras, direto no WhatsApp, com a IA da Piggy.</p>
       </div>
       <div class="footer-cols">
         <div class="footer-col"><span class="footer-title">Navegue</span>


### PR DESCRIPTION
## O quê

Remove os em-dashes (`—`) de **todo o texto visível do site**, trocando por pontuação contextual (vírgula, dois-pontos, ponto ou parênteses conforme a frase).

## Onde

- **21 páginas HTML** (landing, institucionais e do app): copy visível + **títulos** (`—` → `·`) + **meta descriptions**.
- **`termos.html`**: prosa legal, preservando o sentido.
- **`dashboard.js`**: 36 strings visíveis da UI (toasts, labels, títulos de card).
- **Página de descadastro** gerada em Python: `<title>`.

Prova: a landing renderizada retorna `anyEmDashVisible: false`. Substituição 1:1 por linha (140 inserções / 140 remoções), sem mudança de layout.

## Fora do escopo (intencional)

Por decisão de escopo (só texto visível, substituição contextual), **não** foram tocados:

- **Placeholders de valor vazio** (`—` em tabelas/selects, `R$ —`, `— Selecione —`) — convenção de UI, não prosa.
- **Painel admin** e o protótipo `_dash_mockup.html` — interno, não o site público.
- **Mensagens do bot WhatsApp/Discord, e-mails e comentários de código.**

Guarda no diff confirma que nenhum placeholder foi alterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)