### PR TITLE
feat(home): redesenha a tela de confirmação de assinatura

### DIFF
--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -395,12 +395,27 @@ def require_min_tier(user_id: int, minimum: str) -> bool:
     return tier_at_least(get_plan_tier(user_id), minimum)
 
 
+def _ai_monthly_limit(limits: PlanLimits) -> int:
+    """A regra da cota, num lugar só: `ai_monthly_messages: None` NÃO é
+    ilimitado — cai no teto global AI_CHAT_MONTHLY_LIMIT, e mesmo a cota
+    própria é capada por ele. Quem corta é core/services/ai_chat/runner.py."""
+    from .ai_chat_commands import AI_CHAT_MONTHLY_LIMIT
+    per_tier = limits.get("ai_monthly_messages")
+    return AI_CHAT_MONTHLY_LIMIT if per_tier is None else min(per_tier, AI_CHAT_MONTHLY_LIMIT)
+
+
 def ai_monthly_limit_for(user_id: int) -> int:
     """Cota mensal de mensagens da IA pro usuário (sempre um int; tiers sem
     cota própria caem no limite global AI_CHAT_MONTHLY_LIMIT)."""
-    from .ai_chat_commands import AI_CHAT_MONTHLY_LIMIT
-    per_tier = get_user_limits(user_id).get("ai_monthly_messages")
-    return AI_CHAT_MONTHLY_LIMIT if per_tier is None else min(per_tier, AI_CHAT_MONTHLY_LIMIT)
+    return _ai_monthly_limit(get_user_limits(user_id))
+
+
+def ai_monthly_limit_for_tier(tier: str) -> int:
+    """Mesma cota, mas perguntada pelo TIER em vez do usuário. O checkout
+    precisa disso: a tela de confirmação abre antes do webhook gravar o plano,
+    então não dá pra consultar o usuário — o número tem que sair do plano que
+    acabou de ser comprado e viajar no success_url."""
+    return _ai_monthly_limit(limits_for_tier(tier))
 
 
 def ai_chat_allowed(user_id: int) -> bool:

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3701,7 +3701,11 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
 
     # A elegibilidade só é consultada ao criar uma sessão nova. Reabrir a mesma
     # URL preserva exatamente as condições que o usuário já viu no checkout.
-    from core.services.plan_service import plans_v2_enabled, trial_days_total
+    from core.services.plan_service import (
+        ai_monthly_limit_for_tier,
+        plans_v2_enabled,
+        trial_days_total,
+    )
     if plans_v2_enabled():
         from db.plans import TrialEligibilityError, is_trial_eligible_for_user
         try:
@@ -3714,6 +3718,14 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
         trial_days = trial_days_total() if eligible else 0
     else:
         trial_days = int(os.getenv("PRO_TRIAL_DAYS", "30"))
+
+    # Cota mensal da IA do plano comprado. Plus e Pro têm `ai_monthly_messages:
+    # None` em plan_limits.py, o que NÃO é ilimitado: cai no teto global
+    # AI_CHAT_MONTHLY_LIMIT (1.000 por padrão, ajustável por env) e o chat corta
+    # ali. Vai na URL pelo mesmo motivo do `td`: número de backend não pode ficar
+    # chumbado no HTML, e com v2 desligado o tier efetivo de quem paga é o de
+    # cima, não o comprado (get_user_limits → limits_for("pro")).
+    ia_quota = ai_monthly_limit_for_tier(plan if plans_v2_enabled() else "pro")
 
     def _new_session(cust_id: str):
         metadata = {
@@ -3733,16 +3745,18 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             locale="pt-BR",
             allow_promotion_codes=True,
             # `td` = dias de trial concedidos NESTA sessão. `pl` = plano escolhido.
-            # A tela de confirmação usa os dois na cópia. Sem `td` o front chutava
-            # 30, que quebra se trial_days_total()/PRO_TRIAL_DAYS mudar; sem `pl`
-            # ele parabenizava TODO mundo pelo Plus, inclusive quem comprou
-            # Essencial ou Pro. O plano tem que vir na URL e não do /auth/me
-            # porque o modal abre ~450ms depois da volta, quando o webhook ainda
-            # pode não ter caído e o plano gravado ainda ser o antigo.
+            # `ia` = cota mensal de mensagens da Piggy nesse plano. A tela de
+            # confirmação usa os três na cópia. Sem `td` o front chutava 30, que
+            # quebra se trial_days_total()/PRO_TRIAL_DAYS mudar; sem `pl` ele
+            # parabenizava TODO mundo pelo Plus, inclusive quem comprou Essencial
+            # ou Pro; sem `ia` ele prometia IA "sem limite de mensagens", que o
+            # backend não entrega. Tudo isso tem que vir na URL e não do
+            # /auth/me porque o modal abre ~450ms depois da volta, quando o
+            # webhook ainda pode não ter caído e o plano gravado ainda ser o antigo.
             success_url=(
                 f"{DASHBOARD_URL}/home?upgrade=success&sid={{CHECKOUT_SESSION_ID}}"
                 f"&ev={'trial' if trial_days > 0 else 'purchase'}"
-                f"&td={trial_days}&pl={plan}"
+                f"&td={trial_days}&pl={plan}&ia={ia_quota}"
             ),
             cancel_url=f"{DASHBOARD_URL}/home?upgrade=cancelled",
             metadata=metadata,

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3732,9 +3732,13 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             mode="subscription",
             locale="pt-BR",
             allow_promotion_codes=True,
+            # `td` = dias de trial concedidos NESTA sessão. A tela de confirmação
+            # usa esse número na cópia; sem ele o front tinha que chutar 30, o que
+            # fica errado se trial_days_total()/PRO_TRIAL_DAYS mudar de valor.
             success_url=(
                 f"{DASHBOARD_URL}/home?upgrade=success&sid={{CHECKOUT_SESSION_ID}}"
                 f"&ev={'trial' if trial_days > 0 else 'purchase'}"
+                f"&td={trial_days}"
             ),
             cancel_url=f"{DASHBOARD_URL}/home?upgrade=cancelled",
             metadata=metadata,

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3732,13 +3732,17 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             mode="subscription",
             locale="pt-BR",
             allow_promotion_codes=True,
-            # `td` = dias de trial concedidos NESTA sessão. A tela de confirmação
-            # usa esse número na cópia; sem ele o front tinha que chutar 30, o que
-            # fica errado se trial_days_total()/PRO_TRIAL_DAYS mudar de valor.
+            # `td` = dias de trial concedidos NESTA sessão. `pl` = plano escolhido.
+            # A tela de confirmação usa os dois na cópia. Sem `td` o front chutava
+            # 30, que quebra se trial_days_total()/PRO_TRIAL_DAYS mudar; sem `pl`
+            # ele parabenizava TODO mundo pelo Plus, inclusive quem comprou
+            # Essencial ou Pro. O plano tem que vir na URL e não do /auth/me
+            # porque o modal abre ~450ms depois da volta, quando o webhook ainda
+            # pode não ter caído e o plano gravado ainda ser o antigo.
             success_url=(
                 f"{DASHBOARD_URL}/home?upgrade=success&sid={{CHECKOUT_SESSION_ID}}"
                 f"&ev={'trial' if trial_days > 0 else 'purchase'}"
-                f"&td={trial_days}"
+                f"&td={trial_days}&pl={plan}"
             ),
             cancel_url=f"{DASHBOARD_URL}/home?upgrade=cancelled",
             metadata=metadata,

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1282,6 +1282,10 @@ async function mfaOnboardingDismiss() {
   animation: welcomePop .5s cubic-bezier(.16,1,.3,1);
 }
 @keyframes welcomePop { from { transform: translateY(14px) scale(.97); opacity: 0; } to { transform: none; opacity: 1; } }
+/* O card recebe foco programático na abertura (tabindex="-1"); anel de foco num
+   container que o usuário não navegou até seria ruído. Os botões mantêm o
+   :focus-visible deles, que é o que importa pro teclado. */
+.welcome-pro-card:focus { outline: none; }
 /* mesmo grão do body::before: sem isto o card fica mais liso que a página */
 .welcome-pro-card::after {
   content: ""; position: absolute; inset: 0; pointer-events: none; opacity: .5;
@@ -1401,7 +1405,9 @@ async function mfaOnboardingDismiss() {
 </style>
 
 <div class="welcome-pro-overlay" id="welcome-pro-overlay">
-  <div class="welcome-pro-card" role="dialog" aria-modal="true" aria-labelledby="wp-title">
+  <!-- tabindex="-1": o foco de abertura vem pro container, não pro botão do fim
+       do card (ver openWelcomePro). Fora do Tab natural, só programático. -->
+  <div class="welcome-pro-card" role="dialog" aria-modal="true" aria-labelledby="wp-title" tabindex="-1">
     <img class="wp-mark" style="--i:0" src="/brand/icon.png?v=1" alt="" aria-hidden="true"
          width="45" height="48" />
     <p class="wp-eyebrow" style="--i:1">
@@ -1520,7 +1526,24 @@ function openWelcomePro({ trial = true, days = 30, plano = "plus", ia = null } =
 
   _wpLastFocus = document.activeElement;
   ov.classList.add("open");
-  ov.querySelector(".welcome-pro-btn-primary")?.focus();
+
+  /* O card tem `overflow: hidden auto` e `max-height: min(86dvh, 760px)`: quando
+     o conteúdo não cabe, ele rola por dentro. Focar o botão primário, que fica
+     no fim, fazia o navegador rolar o card ATÉ ELE — a tela abria com o título e
+     a cópia da confirmação acima da área visível. Medido em paisagem no
+     Chromium (o Info.plist habilita paisagem no iPhone): a 812x375 o card abria
+     com scrollTop 167 de 489px de conteúdo, com o título 50px acima do topo
+     visível; a 844x390, scrollTop 155.
+
+     O foco de abertura vai pro container, com preventScroll, e o scroll é
+     zerado na mão. Isso resolve duas coisas de uma vez: a tela abre pelo começo,
+     e o leitor de tela anuncia o diálogo pelo aria-labelledby em vez de começar
+     no meio, por um botão. O primeiro Tab leva ao botão primário normalmente. */
+  const card = ov.querySelector(".welcome-pro-card");
+  if (card) {
+    card.scrollTop = 0;
+    card.focus({ preventScroll: true });
+  }
   document.addEventListener("keydown", _wpOnKey);
 }
 
@@ -1542,13 +1565,18 @@ function _wpOnKey(e) {
   const ultimo = alvos[alvos.length - 1];
   const atual = document.activeElement;
   const foraDoCard = !card.contains(atual);
+  // O card em si recebe o foco na abertura (tabindex="-1"). Ele conta como
+  // ANTES do primeiro alvo: sem isto o Shift+Tab logo na abertura não seria
+  // interceptado — card.contains(card) é true — e o foco vazava pra página
+  // atrás do overlay, justamente o que este trap existe pra impedir.
+  const noContainer = atual === card;
 
   // Volta pra dentro nos dois sentidos, inclusive quando o foco já escapou
   // (clique no fundo, foco perdido no body).
-  if (e.shiftKey && (atual === primeiro || foraDoCard)) {
+  if (e.shiftKey && (atual === primeiro || foraDoCard || noContainer)) {
     e.preventDefault();
     ultimo.focus();
-  } else if (!e.shiftKey && (atual === ultimo || foraDoCard)) {
+  } else if (!e.shiftKey && (atual === ultimo || foraDoCard || noContainer)) {
     e.preventDefault();
     primeiro.focus();
   }

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1426,6 +1426,18 @@ async function mfaOnboardingDismiss() {
    só decide se a pessoa vai pro dashboard ou fica na Início. */
 let _wpLastFocus = null;
 
+/* "Cota ampliada" já não mentia, mas também não informava: o assinante fica
+   sem saber quantas mensagens comprou, e é justamente o número que decide se
+   ele vai esbarrar no teto. O `ia` do success_url resolve isso pelo mesmo
+   caminho que o `td` já tinha aberto — o argumento de que o valor "vem de env"
+   é o motivo de ele viajar na URL, não de ele sumir da tela. Sem `ia` (link
+   antigo, anterior ao parâmetro) a frase genérica continua valendo. */
+function _wpFeatIA(ia) {
+  return Number.isFinite(ia) && ia > 0
+    ? `Piggy IA: ${ia.toLocaleString("pt-BR")} mensagens por mês`
+    : "Piggy IA com cota ampliada";
+}
+
 /* O checkout vende TRÊS planos (essencial, plus, pro), e a tela parabenizava
    todo mundo pelo Plus: quem pagou Essencial via prometido o que não comprou, e
    quem pagou Pro era recebido como o plano de metade do preço.
@@ -1442,13 +1454,12 @@ let _wpLastFocus = null;
        ilimitado de verdade;
      - ai_monthly_messages None: cai no teto GLOBAL AI_CHAT_MONTHLY_LIMIT
        (1000/mês por padrão) em ai_monthly_limit_for (plan_service.py:398), e o
-       runner recusa depois disso. Por isso Plus e Pro dizem "cota ampliada" e
-       não "sem limite": eles só escapam da cota de 200 do Essencial, não do
-       teto da casa. O número em si não entra na cópia porque vem de env. */
+       runner recusa depois disso. Por isso Plus e Pro NÃO dizem "sem limite":
+       eles só escapam da cota de 200 do Essencial, não do teto da casa. */
 const WP_PLANOS = {
   essencial: {
     nome: "PigBank Essencial",
-    feats: [
+    feats: () => [
       "Conecte 1 banco pelo Open Finance",
       "Lance por áudio, foto do cupom ou OFX",
       "Caixinhas, metas e cartões sem limite",
@@ -1457,25 +1468,25 @@ const WP_PLANOS = {
   },
   plus: {
     nome: "PigBank+",
-    feats: [
+    feats: (ia) => [
       "Conecte 2 bancos pelo Open Finance",
       "Ligue seus agentes: energia para até 3",
-      "Piggy IA com cota ampliada",
+      _wpFeatIA(ia),
       "Histórico de 12 meses, com tudo do Essencial",
     ],
   },
   pro: {
     nome: "PigBank Pro",
-    feats: [
+    feats: (ia) => [
       "Conecte até 5 bancos pelo Open Finance",
       "Rode a equipe toda: energia para os 7 agentes",
-      "Piggy IA com cota ampliada",
+      _wpFeatIA(ia),
       "Histórico de 24 meses, com tudo do Plus",
     ],
   },
 };
 
-function openWelcomePro({ trial = true, days = 30, plano = "plus" } = {}) {
+function openWelcomePro({ trial = true, days = 30, plano = "plus", ia = null } = {}) {
   const ov = document.getElementById("welcome-pro-overlay");
   if (!ov) return;
 
@@ -1484,7 +1495,7 @@ function openWelcomePro({ trial = true, days = 30, plano = "plus" } = {}) {
   const cfg = WP_PLANOS[String(plano).toLowerCase()] || WP_PLANOS.plus;
   document.getElementById("wp-title").textContent = `Tá dentro do ${cfg.nome}`;
   const ul = document.getElementById("wp-feats");
-  ul.replaceChildren(...cfg.feats.map((texto) => {
+  ul.replaceChildren(...cfg.feats(ia).map((texto) => {
     const li = document.createElement("li");
     const ico = document.createElement("i");
     ico.className = "ph ph-check";
@@ -1571,6 +1582,7 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   const ev = params.get("ev");    // "trial" | "purchase" (definido pelo success_url)
   const td = params.get("td");    // dias de trial concedidos (0 quando ev=purchase)
   const pl = params.get("pl");    // plano escolhido: essencial | plus | pro
+  const ia = params.get("ia");    // cota mensal de mensagens da Piggy nesse plano
   if (!status) return;
 
   // Limpa os query params da URL pra nao reaparecer em refresh.
@@ -1580,6 +1592,7 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   cleanUrl.searchParams.delete("ev");
   cleanUrl.searchParams.delete("td");
   cleanUrl.searchParams.delete("pl");
+  cleanUrl.searchParams.delete("ia");
   window.history.replaceState({}, "", cleanUrl.toString());
 
   if (status === "success") {
@@ -1598,12 +1611,16 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
     // Pequeno delay pra dar o "wow effect" depois da pagina carregar.
     // `ev` ausente cai no texto de trial, que era o comportamento anterior:
     // link antigo na caixa de e-mail não deve virar cópia errada pro outro lado.
+    // `ia` ausente (link antigo, de antes deste parâmetro existir) NÃO vira
+    // número chutado: a linha da IA fica na frase genérica.
     setTimeout(() => {
       const dias = Number.parseInt(td, 10);
+      const cotaIA = Number.parseInt(ia, 10);
       openWelcomePro({
         trial: ev !== "purchase",
         days: Number.isFinite(dias) && dias > 0 ? dias : 30,
         plano: pl || "plus",
+        ia: Number.isFinite(cotaIA) && cotaIA > 0 ? cotaIA : null,
       });
     }, 450);
   } else if (status === "cancelled") {

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1247,54 +1247,133 @@ async function mfaOnboardingDismiss() {
 
 <!-- ─── Welcome to PigBank+ (pós-checkout success) ─────────────────────── -->
 <style>
+/* ─── Confirmação de assinatura ────────────────────────────────────────────
+   Redesenhado para falar a mesma língua da página: fundo neutro #111 (e não o
+   azul-marinho de antes, que trazia uma segunda família de cinza), um único
+   acento (o rosa da marca, sem o lima disputando), grão igual ao do body e
+   composição assimétrica em vez de tudo centralizado. */
 .welcome-pro-overlay {
-  position: fixed; inset: 0; background: rgba(0,0,0,.75);
+  position: fixed; inset: 0; background: rgba(8,8,10,.74);
   display: none; align-items: center; justify-content: center;
-  z-index: 10001; padding: 20px;
-  backdrop-filter: blur(6px);
-  animation: welcomeFade .3s ease;
+  z-index: 10001;
+  /* fixo não herda o padding do body: a área segura entra aqui, nos 4 lados,
+     porque o iPhone também abre esta página em paisagem. */
+  padding: max(20px, env(safe-area-inset-top)) max(20px, env(safe-area-inset-right))
+           max(20px, env(safe-area-inset-bottom)) max(20px, env(safe-area-inset-left));
+  backdrop-filter: blur(14px) saturate(120%); -webkit-backdrop-filter: blur(14px) saturate(120%);
+  animation: welcomeFade .28s var(--ease);
 }
 .welcome-pro-overlay.open { display: flex; }
 @keyframes welcomeFade { from { opacity: 0; } to { opacity: 1; } }
+
 .welcome-pro-card {
-  width: min(520px, 94vw); padding: 36px 32px 30px;
-  background: linear-gradient(180deg, #1a1d2a, #14161e);
-  border: 1.5px solid rgba(255,45,142,.4);
-  border-radius: 22px; color: rgba(255,255,255,.94);
-  box-shadow: 0 30px 80px rgba(0,0,0,.6), 0 0 60px rgba(255,45,142,.15);
-  position: relative; overflow: hidden;
-  animation: welcomePop .45s cubic-bezier(.16,1,.3,1);
+  position: relative; overflow: hidden auto;
+  width: min(440px, 100%); max-height: min(86dvh, 760px);
+  padding: 30px 28px 24px;
+  background:
+    radial-gradient(120% 90% at 8% -10%, rgba(255,45,142,.20), transparent 58%),
+    linear-gradient(180deg, #17171A, #121214);
+  border: 1px solid rgba(255,255,255,.10);
+  border-radius: 26px; color: var(--text);
+  /* sombra tingida com o rosa do fundo, em vez de preto puro */
+  box-shadow: 0 40px 90px -24px rgba(0,0,0,.8),
+              0 24px 70px -34px rgba(255,45,142,.42),
+              inset 0 1px 0 rgba(255,255,255,.10);
+  animation: welcomePop .5s cubic-bezier(.16,1,.3,1);
 }
-@keyframes welcomePop { from { transform: scale(.9) translateY(20px); opacity: 0; } to { transform: scale(1) translateY(0); opacity: 1; } }
-.welcome-pro-card::before {
-  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 4px;
-  background: linear-gradient(90deg,#FF2D8E,#FF7AB8);
+@keyframes welcomePop { from { transform: translateY(14px) scale(.97); opacity: 0; } to { transform: none; opacity: 1; } }
+/* mesmo grão do body::before: sem isto o card fica mais liso que a página */
+.welcome-pro-card::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none; opacity: .5;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.035'/%3E%3C/svg%3E");
 }
-.welcome-pro-emoji {
-  font-size: 3rem; text-align: center; margin-bottom: 8px;
-  animation: welcomeBounce 1.2s ease infinite alternate;
+.welcome-pro-card > * { position: relative; z-index: 1; }
+
+/* entrada em cascata: transform e opacity só, nada de layout */
+@keyframes wpRise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+.welcome-pro-card > * { animation: wpRise .45s var(--ease) backwards; animation-delay: calc(var(--i, 0) * 70ms + 120ms); }
+
+.wp-mark {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 46px; height: 46px; border-radius: 15px; margin-bottom: 18px;
+  background: linear-gradient(135deg, #FF2D8E, #C7186B);
+  box-shadow: 0 10px 26px -8px rgba(255,45,142,.7), inset 0 1px 0 rgba(255,255,255,.28);
+  font-size: 1.45rem; color: #fff;
 }
-@keyframes welcomeBounce { from { transform: translateY(0); } to { transform: translateY(-8px); } }
+.wp-eyebrow {
+  display: flex; align-items: center; gap: 9px; flex-wrap: wrap;
+  font-size: .69rem; font-weight: 600; letter-spacing: .15em; text-transform: uppercase;
+  color: var(--text-3); margin-bottom: 10px;
+}
+.wp-chip {
+  color: #FF80B8; background: rgba(255,45,142,.12);
+  border: 1px solid rgba(255,45,142,.28);
+  border-radius: 7px; padding: 3px 8px; letter-spacing: .06em;
+}
 .welcome-pro-card h2 {
-  font-size: 1.6rem; font-weight: 700; text-align: center; margin-bottom: 8px;
-  background: linear-gradient(135deg,#FF2D8E,#FF7AB8);
-  -webkit-background-clip: text; background-clip: text; color: transparent;
+  font-size: clamp(1.5rem, 6vw, 1.85rem); font-weight: 700; line-height: 1.12;
+  letter-spacing: -.028em; color: #fff; text-wrap: balance; margin-bottom: 10px;
 }
-.welcome-pro-sub { font-size: .94rem; color: rgba(255,255,255,.72); text-align: center; line-height: 1.55; margin-bottom: 22px; }
-.welcome-pro-trial { display: inline-flex; align-items: center; gap: 6px; background: rgba(198,241,26,.13); border: 1px solid rgba(198,241,26,.32); color: #C6F11A; padding: 6px 13px; border-radius: 999px; font-size: .76rem; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; margin: 0 auto 22px; }
-.welcome-pro-feats { display: grid; gap: 10px; margin-bottom: 26px; padding: 16px 18px; background: rgba(255,255,255,.04); border-radius: 14px; border: 1px solid rgba(255,255,255,.06); }
-.welcome-pro-feat { display: flex; align-items: center; gap: 10px; font-size: .87rem; color: rgba(255,255,255,.82); }
-.welcome-pro-feat::before { content: "✓"; color: #C6F11A; font-weight: 800; font-size: 1rem; flex-shrink: 0; }
-.welcome-pro-actions { display: flex; gap: 10px; }
+.wp-sub {
+  font-size: .93rem; font-weight: 400; line-height: 1.6; color: var(--text-2);
+  max-width: 36ch; text-wrap: pretty; margin-bottom: 24px;
+}
+
+/* lista com filetes, sem a caixa com borda e sombra de antes */
+.wp-feats { list-style: none; margin: 0 0 26px; }
+.wp-feats li {
+  /* flex-start, não center: em item de duas linhas o check centralizado pela
+     matemática cai no meio do bloco e lê como desalinhado. O 2px é ajuste
+     óptico pra ele sentar na linha de base da primeira linha. */
+  display: flex; align-items: flex-start; gap: 11px;
+  padding: 11px 0; font-size: .875rem; font-weight: 500; line-height: 1.45;
+  color: rgba(255,255,255,.84);
+  border-top: 1px solid rgba(255,255,255,.07);
+}
+.wp-feats li:last-child { border-bottom: 1px solid rgba(255,255,255,.07); }
+.wp-feats i { color: #FF80B8; font-size: 1rem; flex-shrink: 0; margin-top: 2px; }
+
+.welcome-pro-actions { display: grid; gap: 4px; }
 .welcome-pro-btn-primary {
-  flex: 1; padding: 14px 18px; border-radius: 12px; border: none;
-  background: linear-gradient(135deg,#FF2D8E,#C7186B);
-  color: #fff; font-weight: 700; font-size: .95rem; cursor: pointer;
-  transition: transform .15s, box-shadow .15s;
-  box-shadow: 0 8px 24px rgba(255,45,142,.4);
+  width: 100%; padding: 15px 18px; border-radius: 15px; border: none;
+  background: linear-gradient(135deg, #FF2D8E, #C7186B);
+  color: #fff; font: inherit; font-weight: 600; font-size: .95rem; cursor: pointer;
+  box-shadow: 0 12px 28px -10px rgba(255,45,142,.75), inset 0 1px 0 rgba(255,255,255,.22);
+  transition: transform .18s var(--ease), box-shadow .18s var(--ease), filter .18s var(--ease);
 }
-.welcome-pro-btn-primary:hover { transform: translateY(-1px); box-shadow: 0 12px 30px rgba(255,45,142,.55); }
-.welcome-pro-card .center { text-align: center; }
+.welcome-pro-btn-primary:hover { transform: translateY(-1px); filter: brightness(1.06); box-shadow: 0 18px 36px -12px rgba(255,45,142,.85), inset 0 1px 0 rgba(255,255,255,.22); }
+.welcome-pro-btn-primary:active { transform: translateY(0) scale(.985); box-shadow: 0 8px 18px -10px rgba(255,45,142,.7), inset 0 1px 0 rgba(255,255,255,.18); }
+.wp-btn-ghost {
+  width: 100%; padding: 12px; border: none; background: none;
+  /* --text-2 e não --text-3: com alpha .32 o controle ficava com contraste
+     baixo demais pra algo clicável. */
+  color: var(--text-2); font: inherit; font-size: .855rem; font-weight: 500; cursor: pointer;
+  border-radius: 12px; transition: color .18s var(--ease), background .18s var(--ease);
+}
+.wp-btn-ghost:hover { color: var(--text); background: rgba(255,255,255,.04); }
+.wp-btn-ghost:active { transform: scale(.99); }
+.welcome-pro-btn-primary:focus-visible,
+.wp-btn-ghost:focus-visible { outline: 2px solid #FF80B8; outline-offset: 3px; }
+
+/* Telas baixas (iPhone SE e paisagem): sem isto o card passa da altura máxima,
+   entra em rolagem interna e o "Ficar na Início" fica escondido abaixo da dobra,
+   ou seja, a saída do modal some justamente em quem tem menos tela. Medido a
+   375x667: 640px de conteúdo contra 572px úteis. */
+@media (max-height: 720px) {
+  .welcome-pro-card { padding: 22px 24px 18px; }
+  .wp-mark { width: 40px; height: 40px; border-radius: 13px; margin-bottom: 12px; font-size: 1.25rem; }
+  .welcome-pro-card h2 { font-size: 1.4rem; }
+  .wp-sub { font-size: .89rem; margin-bottom: 16px; }
+  .wp-feats { margin-bottom: 16px; }
+  .wp-feats li { padding: 8px 0; }
+}
+
+/* quem pediu menos movimento não leva cascata nem quique */
+@media (prefers-reduced-motion: reduce) {
+  .welcome-pro-overlay, .welcome-pro-card, .welcome-pro-card > * { animation: none; }
+  .welcome-pro-btn-primary, .wp-btn-ghost { transition-duration: .01ms; }
+  .welcome-pro-btn-primary:hover { transform: none; }
+}
 
 /* Toast melhorado pra cancelamento — maior, mais cativante, dura mais */
 .upgrade-toast {
@@ -1316,22 +1395,24 @@ async function mfaOnboardingDismiss() {
 </style>
 
 <div class="welcome-pro-overlay" id="welcome-pro-overlay">
-  <div class="welcome-pro-card">
-    <div class="welcome-pro-emoji"><i class="ph ph-piggy-bank" aria-hidden="true"></i></div>
-    <h2>Tá dentro do PigBank+!</h2>
-    <p class="welcome-pro-sub">Bora ver o que tu desbloqueou, parceiro?<br/>Os 30 dias grátis começam agora, só tem cobrança depois.</p>
-    <div class="center"><div class="welcome-pro-trial"><i class="ph ph-confetti" aria-hidden="true"></i> 30 dias grátis</div></div>
-    <div class="welcome-pro-feats">
-      <div class="welcome-pro-feat">Caixinhas e cartões sem limite</div>
-      <div class="welcome-pro-feat">Investimentos com IR e IOF no automático</div>
-      <div class="welcome-pro-feat">Histórico completo + exportar CSV</div>
-      <div class="welcome-pro-feat">Importar extrato e fatura por OFX</div>
-      <div class="welcome-pro-feat">Piggy IA: converse sobre suas finanças</div>
-    </div>
-    <div class="welcome-pro-actions">
-      <button class="welcome-pro-btn-primary" type="button" onclick="goExplorePro()">
-        Bora explorar →
-      </button>
+  <div class="welcome-pro-card" role="dialog" aria-modal="true" aria-labelledby="wp-title">
+    <span class="wp-mark" style="--i:0" aria-hidden="true"><i class="ph ph-piggy-bank"></i></span>
+    <p class="wp-eyebrow" style="--i:1">
+      Assinatura confirmada
+      <span class="wp-chip" id="wp-chip" hidden></span>
+    </p>
+    <h2 id="wp-title" style="--i:2">Tá dentro do PigBank+</h2>
+    <p class="wp-sub" id="wp-sub" style="--i:3"></p>
+    <ul class="wp-feats" style="--i:4">
+      <li><i class="ph ph-check" aria-hidden="true"></i> Caixinhas e cartões sem limite</li>
+      <li><i class="ph ph-check" aria-hidden="true"></i> Investimentos com IR e IOF</li>
+      <li><i class="ph ph-check" aria-hidden="true"></i> Histórico completo em CSV</li>
+      <li><i class="ph ph-check" aria-hidden="true"></i> Extrato e fatura por OFX</li>
+      <li><i class="ph ph-check" aria-hidden="true"></i> Piggy IA pra falar das finanças</li>
+    </ul>
+    <div class="welcome-pro-actions" style="--i:5">
+      <button class="welcome-pro-btn-primary" type="button" onclick="goExplorePro()">Abrir o dashboard</button>
+      <button class="wp-btn-ghost" type="button" onclick="dismissWelcomePro()">Ficar na Início</button>
     </div>
   </div>
 </div>
@@ -1339,16 +1420,66 @@ async function mfaOnboardingDismiss() {
 <div class="upgrade-toast" id="upgrade-cancel-toast" role="status"></div>
 
 <script>
+/* O modal é um dialog de verdade agora: prende o Esc, o clique fora e devolve o
+   foco pra quem o tinha antes. Sair daqui NUNCA cobra nada e nunca muda plano,
+   só decide se a pessoa vai pro dashboard ou fica na Início. */
+let _wpLastFocus = null;
+
+function openWelcomePro({ trial = true, days = 30 } = {}) {
+  const ov = document.getElementById("welcome-pro-overlay");
+  if (!ov) return;
+
+  // A cópia muda com o que o backend mandou no success_url. Sem isso, quem
+  // assina SEM direito a período grátis (ev=purchase, já usou o trial antes)
+  // lia "seus 30 dias grátis começam agora", que é falso pra essa pessoa.
+  const chip = document.getElementById("wp-chip");
+  const sub = document.getElementById("wp-sub");
+  if (trial) {
+    chip.textContent = `${days} dias grátis`;
+    chip.hidden = false;
+    sub.textContent = `Seus ${days} dias grátis começam agora. A primeira cobrança só vem depois disso, e dá pra cancelar quando quiser.`;
+  } else {
+    chip.hidden = true;
+    sub.textContent = "Sua assinatura já está ativa. Dá pra cancelar quando quiser, direto nas configurações.";
+  }
+
+  _wpLastFocus = document.activeElement;
+  ov.classList.add("open");
+  ov.querySelector(".welcome-pro-btn-primary")?.focus();
+  document.addEventListener("keydown", _wpOnKey);
+}
+
+function _wpOnKey(e) {
+  if (e.key === "Escape") dismissWelcomePro();
+}
+
+function _wpClose() {
+  document.getElementById("welcome-pro-overlay")?.classList.remove("open");
+  document.removeEventListener("keydown", _wpOnKey);
+}
+
+function dismissWelcomePro() {
+  _wpClose();
+  // devolve o foco pra onde estava, senão o teclado volta pro topo da página
+  if (_wpLastFocus && document.contains(_wpLastFocus)) _wpLastFocus.focus();
+}
+
 function goExplorePro() {
-  document.getElementById("welcome-pro-overlay").classList.remove("open");
+  _wpClose();
   window.location.href = "/app";
 }
+
+// clique no fundo escuro fecha; clique dentro do card não
+document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) => {
+  if (e.target === e.currentTarget) dismissWelcomePro();
+});
 
 (function handleUpgradeReturn() {
   const params = new URLSearchParams(window.location.search);
   const status = params.get("upgrade");
   const sid = params.get("sid");  // id da sessão Stripe → event_id do evento
   const ev = params.get("ev");    // "trial" | "purchase" (definido pelo success_url)
+  const td = params.get("td");    // dias de trial concedidos (0 quando ev=purchase)
   if (!status) return;
 
   // Limpa os query params da URL pra nao reaparecer em refresh.
@@ -1356,6 +1487,7 @@ function goExplorePro() {
   cleanUrl.searchParams.delete("upgrade");
   cleanUrl.searchParams.delete("sid");
   cleanUrl.searchParams.delete("ev");
+  cleanUrl.searchParams.delete("td");
   window.history.replaceState({}, "", cleanUrl.toString());
 
   if (status === "success") {
@@ -1371,9 +1503,15 @@ function goExplorePro() {
         fbq("track", "Purchase", { currency: "BRL" }, { eventID: "purchase_" + sid });
       }
     }
-    // Pequeno delay pra dar o "wow effect" depois da pagina carregar
+    // Pequeno delay pra dar o "wow effect" depois da pagina carregar.
+    // `ev` ausente cai no texto de trial, que era o comportamento anterior:
+    // link antigo na caixa de e-mail não deve virar cópia errada pro outro lado.
     setTimeout(() => {
-      document.getElementById("welcome-pro-overlay").classList.add("open");
+      const dias = Number.parseInt(td, 10);
+      openWelcomePro({
+        trial: ev !== "purchase",
+        days: Number.isFinite(dias) && dias > 0 ? dias : 30,
+      });
     }, 450);
   } else if (status === "cancelled") {
     const toast = document.getElementById("upgrade-cancel-toast");

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1293,12 +1293,17 @@ async function mfaOnboardingDismiss() {
 @keyframes wpRise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
 .welcome-pro-card > * { animation: wpRise .45s var(--ease) backwards; animation-delay: calc(var(--i, 0) * 70ms + 120ms); }
 
+/* Marca oficial (/brand/icon.png), a mesma que o dashboard usa, no lugar do
+   glifo ph-piggy-bank que estava aqui. Ela é rosa sobre transparência, então
+   NÃO leva o quadrado rosa que existia antes: seria rosa sobre rosa e o
+   porquinho sumiria. Fica solta no card, com um brilho no tom dela para não
+   achatar. Observação de marca: o PNG é #FC1863 e o token da página é #FF2D8E,
+   dois rosas diferentes lado a lado. Mantive o arquivo oficial como está, não
+   é papel desta tela recolorir asset de marca. */
 .wp-mark {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 46px; height: 46px; border-radius: 15px; margin-bottom: 18px;
-  background: linear-gradient(135deg, #FF2D8E, #C7186B);
-  box-shadow: 0 10px 26px -8px rgba(255,45,142,.7), inset 0 1px 0 rgba(255,255,255,.28);
-  font-size: 1.45rem; color: #fff;
+  display: block; height: 48px; width: auto; margin-bottom: 18px;
+  object-fit: contain;
+  filter: drop-shadow(0 10px 22px rgba(252,24,99,.45));
 }
 .wp-eyebrow {
   display: flex; align-items: center; gap: 9px; flex-wrap: wrap;
@@ -1361,7 +1366,7 @@ async function mfaOnboardingDismiss() {
    375x667: 640px de conteúdo contra 572px úteis. */
 @media (max-height: 720px) {
   .welcome-pro-card { padding: 22px 24px 18px; }
-  .wp-mark { width: 40px; height: 40px; border-radius: 13px; margin-bottom: 12px; font-size: 1.25rem; }
+  .wp-mark { height: 40px; margin-bottom: 12px; }
   .welcome-pro-card h2 { font-size: 1.4rem; }
   .wp-sub { font-size: .89rem; margin-bottom: 14px; }
   .wp-feats { margin-bottom: 14px; }
@@ -1397,7 +1402,8 @@ async function mfaOnboardingDismiss() {
 
 <div class="welcome-pro-overlay" id="welcome-pro-overlay">
   <div class="welcome-pro-card" role="dialog" aria-modal="true" aria-labelledby="wp-title">
-    <span class="wp-mark" style="--i:0" aria-hidden="true"><i class="ph ph-piggy-bank"></i></span>
+    <img class="wp-mark" style="--i:0" src="/brand/icon.png?v=1" alt="" aria-hidden="true"
+         width="45" height="48" />
     <p class="wp-eyebrow" style="--i:1">
       Assinatura confirmada
       <span class="wp-chip" id="wp-chip" hidden></span>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1434,7 +1434,17 @@ let _wpLastFocus = null;
    (bancos de Open Finance, energia de agentes, cota da IA, janela de histórico),
    e não da /precos: aquela página anuncia previsão de saldo, caça-assinaturas e
    cobranças duplicadas, que não têm implementação nenhuma no repositório. Tela
-   de confirmação de pagamento não é lugar de promessa que ainda não roda. */
+   de confirmação de pagamento não é lugar de promessa que ainda não roda.
+
+   E "None" no plan_limits NÃO quer dizer ilimitado em todo campo, tem de ser
+   conferido um por um até onde o limite é aplicado:
+     - pockets_max / cards_max None: retorna sem checar (plan_service.py:440),
+       ilimitado de verdade;
+     - ai_monthly_messages None: cai no teto GLOBAL AI_CHAT_MONTHLY_LIMIT
+       (1000/mês por padrão) em ai_monthly_limit_for (plan_service.py:398), e o
+       runner recusa depois disso. Por isso Plus e Pro dizem "cota ampliada" e
+       não "sem limite": eles só escapam da cota de 200 do Essencial, não do
+       teto da casa. O número em si não entra na cópia porque vem de env. */
 const WP_PLANOS = {
   essencial: {
     nome: "PigBank Essencial",
@@ -1450,7 +1460,7 @@ const WP_PLANOS = {
     feats: [
       "Conecte 2 bancos pelo Open Finance",
       "Ligue seus agentes: energia para até 3",
-      "Piggy IA sem limite de mensagens",
+      "Piggy IA com cota ampliada",
       "Histórico de 12 meses, com tudo do Essencial",
     ],
   },
@@ -1459,7 +1469,7 @@ const WP_PLANOS = {
     feats: [
       "Conecte até 5 bancos pelo Open Finance",
       "Rode a equipe toda: energia para os 7 agentes",
-      "Piggy IA sem limite de mensagens",
+      "Piggy IA com cota ampliada",
       "Histórico de 24 meses, com tudo do Plus",
     ],
   },
@@ -1504,7 +1514,33 @@ function openWelcomePro({ trial = true, days = 30, plano = "plus" } = {}) {
 }
 
 function _wpOnKey(e) {
-  if (e.key === "Escape") dismissWelcomePro();
+  if (e.key === "Escape") { dismissWelcomePro(); return; }
+  if (e.key !== "Tab") return;
+
+  // aria-modal="true" AFIRMA pro leitor de tela que o resto da página não está
+  // disponível. Sem prender o Tab isso é mentira: o teclado sai do card e vai
+  // parar nos links do header atrás do overlay, que o mouse não alcança. Ou se
+  // prende o foco, ou se tira o aria-modal. Prender é o certo aqui.
+  const card = document.querySelector(".welcome-pro-card");
+  if (!card) return;
+  const alvos = card.querySelectorAll(
+    'button:not([disabled]), [href], input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])');
+  if (!alvos.length) return;
+
+  const primeiro = alvos[0];
+  const ultimo = alvos[alvos.length - 1];
+  const atual = document.activeElement;
+  const foraDoCard = !card.contains(atual);
+
+  // Volta pra dentro nos dois sentidos, inclusive quando o foco já escapou
+  // (clique no fundo, foco perdido no body).
+  if (e.shiftKey && (atual === primeiro || foraDoCard)) {
+    e.preventDefault();
+    ultimo.focus();
+  } else if (!e.shiftKey && (atual === ultimo || foraDoCard)) {
+    e.preventDefault();
+    primeiro.focus();
+  }
 }
 
 function _wpClose() {

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1363,9 +1363,10 @@ async function mfaOnboardingDismiss() {
   .welcome-pro-card { padding: 22px 24px 18px; }
   .wp-mark { width: 40px; height: 40px; border-radius: 13px; margin-bottom: 12px; font-size: 1.25rem; }
   .welcome-pro-card h2 { font-size: 1.4rem; }
-  .wp-sub { font-size: .89rem; margin-bottom: 16px; }
-  .wp-feats { margin-bottom: 16px; }
-  .wp-feats li { padding: 8px 0; }
+  .wp-sub { font-size: .89rem; margin-bottom: 14px; }
+  .wp-feats { margin-bottom: 14px; }
+  .wp-feats li { padding: 7px 0; }
+  .wp-eyebrow { margin-bottom: 8px; }
 }
 
 /* quem pediu menos movimento não leva cascata nem quique */
@@ -1403,13 +1404,7 @@ async function mfaOnboardingDismiss() {
     </p>
     <h2 id="wp-title" style="--i:2">Tá dentro do PigBank+</h2>
     <p class="wp-sub" id="wp-sub" style="--i:3"></p>
-    <ul class="wp-feats" style="--i:4">
-      <li><i class="ph ph-check" aria-hidden="true"></i> Caixinhas e cartões sem limite</li>
-      <li><i class="ph ph-check" aria-hidden="true"></i> Investimentos com IR e IOF</li>
-      <li><i class="ph ph-check" aria-hidden="true"></i> Histórico completo em CSV</li>
-      <li><i class="ph ph-check" aria-hidden="true"></i> Extrato e fatura por OFX</li>
-      <li><i class="ph ph-check" aria-hidden="true"></i> Piggy IA pra falar das finanças</li>
-    </ul>
+    <ul class="wp-feats" id="wp-feats" style="--i:4"></ul>
     <div class="welcome-pro-actions" style="--i:5">
       <button class="welcome-pro-btn-primary" type="button" onclick="goExplorePro()">Abrir o dashboard</button>
       <button class="wp-btn-ghost" type="button" onclick="dismissWelcomePro()">Ficar na Início</button>
@@ -1425,9 +1420,62 @@ async function mfaOnboardingDismiss() {
    só decide se a pessoa vai pro dashboard ou fica na Início. */
 let _wpLastFocus = null;
 
-function openWelcomePro({ trial = true, days = 30 } = {}) {
+/* O checkout vende TRÊS planos (essencial, plus, pro), e a tela parabenizava
+   todo mundo pelo Plus: quem pagou Essencial via prometido o que não comprou, e
+   quem pagou Pro era recebido como o plano de metade do preço.
+
+   Os itens de cada tier saem do que EXISTE em core/services/plan_limits.py
+   (bancos de Open Finance, energia de agentes, cota da IA, janela de histórico),
+   e não da /precos: aquela página anuncia previsão de saldo, caça-assinaturas e
+   cobranças duplicadas, que não têm implementação nenhuma no repositório. Tela
+   de confirmação de pagamento não é lugar de promessa que ainda não roda. */
+const WP_PLANOS = {
+  essencial: {
+    nome: "PigBank Essencial",
+    feats: [
+      "Conecte 1 banco pelo Open Finance",
+      "Lance por áudio, foto do cupom ou OFX",
+      "Caixinhas, metas e cartões sem limite",
+      "Boletos com lembrete de vencimento",
+    ],
+  },
+  plus: {
+    nome: "PigBank+",
+    feats: [
+      "Conecte 2 bancos pelo Open Finance",
+      "Ligue seus agentes: energia para até 3",
+      "Piggy IA sem limite de mensagens",
+      "Histórico de 12 meses, com tudo do Essencial",
+    ],
+  },
+  pro: {
+    nome: "PigBank Pro",
+    feats: [
+      "Conecte até 5 bancos pelo Open Finance",
+      "Rode a equipe toda: energia para os 7 agentes",
+      "Piggy IA sem limite de mensagens",
+      "Histórico de 24 meses, com tudo do Plus",
+    ],
+  },
+};
+
+function openWelcomePro({ trial = true, days = 30, plano = "plus" } = {}) {
   const ov = document.getElementById("welcome-pro-overlay");
   if (!ov) return;
+
+  // `plano` vem da URL, então nunca entra em HTML: só serve de chave do mapa, e
+  // valor desconhecido cai no Plus, que era o texto único de antes.
+  const cfg = WP_PLANOS[String(plano).toLowerCase()] || WP_PLANOS.plus;
+  document.getElementById("wp-title").textContent = `Tá dentro do ${cfg.nome}`;
+  const ul = document.getElementById("wp-feats");
+  ul.replaceChildren(...cfg.feats.map((texto) => {
+    const li = document.createElement("li");
+    const ico = document.createElement("i");
+    ico.className = "ph ph-check";
+    ico.setAttribute("aria-hidden", "true");
+    li.append(ico, " " + texto);   // textContent: nada daqui vira markup
+    return li;
+  }));
 
   // A cópia muda com o que o backend mandou no success_url. Sem isso, quem
   // assina SEM direito a período grátis (ev=purchase, já usou o trial antes)
@@ -1480,6 +1528,7 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   const sid = params.get("sid");  // id da sessão Stripe → event_id do evento
   const ev = params.get("ev");    // "trial" | "purchase" (definido pelo success_url)
   const td = params.get("td");    // dias de trial concedidos (0 quando ev=purchase)
+  const pl = params.get("pl");    // plano escolhido: essencial | plus | pro
   if (!status) return;
 
   // Limpa os query params da URL pra nao reaparecer em refresh.
@@ -1488,6 +1537,7 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   cleanUrl.searchParams.delete("sid");
   cleanUrl.searchParams.delete("ev");
   cleanUrl.searchParams.delete("td");
+  cleanUrl.searchParams.delete("pl");
   window.history.replaceState({}, "", cleanUrl.toString());
 
   if (status === "success") {
@@ -1511,6 +1561,7 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
       openWelcomePro({
         trial: ev !== "purchase",
         days: Number.isFinite(dias) && dias > 0 ? dias : 30,
+        plano: pl || "plus",
       });
     }, 450);
   } else if (status === "cancelled") {

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -395,6 +395,39 @@ def test_checkout_v2_inelegivel_cobra_na_hora(user_id, monkeypatch):
     assert "trial_period_days" not in fake.last_session_kwargs["subscription_data"]
 
 
+def _success_params(fake) -> dict:
+    from urllib.parse import parse_qs, urlparse
+    return {k: v[0] for k, v in parse_qs(urlparse(fake.last_session_kwargs["success_url"]).query).items()}
+
+
+def test_success_url_leva_cota_de_ia_do_plano_comprado(user_id, monkeypatch):
+    """A tela de confirmação prometia "Piggy IA sem limite de mensagens" pra
+    Plus e Pro, mas `ai_monthly_messages: None` cai no teto AI_CHAT_MONTHLY_LIMIT
+    e o chat corta ali. O número tem que sair do backend, junto do `td` e do
+    `pl` — chumbar no HTML é o bug que o `td` já tinha resolvido."""
+    import core.services.ai_chat_commands as aicc
+    _, _, client = _auth_user_setup(f"iaquota-{user_id}")
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    monkeypatch.setattr(aicc, "AI_CHAT_MONTHLY_LIMIT", 777)
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_ESSENCIAL_MENSAL", "price_ess_abc")
+    monkeypatch.setattr("db.plans.is_trial_eligible_for_user", lambda uid: True)
+    fake = _patch_stripe(monkeypatch)
+
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
+    assert resp.status_code == 200, resp.text
+    params = _success_params(fake)
+    assert params["pl"] == "plus"
+    assert params["ia"] == "777", "cota do Plus tem que ser o teto global, não 'ilimitado'"
+
+    resp = client.post("/billing/create-checkout", json={"plan": "essencial"}, headers=_CSRF_HEADERS)
+    assert resp.status_code == 200, resp.text
+    params = _success_params(fake)
+    assert params["pl"] == "essencial"
+    assert params["ia"] == "200", "Essencial tem cota própria (200), menor que o teto"
+
+
 def test_checkout_v2_falha_fechada_se_elegibilidade_indisponivel(user_id, monkeypatch):
     """Sem conseguir decidir o trial, não cobra nem concede benefício no escuro."""
     _, _, client = _auth_user_setup(f"v2fail-{user_id}")

--- a/tests/test_plan_tiers.py
+++ b/tests/test_plan_tiers.py
@@ -393,6 +393,30 @@ class TestAIQuota:
         _patch_user(monkeypatch, _user("pro", FUTURE))
         assert plan_service.ai_monthly_limit_for(1) == AI_CHAT_MONTHLY_LIMIT
 
+    def test_cota_por_tier_bate_com_a_do_usuario(self, v2):
+        """ai_monthly_limit_for_tier existe pro checkout, que precisa da cota
+        antes do webhook gravar o plano. Não pode divergir da do usuário."""
+        from core.services.ai_chat_commands import AI_CHAT_MONTHLY_LIMIT
+        assert plan_service.ai_monthly_limit_for_tier("free") == 20
+        assert plan_service.ai_monthly_limit_for_tier("essencial") == 200
+        assert plan_service.ai_monthly_limit_for_tier("plus") == AI_CHAT_MONTHLY_LIMIT
+        assert plan_service.ai_monthly_limit_for_tier("pro") == AI_CHAT_MONTHLY_LIMIT
+
+    def test_cota_por_tier_nunca_e_ilimitada(self, v2, monkeypatch):
+        """`ai_monthly_messages: None` do Plus/Pro NÃO é "sem limite": é o teto
+        global, e ele acompanha a env. Se este teste voltar a dar um número
+        infinito/None, a tela de confirmação volta a mentir."""
+        import core.services.ai_chat_commands as aicc
+        monkeypatch.setattr(aicc, "AI_CHAT_MONTHLY_LIMIT", 42)
+        assert plan_service.ai_monthly_limit_for_tier("plus") == 42
+        assert plan_service.ai_monthly_limit_for_tier("pro") == 42
+        # cota própria menor que o teto continua valendo
+        assert plan_service.ai_monthly_limit_for_tier("free") == 20
+
+    def test_cota_por_tier_desconhecido_cai_no_free(self, v2):
+        assert plan_service.ai_monthly_limit_for_tier("banana") == 20
+        assert plan_service.ai_monthly_limit_for_tier("") == 20
+
     def test_free_com_cota_pode_falar(self, v2, monkeypatch):
         _patch_user(monkeypatch, _user("free"))
         monkeypatch.setattr("db.ai_chat.get_usage_this_month", lambda uid: 19)


### PR DESCRIPTION
Redesenho do modal pós-checkout (`welcome-pro`), o "Tá dentro do PigBank+". Mesmo stack, CSS vanilla no próprio arquivo.

## Por que

O modal falava uma língua visual diferente do resto da página e tinha buracos de estado:

| problema | antes |
|---|---|
| duas famílias de cinza | card azul-marinho (`#1a1d2a`) dentro de página `#111111` neutra |
| dois acentos disputando | rosa `#FF2D8E` e lima `#C6F11A` no mesmo card |
| assinaturas de template | título com gradiente clipado, listra de 4px no topo, caixa de features com borda + fundo + sombra, tudo centralizado |
| estados ausentes | sem `:active`, sem `:focus-visible`, sem `prefers-reduced-motion`, emoji quicando em loop infinito |
| não era um dialog | sem `role`, sem `aria-modal`, sem foco, sem Esc, sem clique fora. A única saída era o botão que navega pro `/app` |
| área segura | overlay fixo sem reservar inset, e o iPhone abre esta página em paisagem |

## Correção de conteúdo junto

A cópia prometia "30 dias grátis" para todo mundo, mas o backend manda `ev=purchase` quando a pessoa não tem direito a trial (já usou antes), em `finance_bot_websocket_custom.py:3737`. Agora a cópia troca conforme `ev`, e o número de dias vem do backend num parâmetro novo `td`, em vez de `30` chumbado no HTML (`trial_days` já é dinâmico: `trial_days_total()` ou `PRO_TRIAL_DAYS`). Sem `ev`, cai no texto de trial, que era o comportamento anterior.

## Medido no Chromium

| cenário | resultado |
|---|---|
| 375x812 | card 325x622, cabe na tela, 5/5 itens da lista em uma linha |
| 375x667 | o ajuste de ritmo vertical (`max-height:720px`) levou o conteúdo de 640px para 560px em 560px úteis: sem rolagem interna, e o "Ficar na Início" voltou a ficar visível sem rolar. Antes ficava escondido abaixo da dobra do card |
| 1280x800 | card 427x607, eyebrow e pílula na mesma linha |
| interações | Esc fecha, clique no fundo fecha, clique no card não fecha, listener do Esc removido ao fechar, foco no botão ao abrir e devolvido ao fechar |
| variantes | `trial=false` esconde a pílula e troca o texto; `days=14` renderiza "14 dias grátis" |

Suíte: **1088 passed, 0 failed**.

## Não verificado

- `prefers-reduced-motion` e `env(safe-area-inset-*)`: não dá pra emular aqui (o inset vale 0 no navegador). Só no aparelho, depois do build.
- Fluxo real com Stripe: só no deploy.

## Nota de conflito

O #68 mexe no mesmo `handleUpgradeReturn` (adiciona o gate `_pbAccessDenied`) e no mesmo `_new_session` (troca o `cancel_url`). Conflito pequeno e previsto, dependendo da ordem de merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
