### PR TITLE
feat(precos): tabela comparativa dos 5 planos, recurso por recurso

### DIFF
--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -17,6 +17,165 @@
   #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
   #toast.err { border-color: rgba(255,45,45,.5); }
   .btn.loading { opacity: .7; pointer-events: none; }
+
+  /* Rótulo só pra leitor de tela: as células de ✓/— da tabela são ícones, e
+     sem isto o leitor anuncia uma célula vazia. */
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; border: 0; }
+
+  /* ── Ciclo mensal × anual ──────────────────────────────────────────────
+     Era dois .btn colados por border-radius inline, com o setCycle
+     remontando className (e reinjetando btn-block só pra desfazer o
+     width:100% na linha seguinte). Vira um segmented control de verdade:
+     o JS só liga/desliga .is-active + aria-pressed. */
+  .cycle-wrap { display: flex; justify-content: center; margin: 0 0 30px; }
+  .cycle-toggle { display: inline-flex; gap: 4px; padding: 4px; background: var(--card); border: 1px solid var(--line); border-radius: 15px; }
+  .cycle-btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--font); font-size: .9rem; font-weight: 700; color: var(--ink-2);
+    background: transparent; border: none; border-radius: 11px; padding: 10px 22px;
+    cursor: pointer; transition: color var(--dur) var(--ease), background var(--dur) var(--ease), transform var(--dur-fast) var(--ease);
+  }
+  .cycle-btn:hover { color: var(--ink); }
+  .cycle-btn:active { transform: scale(.98); }
+  .cycle-btn:focus-visible { outline: 2px solid var(--pink); outline-offset: 2px; }
+  .cycle-btn.is-active { background: linear-gradient(135deg,var(--pink),var(--pink-dark)); color: #fff; box-shadow: 0 6px 18px rgba(255,45,142,.3); }
+  .cycle-save { background: rgba(198,241,26,.16); color: var(--neon); font-weight: 700; padding: 2px 8px; border-radius: 999px; font-size: .78em; }
+  .cycle-btn.is-active .cycle-save { background: rgba(255,255,255,.22); color: #fff; }
+
+  /* ── Cards: as 5 listas têm de começar no mesmo Y ──────────────────────
+     A regra é a categoria, não o caso: TUDO que fica acima da lista e tem
+     altura variável precisa reservar a altura máxima, senão desalinha.
+       · subtítulo — abaixo de ~1330px o card cai pra 230px e "Organize tudo,
+         sem limites"/"Seu dinheiro no automático" viram duas linhas enquanto
+         os outros três ficam em uma (medido: 20px de desalinho);
+       · bloco do preço — o Premium mostra "Aguarde" em 1.15rem contra 2.5rem
+         dos pagos, e a linha de equivalência mensal só existe no ciclo anual
+         (medido: 32px). */
+  #plans-v2 .plan .plan-sub { min-height: 3em; }
+  #plans-v2 .price-block { min-height: 98px; display: flex; flex-direction: column; justify-content: center; margin: 6px 0 4px; }
+  #plans-v2 .price-block .price { margin: 0; }
+  #plans-v2 .price .per { font-size: .95rem; font-weight: 600; color: var(--ink-2); letter-spacing: 0; }
+  #plans-v2 .price-eq { color: var(--ink-3); font-size: .78rem; font-weight: 500; margin-top: 6px; font-variant-numeric: tabular-nums; }
+  /* O CTA do Grátis é <a> e os pagos são <button>: o <a> herda line-height 1.5
+     do body e o <button> cai no "normal" da UA, o que deixava a fileira de
+     botões 7px fora de esquadro. Fixar o line-height iguala os dois. */
+  #plans-v2 .plan .btn { line-height: 1.4; }
+  /* .btn-outline tem borda de 1px e .btn-primary não tem nenhuma: o CTA do Plus
+     nascia 2px mais baixo que os outros quatro. Borda transparente iguala. */
+  #plans-v2 .plan .btn-primary, .cmp-table tfoot .btn-primary { border: 1px solid transparent; }
+  #plans-v2 .plan .btn:focus-visible { outline: 2px solid var(--pink); outline-offset: 2px; }
+  /* O badge é absoluto com left:50%, então a largura disponível é metade do
+     card (131px em 5 colunas) e "Mais popular" quebrava em duas linhas. */
+  #plans-v2 .plan-badge { white-space: nowrap; }
+
+  /* ── Tabela comparativa ────────────────────────────────────────────────
+     Os cards vendem cada plano isolado; a tabela responde a outra pergunta
+     ("o que EU perco descendo um degrau?"), então mora numa largura menor
+     que a escada de 1560px e usa a mesma linha pra todos os planos. */
+  .cmp { max-width: 1060px; margin: 0 auto; padding: 18px 0 0; }
+  .cmp-head { text-align: center; margin-bottom: 26px; }
+  .cmp-head h3 { font-size: clamp(1.35rem,3vw,1.85rem); font-weight: 800; letter-spacing: -.02em; line-height: 1.15; margin-bottom: 10px; text-wrap: balance; }
+  .cmp-head p { color: var(--ink-2); font-size: .95rem; line-height: 1.6; max-width: 54ch; margin: 0 auto; text-wrap: pretty; }
+
+  .cmp-hint { display: none; align-items: center; justify-content: center; gap: 8px; color: var(--ink-3); font-size: .8rem; margin-bottom: 12px; }
+  .cmp-scrollwrap { position: relative; }
+  /* Véus das bordas: só aparecem quando há conteúdo escondido daquele lado
+     (classes postas pelo updateCmpFade, que lê scrollLeft/scrollWidth). */
+  .cmp-scrollwrap::before, .cmp-scrollwrap::after {
+    content: ""; position: absolute; top: 0; bottom: 0; width: 40px; z-index: 4;
+    pointer-events: none; opacity: 0; transition: opacity var(--dur) var(--ease);
+  }
+  .cmp-scrollwrap::before { left: 0; background: linear-gradient(90deg, var(--bg), transparent); }
+  .cmp-scrollwrap::after { right: 0; background: linear-gradient(270deg, var(--bg), transparent); }
+  .cmp-scrollwrap.fade-left::before, .cmp-scrollwrap.fade-right::after { opacity: 1; }
+  .cmp-scroll:focus-visible { outline: 2px solid var(--pink); outline-offset: 4px; border-radius: 8px; }
+
+  /* table-layout:fixed: no automático as colunas ficam do tamanho do texto
+     mais largo de cada uma (medido: 195/196/155/148/130px), e coluna estreita
+     se lê como plano menos importante — justo o contrário do que a faixa do
+     Plus está dizendo. Fixo, as 5 dividem em partes iguais o que sobra da
+     coluna de recursos. */
+  .cmp-table { width: 100%; table-layout: fixed; border-collapse: separate; border-spacing: 0; font-size: .88rem; font-variant-numeric: tabular-nums; }
+  .cmp-table th, .cmp-table td { padding: 13px 12px; text-align: center; vertical-align: middle; border-bottom: 1px solid var(--line); }
+  .cmp-table td { color: var(--ink-2); }
+
+  /* Coluna dos recursos: gruda à esquerda pra a linha não perder o nome
+     quando a tabela rola no celular. Precisa de fundo opaco. */
+  .cmp-table .cmp-feat {
+    position: sticky; left: 0; z-index: 2; background: var(--bg);
+    text-align: left; font-weight: 500; color: var(--ink-2);
+    width: 268px; min-width: 268px;
+  }
+  .cmp-table tbody tr:hover td { background: rgba(255,255,255,.03); }
+  .cmp-table tbody tr:hover .cmp-feat { background: #131315; }
+
+  /* Cabeçalho gruda sob a nav — só no desktop: em telas estreitas o wrapper
+     vira scroller horizontal e o sticky vertical passa a valer em relação a
+     ele (que nunca rola no eixo Y), virando no-op. */
+  .cmp-table thead th {
+    position: sticky; top: calc(84px + env(safe-area-inset-top)); z-index: 3;
+    background: var(--bg); padding: 16px 12px 14px; border-bottom: 1px solid var(--line-2);
+  }
+  .cmp-table thead .cmp-feat { z-index: 4; }
+  .cmp-plan-name { display: block; font-size: 1rem; font-weight: 800; letter-spacing: -.01em; color: var(--ink); }
+  .cmp-plan-price { display: block; color: var(--ink-3); font-size: .76rem; font-weight: 600; margin-top: 4px; }
+  .cmp-plan-tag { display: inline-block; background: var(--pink); color: #fff; font-size: .58rem; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; padding: 3px 9px; border-radius: 999px; margin-bottom: 7px; }
+
+  /* Faixa da coluna recomendada: pintada no <col> (embaixo das células), pra
+     não quebrar nas linhas de grupo que usam colspan. */
+  .cmp-col-hl { background: rgba(255,45,142,.07); }
+  /* O cabeçalho é sticky: precisa ser OPACO, senão as linhas do corpo passam
+     por baixo e aparecem sobre ele ("Plus / R$ 19,90" com "12 meses" da linha
+     de histórico por cima). As outras colunas já usam var(--bg) sólido; esta
+     ganha a mesma base sólida com o tingimento por cima, em vez de um rgba
+     translúcido direto. O .19 é a soma da faixa do <col> (.07) com o realce
+     do cabeçalho (.13). */
+  .cmp-table thead th.is-hl {
+    background-color: var(--bg);
+    background-image: linear-gradient(rgba(255,45,142,.19), rgba(255,45,142,.19));
+    border-top: 2px solid var(--pink); border-radius: 12px 12px 0 0;
+  }
+  .cmp-table tfoot td.is-hl { background: rgba(255,45,142,.13); border-radius: 0 0 12px 12px; }
+
+  /* Linha de grupo: o rótulo gruda à esquerda por dentro da célula (a célula
+     em si tem colspan e é larga demais pra grudar sozinha). */
+  .cmp-group th { text-align: left; background: transparent; padding: 30px 0 9px; border-bottom: 1px solid var(--line-2); }
+  .cmp-group th span { position: sticky; left: 0; display: inline-block; padding: 0 12px; background: var(--bg); color: var(--neon); font-size: .69rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+
+  .c-yes { color: var(--neon); font-size: 1.05rem; line-height: 1; }
+  .c-no { color: rgba(255,255,255,.2); font-size: .95rem; line-height: 1; }
+  .c-val { color: var(--ink); font-weight: 700; }
+  .c-val small { display: block; color: var(--ink-3); font-weight: 500; font-size: .78em; margin-top: 2px; }
+
+  .cmp-table tfoot td, .cmp-table tfoot th { border-bottom: none; padding: 18px 10px 0; vertical-align: top; }
+  /* .btn é white-space:nowrap no site.css; aqui os rótulos são reescritos pelo
+     refreshPlanButtons ("Agendado pra 12/09/2026 ✓ · desfazer") e precisam
+     quebrar dentro da célula em vez de estourar a coluna. */
+  .cmp-table tfoot .btn { width: 100%; padding: 10px 12px; font-size: .82rem; white-space: normal; line-height: 1.3; }
+  /* Rótulo que quebra em duas linhas ("Assinar Essencial", e os dinâmicos do
+     refreshPlanButtons) deixava um botão mais alto que os outros quatro. As
+     células de uma mesma linha já têm a altura da mais alta; height:1px força
+     esse colapso e o height:100% faz cada botão preencher a linha inteira. */
+  .cmp-table tfoot td { height: 1px; }
+  .cmp-table tfoot .btn { height: 100%; }
+  .cmp-table tfoot .btn:focus-visible { outline: 2px solid var(--pink); outline-offset: 2px; }
+  .cmp-table tfoot .btn[disabled] { opacity: .45; cursor: default; }
+
+  .cmp-note { color: var(--ink-3); font-size: .84rem; line-height: 1.65; max-width: 780px; margin: 30px auto 0; text-align: center; }
+  .cmp-note strong { color: var(--ink-2); }
+  .cmp-note .e { color: var(--neon); font-weight: 700; white-space: nowrap; }
+
+  @media (max-width: 900px) {
+    .cmp-hint { display: flex; }
+    .cmp-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .cmp-table { min-width: 664px; font-size: .82rem; }
+    .cmp-table th, .cmp-table td { padding: 11px 8px; }
+    .cmp-table .cmp-feat { width: 154px; min-width: 154px; padding-left: 0; padding-right: 10px; }
+    .cmp-table thead th { position: static; padding: 12px 8px 12px; }
+    .cmp-group th { padding: 24px 0 8px; }
+    .cmp-group th span { padding: 0 12px 0 0; }
+    .cmp-plan-name { font-size: .92rem; }
+  }
 </style>
 <script src="/safe-area.js?v=1"></script>
 </head>
@@ -56,16 +215,20 @@
       <!-- width breakout: a escada de 5 cards precisa de mais que os 1200px do
            .wrap pra não ficar espremida; centraliza na página via translate. -->
       <div id="plans-v2-wrap" style="width:min(1560px,calc(100vw - 48px));margin-left:50%;transform:translateX(-50%)">
-        <div style="display:flex;justify-content:center;gap:0;margin:0 0 26px">
-          <button type="button" id="cycle-monthly" class="btn btn-primary" style="border-radius:12px 0 0 12px" onclick="setCycle('monthly')">Mensal</button>
-          <button type="button" id="cycle-annual" class="btn btn-outline" style="border-radius:0 12px 12px 0" onclick="setCycle('annual')">Anual <span style="background:rgba(198,241,26,.16);color:#C6F11A;font-weight:700;padding:2px 9px;border-radius:999px;font-size:.82em">-17%</span></button>
+        <div class="cycle-wrap">
+          <div class="cycle-toggle" role="group" aria-label="Ciclo de cobrança">
+            <button type="button" id="cycle-monthly" class="cycle-btn is-active" aria-pressed="true" onclick="setCycle('monthly')">Mensal</button>
+            <button type="button" id="cycle-annual" class="cycle-btn" aria-pressed="false" onclick="setCycle('annual')">Anual <span class="cycle-save">−17%</span></button>
+          </div>
         </div>
 
         <div class="plans" id="plans-v2" style="grid-template-columns:repeat(auto-fit,minmax(220px,1fr))">
           <article class="plan">
             <h3>Grátis</h3>
             <div class="plan-sub">Pra conhecer a Piggy</div>
-            <div class="price">R$ 0 <span>/ sempre</span></div>
+            <div class="price-block">
+              <div class="price">R$ 0 <span>/ sempre</span></div>
+            </div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Registro por texto no WhatsApp</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard completo · 30 lançamentos/mês</li>
@@ -73,13 +236,16 @@
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> 1 caixinha e 1 cartão</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA · 20 mensagens/mês</li>
             </ul>
-            <a class="btn btn-outline btn-block" id="free-cta" href="/cadastro">Criar conta grátis</a>
+            <a class="btn btn-outline btn-block" id="free-cta" data-free-cta href="/cadastro">Criar conta grátis</a>
           </article>
 
           <article class="plan">
             <h3>Essencial</h3>
             <div class="plan-sub">Organize tudo, sem limites</div>
-            <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;9,90</span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;99</span></div>
+            <div class="price-block">
+              <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;9,90<small class="per">/mês</small></span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;99<small class="per">/ano</small></span></div>
+              <div class="price-eq" data-price-annual style="display:none">Equivale a R$&nbsp;8,25 por mês</div>
+            </div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>1&nbsp;banco conectado</strong> (Open&nbsp;Finance)</span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Lançamentos ilimitados: áudio, foto de cupom, OFX</li>
@@ -94,7 +260,10 @@
             <span class="plan-badge"><i class="ph ph-star" aria-hidden="true"></i> Mais popular</span>
             <h3>Plus</h3>
             <div class="plan-sub">Seu dinheiro no automático</div>
-            <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;19,90</span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;199</span></div>
+            <div class="price-block">
+              <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;19,90<small class="per">/mês</small></span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;199<small class="per">/ano</small></span></div>
+              <div class="price-eq" data-price-annual style="display:none">Equivale a R$&nbsp;16,58 por mês</div>
+            </div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>2&nbsp;bancos conectados</strong> (Open&nbsp;Finance)</span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Agentes</strong>: energia pra até 3, você escolhe quais</span></li>
@@ -108,7 +277,10 @@
           <article class="plan">
             <h3>Pro</h3>
             <div class="plan-sub">Planejamento e previsão</div>
-            <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;49,90</span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;499</span></div>
+            <div class="price-block">
+              <div class="price"><span data-price-monthly style="font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;49,90<small class="per">/mês</small></span><span data-price-annual style="display:none;font-size:inherit;font-weight:inherit;color:inherit">R$&nbsp;499<small class="per">/ano</small></span></div>
+              <div class="price-eq" data-price-annual style="display:none">Equivale a R$&nbsp;41,58 por mês</div>
+            </div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>5&nbsp;bancos conectados</strong></span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Todos os 7 agentes</strong>: energia pra rodar a equipe inteira</span></li>
@@ -124,7 +296,9 @@
             <span class="plan-badge" style="background:rgba(255,255,255,.14)"><i class="ph ph-diamond" aria-hidden="true"></i> Em breve</span>
             <h3>Premium</h3>
             <div class="plan-sub">O máximo do PigBank</div>
-            <div class="price" style="font-size:1.15rem;padding:14px 0">Aguarde</div>
+            <div class="price-block">
+              <div class="price" style="font-size:1.15rem">Aguarde</div>
+            </div>
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Bancos ilimitados</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Todos os agentes + crie o seu</li>
@@ -139,6 +313,276 @@
         <p class="plans-note"><i class="ph ph-piggy-bank" aria-hidden="true"></i> <strong>Preço de fundador:</strong> assinando agora, seu valor fica congelado pra sempre: enquanto a assinatura estiver ativa, ele nunca sobe.</p>
       </div>
       <p class="plans-note" id="plans-note-v2"><i class="ph ph-confetti" aria-hidden="true"></i> Todo plano vem com <strong>30 dias grátis pra testar</strong> (um teste por número). A primeira cobrança só acontece depois do trial. Cancele antes pelo dashboard e não paga nada. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
+      <p class="plans-cta"><a href="#comparar">Ver a comparação completa, recurso por recurso <i class="ph ph-caret-right" aria-hidden="true"></i></a></p>
+    </section>
+
+    <!-- ══════════════════════════════════════════════════════════════════
+         Tabela comparativa. Os cards vendem cada plano isolado; aqui a
+         pergunta é outra: "o que eu perco descendo um degrau?". Cada linha
+         é ancorada em core/services/plan_limits.py (fonte única dos
+         limites) — mudou lá, muda aqui.
+         ══════════════════════════════════════════════════════════════════ -->
+    <section class="section" id="comparar" style="padding-top:0">
+      <div class="cmp">
+        <div class="cmp-head">
+          <h3>Compare os planos lado a lado</h3>
+          <p>A mesma linha para todos os planos, para você ver exatamente o que ganha (e o que deixa de ter) em cada degrau.</p>
+        </div>
+
+        <p class="cmp-hint"><i class="ph ph-arrows-horizontal" aria-hidden="true"></i> Arraste a tabela para o lado para ver todos os planos</p>
+
+        <div class="cmp-scrollwrap" id="cmp-scrollwrap">
+          <div class="cmp-scroll" id="cmp-scroll" tabindex="0" role="region" aria-label="Comparação de recursos entre os planos">
+            <table class="cmp-table">
+              <caption class="sr-only">Recursos incluídos em cada plano do PigBank</caption>
+              <colgroup>
+                <col /><col /><col /><col class="cmp-col-hl" /><col /><col />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th scope="col" class="cmp-feat"><span class="sr-only">Recurso</span></th>
+                  <th scope="col">
+                    <span class="cmp-plan-name">Grátis</span>
+                    <span class="cmp-plan-price">R$&nbsp;0</span>
+                  </th>
+                  <th scope="col">
+                    <span class="cmp-plan-name">Essencial</span>
+                    <span class="cmp-plan-price"><span data-price-monthly>R$&nbsp;9,90/mês</span><span data-price-annual style="display:none">R$&nbsp;99/ano</span></span>
+                  </th>
+                  <th scope="col" class="is-hl">
+                    <span class="cmp-plan-tag">Mais popular</span>
+                    <span class="cmp-plan-name">Plus</span>
+                    <span class="cmp-plan-price"><span data-price-monthly>R$&nbsp;19,90/mês</span><span data-price-annual style="display:none">R$&nbsp;199/ano</span></span>
+                  </th>
+                  <th scope="col">
+                    <span class="cmp-plan-name">Pro</span>
+                    <span class="cmp-plan-price"><span data-price-monthly>R$&nbsp;49,90/mês</span><span data-price-annual style="display:none">R$&nbsp;499/ano</span></span>
+                  </th>
+                  <th scope="col">
+                    <span class="cmp-plan-name">Premium</span>
+                    <span class="cmp-plan-price">Em breve</span>
+                  </th>
+                </tr>
+              </thead>
+
+              <tbody>
+                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Registro no WhatsApp</span></th></tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Registro por texto</th>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Lançamentos por mês</th>
+                  <td><span class="c-val">30</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Registro por áudio</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Foto de cupom e comprovante</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Importar extrato (OFX, CSV, PDF)</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+
+                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Contas e organização</span></th></tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Bancos conectados (Open&nbsp;Finance)</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhum</span></span></td>
+                  <td><span class="c-val">1</span></td>
+                  <td><span class="c-val">2</span></td>
+                  <td><span class="c-val">5</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Investimentos no painel</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Caixinhas e metas</th>
+                  <td><span class="c-val">1</span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Cartões</th>
+                  <td><span class="c-val">1</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                  <td><span class="c-val">Ilimitados</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Boletos com lembrete de vencimento</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Gastos recorrentes</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+
+                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Piggy IA</span></th></tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Mensagens com a Piggy</th>
+                  <td><span class="c-val">20<small>por mês</small></span></td>
+                  <td><span class="c-val">200<small>por mês</small></span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                  <td><span class="c-val">Ilimitadas</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Categorização automática</th>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+
+                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Agentes do Piggy</span></th></tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Agentes liberados</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhum</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhum</span></span></td>
+                  <td><span class="c-val">Os 7<small>você escolhe</small></span></td>
+                  <td><span class="c-val">Os 7<small>você escolhe</small></span></td>
+                  <td><span class="c-val">Todos</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Energia para mantê-los ligados</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhuma</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhuma</span></span></td>
+                  <td><span class="c-val"><i class="ph ph-lightning" aria-hidden="true"></i> 4<small>até 3 agentes</small></span></td>
+                  <td><span class="c-val"><i class="ph ph-lightning" aria-hidden="true"></i> 14<small>a equipe inteira</small></span></td>
+                  <td><span class="c-val">Ilimitada</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Criar o seu próprio agente</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+
+                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Histórico e relatórios</span></th></tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Histórico que você enxerga</th>
+                  <td><span class="c-val">Mês corrente</span></td>
+                  <td><span class="c-val">90 dias</span></td>
+                  <td><span class="c-val">12 meses</span></td>
+                  <td><span class="c-val">24 meses</span></td>
+                  <td><span class="c-val">Completo</span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Exportar seus dados</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Previsão de saldo 30/60/90 dias</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Relatórios semanais</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+
+                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Ainda por vir, no Premium</span></th></tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Modo família</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Visão completa do patrimônio</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+                <tr>
+                  <th scope="row" class="cmp-feat">Suporte exclusivo</th>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
+                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
+                </tr>
+              </tbody>
+
+              <tfoot>
+                <tr>
+                  <td class="cmp-feat"></td>
+                  <td><a class="btn btn-outline" data-free-cta href="/cadastro">Criar conta grátis</a></td>
+                  <td><button class="btn btn-outline" type="button" data-plan-btn="essencial" onclick="startCheckout(currentCycle, this, 'essencial')">Assinar Essencial</button></td>
+                  <td class="is-hl"><button class="btn btn-primary" type="button" data-plan-btn="plus" onclick="startCheckout(currentCycle, this, 'plus')">Assinar Plus</button></td>
+                  <td><button class="btn btn-outline" type="button" data-plan-btn="pro" onclick="startCheckout(currentCycle, this, 'pro')">Assinar Pro</button></td>
+                  <td><button class="btn btn-outline" type="button" disabled>Em breve</button></td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+
+        <p class="cmp-note">
+          <i class="ph ph-lightning" aria-hidden="true"></i> <strong>Energia</strong> é o que limita quantos agentes ficam ligados ao mesmo tempo, não quais. Cada um custa o que dá trabalho para rodar:
+          Repórter <span class="e">⚡1</span> · Carteiro <span class="e">⚡1</span> · Xerife <span class="e">⚡2</span> · Barão <span class="e">⚡2</span> · Faria Limer <span class="e">⚡2</span> · Detetive <span class="e">⚡3</span> · Banqueiro <span class="e">⚡3</span>.
+          No Plus você distribui <span class="e">⚡4</span> entre os que quiser; no Pro, <span class="e">⚡14</span> ligam os sete de uma vez.
+        </p>
+      </div>
     </section>
 
   </div>
@@ -196,16 +640,39 @@ let currentCycle = "monthly";
 
 function setCycle(cycle) {
   currentCycle = cycle;
-  const bm = document.getElementById("cycle-monthly");
-  const ba = document.getElementById("cycle-annual");
-  if (bm) bm.className = "btn btn-block " + (cycle === "monthly" ? "btn-primary" : "btn-outline");
-  if (ba) ba.className = "btn btn-block " + (cycle === "annual" ? "btn-primary" : "btn-outline");
-  if (bm) { bm.style.borderRadius = "12px 0 0 12px"; bm.style.width = "auto"; }
-  if (ba) { ba.style.borderRadius = "0 12px 12px 0"; ba.style.width = "auto"; }
+  // Segmented control: só liga/desliga a classe. Os [data-price-*] cobrem de
+  // uma vez os cards E o cabeçalho da tabela comparativa — os dois têm de
+  // mostrar o mesmo ciclo, senão o card diz "R$ 99/ano" e a tabela "R$ 9,90".
+  document.querySelectorAll(".cycle-btn").forEach(b => {
+    const on = b.id === "cycle-" + cycle;
+    b.classList.toggle("is-active", on);
+    b.setAttribute("aria-pressed", on ? "true" : "false");
+  });
   document.querySelectorAll("[data-price-monthly]").forEach(el => { el.style.display = cycle === "monthly" ? "" : "none"; });
   document.querySelectorAll("[data-price-annual]").forEach(el => { el.style.display = cycle === "annual" ? "" : "none"; });
   if (typeof refreshPlanButtons === "function") refreshPlanButtons();
 }
+
+// ── Véus das bordas da tabela comparativa ────────────────────────────────────
+// Só aparecem quando há coluna escondida daquele lado. Sem isto o usuário de
+// celular não descobre que a tabela rola. Função pura do scroll medido.
+function updateCmpFade() {
+  const sc = document.getElementById("cmp-scroll");
+  const wrap = document.getElementById("cmp-scrollwrap");
+  if (!sc || !wrap) return;
+  const max = sc.scrollWidth - sc.clientWidth;
+  wrap.classList.toggle("fade-left", sc.scrollLeft > 2);
+  wrap.classList.toggle("fade-right", max > 2 && sc.scrollLeft < max - 2);
+}
+(function initCmpFade() {
+  const sc = document.getElementById("cmp-scroll");
+  if (!sc) return;
+  sc.addEventListener("scroll", updateCmpFade, { passive: true });
+  window.addEventListener("resize", updateCmpFade);
+  // A fonte de ícones muda a largura das células depois do parse — remedir.
+  window.addEventListener("load", updateCmpFade);
+  updateCmpFade();
+})();
 
 // ── Troca de plano (assinante logado) ───────────────────────────────────────
 // Regra: sem cobrança agora — o plano vira na PRÓXIMA cobrança. O backend
@@ -364,25 +831,30 @@ async function applyOnboardingChoice() {
     me = await r.json();
   } catch { return; }
 
-  const cta = document.getElementById("free-cta");
+  // São DOIS CTAs de Grátis desde a tabela comparativa (card + rodapé da
+  // tabela). Iterar em [data-free-cta] em vez de #free-cta — com getElementById
+  // só o do card mudava e o da tabela continuava mandando pro /cadastro.
+  const ctas = document.querySelectorAll("[data-free-cta]");
   if (me && me.needs_plan_selection) {
     // Guia visual: deixa claro que precisa escolher um plano pra começar.
     const sub = document.getElementById("precos-sub");
     if (sub) sub.textContent = "Escolha um plano pra começar: dá pra seguir no Grátis ou testar um plano pago 30 dias de graça.";
-    if (cta) {
+    ctas.forEach(cta => {
       cta.removeAttribute("href");
       cta.style.cursor = "pointer";
       cta.textContent = "Continuar com o plano Grátis";
       cta.onclick = function (e) { e.preventDefault(); selectFree(cta); };
-    }
-  } else if (me && cta) {
+    });
+  } else if (me) {
     // Já logado e com plano escolhido: o card Grátis não leva pro /cadastro.
-    cta.removeAttribute("href");
-    cta.textContent = "Seu cadastro está pronto";
-    cta.classList.add("btn-outline");
-    cta.style.opacity = ".7";
-    cta.style.cursor = "default";
-    cta.onclick = function (e) { e.preventDefault(); };
+    ctas.forEach(cta => {
+      cta.removeAttribute("href");
+      cta.textContent = "Seu cadastro está pronto";
+      cta.classList.add("btn-outline");
+      cta.style.opacity = ".7";
+      cta.style.cursor = "default";
+      cta.onclick = function (e) { e.preventDefault(); };
+    });
   }
 }
 
@@ -425,15 +897,14 @@ async function selectFree(btn) {
     if (resp.ok) {
       const cfg = await resp.json();
       // Plano sem price configurado no Stripe → botão vira "Indisponível" (não
-      // deixa o usuário clicar pra tomar um erro).
-      if (!cfg.essencial_available) {
-        const b = document.querySelector('[data-plan-btn="essencial"]');
-        if (b) { b.disabled = true; b.textContent = "Indisponível"; b.dataset.unavailable = "1"; }
-      }
-      if (!cfg.pro_available) {
-        const b = document.querySelector('[data-plan-btn="pro"]');
-        if (b) { b.disabled = true; b.textContent = "Indisponível"; b.dataset.unavailable = "1"; }
-      }
+      // deixa o usuário clicar pra tomar um erro). querySelectorAll, não
+      // querySelector: cada plano pago tem DOIS botões (card + rodapé da
+      // tabela comparativa) e o segundo ficava clicável rumo ao erro.
+      const markUnavailable = sel => document.querySelectorAll(sel).forEach(b => {
+        b.disabled = true; b.textContent = "Indisponível"; b.dataset.unavailable = "1";
+      });
+      if (!cfg.essencial_available) markUnavailable('[data-plan-btn="essencial"]');
+      if (!cfg.pro_available) markUnavailable('[data-plan-btn="pro"]');
     }
     // Assinante logado: botões viram "Seu plano atual / Trocar / Agendado".
     await loadSubscription();


### PR DESCRIPTION
## O que muda

A `/precos` só tinha os 5 cards, cada um vendendo um plano isolado — não dava pra ver **o que se perde descendo um degrau**. Entra uma seção `#comparar` com **23 recursos × 5 planos** em 6 grupos.

Cada linha é ancorada em `core/services/plan_limits.py` (fonte única dos limites) e em `AGENT_ENERGY_COST`. Nada foi inventado — as duas exceções estão listadas em "Precisa de confirmação" abaixo.

## Decisões de implementação

| Decisão | Por quê |
|---|---|
| Faixa da coluna Plus pintada no `<col>` | As linhas de grupo usam `colspan=6`; fundo na célula quebraria a faixa em seis pedaços |
| `table-layout: fixed` | No automático as 5 colunas saíam 195/196/155/148/130px — coluna estreita se lê como plano menos importante, o contrário do que a faixa do Plus diz |
| Cabeçalho da coluna Plus **opaco** | Com `rgba(...,.13)` translúcido as linhas do corpo passavam por baixo do sticky e apareciam sobre ele ("Plus / R$ 19,90" com "12 meses" por cima). Achado no screenshot |
| `thead` sticky só no desktop | Abaixo de 900px o wrapper vira scroller horizontal e o sticky vertical passa a valer em relação a ele (que nunca rola em Y) — vira no-op |
| CSS na própria página | Componente exclusivo da `/precos`; `site.css` é carregado pelas 25 páginas |

## Par escrita/leitura: os CTAs do rodapé duplicam os dos cards

Adicionar botões no `tfoot` duplicou o alvo de três funções. As três foram ajustadas juntas:

- `loadPlansState`: `querySelector` → `querySelectorAll`. Sem isso, num plano sem price configurado no Stripe só o botão do card travava e **o da tabela continuava clicável rumo ao erro**.
- `applyOnboardingChoice`: `#free-cta` → `[data-free-cta]` iterando os dois. Sem isso o CTA da tabela continuava mandando pro `/cadastro` no gate de escolha de plano.
- `refreshPlanButtons` já usava `querySelectorAll` — nada a fazer.

## Cards: corrigida a categoria, não a instância

O defeito era "tudo que fica acima da lista e tem altura variável desalinha as 5 colunas". Os dois casos:

- **bloco de preço** — o Premium mostra "Aguarde" em 1.15rem contra 2.5rem dos pagos → **32px** de desalinho
- **subtítulo** — abaixo de ~1330px o card cai pra 230px e dois subtítulos viram duas linhas → **20px** (só apareceu ao medir em 1280px)

Junto, a fileira de CTAs estava **7px + 2px** fora de esquadro: o Grátis é `<a>` (herda `line-height: 1.5` do body) e os pagos são `<button>` (cai no `normal` da UA); e `.btn-outline` tem borda de 1px enquanto `.btn-primary` não tem nenhuma.

Também: preço ganha `/mês` e `/ano` (antes o toggle trocava 9,90 por 99 **sem unidade nenhuma**), equivalência mensal no ciclo anual, e o toggle vira segmented control com `aria-pressed` e focus ring — saindo do hack de remontar `className` e reinjetar `btn-block` só pra desfazer o `width:100%` na linha seguinte.

## Acessibilidade

`✓`/`—` com rótulo `.sr-only` (0 células de ícone sem texto), `th[scope]` em **35/35** cabeçalhos, `<caption>`, região rolável com `role="region"` + `tabindex="0"` + `aria-label`, focus ring em todos os controles.

## O que foi medido

Chromium, larguras 375 / 1240 / 1280 / 1440 / 1600px:

| Verificação | Resultado |
|---|---|
| Listas dos cards no mesmo Y | spread **0px** em todas as larguras (contraprova: **32px** com o `min-height` desligado) |
| Fileira de CTAs dos cards | spread **0px** (era 7px, depois 2px) |
| Botões do rodapé da tabela | spread **0px**, inclusive com os rótulos longos do `refreshPlanButtons` (73px cada) |
| Colunas dos planos | 5 × 158px iguais |
| Faixa do Plus | mesmo x/largura em `thead`, `tbody` e `tfoot` |
| Cabeçalho sticky | todas as 6 células com alfa 1 |
| Células estourando a coluna | **0**, em 375 e em 1600 |
| Coluna de recursos sticky em 375px | fica em x=24 após rolar 200px (sem o sticky daria −176) |
| Véus das bordas | só à direita no início · ambos no meio · só à esquerda no fim |
| Toggle mensal↔anual | cards **e** cabeçalho da tabela trocam juntos; voltar pro mensal é idempotente |
| Overflow horizontal de página | nenhum (`.cmp-scroll` contém os 664px da tabela em 327px) |

## O que **não** foi medido

- **Comportamento no app iOS.** A `/precos` é uma das 19 páginas sem `app-mode.css` (carrega só o `safe-area.js`). O `top` do cabeçalho sticky usa `calc(84px + env(safe-area-inset-top))`, mas `env()` vale 0 no Chromium headless — a aritmética com inset real só dá pra conferir no aparelho, depois do build. O momentum de scroll horizontal no WKWebView também.
- **Produção.** Bloqueada pelo proxy daqui.
- A suíte pytest não foi rodada: a mudança é só `frontend/precos.html` e nenhum teste toca esse arquivo (`serve_precos` apenas devolve o HTML, sem cirurgia de string).

## Precisa de confirmação do @JapaLcK

Duas linhas vieram da copy que **já estava** no card do Pro, mas **não têm gate em `plan_limits.py`**:

1. **Previsão de saldo 30/60/90 dias** — `core/services/cashflow.py::project` existe, sem checagem de tier
2. **Relatórios semanais** — `weekly_report_enabled` em `settings.py` tem default `True` para todo mundo

Numa tabela isso se lê como contrato preciso, diferente de um bullet de card. Se o gate não existir mesmo, ou a linha sai da tabela ou o gate entra no backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
