### PR TITLE
fix(precos): a cota da Piggy IA é finita, no card do Plus e na tabela

### DIFF
--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -267,7 +267,11 @@
             <ul>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>2&nbsp;bancos conectados</strong> (Open&nbsp;Finance)</span></li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> <span><strong>Agentes</strong>: energia pra até 3, você escolhe quais</span></li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA sem limites</li>
+              <!-- 1.000 = AI_CHAT_MONTHLY_LIMIT (core/services/ai_chat_commands.py).
+                   `ai_monthly_messages: None` no PLUS_LIMITS/PRO_LIMITS NÃO é ilimitado:
+                   ai_monthly_limit_for() troca None por esse teto e o runner do chat corta
+                   ali. Mudou a env, muda aqui e na tabela comparativa também. -->
+              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA · 1.000 mensagens/mês</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Alertas de gastos fora do padrão</li>
               <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Histórico de 12 meses + tudo do Essencial</li>
             </ul>
@@ -463,9 +467,11 @@
                   <th scope="row" class="cmp-feat">Mensagens com a Piggy</th>
                   <td><span class="c-val">20<small>por mês</small></span></td>
                   <td><span class="c-val">200<small>por mês</small></span></td>
-                  <td><span class="c-val">Ilimitadas</span></td>
-                  <td><span class="c-val">Ilimitadas</span></td>
-                  <td><span class="c-val">Ilimitadas</span></td>
+                  <!-- Plus/Pro/Premium: `ai_monthly_messages: None` cai no teto GLOBAL
+                       AI_CHAT_MONTHLY_LIMIT, não em "ilimitado" (ver o card do Plus). -->
+                  <td><span class="c-val">1.000<small>por mês</small></span></td>
+                  <td><span class="c-val">1.000<small>por mês</small></span></td>
+                  <td><span class="c-val">1.000<small>por mês</small></span></td>
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Categorização automática</th>


### PR DESCRIPTION
Mesmo apontamento que o Codex fez no #70, na página que **vende**.

## O que estava errado

Quatro pontos da `/precos` prometiam IA ilimitada:

| onde | dizia |
|---|---|
| card do Plus (`precos.html:270`) | "Piggy IA sem limites" |
| tabela comparativa, coluna Plus | "Ilimitadas" |
| tabela comparativa, coluna Pro | "Ilimitadas" |
| tabela comparativa, coluna Premium | "Ilimitadas" |

Nenhum dos três é ilimitado. `ai_monthly_messages: None` em `PLUS_LIMITS`/`PRO_LIMITS` **não** significa sem limite: `ai_monthly_limit_for` troca `None` pelo teto **global** `AI_CHAT_MONTHLY_LIMIT` (1.000/mês por padrão) e `core/services/ai_chat/runner.py:151` recusa a partir de `used >= monthly_limit`. Quem batesse o teto perderia um benefício que a página de preços chama de ilimitado.

## O que mudou

Os quatro pontos viram **"1.000 mensagens/mês"**, no mesmo formato das linhas que já existiam (Free 20, Essencial 200 — números igualmente chumbados, vindos das mesmas constantes de `plan_limits.py`). Comentário no HTML apontando pra env nos dois lugares, porque agora são dois que precisam mudar juntos.

## O que NÃO foi tocado, de propósito

As linhas de **caixinhas, metas e cartões** continuam "Ilimitadas", e estão certas: `pockets_max`/`cards_max` com `None` fazem o `plan_service` retornar sem checar nada. `None` não tem semântica única no `plan_limits` — cada campo foi conferido até o ponto de enforcement, e `ai_monthly_messages` é o único com fallback pro teto global.

## Medido

Chromium a 375x812 e 1280x800:

- nenhum `li`/`td`/`p` que fale de "Piggy" ou "mensagens" contém "ilimitad"/"sem limite";
- card do Plus lê exatamente `Piggy IA · 1.000 mensagens/mês`;
- linha "Mensagens com a Piggy" lê `20 / 200 / 1.000 / 1.000 / 1.000`;
- linha "Caixinhas e metas" segue `1 / Ilimitadas ×4` — a mudança não vazou pra ela.

Suíte: **1088 passed, 0 failed**, igual à baseline da `main` (esta mudança não toca Python).

## Achado que fica de fora

A `/precos` **rola na horizontal a 375px** de largura: `scrollWidth 645` vs `innerWidth 375`. O número é idêntico com e sem esta mudança, então é anterior — vem da tabela comparativa do #71. Importa porque o app abre essa rota no WebView (o "Ver planos" do dashboard leva pra cá) e ela é uma das 19 páginas sem tratamento de área segura. Não corrigi aqui porque é outra natureza de problema e merece o próprio PR.

Também fora de escopo, registrando: o `termos.html:87–90` ainda descreve o modelo binário Free × PigBank+ de antes da escada v2 ("histórico ilimitado", "uso ilimitado de transações"), que hoje são 365/730 dias e 30 lançamentos/mês no Free. É texto de Termos de Uso, decisão do dono.

## Não verificado

O site em produção (o proxy bloqueia `pigbankai.com` daqui) e o rendering dentro do WebView do app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ysAAGjPzs9t8tfHdS7MmJ)_