### PR TITLE
fix(a11y): prende o Tab nos outros dois modais com aria-modal

### DIFF
--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1364,16 +1364,24 @@ const usersState = { q: '', status: '', page: 0, perPage: 50, sort: 'created_at'
 let usersSearchDebounce = null;
 let usersController = null;
 
+let _usersLastFocus = null;
+
 function openUsersModal() {
   usersState.open = true;
+  _usersLastFocus = document.activeElement;
   $id('users-modal').classList.add('visible');
   showUsersList();
   loadUsers();
+  // foco pro campo de busca, que é o primeiro controle útil do diálogo
+  $id('users-search')?.focus();
 }
 function closeUsersModal() {
   usersState.open = false;
   usersController?.abort();
   $id('users-modal').classList.remove('visible');
+  // devolve o foco pro card que abriu, senão o teclado volta pro topo do painel
+  if (_usersLastFocus && document.contains(_usersLastFocus)) _usersLastFocus.focus();
+  _usersLastFocus = null;
 }
 function showUsersList() {
   $id('user-detail').style.display = 'none';
@@ -1615,8 +1623,42 @@ $id('users-sort').addEventListener('change', () => {
 $id('users-modal').addEventListener('click', (e) => {
   if (e.target === $id('users-modal')) closeUsersModal();
 });
+/* O Esc já existia; o Tab não estava preso. O modal declara aria-modal="true",
+   que AFIRMA pro leitor de tela que o resto da página não está disponível — mas
+   o teclado saía do diálogo pros controles do painel atrás dele. Mesmo defeito
+   que o Codex apontou no modal da Início (PR #70).
+
+   Os alvos são consultados a cada Tab porque o conteúdo troca: a lista de
+   usuários é paginada e o detalhe de um usuário substitui a tabela. */
+function _usersFocaveis() {
+  const dlg = document.querySelector('#users-modal .users-dialog');
+  if (!dlg) return [];
+  const sel = 'a[href], button:not([disabled]), input:not([disabled]),'
+            + ' select:not([disabled]), textarea:not([disabled]),'
+            + ' [tabindex]:not([tabindex="-1"])';
+  return [...dlg.querySelectorAll(sel)].filter(
+    (el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0,
+  );
+}
+
 document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape' && usersState.open) closeUsersModal();
+  if (!usersState.open) return;
+  if (e.key === 'Escape') { closeUsersModal(); return; }
+  if (e.key !== 'Tab') return;
+
+  const dlg = document.querySelector('#users-modal .users-dialog');
+  const alvos = _usersFocaveis();
+  if (!dlg || !alvos.length) return;
+
+  const primeiro = alvos[0];
+  const ultimo = alvos[alvos.length - 1];
+  const proximo = e.shiftKey ? ultimo : primeiro;
+  const borda = e.shiftKey ? primeiro : ultimo;
+
+  if (!dlg.contains(document.activeElement) || document.activeElement === borda) {
+    e.preventDefault();
+    proximo.focus();
+  }
 });
 
 /* ── Auto-refresh ────────────────────────────────────────────────── */

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1054,8 +1054,14 @@ function renderSummary(s) {
      abertura capturava o `body` em vez do card, então devolver o foco ao fechar
      não devolvia pra lugar nenhum útil. Vira um alvo de verdade: role, tabindex
      e Enter/Espaço, que é o contrato que `role="button"` promete. */
+  /* id estável: o auto-refresh de 60s chama renderSummary() e TROCA todo o DOM
+     dos cards. Guardar o elemento em _usersLastFocus não sobrevive a isso — na
+     hora de fechar, o `document.contains` falha e o foco fica num nó órfão. Por
+     isso guardamos o id e resolvemos o elemento só no fechamento, achando o
+     card NOVO. */
   const gatilho = (c) => c.click
-    ? ` role="button" tabindex="0" onclick="${c.click}"`
+    ? ` id="summary-card-${c.label.toLowerCase().replace(/[^a-z]+/g, "-")}"`
+      + ` role="button" tabindex="0" onclick="${c.click}"`
       + ` onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();${c.click}}"`
     : '';
   $id('summary-cards').innerHTML = cards.map(c => `
@@ -1375,12 +1381,16 @@ let usersSearchDebounce = null;
 let usersController = null;
 
 let _usersLastFocus = null;
+let _usersLastFocusId = null;
 
 function openUsersModal(ev) {
   usersState.open = true;
-  // vem do evento, não do document.activeElement: num clique de mouse o
-  // activeElement é o body, e o foco voltaria pro topo do painel ao fechar
-  _usersLastFocus = ev?.currentTarget || document.activeElement;
+  /* Do evento, não do document.activeElement: num clique de mouse o
+     activeElement é o body. E guardamos o ID, não o nó — o auto-refresh de 60s
+     recria os cards, e um nó guardado vira órfão no meio da sessão. */
+  const alvo = ev?.currentTarget || document.activeElement;
+  _usersLastFocusId = alvo?.id || null;
+  _usersLastFocus = _usersLastFocusId ? null : alvo;
   $id('users-modal').classList.add('visible');
   showUsersList();
   loadUsers();
@@ -1391,9 +1401,14 @@ function closeUsersModal() {
   usersState.open = false;
   usersController?.abort();
   $id('users-modal').classList.remove('visible');
-  // devolve o foco pro card que abriu, senão o teclado volta pro topo do painel
-  if (_usersLastFocus && document.contains(_usersLastFocus)) _usersLastFocus.focus();
+  // resolve o alvo AGORA: se o auto-refresh recriou os cards, o id acha o card
+  // novo; o nó guardado só é usado quando não havia id
+  const volta = _usersLastFocusId
+    ? document.getElementById(_usersLastFocusId)
+    : _usersLastFocus;
+  if (volta && document.contains(volta)) volta.focus();
   _usersLastFocus = null;
+  _usersLastFocusId = null;
 }
 function showUsersList() {
   $id('user-detail').style.display = 'none';

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -1038,7 +1038,7 @@ function renderOpsHealthGrid(ops) {
 function renderSummary(s) {
   const cards = [
     { label:"Usuários",          val: fInt(s.total_accounts),    sub:`+${fInt(s.accounts_30d)} em 30d`,
-      click:"openUsersModal()" },
+      click:"openUsersModal(event)" },
     { label:"Ativos 30d",        val: fInt(s.active_users_30d),  sub:`${fInt(s.active_users_7d)} ativos 7d` },
     { label:"Logins ok 30d",     val: fInt(s.login_success_30d), sub:`${s.login_success_rate_30d}% taxa sucesso` },
     { label:"Transações 30d",    val: fInt(s.transactions_30d),  sub:"Movimentações externas" },
@@ -1048,8 +1048,18 @@ function renderSummary(s) {
     { label:"Investimentos",     val: fMoney(s.investments_balance), sub:"Saldo consolidado atual" },
     { label:"Cartões em aberto", val: fMoney(s.cards_due_open),  sub:"Faturas abertas/fechadas" },
   ];
+  /* O card que abre o modal era um <article> só com onclick: fora da ordem de
+     Tab, sem ativação por teclado e sem receber foco. Duas consequências — quem
+     navega por teclado não tinha como abrir o modal, e o `_usersLastFocus` da
+     abertura capturava o `body` em vez do card, então devolver o foco ao fechar
+     não devolvia pra lugar nenhum útil. Vira um alvo de verdade: role, tabindex
+     e Enter/Espaço, que é o contrato que `role="button"` promete. */
+  const gatilho = (c) => c.click
+    ? ` role="button" tabindex="0" onclick="${c.click}"`
+      + ` onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();${c.click}}"`
+    : '';
   $id('summary-cards').innerHTML = cards.map(c => `
-    <article class="card${c.click ? ' card-clickable' : ''}"${c.click ? ` onclick="${c.click}"` : ''}>
+    <article class="card${c.click ? ' card-clickable' : ''}"${gatilho(c)}>
       <div class="metric-label">${c.label}</div>
       <div class="metric-value">${c.val}</div>
       <div class="metric-sub">${c.sub}</div>
@@ -1366,9 +1376,11 @@ let usersController = null;
 
 let _usersLastFocus = null;
 
-function openUsersModal() {
+function openUsersModal(ev) {
   usersState.open = true;
-  _usersLastFocus = document.activeElement;
+  // vem do evento, não do document.activeElement: num clique de mouse o
+  // activeElement é o body, e o foco voltaria pro topo do painel ao fechar
+  _usersLastFocus = ev?.currentTarget || document.activeElement;
   $id('users-modal').classList.add('visible');
   showUsersList();
   loadUsers();

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -2314,12 +2314,13 @@ async function budgetDeleteFromModal() {
 // ══════════════════════════════════════════════════════════════════════
 
 let _genericModalResolver = null;
+let _genericModalLastFocus = null;
 
 function _ensureGenericConfirmModal() {
   if (document.getElementById("generic-confirm-overlay")) return;
   const html = `
     <div class="overlay" id="generic-confirm-overlay">
-      <div class="modal">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="generic-confirm-title">
         <h3 id="generic-confirm-title">Confirmar</h3>
         <p class="msub" id="generic-confirm-body" style="white-space:pre-wrap"></p>
         <div class="modal-acts" style="margin-top:18px">
@@ -2335,11 +2336,32 @@ function _ensureGenericConfirmModal() {
   });
   document.getElementById("generic-confirm-cancel").addEventListener("click", () => _genericModalClose(false));
   document.getElementById("generic-confirm-ok").addEventListener("click", () => _genericModalClose(true));
+
+  /* Este arquivo REDECLARA confirmModal/alertModal, e a dashboard.html carrega
+     dashboard.js depois de modals.js — então no dashboard quem roda é este
+     modal aqui, e o trap que o modals.js ganhou nunca era alcançado. Era o
+     furo que o Codex achou: o helper compartilhado cobria home e settings, e
+     deixava de fora justamente a página com mais chamadas de confirm/alert.
+
+     O trap vem do window.pigTrapTab, exposto pelo modals.js, pra não virar a
+     quarta cópia do mesmo bloco. Se por algum motivo o modals.js não tiver
+     carregado, o Esc continua funcionando e o Tab só não fica preso. */
+  document.addEventListener("keydown", (e) => {
+    const ov = document.getElementById("generic-confirm-overlay");
+    if (!ov || !ov.classList.contains("open")) return;
+    if (e.key === "Escape") { _genericModalClose(false); return; }
+    if (window.pigTrapTab) window.pigTrapTab(e, ov.querySelector(".modal"));
+  });
 }
 
 function _genericModalClose(value) {
   const overlay = document.getElementById("generic-confirm-overlay");
   if (overlay) overlay.classList.remove("open");
+  // devolve o foco pra quem abriu, senão o teclado volta pro topo do dashboard
+  if (_genericModalLastFocus && document.contains(_genericModalLastFocus)) {
+    _genericModalLastFocus.focus();
+  }
+  _genericModalLastFocus = null;
   if (_genericModalResolver) {
     const r = _genericModalResolver;
     _genericModalResolver = null;
@@ -2361,7 +2383,9 @@ function confirmModal(message, opts = {}) {
   cancelBtn.style.display = "";
   okBtn.textContent = okText;
   okBtn.className = danger ? "inst-delete-btn" : "btn-save";
+  _genericModalLastFocus = document.activeElement;
   document.getElementById("generic-confirm-overlay").classList.add("open");
+  okBtn.focus();
   return new Promise(resolve => { _genericModalResolver = resolve; });
 }
 
@@ -2376,7 +2400,9 @@ function alertModal(message, opts = {}) {
   cancelBtn.style.display = "none";
   okBtn.textContent = okText;
   okBtn.className = "btn-save";
+  _genericModalLastFocus = document.activeElement;
   document.getElementById("generic-confirm-overlay").classList.add("open");
+  okBtn.focus();
   return new Promise(resolve => { _genericModalResolver = () => resolve(undefined); _genericModalResolver = resolve; });
 }
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -2345,13 +2345,26 @@ function _ensureGenericConfirmModal() {
 
      O trap vem do window.pigTrapTab, exposto pelo modals.js, pra não virar a
      quarta cópia do mesmo bloco. Se por algum motivo o modals.js não tiver
-     carregado, o Esc continua funcionando e o Tab só não fica preso. */
+     carregado, o Esc continua funcionando e o Tab só não fica preso.
+
+     CAPTURE + stopPropagation, e isso importa: este listener é registrado
+     preguiçosamente, na primeira chamada de confirmModal(), então em fase de
+     bolha ele rodaria DEPOIS dos listeners de Escape que a página já tinha —
+     em especial o de :9178, que fecha os modais de fatura sem checar nada.
+     O submitPayBill() abre esta confirmação COM o overlay de pagamento aberto
+     atrás; um Esc pra dispensar o aviso fecharia junto o fluxo de pagamento e
+     o valor digitado. Em captura, este handler vê a tecla primeiro e a
+     consome, então o Esc fecha só a confirmação. */
   document.addEventListener("keydown", (e) => {
     const ov = document.getElementById("generic-confirm-overlay");
     if (!ov || !ov.classList.contains("open")) return;
-    if (e.key === "Escape") { _genericModalClose(false); return; }
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      _genericModalClose(false);
+      return;
+    }
     if (window.pigTrapTab) window.pigTrapTab(e, ov.querySelector(".modal"));
-  });
+  }, true);
 }
 
 function _genericModalClose(value) {

--- a/frontend/modals.js
+++ b/frontend/modals.js
@@ -202,15 +202,6 @@
 
          Os alvos são consultados a cada Tab e não uma vez, porque o corpo do
          modal aceita HTML arbitrário (`opts.html`) e pode conter links. */
-      const focaveis = () => {
-        const sel = 'a[href], button:not([disabled]), input:not([disabled]),'
-                  + ' select:not([disabled]), textarea:not([disabled]),'
-                  + ' [tabindex]:not([tabindex="-1"])';
-        return [...modal.querySelectorAll(sel)].filter(
-          (el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0,
-        );
-      };
-
       const onKey = (e) => {
         if (e.key === "Escape") {
           if (isConfirm) close(false);
@@ -221,20 +212,7 @@
           close(isConfirm ? true : undefined);
           return;
         }
-        if (e.key !== "Tab") return;
-
-        const alvos = focaveis();
-        if (!alvos.length) return;
-        const primeiro = alvos[0];
-        const ultimo = alvos[alvos.length - 1];
-        const proximo = e.shiftKey ? ultimo : primeiro;
-        const borda = e.shiftKey ? primeiro : ultimo;
-
-        // `fora do modal` cobre o foco que já escapou (clique no overlay, body)
-        if (!modal.contains(document.activeElement) || document.activeElement === borda) {
-          e.preventDefault();
-          proximo.focus();
-        }
+        window.pigTrapTab(e, modal);
       };
       document.addEventListener("keydown", onKey);
 
@@ -242,6 +220,38 @@
       setTimeout(() => btnPrimary.focus(), 50);
     });
   }
+
+  /* Trap de Tab reutilizável. Esta é a QUARTA vez que o mesmo bloco ia ser
+     copiado (home.html, settings.html, admin-dashboard.html e aqui), e o Codex
+     mostrou que copiar não fecha a classe: cada cópia nova é mais um lugar pra
+     esquecer. Exposto no window porque o dashboard.js redeclara confirmModal e
+     alertModal com markup próprio (#generic-confirm-overlay) e precisa do mesmo
+     comportamento sem herdar este arquivo.
+
+     Chame de dentro de um handler de keydown, passando o elemento do diálogo.
+     Não faz nada se a tecla não for Tab, então é seguro chamar sempre. */
+  window.pigTrapTab = function (e, modal) {
+    if (!e || e.key !== "Tab" || !modal) return;
+    const sel = 'a[href], button:not([disabled]), input:not([disabled]),'
+              + ' select:not([disabled]), textarea:not([disabled]),'
+              + ' [tabindex]:not([tabindex="-1"])';
+    // consultado a cada Tab: o corpo dos diálogos é remontado em runtime
+    const alvos = [...modal.querySelectorAll(sel)].filter(
+      (el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0,
+    );
+    if (!alvos.length) return;
+
+    const primeiro = alvos[0];
+    const ultimo = alvos[alvos.length - 1];
+    const proximo = e.shiftKey ? ultimo : primeiro;
+    const borda = e.shiftKey ? primeiro : ultimo;
+
+    // `fora do modal` cobre o foco que já escapou (clique no overlay, body)
+    if (!modal.contains(document.activeElement) || document.activeElement === borda) {
+      e.preventDefault();
+      proximo.focus();
+    }
+  };
 
   window.alertModal = function (message, opts) {
     return openModal({ kind: "alert", message, opts });

--- a/frontend/modals.js
+++ b/frontend/modals.js
@@ -169,9 +169,16 @@
       // Trigger animation on next frame
       requestAnimationFrame(() => overlay.classList.add("open"));
 
+      // quem tinha o foco antes: devolvido no close, senão o teclado volta pro
+      // topo da página depois de qualquer confirm()
+      const focoAnterior = document.activeElement;
+
       const close = (value) => {
         document.removeEventListener("keydown", onKey);
         overlay.remove();
+        if (focoAnterior && document.contains(focoAnterior) && focoAnterior.focus) {
+          focoAnterior.focus();
+        }
         resolve(value);
       };
 
@@ -185,12 +192,48 @@
         if (e.target === overlay && isConfirm) close(false);
       });
 
+      /* O modal declara role="dialog" + aria-modal="true" logo acima, o que
+         AFIRMA pro leitor de tela que o resto da página não está disponível.
+         Sem prender o Tab isso é mentira: o foco sai do card pros controles da
+         página atrás do overlay, que o mouse não alcança. Mesmo defeito que o
+         Codex apontou no modal da Início (PR #70) — e aqui pesa mais, porque
+         este arquivo é carregado por home, dashboard e settings, então cobre
+         todos os confirm()/alert() do produto de uma vez.
+
+         Os alvos são consultados a cada Tab e não uma vez, porque o corpo do
+         modal aceita HTML arbitrário (`opts.html`) e pode conter links. */
+      const focaveis = () => {
+        const sel = 'a[href], button:not([disabled]), input:not([disabled]),'
+                  + ' select:not([disabled]), textarea:not([disabled]),'
+                  + ' [tabindex]:not([tabindex="-1"])';
+        return [...modal.querySelectorAll(sel)].filter(
+          (el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0,
+        );
+      };
+
       const onKey = (e) => {
         if (e.key === "Escape") {
           if (isConfirm) close(false);
-        } else if (e.key === "Enter") {
+          return;
+        }
+        if (e.key === "Enter") {
           e.preventDefault();
           close(isConfirm ? true : undefined);
+          return;
+        }
+        if (e.key !== "Tab") return;
+
+        const alvos = focaveis();
+        if (!alvos.length) return;
+        const primeiro = alvos[0];
+        const ultimo = alvos[alvos.length - 1];
+        const proximo = e.shiftKey ? ultimo : primeiro;
+        const borda = e.shiftKey ? primeiro : ultimo;
+
+        // `fora do modal` cobre o foco que já escapou (clique no overlay, body)
+        if (!modal.contains(document.activeElement) || document.activeElement === borda) {
+          e.preventDefault();
+          proximo.focus();
         }
       };
       document.addEventListener("keydown", onKey);

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -2467,7 +2467,11 @@ async function openBankPicker() {
   // já roteia o botão pra /precos nesse caso).
   if (OF_BANKS_MAX === 0) { window.location.href = "/precos"; return; }
   const ov = document.getElementById("bankpick-overlay");
+  _bankPickLastFocus = document.activeElement;
   ov.classList.add("open");
+  // registrado aqui, antes dos returns/await abaixo, pra valer em TODOS os
+  // caminhos: lista em cache, lista carregada do servidor e erro de fetch
+  document.addEventListener("keydown", _bankPickOnKey);
   const q = document.getElementById("bankpick-search");
   q.value = "";
   _bankPickSelected = null;
@@ -2488,8 +2492,54 @@ async function openBankPicker() {
     console.error("connectors fetch:", err);
   }
 }
+/* O modal declara aria-modal="true", que AFIRMA pro leitor de tela que o resto
+   da página não está disponível enquanto ele está aberto. Isso era mentira em
+   dois níveis: este arquivo não tinha NENHUM handler de keydown (nem Esc), e o
+   Tab saía da lista de bancos direto pros controles das Configurações atrás do
+   overlay — sem sinal nenhum, porque o overlay continua cobrindo tudo. Mesmo
+   defeito que o Codex apontou no modal da Início (PR #70).
+
+   Os alvos são consultados a cada Tab, e não uma vez na abertura, porque a
+   lista de instituições é remontada a cada tecla digitada na busca. */
+let _bankPickLastFocus = null;
+
+function _bankPickFocaveis() {
+  const modal = document.querySelector("#bankpick-overlay .bankpick-modal");
+  if (!modal) return [];
+  const sel = 'a[href], button:not([disabled]), input:not([disabled]),'
+            + ' select:not([disabled]), textarea:not([disabled]),'
+            + ' [tabindex]:not([tabindex="-1"])';
+  return [...modal.querySelectorAll(sel)].filter(
+    (el) => el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0,
+  );
+}
+
+function _bankPickOnKey(e) {
+  if (e.key === "Escape") { closeBankPicker(); return; }
+  if (e.key !== "Tab") return;
+
+  const modal = document.querySelector("#bankpick-overlay .bankpick-modal");
+  const alvos = _bankPickFocaveis();
+  if (!modal || !alvos.length) return;
+
+  const primeiro = alvos[0];
+  const ultimo = alvos[alvos.length - 1];
+  const proximo = e.shiftKey ? ultimo : primeiro;
+  const borda = e.shiftKey ? primeiro : ultimo;
+
+  // `foco fora` cobre o caso de já ter escapado (clique no fundo, foco no body)
+  if (!modal.contains(document.activeElement) || document.activeElement === borda) {
+    e.preventDefault();
+    proximo.focus();
+  }
+}
+
 function closeBankPicker() {
   document.getElementById("bankpick-overlay").classList.remove("open");
+  document.removeEventListener("keydown", _bankPickOnKey);
+  // devolve o foco pra quem abriu, senão o teclado volta pro topo da página
+  if (_bankPickLastFocus && document.contains(_bankPickLastFocus)) _bankPickLastFocus.focus();
+  _bankPickLastFocus = null;
 }
 function renderBankPicker(filter) {
   const f = _stripAccent(filter).trim();

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -2474,9 +2474,16 @@ async function openBankPicker() {
   document.addEventListener("keydown", _bankPickOnKey);
   const q = document.getElementById("bankpick-search");
   q.value = "";
+  /* Foco ANTES do await, não depois: o `q.focus()` só existia no ramo do cache e
+     no de sucesso, então enquanto a lista carregava — e para sempre, se o fetch
+     falhasse — o foco ficava no botão "Conectar banco" ATRÁS do overlay. O trap
+     de Tab conserta isso na tecla seguinte, mas Enter não passa pelo trap: ele
+     reativaria o botão obscurecido e chamaria openBankPicker() de novo. Assim os
+     estados de carregando e de erro também começam dentro do modal. */
+  q.focus();
   _bankPickSelected = null;
   _syncBankPickFoot();
-  if (_bankConnectors) { renderBankPicker(""); q.focus(); return; }
+  if (_bankConnectors) { renderBankPicker(""); return; }
   document.getElementById("bankpick-list").innerHTML =
     `<div class="bankpick-empty">Carregando bancos…</div>`;
   try {
@@ -2485,7 +2492,8 @@ async function openBankPicker() {
     const data = await resp.json();
     _bankConnectors = (data.connectors || []).filter(b => b && b.name);
     renderBankPicker("");
-    q.focus();
+    // sem q.focus() aqui: o foco já entrou no modal antes do await, e refocar
+    // agora roubaria o foco de quem já tivesse tabulado pra dentro do card
   } catch (err) {
     document.getElementById("bankpick-list").innerHTML =
       `<div class="bankpick-empty">Não deu pra carregar a lista de bancos. Tente de novo.</div>`;


### PR DESCRIPTION
Varredura que ficou pendente do #70. O apontamento do Codex era sobre o modal da Início, mas `grep -rn 'aria-modal="true"' frontend/` acha **três** — e os outros dois tinham o mesmo defeito.

## settings.html — `.bankpick-modal` (escolher banco do Open Finance)

O pior dos dois: `grep -c keydown frontend/settings.html` dava **0**. Não faltava só o trap de Tab, **faltava o Esc**. As únicas saídas eram o X e o clique no fundo; quem navega por teclado tabulava a lista de instituições, chegava ao fim e caía nos controles das Configurações atrás do overlay — sem sinal nenhum, porque o overlay continua cobrindo tudo.

Agora: Esc, Tab preso nos dois sentidos, foco devolvido a quem abriu.

## admin-dashboard.html — `#users-modal`

Tinha Esc, não tinha Tab. Ganhou o trap, foco no campo de busca ao abrir e devolução do foco ao fechar.

## Medido

Chromium, modais abertos, 20 Tabs e 20 Shift+Tabs seguidos:

| | antes | depois |
|---|---|---|
| settings/bankpick, Tab | escapa no **#4** (`#of-refresh-btn`) | 20 sem sair |
| settings/bankpick, Shift+Tab | escapa no **#6** (`.btn-danger`) | 20 sem sair |
| settings/bankpick, Esc | **não fechava** | fecha |
| admin/users, Tab | escapa no **#1** (`#window-select`) | 20 sem sair |
| admin/users, Shift+Tab | escapa no **#1** (`body`) | 20 sem sair |
| admin/users, Esc | já fechava | fecha |

Também exercitado: foco arrancado por script pra um elemento de fora volta pra dentro na tecla seguinte. Havia **67** focáveis atrás do overlay na settings e **12** no admin — não é caso teórico. Contra a `main` sem as correções, o mesmo teste dá 7 falhas.

## Detalhe de implementação

Nos dois, os focáveis são consultados **a cada Tab**, não uma vez na abertura, porque o conteúdo troca: a lista de bancos é remontada a cada tecla da busca (`renderBankPicker`), e a de usuários é paginada e dá lugar ao detalhe de um usuário.

## Ressalva de método

As duas páginas têm guarda de sessão que redireciona em laço sem backend, e o overlay da settings vive dentro de `#section-open-finance` — as seções trocam por `hidden`, e dentro de seção escondida nada tem tamanho nem recebe foco. O teste responde `/auth/validate` e chama `showSettingsSection("open-finance")` antes de abrir. **Sem isso ele mede um DOM invisível e passa por vazio** — aconteceu comigo na primeira rodada: `_bankPickFocaveis()` retornava 0 alvos e o trap não fazia nada, com o teste dando verde no Esc.

## Não verificado

Comportamento com leitor de tela real (VoiceOver/NVDA). O que medi é a travessia de foco, não o anúncio do diálogo.

Suíte: **1092 passed, 0 failed** (nenhum Python tocado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ysAAGjPzs9t8tfHdS7MmJ)_