### PR TITLE
fix(investimentos): não devolver código cru de erro no aporte pelo WhatsApp

### DIFF
--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -4,6 +4,7 @@ import re
 import db
 from utils_text import fmt_brl, fmt_rate
 from core.dashboard_links import build_dashboard_link
+from core.services.plan_limits import PlanLimitExceeded
 import logging
 
 logger = logging.getLogger(__name__)
@@ -57,8 +58,9 @@ def _format_inv_name(name: str) -> str:
     return " ".join(out)
 
 
-def list_investments(user_id: int, intro: str | None = None) -> str:
-    rows = db.accrue_all_investments(user_id)
+def list_investments(user_id: int, intro: str | None = None, rows: list | None = None) -> str:
+    if rows is None:
+        rows = db.accrue_all_investments(user_id)
     header = intro or "📈 **Sua carteira**"
     if not rows:
         return (
@@ -91,6 +93,29 @@ def list_investments(user_id: int, intro: str | None = None) -> str:
     )
 
 
+def _investment_not_found(user_id: int, investment_name: str, *, action: str) -> str:
+    """Resposta para INV_NOT_FOUND (nome não bate com nada cadastrado).
+
+    O cadastro de investimento é feito só pelo dashboard (ver `create`), então
+    a resposta precisa levar o usuário até lá. Só dizer "não encontrei" — ou
+    pior, devolver o código cru — deixa ele sem saída nenhuma.
+    """
+    rows = db.accrue_all_investments(user_id)
+    pretty = _format_inv_name(investment_name)
+    if not rows:
+        return (
+            f"Você ainda não tem nenhum investimento cadastrado, "
+            f"por isso não dá para {action} **{pretty}**.\n"
+            "Cadastre ele primeiro no dashboard — depois é só mandar o comando aqui pelo WhatsApp.\n\n"
+            + _investment_dashboard_link(user_id)
+        )
+    return list_investments(
+        user_id,
+        f"Não encontrei **{pretty}**. Estes são seus investimentos:",
+        rows=rows,
+    )
+
+
 def create(user_id: int, raw_name: str, original_text: str) -> str:
     return list_investments(
         user_id,
@@ -115,20 +140,31 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     if not amount or float(amount) <= 0:
         return list_investments(user_id, "Qual valor você quer aportar?")
 
+    # Códigos vêm de db/investments.py como str(exc) — trate por TIPO e código
+    # exato. Casar substring é frágil: "not found" nunca casou com
+    # "INV_NOT_FOUND" (espaço × underscore) e o código cru vazava pro WhatsApp.
     try:
         launch_id, _new_acc, _new_inv, canon = db.investment_deposit_from_account(
             user_id, investment_name, float(amount), text
         )
-        display_id = db.display_id_for(user_id, launch_id)
-        return f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**. ID #{display_id}."
-    except Exception as e:
-        err = str(e)
-        if "not found" in err.lower():
-            return list_investments(user_id, f"Não encontrei **{investment_name}**. Estes são seus investimentos:")
-        if "saldo insuficiente" in err.lower() or "insufficient" in err.lower():
+    except LookupError:
+        return _investment_not_found(user_id, investment_name, action="aportar em")
+    except ValueError as e:
+        code = str(e)
+        if code == "INSUFFICIENT_ACCOUNT":
             return "Saldo insuficiente na conta para esse aporte.\n\n" + _investment_dashboard_link(user_id)
-        return f"Erro ao aportar: {err}"
-    return f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**. ID #{db.display_id_for(user_id, launch_id)}.\n\n" + list_investments(user_id)
+        if code == "AMOUNT_INVALID":
+            return "Valor inválido para aporte. Tente: *aportar 500 no CDB Nubank*."
+        logger.warning("deposit: código inesperado user=%s inv=%s code=%s", user_id, investment_name, code)
+        return "Não consegui registrar esse aporte. Confira o valor e tente de novo."
+    except PlanLimitExceeded:
+        raise  # handle_incoming responde com a mensagem amigável de upgrade
+    except Exception:
+        logger.exception("deposit falhou user=%s inv=%s", user_id, investment_name)
+        return "Não consegui registrar esse aporte agora. Tente de novo em instantes."
+
+    display_id = db.display_id_for(user_id, launch_id)
+    return f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**. ID #{display_id}."
 
 
 def check_cdi() -> str:
@@ -190,13 +226,21 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
             text,
             withdraw_all=want_all,
         )
-    except Exception as e:
-        err = str(e)
-        if "not found" in err.lower() or "inv_not_found" in err.lower():
-            return list_investments(user_id, f"Não encontrei **{investment_name}**. Estes são seus investimentos:")
-        if "saldo insuficiente" in err.lower() or "insufficient" in err.lower():
+    except LookupError:
+        return _investment_not_found(user_id, investment_name, action="resgatar de")
+    except ValueError as e:
+        code = str(e)
+        if code == "INSUFFICIENT_INVEST":
             return f"Saldo insuficiente no investimento **{investment_name}**.\n\n" + list_investments(user_id)
-        return f"Erro ao resgatar: {err}"
+        if code == "AMOUNT_INVALID":
+            return "Valor inválido para resgate. Tente: *resgatar 500 do CDB Nubank*."
+        logger.warning("withdraw: código inesperado user=%s inv=%s code=%s", user_id, investment_name, code)
+        return "Não consegui registrar esse resgate. Confira o valor e tente de novo."
+    except PlanLimitExceeded:
+        raise  # handle_incoming responde com a mensagem amigável de upgrade
+    except Exception:
+        logger.exception("withdraw falhou user=%s inv=%s", user_id, investment_name)
+        return "Não consegui registrar esse resgate agora. Tente de novo em instantes."
 
     gross = float(taxes.get("gross", amount or 0)) if taxes else float(amount or 0)
     tax_note = ""

--- a/core/services/ai_chat/tools/investments.py
+++ b/core/services/ai_chat/tools/investments.py
@@ -180,8 +180,21 @@ def _investment_deposit_execute(user_id: int, args: dict[str, Any]) -> str:
     try:
         db.investment_deposit_from_account(user_id, name, amount)
         return f'✅ Aporte de R$ {amount:.2f} no "{name}" registrado.'
+    except LookupError:
+        # INV_NOT_FOUND: o cadastro é só pelo dashboard, então aponta o caminho.
+        return (
+            f'🐷 Não achei o investimento "{name}". '
+            "Cadastre ele no dashboard primeiro e depois manda o aporte."
+        )
+    except ValueError as e:
+        if "INSUFFICIENT_ACCOUNT" in str(e):
+            return "🐷 Saldo insuficiente na conta pra esse aporte."
+        return "🐷 Valor inválido pra aporte."
     except Exception as e:
-        return f"🐷 Não consegui aportar: {e}"
+        from core.services.plan_limits import PlanLimitExceeded
+        if isinstance(e, PlanLimitExceeded):
+            return e.message
+        return "🐷 Não consegui aportar agora. Tenta de novo em instantes."
 
 
 # ─── Write: investment_withdraw (resgate) ───────────────────────────────────
@@ -240,8 +253,14 @@ def _delete_investment_execute(user_id: int, args: dict[str, Any]) -> str:
     try:
         db.delete_investment(user_id, name)
         return f'✅ Investimento "{name}" apagado.'
-    except Exception as e:
-        return f"🐷 Não consegui apagar: {e}"
+    except LookupError:
+        return f'🐷 Não achei o investimento "{name}".'
+    except ValueError as e:
+        if "INV_NOT_ZERO" in str(e):
+            return f'🐷 O investimento "{name}" ainda tem saldo — resgata tudo antes de apagar.'
+        return f'🐷 Não consegui apagar "{name}".'
+    except Exception:
+        return "🐷 Não consegui apagar agora. Tenta de novo em instantes."
 
 
 # ─── Tools registry ─────────────────────────────────────────────────────────

--- a/tests/test_investments_handler.py
+++ b/tests/test_investments_handler.py
@@ -1,6 +1,8 @@
 from datetime import date
 from unittest.mock import patch
 
+import pytest
+
 from core.handlers import investments as h_investments
 
 
@@ -67,3 +69,142 @@ def test_create_investment_com_aporte_inicial_redireciona_para_dashboard():
     accrue.assert_called_once_with(123)
     link.assert_called_once_with(123, view="investments")
     assert "https://app.test/d/abc" in msg
+
+
+# ─── Aporte/resgate: nenhum código cru de erro pode chegar ao usuário ────────
+#
+# Regressão do bug relatado no WhatsApp: "Investi 870 em tesouro direto" com o
+# investimento não cadastrado devolvia literalmente "Erro ao aportar:
+# INV_NOT_FOUND". A causa era casar substring — `"not found" in err.lower()`
+# nunca casa com "inv_not_found" (espaço × underscore).
+
+# Todos os códigos que db/investments.py levanta nos caminhos de aporte/resgate
+# (inclui os do accrual, que roda dentro das duas operações). Enumerados à mão a
+# partir de `grep -nE 'raise (ValueError|LookupError|RuntimeError)\(' db/investments.py`
+# em vez de testar só o caso do print — é a classe que precisa ficar fechada.
+_DEPOSIT_ERRORS = [
+    LookupError("INV_NOT_FOUND"),
+    ValueError("INSUFFICIENT_ACCOUNT"),
+    ValueError("AMOUNT_INVALID"),
+    ValueError("PURCHASE_DATE_FUTURE"),
+    ValueError("INVALID_PERIOD"),
+    ValueError("INVALID_RATE"),
+    RuntimeError("ACCOUNT_MISSING"),
+    RuntimeError("CDI_DAILY_NOT_AVAILABLE"),
+    RuntimeError("INVESTMENT_LOOKUP_FAILED"),
+]
+
+_WITHDRAW_ERRORS = [
+    LookupError("INV_NOT_FOUND"),
+    ValueError("INSUFFICIENT_INVEST"),
+    ValueError("AMOUNT_INVALID"),
+    RuntimeError("CDI_DAILY_NOT_AVAILABLE"),
+]
+
+
+def _assert_sem_codigo_cru(msg, exc):
+    code = str(exc)
+    assert code not in msg, f"código cru {code!r} vazou para o usuário: {msg!r}"
+    # o prefixo antigo ("Erro ao aportar: <CODE>") não pode voltar
+    assert "Erro ao aportar:" not in msg
+    assert "Erro ao resgatar:" not in msg
+    assert msg.strip(), "resposta vazia"
+
+
+@pytest.mark.parametrize("exc", _DEPOSIT_ERRORS, ids=lambda e: str(e))
+def test_deposit_nunca_devolve_codigo_cru(exc):
+    with patch("core.handlers.investments.db.investment_deposit_from_account", side_effect=exc), \
+         patch("core.handlers.investments.db.accrue_all_investments", return_value=[]), \
+         patch("core.handlers.investments.build_dashboard_link", return_value="https://app.test/d/abc"):
+        msg = h_investments.deposit(
+            123, "investi 870 em tesouro direto",
+            {"investment_name": "tesouro direto", "amount": 870},
+        )
+    _assert_sem_codigo_cru(msg, exc)
+
+
+@pytest.mark.parametrize("exc", _WITHDRAW_ERRORS, ids=lambda e: str(e))
+def test_withdraw_nunca_devolve_codigo_cru(exc):
+    with patch("core.handlers.investments.db.investment_withdraw_to_account", side_effect=exc), \
+         patch("core.handlers.investments.db.accrue_all_investments", return_value=[]), \
+         patch("core.handlers.investments.build_dashboard_link", return_value="https://app.test/d/abc"):
+        msg = h_investments.withdraw(
+            123, "resgatei 100 do tesouro direto",
+            {"investment_name": "tesouro direto", "amount": 100},
+        )
+    _assert_sem_codigo_cru(msg, exc)
+
+
+def test_deposit_investimento_inexistente_manda_pro_dashboard():
+    """Carteira vazia: a resposta precisa dizer COMO cadastrar, não só que não achou.
+
+    O cadastro é exclusivo do dashboard (ver `create`), então sem o link o
+    usuário fica sem saída — foi exatamente o que o INV_NOT_FOUND cru fazia.
+    """
+    with patch("core.handlers.investments.db.investment_deposit_from_account",
+               side_effect=LookupError("INV_NOT_FOUND")), \
+         patch("core.handlers.investments.db.accrue_all_investments", return_value=[]), \
+         patch("core.handlers.investments.build_dashboard_link", return_value="https://app.test/d/abc"):
+        msg = h_investments.deposit(
+            123, "Investi 870 em tesouro direto",
+            {"investment_name": "tesouro direto", "amount": 870},
+        )
+
+    assert "INV_NOT_FOUND" not in msg
+    assert "Tesouro Direto" in msg          # capitalizado como no resto do bot
+    assert "dashboard" in msg.lower()
+    assert "https://app.test/d/abc" in msg
+
+
+def test_deposit_investimento_inexistente_com_carteira_lista_os_existentes():
+    rows = [{"name": "CDB Banco Luso", "balance": 821.91, "rate": 1.16,
+             "period": "cdi", "last_date": date(2026, 4, 16)}]
+    with patch("core.handlers.investments.db.investment_deposit_from_account",
+               side_effect=LookupError("INV_NOT_FOUND")), \
+         patch("core.handlers.investments.db.accrue_all_investments", return_value=rows) as accrue, \
+         patch("core.handlers.investments.build_dashboard_link", return_value="https://app.test/d/abc"):
+        msg = h_investments.deposit(
+            123, "investi 870 em tesouro direto",
+            {"investment_name": "tesouro direto", "amount": 870},
+        )
+
+    assert "Não encontrei" in msg
+    assert "CDB Banco Luso" in msg
+    # a lista é reaproveitada, não buscada duas vezes
+    assert accrue.call_count == 1
+
+
+def test_deposit_saldo_insuficiente_continua_com_mensagem_propria():
+    with patch("core.handlers.investments.db.investment_deposit_from_account",
+               side_effect=ValueError("INSUFFICIENT_ACCOUNT")), \
+         patch("core.handlers.investments.build_dashboard_link", return_value="https://app.test/d/abc"):
+        msg = h_investments.deposit(
+            123, "investi 999999 no cdb", {"investment_name": "CDB", "amount": 999999},
+        )
+    assert "Saldo insuficiente na conta" in msg
+
+
+def test_deposit_sucesso_responde_com_id():
+    with patch("core.handlers.investments.db.investment_deposit_from_account",
+               return_value=(55, 100.0, 870.0, "Tesouro Selic 2029")), \
+         patch("core.handlers.investments.db.display_id_for", return_value=7):
+        msg = h_investments.deposit(
+            123, "investi 870 no tesouro selic 2029",
+            {"investment_name": "Tesouro Selic 2029", "amount": 870},
+        )
+    assert "✅" in msg
+    assert "Tesouro Selic 2029" in msg
+    assert "#7" in msg
+
+
+def test_deposit_deixa_plan_limit_subir():
+    """PlanLimitExceeded tem mensagem amigável e é tratado no handle_incoming —
+    o catch genérico não pode engoli-la."""
+    from core.services.plan_limits import PlanLimitExceeded
+
+    with patch("core.handlers.investments.db.investment_deposit_from_account",
+               side_effect=PlanLimitExceeded("investments", "Faça upgrade!")):
+        with pytest.raises(PlanLimitExceeded):
+            h_investments.deposit(
+                123, "investi 870 no cdb", {"investment_name": "CDB", "amount": 870},
+            )


### PR DESCRIPTION
## O problema

No WhatsApp, `Investi 870 em tesouro direto` — com o investimento não cadastrado — respondia literalmente:

> Erro ao aportar: INV_NOT_FOUND

## Causa

`core/handlers/investments.py` classificava o erro por substring:

```python
if "not found" in err.lower():   # nunca casa com "inv_not_found"
```

`"not found"` tem espaço, o código levantado pelo `db/investments.py` tem underscore (`INV_NOT_FOUND`). A comparação nunca casa, então o caso caía no fallback `f"Erro ao aportar: {err}"`, que interpola `str(e)` direto na resposta ao usuário.

O irmão `withdraw` já tinha a cláusula extra `or "inv_not_found" in err.lower()`. O `deposit` nunca ganhou.

## O que a varredura mostrou além do relato

Em vez de acrescentar mais uma substring, enumerei todos os códigos que `db/investments.py` levanta nesses caminhos (`grep -nE 'raise (ValueError|LookupError|RuntimeError)\('`). O vazamento era bem maior que o do relato:

| caminho | códigos que chegavam crus ao usuário |
|---|---|
| aporte | **8 dos 9** — só `INSUFFICIENT_ACCOUNT` era tratado, e por acidente (`"insufficient"` casa com o código) |
| resgate | `AMOUNT_INVALID` e `CDI_DAILY_NOT_AVAILABLE` |

`CDI_DAILY_NOT_AVAILABLE` dispara quando o Banco Central está fora do ar — ou seja, uma indisponibilidade externa virava código cru na tela do usuário.

## A correção

Os dois caminhos passam a tratar por **tipo de exceção e código exato**, que é o que `core/handlers/pockets.py` e o cog do Discord já faziam. Nenhum código cru pode mais chegar ao usuário: o fallback genérico loga e responde com texto neutro.

Como o cadastro de investimento é exclusivo do dashboard (ver `create`), a resposta de não-encontrado agora leva o link em vez de só informar a falha — com a carteira vazia o usuário ficava sem saída nenhuma:

> Você ainda não tem nenhum investimento cadastrado, por isso não dá para aportar em **Tesouro Direto**.
> Cadastre ele primeiro no dashboard — depois é só mandar o comando aqui pelo WhatsApp.

Mesma classe corrigida nas tools da IA conversacional (`core/services/ai_chat/tools/investments.py`), onde `_investment_deposit_execute` também não tratava `LookupError` enquanto seu irmão `_investment_withdraw_execute` tratava.

Detalhes que acompanham a mudança:

- `PlanLimitExceeded` segue subindo para o `handle_incoming`, que já responde com a mensagem amigável de upgrade — o catch genérico não a engole (tem teste).
- A formatação de sucesso saiu do `try`: com o aporte já commitado, uma falha em `display_id_for` não pode responder "erro ao aportar".
- Remove o `return` morto depois do `except` em `deposit`.
- `list_investments` ganhou um parâmetro opcional `rows` para não buscar a carteira duas vezes no caminho de não-encontrado. Os dois callers existentes passam ≤2 argumentos, então não são afetados.

## Testes

18 novos em `tests/test_investments_handler.py`, parametrizados sobre **todos** os códigos de erro dos dois caminhos — a lista foi enumerada do `db/investments.py`, não só o caso do print.

Verifiquei nos dois sentidos, para o teste não ser verde vazio:

- revertendo só o código-fonte e mantendo os testes, **13 falham**;
- com a correção, os 22 do arquivo passam;
- e passam exatamente nos códigos que o código antigo já acertava (`INSUFFICIENT_ACCOUNT` no aporte; `INV_NOT_FOUND` e `INSUFFICIENT_INVEST` no resgate), o que confirma que estão medindo a mudança e não aprovando tudo.

Também reproduzi o bug contra Postgres real antes e depois, e validei o caminho completo pelo `intent_router` — não só pelo handler isolado.

## Suíte

Postgres 16 local, excluindo os 9 arquivos que dependem de `ofxparse`:

| | falhas | passes |
|---|---|---|
| baseline (antes de mexer) | 60 | 972 |
| depois | 60 | 990 |

**Mesma lista de nomes com falha** nas duas rodadas — zero regressão. Os +18 passes são os testes novos. As 60 falhas são ruído pré-existente do ambiente local (`httpx`/TestClient e `ofxparse`), nenhuma em investimentos.

## Não verificado

O comportamento real no WhatsApp de produção. O proxy do ambiente bloqueia `pigbankai.com`, então isso só dá para conferir depois do deploy.

## Fora do escopo deste PR

Na mesma conversa do print, `investi 800 em renda fixa` respondeu perguntando o valor, mesmo com o `800` na frase. Não é o mesmo bug: vem do classificador de IA marcando `needs_clarification`, é comportamento do modelo e não código determinístico. Fica registrado aqui, mas não foi tocado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtWzacGdU7t8D8iXvobgyM)_