### PR TITLE
fix(home): ícone do "Sair" no dropdown volta ao padrão Phosphor

### DIFF
--- a/frontend/home.html
+++ b/frontend/home.html
@@ -463,7 +463,7 @@ footer a:hover { color:var(--text); }
           <a class="dd-link" href="/settings?view=security"><span class="dd-icon"><i class="ph ph-gear" aria-hidden="true"></i></span>Configurações</a>
           <a class="dd-link" href="/conta"><span class="dd-icon"><i class="ph ph-credit-card" aria-hidden="true"></i></span>Gerenciar assinatura</a>
           <a class="dd-link" href="/?site=1" data-landing><span class="dd-icon"><i class="ph ph-globe" aria-hidden="true"></i></span>Ir para o site</a>
-          <button class="dd-link danger" type="button" onclick="logoutFromHome()"><span class="dd-icon">↪</span>Sair</button>
+          <button class="dd-link danger" type="button" onclick="logoutFromHome()"><span class="dd-icon"><i class="ph ph-sign-out" aria-hidden="true"></i></span>Sair</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problema

No dropdown do usuário em `/home`, o botão **Sair** aparecia com um emoji colorido (seta azul) enquanto todos os outros itens do menu usavam os ícones de linha monocromáticos do Phosphor.

A causa: o item de logout ficou de fora da migração pros ícones Phosphor e ainda usava o caractere cru `↪` (U+21AA). No iOS esse caractere é renderizado em apresentação de emoji, por isso o destaque azul.

## Correção

`frontend/home.html:466`

```diff
-<span class="dd-icon">↪</span>Sair
+<span class="dd-icon"><i class="ph ph-sign-out" aria-hidden="true"></i></span>Sair
```

É exatamente o mesmo markup que o "Sair" do `frontend/dashboard.html:156` já usa, então os dois menus ficam consistentes.

## Verificação

- `.ph-sign-out` está definido em `frontend/phosphor.css`
- `home.html:14` já carrega `/phosphor.css`
- Uma linha alterada, sem mudança de comportamento — `logoutFromHome()` continua igual

🤖 Generated with [Claude Code](https://claude.com/claude-code)
