### PR TITLE
test: isolar o banco por execução da suíte

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -46,6 +46,24 @@ def get_conn():
     return _get_pool().connection()
 
 
+def close_pool() -> None:
+    """Fecha o pool e zera o singleton — a próxima chamada reabre lendo
+    DATABASE_URL de novo.
+
+    Existe para a suíte: o conftest cria um database por execução e precisa
+    soltar as conexões antes de derrubá-lo no fim. Em produção o pool vive
+    enquanto o processo viver, então isto não é chamado.
+    """
+    global _pool
+    with _pool_lock:
+        if _pool is None:
+            return
+        try:
+            _pool.close()
+        finally:
+            _pool = None
+
+
 # ── comparação de categoria case- E acento-insensível ────────────────────────
 # Dados legados guardam a mesma categoria com/sem acento ("alimentacao" vs
 # "alimentação"). Pra somar/filtrar por categoria sem perder linhas, comparamos

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,11 +23,73 @@ from db import init_db, ensure_user, get_conn
 
 
 
+def _make_isolated_db(base_url: str) -> tuple[str, str] | None:
+    """Cria um database só desta execução. Devolve (url_nova, nome) ou None
+    se não for possível (sem permissão de CREATE DATABASE, por exemplo)."""
+    import psycopg
+    from urllib.parse import urlsplit, urlunsplit
+
+    name = f"pytest_{uuid.uuid4().hex[:12]}"
+    try:
+        with psycopg.connect(base_url, autocommit=True) as conn:
+            # Nome é gerado aqui (hex de uuid), não vem de fora — sem risco
+            # de injeção. Aspas duplas porque CREATE DATABASE não aceita
+            # parâmetro ligado.
+            conn.execute(f'create database "{name}"')
+    except Exception as exc:
+        print(f"[conftest] sem isolamento de banco ({exc}); usando o DATABASE_URL original")
+        return None
+    parts = urlsplit(base_url)
+    return urlunsplit(parts._replace(path=f"/{name}")), name
+
+
+def _drop_isolated_db(base_url: str, name: str) -> None:
+    import psycopg
+
+    from db.connection import close_pool
+
+    close_pool()  # solta as conexões, senão o DROP é recusado
+    try:
+        with psycopg.connect(base_url, autocommit=True) as conn:
+            # FORCE derruba conexões remanescentes (Postgres 13+).
+            conn.execute(f'drop database if exists "{name}" with (force)')
+    except Exception as exc:
+        print(f"[conftest] não consegui remover o database {name}: {exc}")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _init_schema():
-    if not os.getenv("DATABASE_URL"):
+    """Prepara o schema — num database exclusivo desta execução.
+
+    Sem o isolamento, duas execuções simultâneas da suíte contra o mesmo
+    DATABASE_URL se destroem: a fixture `_auto_cleanup_orphan_users` abaixo
+    apaga QUALQUER usuário que apareça em `users` durante um teste, e não
+    tem como distinguir os da outra execução. O resultado são falhas em
+    testes sem relação com a mudança, que não reproduzem sozinhas.
+
+    Custa ~1s (createdb + init_db). Para inspecionar o banco depois de rodar,
+    desligue com PYTEST_DB_ISOLATION=0.
+    """
+    base_url = os.getenv("DATABASE_URL")
+    if not base_url:
         raise RuntimeError("Faltou DATABASE_URL no ambiente para rodar os testes.")
-    init_db()
+
+    isolated = None
+    if os.getenv("PYTEST_DB_ISOLATION", "1") != "0":
+        isolated = _make_isolated_db(base_url)
+
+    if isolated:
+        url, name = isolated
+        # Trocar antes de qualquer conexão: o pool de db/connection.py é lazy
+        # e só lê DATABASE_URL quando abre.
+        os.environ["DATABASE_URL"] = url
+        init_db()
+        yield
+        os.environ["DATABASE_URL"] = base_url
+        _drop_isolated_db(base_url, name)
+    else:
+        init_db()
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,32 +23,80 @@ from db import init_db, ensure_user, get_conn
 
 
 
-def _make_isolated_db(base_url: str) -> tuple[str, str] | None:
-    """Cria um database só desta execução. Devolve (url_nova, nome) ou None
-    se não for possível (sem permissão de CREATE DATABASE, por exemplo)."""
+# ── Isolamento do banco por execução ─────────────────────────────────────────
+# Cada execução da suíte trabalha num database só dela. Sem isso, duas
+# execuções simultâneas se destroem: a fixture `_auto_cleanup_orphan_users`
+# abaixo apaga QUALQUER usuário que apareça em `users` durante um teste, e não
+# tem como distinguir os da outra execução.
+#
+# A troca acontece em `pytest_configure`, que roda ANTES da coleta. Isso é
+# essencial e não é detalhe de estilo: o pytest importa os módulos de teste na
+# coleta, e módulos como `frontend/routes/shared.py` e `core/admin_dashboard.py`
+# leem DATABASE_URL no nível de módulo. Numa fixture de sessão (que roda depois
+# da coleta) esses módulos já teriam cacheado a URL antiga e as rotas async
+# continuariam batendo no banco compartilhado — o isolamento valeria só para o
+# pool síncrono.
+#
+# PYTEST_DB_ISOLATION=0 desliga, para inspecionar o banco depois da rodada.
+
+_ISOLATION: dict[str, str] = {}
+
+
+def _cached_database_url_modules() -> tuple[str, ...]:
+    """Módulos que leem DATABASE_URL no import — a razão de trocar antes da coleta.
+
+    Levantado com `grep -rn DATABASE_URL --include=*.py` e filtrando as leituras
+    a nível de módulo. `finance_bot_websocket_custom.py` também guarda a URL, mas
+    só para validar que está presente; não conecta com ela.
+    """
+    return ("frontend/routes/shared.py", "core/admin_dashboard.py")
+
+
+def pytest_configure(config):
+    base_url = os.getenv("DATABASE_URL")
+    if not base_url or os.getenv("PYTEST_DB_ISOLATION", "1") == "0":
+        return
+
     import psycopg
     from urllib.parse import urlsplit, urlunsplit
 
     name = f"pytest_{uuid.uuid4().hex[:12]}"
     try:
         with psycopg.connect(base_url, autocommit=True) as conn:
-            # Nome é gerado aqui (hex de uuid), não vem de fora — sem risco
-            # de injeção. Aspas duplas porque CREATE DATABASE não aceita
-            # parâmetro ligado.
+            # Nome gerado aqui (hex de uuid), não vem de fora — sem risco de
+            # injeção. Aspas duplas porque CREATE DATABASE não aceita parâmetro.
             conn.execute(f'create database "{name}"')
     except Exception as exc:
         print(f"[conftest] sem isolamento de banco ({exc}); usando o DATABASE_URL original")
-        return None
+        return
+
     parts = urlsplit(base_url)
-    return urlunsplit(parts._replace(path=f"/{name}")), name
+    os.environ["DATABASE_URL"] = urlunsplit(parts._replace(path=f"/{name}"))
+    _ISOLATION["base_url"] = base_url
+    _ISOLATION["name"] = name
 
 
-def _drop_isolated_db(base_url: str, name: str) -> None:
+def pytest_unconfigure(config):
+    """Remove o database desta execução.
+
+    Roda no shutdown do pytest, inclusive quando `init_db()` estoura no setup —
+    numa fixture, um erro antes do `yield` pularia a limpeza e deixaria um
+    database `pytest_*` órfão a cada tentativa falha.
+    """
+    base_url = _ISOLATION.pop("base_url", None)
+    name = _ISOLATION.pop("name", None)
+    if not base_url or not name:
+        return
+
     import psycopg
 
-    from db.connection import close_pool
+    os.environ["DATABASE_URL"] = base_url
+    try:
+        from db.connection import close_pool
 
-    close_pool()  # solta as conexões, senão o DROP é recusado
+        close_pool()  # solta as conexões, senão o DROP é recusado
+    except Exception:
+        pass
     try:
         with psycopg.connect(base_url, autocommit=True) as conn:
             # FORCE derruba conexões remanescentes (Postgres 13+).
@@ -59,37 +107,9 @@ def _drop_isolated_db(base_url: str, name: str) -> None:
 
 @pytest.fixture(scope="session", autouse=True)
 def _init_schema():
-    """Prepara o schema — num database exclusivo desta execução.
-
-    Sem o isolamento, duas execuções simultâneas da suíte contra o mesmo
-    DATABASE_URL se destroem: a fixture `_auto_cleanup_orphan_users` abaixo
-    apaga QUALQUER usuário que apareça em `users` durante um teste, e não
-    tem como distinguir os da outra execução. O resultado são falhas em
-    testes sem relação com a mudança, que não reproduzem sozinhas.
-
-    Custa ~1s (createdb + init_db). Para inspecionar o banco depois de rodar,
-    desligue com PYTEST_DB_ISOLATION=0.
-    """
-    base_url = os.getenv("DATABASE_URL")
-    if not base_url:
+    if not os.getenv("DATABASE_URL"):
         raise RuntimeError("Faltou DATABASE_URL no ambiente para rodar os testes.")
-
-    isolated = None
-    if os.getenv("PYTEST_DB_ISOLATION", "1") != "0":
-        isolated = _make_isolated_db(base_url)
-
-    if isolated:
-        url, name = isolated
-        # Trocar antes de qualquer conexão: o pool de db/connection.py é lazy
-        # e só lê DATABASE_URL quando abre.
-        os.environ["DATABASE_URL"] = url
-        init_db()
-        yield
-        os.environ["DATABASE_URL"] = base_url
-        _drop_isolated_db(base_url, name)
-    else:
-        init_db()
-        yield
+    init_db()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## O problema

Duas execuções simultâneas do pytest contra o mesmo `DATABASE_URL` se destroem.

A fixture autouse `_auto_cleanup_orphan_users` (`tests/conftest.py`) fotografa a tabela `users` **inteira** antes e depois de cada teste e apaga tudo que apareceu no intervalo:

```python
before = _all_user_ids()      # select id from users  ← o banco todo, sem filtro
yield
after = _all_user_ids()
for orphan in (after - before):
    _cleanup_user(orphan)     # apaga launches, pockets, investments, accounts, users…
```

Nada distingue quem criou o quê. Se outra execução criar um usuário durante esse intervalo, ele entra na conta de "órfão" e é apagado junto com os lançamentos, caixinhas e investimentos dele.

Isso morde quem trabalha com várias sessões de agente em paralelo — há **30 branches `claude/*`** neste repositório.

## Não é hipótese — está medido

Rodando o mesmo subconjunto (`test_db_investments`, `test_ai_chat_investments`, `test_investments_handler`, `test_db_core`) duas vezes em paralelo:

| | execução A | execução B | resultados iguais? |
|---|---|---|---|
| **sem** isolamento | 10 falhas | 18 falhas | ❌ |
| **com** isolamento | 6 falhas | 6 falhas | ✅ |

Sem o isolamento, as duas execuções divergem entre si e trazem **14 falhas que não existem na baseline** — testes que passam quando rodam sozinhos. Com ele, as duas dão resultado idêntico e só sobram as falhas já conhecidas.

Antes disso, isolei o mecanismo num script que reproduz a fixture passo a passo: a "sessão A" apagou o usuário criado pela "sessão B", confirmando a causa antes de escrever a correção.

O próprio `CLAUDE.md` já descrevia o sintoma sem nomear a causa:

> *"`test_export_email`, `test_nlp_and_pending_flow`, `test_security_alerts` — aparecem e somem entre execuções: há dependência de ordem ou de estado compartilhado no banco de teste."*

Execução concorrente é pelo menos um dos mecanismos por trás disso.

## A correção

Cada execução passa a criar seu próprio database (`pytest_<hex>`), rodar o schema nele e derrubá-lo no fim.

- a troca do `DATABASE_URL` acontece **antes da primeira conexão** — o pool de `db/connection.py` é lazy e só lê a variável quando abre;
- a URL é remontada com `urlsplit`/`urlunsplit` para preservar query string (`sslmode` etc.), em vez de cortar na última barra;
- `DROP ... WITH (FORCE)` mais `close_pool()` para não esbarrar em conexão viva;
- se o `CREATE DATABASE` falhar (sem permissão), avisa e segue no banco original — não quebra ambiente restrito;
- `PYTEST_DB_ISOLATION=0` desliga, para quando se quer inspecionar o banco depois da rodada.

Acrescenta `close_pool()` em `db/connection.py`: fecha o pool e zera o singleton. Só a suíte chama — em produção o pool vive enquanto o processo viver.

## Custo

| | |
|---|---|
| `createdb` | 0,17s |
| `init_db` | 0,78s |
| **total por execução** | **~1s** |

Suíte completa: 50,92s na baseline contra 51,09s com a mudança — dentro do ruído.

## Verificação

Postgres 16 local, com os 9 arquivos que dependem de `ofxparse` fora:

| | falhas | passes |
|---|---|---|
| baseline (`main` pura) | 4 | 1053 |
| com esta mudança | 4 | 1053 |

**Mesma lista de nomes** — zero regressão. As 4 são 3 de `ofxparse` ausente e 1 intermitente já conhecida (`test_nlp_and_pending_flow`).

## Não verificado

O comportamento no CI, porque o GitHub Actions do repositório está travado (todos os runs falham em segundos, sem runner atribuído, em todos os branches — cota/billing). A mudança não altera o comando de teste, e no CI só roda uma execução por vez, então o isolamento é neutro lá.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtWzacGdU7t8D8iXvobgyM)_