### PR TITLE
chore(dev): hook de SessionStart prepara o ambiente da suíte sozinho

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -125,7 +125,13 @@ if [ -n "$PGBIN" ]; then
     mkdir -p "$PGDATA" "$PGSOCK"
     if [ "${PGRUN:-}" = "su postgres -c" ]; then
       chown postgres:postgres "$PGDATA" "$PGSOCK"; chmod 700 "$PGDATA"
-      chmod 755 "${TMPDIR:-/tmp}" 2>/dev/null
+      # O postgres precisa ATRAVESSAR o diretório-pai para chegar no PGDATA.
+      # `chmod 755` aqui seria destrutivo: com TMPDIR vazio o alvo é /tmp, e
+      # trocar 1777 por 755 tira o world-write e o sticky bit do diretório
+      # compartilhado — mktemp, pip e os hooks das outras sessões param de
+      # funcionar no host inteiro. `o+x` concede só o bit necessário e
+      # preserva o modo existente.
+      chmod o+x "${TMPDIR:-/tmp}" 2>/dev/null
     fi
     if ! $PGRUN "$PGBIN/initdb -D $PGDATA -U postgres --auth=trust" >/dev/null 2>&1; then
       # Limpa o que ficou pela metade. O initdb recusa diretório NÃO-VAZIO, então

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -165,18 +165,21 @@ sys.exit(0 if s.connect_ex(('127.0.0.1', $PGPORT)) != 0 else 1)
       $PGRUN "$PGBIN/pg_ctl -D $PGDATA -o '-p $PGPORT -k $PGSOCK -c listen_addresses=127.0.0.1' -l $LOGF -w -t 30 start" >/dev/null 2>&1
     fi
 
-    $PGRUN "$PGBIN/createdb -h 127.0.0.1 -p $PGPORT -U postgres bot_financeiro_test" >/dev/null 2>&1
+    # ORDEM IMPORTA: identificar antes de qualquer comando que mute.
+    # A porta pode ter sido tomada por outro processo entre o _porta_livre e o
+    # pg_ctl. Se o createdb viesse primeiro, ele criaria um database dentro do
+    # cluster de OUTRA sessão — todos aceitam conexão trust como postgres —
+    # antes de a URL ser recusada. `show data_directory` é leitura pura e
+    # portanto seguro de rodar contra servidor alheio.
     if $PGRUN "$PGBIN/pg_isready -h 127.0.0.1 -p $PGPORT -U postgres" >/dev/null 2>&1; then
-      # Responder na porta não basta: pode ser o servidor de outra sessão. Só
-      # aceita se o data_directory for o desta sessão — a suíte APAGA linhas,
-      # então apontar para o banco de outra pessoa é destrutivo.
       DDIR=$($PGRUN "$PGBIN/psql -h 127.0.0.1 -p $PGPORT -U postgres -tAc 'show data_directory'" 2>/dev/null | tr -d ' ')
       if [ "$DDIR" = "$PGDATA" ]; then
+        $PGRUN "$PGBIN/createdb -h 127.0.0.1 -p $PGPORT -U postgres bot_financeiro_test" >/dev/null 2>&1
         DB_URL="postgresql://postgres:postgres@127.0.0.1:$PGPORT/bot_financeiro_test"
         log "Postgres pronto na porta $PGPORT (data_directory conferido)."
       else
         log "AVISO: a porta $PGPORT responde, mas de outro servidor ($DDIR)."
-        log "       Não vou usá-lo — seria o banco de outra sessão."
+        log "       Não vou tocar nele — nem para criar o banco de teste."
       fi
     else
       log "AVISO: Postgres não respondeu na porta $PGPORT; veja $PGDATA/server.log."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -181,6 +181,30 @@ else
 fi
 
 # ── 4. Variáveis de ambiente da sessão ───────────────────────────────────────
+# A chave Fernet acompanha o CLUSTER, não o disparo do hook. Como o PGDATA
+# agora é reaproveitado entre startup/resume/compact, gerar chave nova a cada
+# vez deixaria ilegível todo PII escrito antes — o dado continua cifrado com a
+# chave anterior e o decrypt_pii falha. Fica persistida ao lado da porta, no
+# próprio PGDATA, com o mesmo ciclo de vida do banco que ela protege.
+#
+# É o único valor gerado aqui: JWT_SECRET e PII_HASH_PEPPER são constantes de
+# desenvolvimento (e o pepper, por definição, nunca rotaciona — core/crypto.py).
+PII_KEY=""
+PII_KEY_FILE=""
+[ -n "${PGDATA:-}" ] && [ -d "${PGDATA:-/nao-existe}" ] && PII_KEY_FILE="$PGDATA/.session_pii_key"
+
+if [ -n "$PII_KEY_FILE" ] && [ -s "$PII_KEY_FILE" ]; then
+  PII_KEY=$(cat "$PII_KEY_FILE" 2>/dev/null | tr -d '\n')
+fi
+if [ -z "$PII_KEY" ]; then
+  PII_KEY=$(python3 -c 'from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())' 2>/dev/null)
+  if [ -n "$PII_KEY_FILE" ] && [ -n "$PII_KEY" ]; then
+    printf '%s' "$PII_KEY" > "$PII_KEY_FILE" 2>/dev/null
+    chmod 600 "$PII_KEY_FILE" 2>/dev/null
+    [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$PII_KEY_FILE" 2>/dev/null
+  fi
+fi
+
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   {
     echo 'export PYTHONPATH="."'
@@ -195,7 +219,7 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
       echo 'export DATABASE_URL=""'
     fi
     echo 'export JWT_SECRET="dev-only-jwt-secret-32-bytes-minimum-len"'
-    echo "export PII_ENCRYPTION_KEY=\"$(python3 -c 'from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())' 2>/dev/null)\""
+    echo "export PII_ENCRYPTION_KEY=\"$PII_KEY\""
     echo 'export PII_HASH_PEPPER="dev-only-pepper-must-be-32-chars-long!!"'
     echo 'export PII_AUDIT_DISABLED=1'
     echo 'export RUN_BACKGROUND_TASKS=0'

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -101,7 +101,13 @@ s.close()
 " 2>/dev/null || echo ""
 }
 
+# Zeradas de propósito, ANTES de qualquer uso: o ambiente remoto pode já trazer
+# PGDATA apontando para um cluster que não é nosso. Herdar essas variáveis faria
+# o hook tratar cluster alheio como próprio — e, sem PGBIN, deixaria PGRUN
+# indefinido, que sob `set -u` mata o script antes de ele zerar o DATABASE_URL.
 DB_URL=""
+PGDATA=""
+PGRUN=""
 if [ -n "$PGBIN" ]; then
   PGDATA="${TMPDIR:-/tmp}/pgdata-${SID}"
   PGSOCK="/tmp/pgsock-${SID}"
@@ -117,7 +123,7 @@ if [ -n "$PGBIN" ]; then
   if [ ! -d "$PGDATA/base" ]; then
     log "inicializando Postgres em $PGDATA ..."
     mkdir -p "$PGDATA" "$PGSOCK"
-    if [ "$PGRUN" = "su postgres -c" ]; then
+    if [ "${PGRUN:-}" = "su postgres -c" ]; then
       chown postgres:postgres "$PGDATA" "$PGSOCK"; chmod 700 "$PGDATA"
       chmod 755 "${TMPDIR:-/tmp}" 2>/dev/null
     fi
@@ -156,12 +162,12 @@ sys.exit(0 if s.connect_ex(('127.0.0.1', $PGPORT)) != 0 else 1)
       fi
       [ -z "$PGPORT" ] && PGPORT=5432
       echo "$PGPORT" > "$PORTFILE" 2>/dev/null
-      [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$PORTFILE" 2>/dev/null
+      [ "${PGRUN:-}" = "su postgres -c" ] && chown postgres:postgres "$PORTFILE" 2>/dev/null
 
       mkdir -p "$PGSOCK"
-      [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$PGSOCK"
+      [ "${PGRUN:-}" = "su postgres -c" ] && chown postgres:postgres "$PGSOCK"
       LOGF="$PGDATA/server.log"; : > "$LOGF"
-      [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$LOGF"
+      [ "${PGRUN:-}" = "su postgres -c" ] && chown postgres:postgres "$LOGF"
       $PGRUN "$PGBIN/pg_ctl -D $PGDATA -o '-p $PGPORT -k $PGSOCK -c listen_addresses=127.0.0.1' -l $LOGF -w -t 30 start" >/dev/null 2>&1
     fi
 
@@ -200,10 +206,11 @@ fi
 # desenvolvimento (e o pepper, por definição, nunca rotaciona — core/crypto.py).
 PII_KEY=""
 PII_KEY_FILE=""
-# Só grava num cluster REALMENTE inicializado — `$PGDATA/base` é o mesmo teste
-# que o bloco acima usa. Escrever com o initdb falhado deixaria o diretório
-# não-vazio e envenenaria a próxima tentativa.
-[ -n "${PGDATA:-}" ] && [ -d "${PGDATA:-/nao-existe}/base" ] && PII_KEY_FILE="$PGDATA/.session_pii_key"
+# A condição é a PROPRIEDADE confirmada, não a existência de um diretório:
+# DB_URL só está preenchido depois de o hook comparar o data_directory do
+# servidor com o PGDATA desta sessão. Assim a chave nunca é escrita num cluster
+# alheio nem num PGDATA com initdb falhado (que envenenaria a próxima tentativa).
+[ -n "$DB_URL" ] && [ -n "$PGDATA" ] && PII_KEY_FILE="$PGDATA/.session_pii_key"
 
 if [ -n "$PII_KEY_FILE" ] && [ -s "$PII_KEY_FILE" ]; then
   PII_KEY=$(cat "$PII_KEY_FILE" 2>/dev/null | tr -d '\n')
@@ -213,7 +220,7 @@ if [ -z "$PII_KEY" ]; then
   if [ -n "$PII_KEY_FILE" ] && [ -n "$PII_KEY" ]; then
     printf '%s' "$PII_KEY" > "$PII_KEY_FILE" 2>/dev/null
     chmod 600 "$PII_KEY_FILE" 2>/dev/null
-    [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$PII_KEY_FILE" 2>/dev/null
+    [ "${PGRUN:-}" = "su postgres -c" ] && chown postgres:postgres "$PII_KEY_FILE" 2>/dev/null
   fi
 fi
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,6 +17,22 @@ cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" || exit 0
 
 log() { echo "[session-start] $*"; }
 
+# O identificador da sessão chega no JSON do stdin, não no ambiente — não existe
+# CLAUDE_SESSION_ID exportado. Sem ler daqui, o fallback vira $$ (PID do shell),
+# que MUDA a cada disparo: startup, resume e compact criariam um cluster novo
+# cada um, em vez de reaproveitar o da sessão.
+SID=""
+if [ ! -t 0 ]; then   # só lê se houver algo canalizado; não trava em teste manual
+  SID=$(python3 -c "
+import sys, json
+try:
+    print((json.load(sys.stdin).get('session_id') or '')[:32])
+except Exception:
+    print('')
+" 2>/dev/null)
+fi
+SID="${SID:-${CLAUDE_SESSION_ID:-$$}}"
+
 # ── 1. Aviso de branch atrasada ──────────────────────────────────────────────
 # Branch velha mente com confiança: o grep não acha arquivo que existe na main
 # e a conclusão sai redonda e errada. Já aconteceu neste repositório.
@@ -54,48 +70,95 @@ rm -f "$REQ_TMP"
 python3 -m pip install -q --disable-pip-version-check pytest anyio 2>/dev/null
 
 # ── 3. Postgres próprio desta sessão ─────────────────────────────────────────
+# Enumerado por estado, não remendado caso a caso. O hook dispara mais de uma
+# vez na mesma sessão (startup, resume, compact), então os três estados abaixo
+# são rotina, não exceção:
+#
+#   PGDATA ausente          -> initdb, sorteia porta, persiste, sobe
+#   PGDATA + servidor vivo   -> REUSA a porta do postmaster.pid, não sobe nada
+#   PGDATA + servidor morto  -> reusa a porta persistida (ou sorteia outra se
+#                               ela foi tomada), sobe
+#
+# A porta precisa ser persistida: sorteá-la de novo num resume faria o pg_ctl
+# recusar (cluster já rodando), os testes sondarem uma porta vazia e o hook
+# zerar o DATABASE_URL — quebrando a suíte num evento de ciclo de vida normal.
+#
+# PGPORT do ambiente NÃO é herdado de propósito: um valor global no host
+# colocaria todas as sessões concorrentes na mesma porta, que é exatamente o
+# que a alocação por sessão evita.
 PGBIN=""
 for v in 17 16 15 14; do
   [ -x "/usr/lib/postgresql/$v/bin/pg_ctl" ] && PGBIN="/usr/lib/postgresql/$v/bin" && break
 done
 
-DB_URL=""
-if [ -n "$PGBIN" ]; then
-  PGDATA="${TMPDIR:-/tmp}/pgdata-${CLAUDE_SESSION_ID:-$$}"
-  PGSOCK="/tmp/pgsock-${CLAUDE_SESSION_ID:-$$}"
-  # Porta livre por sessão. Fixar 5432 faria a segunda sessão do mesmo host
-  # falhar no pg_ctl e, pior, o createdb/pg_isready seguintes conversariam com
-  # o servidor da PRIMEIRA — as duas exportariam a mesma URL e a limpeza
-  # destrutiva da suíte voltaria a se cruzar, que é o que este hook evita.
-  PGPORT="${PGPORT:-$(python3 -c "
+_porta_livre() {
+  python3 -c "
 import socket
 s = socket.socket()
 s.bind(('127.0.0.1', 0))
 print(s.getsockname()[1])
 s.close()
-" 2>/dev/null || echo 5432)}"
+" 2>/dev/null || echo ""
+}
 
+DB_URL=""
+if [ -n "$PGBIN" ]; then
+  PGDATA="${TMPDIR:-/tmp}/pgdata-${SID}"
+  PGSOCK="/tmp/pgsock-${SID}"
+  PORTFILE="$PGDATA/.session_port"
+
+  if [ "$(id -u)" = "0" ] && id postgres >/dev/null 2>&1; then
+    PGRUN="su postgres -c"
+  else
+    PGRUN="bash -c"
+  fi
+
+  # initdb só quando o cluster ainda não existe.
   if [ ! -d "$PGDATA/base" ]; then
     log "inicializando Postgres em $PGDATA ..."
     mkdir -p "$PGDATA" "$PGSOCK"
-    # initdb recusa rodar como root; se existir o usuário postgres, usa ele.
-    if [ "$(id -u)" = "0" ] && id postgres >/dev/null 2>&1; then
+    if [ "$PGRUN" = "su postgres -c" ]; then
       chown postgres:postgres "$PGDATA" "$PGSOCK"; chmod 700 "$PGDATA"
       chmod 755 "${TMPDIR:-/tmp}" 2>/dev/null
-      PGRUN="su postgres -c"
-    else
-      PGRUN="bash -c"
     fi
     $PGRUN "$PGBIN/initdb -D $PGDATA -U postgres --auth=trust" >/dev/null 2>&1 \
       || log "AVISO: initdb falhou."
-  else
-    [ "$(id -u)" = "0" ] && id postgres >/dev/null 2>&1 && PGRUN="su postgres -c" || PGRUN="bash -c"
   fi
 
   if [ -d "$PGDATA/base" ]; then
-    LOGF="$PGDATA/server.log"; : > "$LOGF"
-    [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$LOGF"
-    $PGRUN "$PGBIN/pg_ctl -D $PGDATA -o '-p $PGPORT -k $PGSOCK -c listen_addresses=127.0.0.1' -l $LOGF -w -t 30 start" >/dev/null 2>&1
+    VIVO=0
+    if $PGRUN "$PGBIN/pg_ctl -D $PGDATA status" >/dev/null 2>&1; then
+      VIVO=1
+    fi
+
+    if [ "$VIVO" = "1" ]; then
+      # Já rodando (resume/compact): a porta real está na linha 4 do
+      # postmaster.pid. Reusar, nunca sortear outra.
+      PGPORT=$(sed -n 4p "$PGDATA/postmaster.pid" 2>/dev/null | tr -d ' ')
+      log "Postgres desta sessão já estava no ar (porta $PGPORT)."
+    else
+      # Parado: tenta a porta persistida; se estiver ocupada, sorteia outra.
+      PGPORT=$(cat "$PORTFILE" 2>/dev/null | tr -d ' ')
+      if [ -n "$PGPORT" ] && python3 -c "
+import socket, sys
+s = socket.socket()
+sys.exit(0 if s.connect_ex(('127.0.0.1', $PGPORT)) != 0 else 1)
+" 2>/dev/null; then
+        :  # porta persistida continua livre
+      else
+        PGPORT=$(_porta_livre)
+      fi
+      [ -z "$PGPORT" ] && PGPORT=5432
+      echo "$PGPORT" > "$PORTFILE" 2>/dev/null
+      [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$PORTFILE" 2>/dev/null
+
+      mkdir -p "$PGSOCK"
+      [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$PGSOCK"
+      LOGF="$PGDATA/server.log"; : > "$LOGF"
+      [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$LOGF"
+      $PGRUN "$PGBIN/pg_ctl -D $PGDATA -o '-p $PGPORT -k $PGSOCK -c listen_addresses=127.0.0.1' -l $LOGF -w -t 30 start" >/dev/null 2>&1
+    fi
+
     $PGRUN "$PGBIN/createdb -h 127.0.0.1 -p $PGPORT -U postgres bot_financeiro_test" >/dev/null 2>&1
     if $PGRUN "$PGBIN/pg_isready -h 127.0.0.1 -p $PGPORT -U postgres" >/dev/null 2>&1; then
       # Responder na porta não basta: pode ser o servidor de outra sessão. Só
@@ -104,13 +167,13 @@ s.close()
       DDIR=$($PGRUN "$PGBIN/psql -h 127.0.0.1 -p $PGPORT -U postgres -tAc 'show data_directory'" 2>/dev/null | tr -d ' ')
       if [ "$DDIR" = "$PGDATA" ]; then
         DB_URL="postgresql://postgres:postgres@127.0.0.1:$PGPORT/bot_financeiro_test"
-        log "Postgres no ar na porta $PGPORT (data_directory conferido)."
+        log "Postgres pronto na porta $PGPORT (data_directory conferido)."
       else
         log "AVISO: a porta $PGPORT responde, mas de outro servidor ($DDIR)."
         log "       Não vou usá-lo — seria o banco de outra sessão."
       fi
     else
-      log "AVISO: Postgres não subiu; veja $LOGF."
+      log "AVISO: Postgres não respondeu na porta $PGPORT; veja $PGDATA/server.log."
     fi
   fi
 else

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -121,8 +121,14 @@ if [ -n "$PGBIN" ]; then
       chown postgres:postgres "$PGDATA" "$PGSOCK"; chmod 700 "$PGDATA"
       chmod 755 "${TMPDIR:-/tmp}" 2>/dev/null
     fi
-    $PGRUN "$PGBIN/initdb -D $PGDATA -U postgres --auth=trust" >/dev/null 2>&1 \
-      || log "AVISO: initdb falhou."
+    if ! $PGRUN "$PGBIN/initdb -D $PGDATA -U postgres --auth=trust" >/dev/null 2>&1; then
+      # Limpa o que ficou pela metade. O initdb recusa diretório NÃO-VAZIO, então
+      # qualquer resto (log parcial, arquivo de estado) transformaria uma falha
+      # transitória em permanente: toda sessão seguinte tentaria de novo e seria
+      # recusada até alguém apagar o diretório à mão.
+      log "AVISO: initdb falhou — limpando $PGDATA para a próxima tentativa."
+      rm -rf "$PGDATA" 2>/dev/null
+    fi
   fi
 
   if [ -d "$PGDATA/base" ]; then
@@ -191,7 +197,10 @@ fi
 # desenvolvimento (e o pepper, por definição, nunca rotaciona — core/crypto.py).
 PII_KEY=""
 PII_KEY_FILE=""
-[ -n "${PGDATA:-}" ] && [ -d "${PGDATA:-/nao-existe}" ] && PII_KEY_FILE="$PGDATA/.session_pii_key"
+# Só grava num cluster REALMENTE inicializado — `$PGDATA/base` é o mesmo teste
+# que o bloco acima usa. Escrever com o initdb falhado deixaria o diretório
+# não-vazio e envenenaria a próxima tentativa.
+[ -n "${PGDATA:-}" ] && [ -d "${PGDATA:-/nao-existe}/base" ] && PII_KEY_FILE="$PGDATA/.session_pii_key"
 
 if [ -n "$PII_KEY_FILE" ] && [ -s "$PII_KEY_FILE" ]; then
   PII_KEY=$(cat "$PII_KEY_FILE" 2>/dev/null | tr -d '\n')

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# SessionStart — prepara o ambiente para a suíte rodar em sessões do Claude Code na web.
+#
+# Sem isto, cada sessão repete o mesmo setup à mão: instalar as dependências,
+# subir um Postgres e adivinhar as variáveis de ambiente. Pior, uma sessão que
+# aponte para um Postgres compartilhado atropela as outras — a suíte apaga
+# usuários que não são dela (ver tests/conftest.py). Aqui cada sessão ganha o
+# seu próprio Postgres, no diretório da própria sessão.
+set -uo pipefail
+
+# Só no ambiente remoto: na máquina do dev o setup é o dele.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" || exit 0
+
+log() { echo "[session-start] $*"; }
+
+# ── 1. Aviso de branch atrasada ──────────────────────────────────────────────
+# Branch velha mente com confiança: o grep não acha arquivo que existe na main
+# e a conclusão sai redonda e errada. Já aconteceu neste repositório.
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  git fetch origin main --quiet 2>/dev/null
+  atras=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+  if [ "${atras:-0}" -gt 0 ]; then
+    log "AVISO: esta branch está $atras commit(s) atrás de origin/main."
+    log "       Antes de afirmar que algo 'não existe', confira contra a main:"
+    log "         git grep -l '<termo>' origin/main -- <caminho>"
+  else
+    log "branch em dia com origin/main."
+  fi
+fi
+
+# ── 2. Dependências Python ───────────────────────────────────────────────────
+# Alguns pacotes do requirements.txt não instalam neste ambiente e derrubariam
+# o resto do `pip install` junto:
+#   audioop-lts  exige Python >= 3.13
+#   ofxparse     falha ao construir a wheel (setuptools/install_layout)
+# Ficam de fora aqui; no CI, com Python 3.13, o requirements.txt roda inteiro.
+# A ausência de ofxparse causa 9 erros de coleta; o tests/conftest.py os ignora
+# automaticamente quando o pacote não está presente.
+PULAR='^(audioop-lts|ofxparse)'
+REQ_TMP="$(mktemp)"
+grep -vE "$PULAR" requirements.txt > "$REQ_TMP"
+
+log "instalando dependências Python..."
+if python3 -m pip install -q --disable-pip-version-check -r "$REQ_TMP" 2>&1 | tail -3; then
+  log "dependências instaladas."
+else
+  log "AVISO: parte das dependências falhou; a suíte pode não rodar."
+fi
+rm -f "$REQ_TMP"
+python3 -m pip install -q --disable-pip-version-check pytest anyio 2>/dev/null
+
+# ── 3. Postgres próprio desta sessão ─────────────────────────────────────────
+PGBIN=""
+for v in 17 16 15 14; do
+  [ -x "/usr/lib/postgresql/$v/bin/pg_ctl" ] && PGBIN="/usr/lib/postgresql/$v/bin" && break
+done
+
+DB_URL=""
+if [ -n "$PGBIN" ]; then
+  PGDATA="${TMPDIR:-/tmp}/pgdata-${CLAUDE_SESSION_ID:-$$}"
+  PGSOCK="/tmp/pgsock-${CLAUDE_SESSION_ID:-$$}"
+  PGPORT="${PGPORT:-5432}"
+
+  if [ ! -d "$PGDATA/base" ]; then
+    log "inicializando Postgres em $PGDATA ..."
+    mkdir -p "$PGDATA" "$PGSOCK"
+    # initdb recusa rodar como root; se existir o usuário postgres, usa ele.
+    if [ "$(id -u)" = "0" ] && id postgres >/dev/null 2>&1; then
+      chown postgres:postgres "$PGDATA" "$PGSOCK"; chmod 700 "$PGDATA"
+      chmod 755 "${TMPDIR:-/tmp}" 2>/dev/null
+      PGRUN="su postgres -c"
+    else
+      PGRUN="bash -c"
+    fi
+    $PGRUN "$PGBIN/initdb -D $PGDATA -U postgres --auth=trust" >/dev/null 2>&1 \
+      || log "AVISO: initdb falhou."
+  else
+    [ "$(id -u)" = "0" ] && id postgres >/dev/null 2>&1 && PGRUN="su postgres -c" || PGRUN="bash -c"
+  fi
+
+  if [ -d "$PGDATA/base" ]; then
+    LOGF="$PGDATA/server.log"; : > "$LOGF"
+    [ "$PGRUN" = "su postgres -c" ] && chown postgres:postgres "$LOGF"
+    $PGRUN "$PGBIN/pg_ctl -D $PGDATA -o '-p $PGPORT -k $PGSOCK -c listen_addresses=127.0.0.1' -l $LOGF -w -t 30 start" >/dev/null 2>&1
+    $PGRUN "$PGBIN/createdb -h 127.0.0.1 -p $PGPORT -U postgres bot_financeiro_test" >/dev/null 2>&1
+    if $PGRUN "$PGBIN/pg_isready -h 127.0.0.1 -p $PGPORT -U postgres" >/dev/null 2>&1; then
+      DB_URL="postgresql://postgres:postgres@127.0.0.1:$PGPORT/bot_financeiro_test"
+      log "Postgres no ar na porta $PGPORT."
+    else
+      log "AVISO: Postgres não subiu; veja $LOGF."
+    fi
+  fi
+else
+  log "AVISO: Postgres não encontrado — os testes que usam banco não vão rodar."
+fi
+
+# ── 4. Variáveis de ambiente da sessão ───────────────────────────────────────
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    echo 'export PYTHONPATH="."'
+    [ -n "$DB_URL" ] && echo "export DATABASE_URL=\"$DB_URL\""
+    echo 'export JWT_SECRET="dev-only-jwt-secret-32-bytes-minimum-len"'
+    echo "export PII_ENCRYPTION_KEY=\"$(python3 -c 'from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())' 2>/dev/null)\""
+    echo 'export PII_HASH_PEPPER="dev-only-pepper-must-be-32-chars-long!!"'
+    echo 'export PII_AUDIT_DISABLED=1'
+    echo 'export RUN_BACKGROUND_TASKS=0'
+  } >> "$CLAUDE_ENV_FILE"
+  log "variáveis de ambiente exportadas."
+fi
+
+log "pronto. Rode a suíte com: python3 -m pytest -q"
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -63,7 +63,17 @@ DB_URL=""
 if [ -n "$PGBIN" ]; then
   PGDATA="${TMPDIR:-/tmp}/pgdata-${CLAUDE_SESSION_ID:-$$}"
   PGSOCK="/tmp/pgsock-${CLAUDE_SESSION_ID:-$$}"
-  PGPORT="${PGPORT:-5432}"
+  # Porta livre por sessão. Fixar 5432 faria a segunda sessão do mesmo host
+  # falhar no pg_ctl e, pior, o createdb/pg_isready seguintes conversariam com
+  # o servidor da PRIMEIRA — as duas exportariam a mesma URL e a limpeza
+  # destrutiva da suíte voltaria a se cruzar, que é o que este hook evita.
+  PGPORT="${PGPORT:-$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+" 2>/dev/null || echo 5432)}"
 
   if [ ! -d "$PGDATA/base" ]; then
     log "inicializando Postgres em $PGDATA ..."
@@ -88,8 +98,17 @@ if [ -n "$PGBIN" ]; then
     $PGRUN "$PGBIN/pg_ctl -D $PGDATA -o '-p $PGPORT -k $PGSOCK -c listen_addresses=127.0.0.1' -l $LOGF -w -t 30 start" >/dev/null 2>&1
     $PGRUN "$PGBIN/createdb -h 127.0.0.1 -p $PGPORT -U postgres bot_financeiro_test" >/dev/null 2>&1
     if $PGRUN "$PGBIN/pg_isready -h 127.0.0.1 -p $PGPORT -U postgres" >/dev/null 2>&1; then
-      DB_URL="postgresql://postgres:postgres@127.0.0.1:$PGPORT/bot_financeiro_test"
-      log "Postgres no ar na porta $PGPORT."
+      # Responder na porta não basta: pode ser o servidor de outra sessão. Só
+      # aceita se o data_directory for o desta sessão — a suíte APAGA linhas,
+      # então apontar para o banco de outra pessoa é destrutivo.
+      DDIR=$($PGRUN "$PGBIN/psql -h 127.0.0.1 -p $PGPORT -U postgres -tAc 'show data_directory'" 2>/dev/null | tr -d ' ')
+      if [ "$DDIR" = "$PGDATA" ]; then
+        DB_URL="postgresql://postgres:postgres@127.0.0.1:$PGPORT/bot_financeiro_test"
+        log "Postgres no ar na porta $PGPORT (data_directory conferido)."
+      else
+        log "AVISO: a porta $PGPORT responde, mas de outro servidor ($DDIR)."
+        log "       Não vou usá-lo — seria o banco de outra sessão."
+      fi
     else
       log "AVISO: Postgres não subiu; veja $LOGF."
     fi
@@ -102,7 +121,16 @@ fi
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   {
     echo 'export PYTHONPATH="."'
-    [ -n "$DB_URL" ] && echo "export DATABASE_URL=\"$DB_URL\""
+    # Sem banco isolado, ZERA a variável em vez de deixar passar o valor
+    # herdado do ambiente. A suíte apaga usuários, lançamentos, caixinhas e
+    # investimentos (tests/conftest.py); herdar um DATABASE_URL apontando para
+    # base compartilhada faria `pytest` destruir dados de verdade. Zerada, o
+    # conftest recusa rodar com "Faltou DATABASE_URL" — falha segura.
+    if [ -n "$DB_URL" ]; then
+      echo "export DATABASE_URL=\"$DB_URL\""
+    else
+      echo 'export DATABASE_URL=""'
+    fi
     echo 'export JWT_SECRET="dev-only-jwt-secret-32-bytes-minimum-len"'
     echo "export PII_ENCRYPTION_KEY=\"$(python3 -c 'from cryptography.fernet import Fernet;print(Fernet.generate_key().decode())' 2>/dev/null)\""
     echo 'export PII_HASH_PEPPER="dev-only-pepper-must-be-32-chars-long!!"'
@@ -112,5 +140,11 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   log "variáveis de ambiente exportadas."
 fi
 
-log "pronto. Rode a suíte com: python3 -m pytest -q"
+if [ -n "$DB_URL" ]; then
+  log "pronto. Rode a suíte com: python3 -m pytest -q"
+else
+  log "ATENÇÃO: sem banco isolado. DATABASE_URL foi zerado de propósito e a"
+  log "         suíte vai recusar rodar — ela apaga linhas e não pode cair"
+  log "         num banco compartilhado. Suba um Postgres antes de testar."
+fi
 exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -232,6 +232,11 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     echo 'export PII_HASH_PEPPER="dev-only-pepper-must-be-32-chars-long!!"'
     echo 'export PII_AUDIT_DISABLED=1'
     echo 'export RUN_BACKGROUND_TASKS=0'
+    # Este ambiente monta o requirements SEM ofxparse (a wheel não constrói
+    # aqui), então autoriza a suíte a pular o que depende dele. É explícito de
+    # propósito: sem esta variável, ofxparse faltando continua estourando no
+    # CI e na máquina do dev, como deve ser para dependência obrigatória.
+    echo 'export PYTEST_ALLOW_MISSING_OPTIONAL_DEPS=1'
   } >> "$CLAUDE_ENV_FILE"
   log "variáveis de ambiente exportadas."
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,40 @@ os.environ.setdefault("PLANS_V2_ENABLED", "0")
 from db import init_db, ensure_user, get_conn
 
 
+# ── Coleta: arquivos que dependem de `ofxparse` ──────────────────────────────
+# Sem o pacote, estes 9 arquivos estouram no IMPORT e o pytest aborta a suíte
+# inteira antes de rodar um teste — o resultado não é "alguns testes falham",
+# é sinal nenhum, nem verde nem vermelho.
+#
+# A lista é FIXA de propósito. Gerá-la a partir dos erros de coleta ("ignore
+# tudo que falhou ao importar") engoliria também um ImportError ou erro de
+# sintaxe recém-introduzido, e o arquivo quebrado nunca mais rodaria.
+#
+# A condição é a ausência do pacote, não o erro: no CI o ofxparse está no
+# requirements.txt, então nada aqui é ignorado e os 9 rodam normalmente.
+_OFXPARSE_DEPENDENTES = [
+    "test_audio_clarification.py",
+    "test_audio_multi_launch_ask_value.py",
+    "test_full_handler_smoke.py",
+    "test_handle_incoming_routing.py",
+    "test_recurring_value.py",
+    "test_split_audio_transactions.py",
+    "test_whatsapp_confirmations.py",
+    "test_whatsapp_daily_report.py",
+    "test_whatsapp_simulation.py",
+]
+
+collect_ignore = []
+try:
+    import ofxparse  # noqa: F401
+except ImportError:
+    collect_ignore = list(_OFXPARSE_DEPENDENTES)
+    print(
+        f"[conftest] ofxparse ausente — ignorando {len(collect_ignore)} arquivos "
+        "que dependem dele (no CI o pacote existe e todos rodam)."
+    )
+
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _init_schema():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,15 +45,48 @@ _OFXPARSE_DEPENDENTES = [
     "test_whatsapp_simulation.py",
 ]
 
+# Estes quatro NÃO estouram na coleta: importam `core.handle_incoming` ou
+# `statement_import` DENTRO do corpo do teste, e a cadeia
+# handle_incoming -> ofx_service -> ofx_import -> ofxparse só é percorrida
+# quando o teste roda. O collect_ignore acima não os alcança, então sem este
+# skip a suíte "de dependências reduzidas" ainda termina com 4 vermelhos que
+# nada têm a ver com a mudança em revisão.
+_OFXPARSE_IMPORT_TARDIO = [
+    "tests/test_statement_import.py::test_attachment_detection",
+    "tests/test_statement_import.py::test_import_statement_bytes_csv_idempotente",
+    "tests/test_statement_import.py::test_import_statement_bytes_vazio_ou_grande",
+    "tests/test_nlp_and_pending_flow.py::test_handle_incoming_clarification_tem_precedencia_sobre_fallback_ia",
+]
+
 collect_ignore = []
 try:
     import ofxparse  # noqa: F401
+
+    _TEM_OFXPARSE = True
 except ImportError:
+    _TEM_OFXPARSE = False
     collect_ignore = list(_OFXPARSE_DEPENDENTES)
     print(
         f"[conftest] ofxparse ausente — ignorando {len(collect_ignore)} arquivos "
-        "que dependem dele (no CI o pacote existe e todos rodam)."
+        f"e pulando {len(_OFXPARSE_IMPORT_TARDIO)} testes de import tardio "
+        "(no CI o pacote existe e todos rodam)."
     )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Pula os testes que só descobrem a falta do ofxparse ao executar.
+
+    Mesma filosofia da lista de arquivos: nomes FIXOS e condição ligada à
+    ausência do pacote, não ao erro. Marcar pelo erro esconderia um
+    ImportError novo introduzido por outra mudança.
+    """
+    if _TEM_OFXPARSE:
+        return
+    motivo = pytest.mark.skip(reason="ofxparse ausente (import tardio); no CI o pacote existe")
+    alvos = set(_OFXPARSE_IMPORT_TARDIO)
+    for item in items:
+        if item.nodeid in alvos:
+            item.add_marker(motivo)
 
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib.util
 import os
 import sys
 import uuid
@@ -58,18 +59,30 @@ _OFXPARSE_IMPORT_TARDIO = [
     "tests/test_nlp_and_pending_flow.py::test_handle_incoming_clarification_tem_precedencia_sobre_fallback_ia",
 ]
 
-collect_ignore = []
-try:
-    import ofxparse  # noqa: F401
+# O alívio NÃO é automático: exige PYTEST_ALLOW_MISSING_OPTIONAL_DEPS=1.
+#
+# Detectar a ausência sozinho seria pior que o problema — se o ofxparse caísse
+# do requirements.txt por engano, ou sumisse do CI, a suíte silenciaria 9
+# arquivos e pularia 4 testes e passaria VERDE, enquanto `core.handle_incoming`
+# estaria quebrado em produção. Um ambiente de dependências reduzidas é uma
+# decisão consciente de quem o monta (o .claude/hooks/session-start.sh exporta
+# a variável); a execução normal do dev e do CI continua estourando, que é o
+# comportamento certo para dependência obrigatória faltando.
+_DEPS_REDUZIDAS = os.getenv("PYTEST_ALLOW_MISSING_OPTIONAL_DEPS") == "1"
 
-    _TEM_OFXPARSE = True
-except ImportError:
-    _TEM_OFXPARSE = False
+# find_spec em vez de `try: import`: `except ImportError` também captura um
+# ImportError levantado DE DENTRO de um ofxparse instalado (dependência interna
+# quebrada, por exemplo) e trataria pacote defeituoso como pacote ausente,
+# escondendo justamente o que precisa aparecer.
+_TEM_OFXPARSE = importlib.util.find_spec("ofxparse") is not None
+
+collect_ignore = []
+if _DEPS_REDUZIDAS and not _TEM_OFXPARSE:
     collect_ignore = list(_OFXPARSE_DEPENDENTES)
     print(
-        f"[conftest] ofxparse ausente — ignorando {len(collect_ignore)} arquivos "
-        f"e pulando {len(_OFXPARSE_IMPORT_TARDIO)} testes de import tardio "
-        "(no CI o pacote existe e todos rodam)."
+        f"[conftest] PYTEST_ALLOW_MISSING_OPTIONAL_DEPS=1 e ofxparse ausente — "
+        f"ignorando {len(collect_ignore)} arquivos e pulando "
+        f"{len(_OFXPARSE_IMPORT_TARDIO)} testes de import tardio."
     )
 
 
@@ -80,7 +93,7 @@ def pytest_collection_modifyitems(config, items):
     ausência do pacote, não ao erro. Marcar pelo erro esconderia um
     ImportError novo introduzido por outra mudança.
     """
-    if _TEM_OFXPARSE:
+    if _TEM_OFXPARSE or not _DEPS_REDUZIDAS:
         return
     motivo = pytest.mark.skip(reason="ofxparse ausente (import tardio); no CI o pacote existe")
     alvos = set(_OFXPARSE_IMPORT_TARDIO)


### PR DESCRIPTION
## O problema

Toda sessão nova do Claude Code na web repete o mesmo setup à mão — instalar dependências, subir um Postgres, adivinhar variáveis de ambiente — e cada uma acerta de um jeito diferente.

O custo não é teórico. Nesta sessão eu mesmo exportei uma `PII_ENCRYPTION_KEY` em hexadecimal, que **não é chave Fernet válida**. Como o `conftest.py` usa `setdefault`, ele respeitou a chave quebrada, e tudo que toca PII caiu junto — sessions, MFA, billing, audit. Passei horas reportando **61 falhas** numa suíte que, com o ambiente correto, tem **zero**.

## O que o hook faz

Só no ambiente remoto (`CLAUDE_CODE_REMOTE`); na máquina do dev sai na hora.

1. **Avisa quando a branch está atrasada** em relação à `origin/main`, com o comando para conferir contra a árvore certa. Branch velha mente com confiança — foi assim que o `CLAUDE.md` documentou como inexistentes o `frontend/safe-area.js` e as classes `pb-root-*`, ambos criados no #56.
2. **Instala o `requirements.txt`**, pulando `audioop-lts` (exige Python ≥ 3.13) e `ofxparse` (a wheel não constrói aqui), que derrubariam o resto do `pip install` junto.
3. **Sobe um Postgres exclusivo da sessão** — ver a máquina de estados abaixo.
4. **Exporta** `DATABASE_URL`, `JWT_SECRET`, `PII_*`, `PYTHONPATH` e `PYTEST_ALLOW_MISSING_OPTIONAL_DEPS` via `CLAUDE_ENV_FILE`.

Cada passo degrada sem quebrar: sem Postgres, sem permissão, sem pacote — avisa e segue.

## O Postgres, por estados

O hook dispara mais de uma vez por sessão (startup, resume, compact), então os três são rotina:

| estado | ação |
|---|---|
| `PGDATA` ausente | `initdb`, sorteia porta livre, **persiste**, sobe |
| `PGDATA` + servidor **vivo** | reusa a porta do `postmaster.pid`, não sobe nada |
| `PGDATA` + servidor **morto** | reusa a porta persistida (ou outra se foi tomada), sobe |

Decisões que sustentam isso:

- **porta por sessão**, nunca 5432 fixa nem `PGPORT` herdado — senão duas sessões acabam no mesmo servidor e a limpeza destrutiva da suíte se cruza;
- **identidade antes de mutar**: `show data_directory` é comparado com o `PGDATA` desta sessão *antes* do `createdb`, porque recusar a URL depois não desfaz a escrita;
- **`PGDATA`/`PGRUN` nunca herdados** do ambiente;
- **`initdb` que falha limpa o diretório** — o `initdb` recusa diretório não-vazio, e qualquer resto tornaria a falha permanente;
- **`session_id` vem do stdin**, não do ambiente (`CLAUDE_SESSION_ID` não existe); sem isso o `PGDATA` caía no PID e mudava a cada disparo — esta sessão chegou a acumular 3 clusters;
- **chave Fernet persistida no `PGDATA`**, com o mesmo ciclo de vida do banco: como o cluster é reaproveitado, gerar chave nova a cada disparo deixaria ilegível todo PII escrito antes;
- **falha fechada**: sem cluster próprio, o hook exporta `DATABASE_URL=""` e a suíte recusa rodar — ela apaga linhas e não pode cair num banco compartilhado.

## Dependências ausentes: alívio explícito, nunca automático

Sem `ofxparse`, 9 arquivos estouram no import (o pytest aborta tudo) e outros 4 testes falham em execução, por importarem `core.handle_incoming`/`statement_import` dentro do corpo.

O `conftest.py` trata os dois casos, mas **só com `PYTEST_ALLOW_MISSING_OPTIONAL_DEPS=1`**, que apenas o hook exporta. Detecção automática seria pior que o problema: se o `ofxparse` caísse do `requirements.txt` por engano, a suíte silenciaria 13 itens e passaria verde com `core.handle_incoming` quebrado.

As listas são **fixas** e a checagem usa `importlib.util.find_spec` — `except ImportError` também captura erro vindo *de dentro* de um pacote instalado, tratando defeituoso como ausente.

| | resultado |
|---|---|
| sem a flag (dev/CI) | 9 errors during collection, interrompe |
| com a flag (hook remoto) | **1053 passed, 4 skipped** |

Guarda verificada nos dois sentidos: um arquivo com `ImportError` novo em `tests/` continua sendo acusado e interrompendo.

## Validação

Ponta a ponta, em ambiente limpo (`env -i`), usando só o que o hook preparou: `rc=0`, Postgres no ar, variáveis exportadas, e `pytest -q` sem nenhum `--ignore` manual → **1053 passed, 4 skipped**.

Cenários adversos, cada um medido com o contrafactual:

- **resume** com servidor vivo → mesma porta, mesma chave; dado cifrado antes continua legível (sem a correção: `InvalidToken`);
- **`initdb` falho** → diretório limpo, sessão seguinte se recupera (antes: falha permanente);
- **cluster alheio na porta** → recusa e não cria database nele;
- **host sem Postgres + `PGDATA` herdado** → `DATABASE_URL=""` (antes: `unbound variable`, env file vazio, URL de produção herdada ativa);
- **`TMPDIR` vazio** → `/tmp` preservado em `1777`.

## Histórico de revisão

Dez rodadas com o Codex, com apontamento procedente em nove. Vale registrar que **seis nasceram de correções minhas anteriores** — o padrão que o `CLAUDE.md` §4 chama de gerador de bug. Os achados mais graves:

- `chmod 755` no `TMPDIR` destruía o `1777` e o sticky bit do `/tmp` do host — **o `/tmp` deste container já estava danificado** quando o apontamento chegou;
- sem Postgres no host, o script morria em `unbound variable` antes de zerar a `DATABASE_URL`, deixando ativa uma URL herdada contra a qual a suíte apagaria linhas;
- o `createdb` rodava antes da checagem de identidade do cluster.

Nenhum desses era visível sem revisão adversarial. Aprovado em `15dc23c`.

## Ressalvas

- **Não verificado no CI** — o GitHub Actions do repositório está travado (todo run morre em ~2s, sem runner atribuído, em todos os branches, por cota/billing). O CI vermelho aqui não é deste diff. O hook não rodaria no CI de qualquer forma: é guardado por `CLAUDE_CODE_REMOTE`.
- **Não há linter no projeto** (nenhum ruff/flake8/black/mypy), então o hook não instala nem roda nenhum.
- **Modo síncrono**: garante o ambiente pronto antes da sessão começar, ao custo de ~1–2 min de abertura, dominados pelo `pip install`.
- O hook só passa a valer para sessões futuras depois de entrar na branch padrão.
- **Alternativa em aberto**, que levei ao dono do repositório: quase todos os achados desta revisão vêm da parte que administra ciclo de vida de Postgres. Um hook reduzido a dependências + variáveis + aviso de branch eliminaria essa classe inteira, ao custo de o dev subir o banco por conta própria.