### PR TITLE
fix(test): fechar os furos do kill switch de rede

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,7 @@ def _block_outbound_network(monkeypatch):
 
     # httpx async client — qualquer .request bloqueia
     import httpx as _httpx
+    import requests as _requests
     async def _blocked_async(*args, **kwargs):
         raise RuntimeError(
             "Outbound HTTP (async) blocked in tests. Mock the call locally."
@@ -243,6 +244,49 @@ def _block_outbound_network(monkeypatch):
     monkeypatch.setattr(_httpx.AsyncClient, "request", _blocked_async, raising=False)
     monkeypatch.setattr(_httpx.AsyncClient, "get", _blocked_async, raising=False)
     monkeypatch.setattr(_httpx.AsyncClient, "post", _blocked_async, raising=False)
+
+    # Os clientes, não só os helpers de módulo. `httpx.Client` é a forma MAIS
+    # usada em produção (8 ocorrências) — core/services/pluggy.py inteiro
+    # depende dela, com GET/POST/PATCH/DELETE autenticados contra a conta
+    # bancária real do usuário. Enquanto só os helpers eram bloqueados, esse
+    # caminho saía para a rede sem nada falhar.
+    #
+    # O bloqueio vai no `send`, não verbo a verbo: get/post/put/patch/delete
+    # chamam `request`, que chama `send`. Um ponto só cobre todos, inclusive
+    # os que ninguém lembrou de listar (foi assim que PATCH e DELETE, usados
+    # pelo Pluggy, ficaram de fora da lista original).
+    #
+    # MAS o critério não pode ser "é um httpx.Client": o TestClient do
+    # Starlette/FastAPI HERDA de httpx.Client e é como a suíte chama as próprias
+    # rotas. Bloquear por classe derrubaria 125 testes que não têm nada a ver
+    # com rede externa. O que separa os dois é o TRANSPORTE: só o HTTPTransport
+    # do httpx abre socket; o do TestClient (_TestClientTransport) e os mocks
+    # rodam in-process.
+    _transportes_de_rede = tuple(
+        t for t in (getattr(_httpx, "HTTPTransport", None), getattr(_httpx, "AsyncHTTPTransport", None)) if t
+    )
+
+    def _vai_para_a_rede(client) -> bool:
+        return isinstance(getattr(client, "_transport", None), _transportes_de_rede)
+
+    _send_sync, _send_async = _httpx.Client.send, _httpx.AsyncClient.send
+
+    def _send_guardado(self, *a, **kw):
+        if _vai_para_a_rede(self):
+            _blocked_call()
+        return _send_sync(self, *a, **kw)
+
+    async def _send_guardado_async(self, *a, **kw):
+        if _vai_para_a_rede(self):
+            _blocked_call()
+        return await _send_async(self, *a, **kw)
+
+    monkeypatch.setattr(_httpx.Client, "send", _send_guardado, raising=False)
+    monkeypatch.setattr(_httpx.AsyncClient, "send", _send_guardado_async, raising=False)
+
+    # Mesmo furo do lado do requests: os verbos do módulo estavam cobertos, os
+    # da sessão não. Session.get/post/... chamam self.request.
+    monkeypatch.setattr(_requests.Session, "request", _blocked_call, raising=False)
 
     # OpenAI — qualquer atributo do client levanta
     class _FakeOpenAIClient:
@@ -252,6 +296,21 @@ def _block_outbound_network(monkeypatch):
                 "Mock the call locally."
             )
     monkeypatch.setattr("openai.OpenAI", lambda *a, **kw: _FakeOpenAIClient())
+
+    # `ai_router.py:20` faz `from openai import OpenAI`, o que COPIA o nome para
+    # dentro do módulo no momento do import. Trocar `openai.OpenAI` não alcança
+    # essa cópia — e `core/handle_incoming.py:38` importa o ai_router na coleta,
+    # antes desta fixture rodar. Sem o patch abaixo, `_get_client()` constrói o
+    # cliente REAL e a chamada é cobrada.
+    try:
+        import ai_router as _ai_router
+
+        monkeypatch.setattr(_ai_router, "OpenAI", lambda *a, **kw: _FakeOpenAIClient())
+        # `_get_client()` guarda o cliente num global; um cliente real cacheado
+        # por outro teste sobreviveria ao patch.
+        monkeypatch.setattr(_ai_router, "_client", None, raising=False)
+    except Exception:
+        pass  # ai_router indisponível (deps faltando) — nada a proteger aqui
 
 
 def _cleanup_user(user_id: int):

--- a/tests/test_killswitch_rede.py
+++ b/tests/test_killswitch_rede.py
@@ -1,0 +1,91 @@
+"""O kill switch de rede (`_block_outbound_network`, em conftest.py) precisa
+cobrir os caminhos que o código de PRODUÇÃO realmente usa — não só os que
+alguém lembrou de listar.
+
+Sem essa cobertura, rodar a suíte numa máquina com credenciais no ambiente
+pode tocar a conta Pluggy de verdade ou gastar quota da OpenAI. A fixture
+existe justamente para impedir isso, então o furo é silencioso: nada falha,
+a chamada só sai.
+
+Cada teste aqui parte de um inventário do que produção usa
+(`grep -rhoE "httpx\\.(Client|AsyncClient|...)" --include=*.py`), não de uma
+lista escrita de memória.
+"""
+import httpx
+import pytest
+import requests
+
+# Importado no TOPO de propósito: acontece durante a COLETA, antes de a fixture
+# rodar — que é exatamente como o furo se manifesta. `core/handle_incoming.py:38`
+# faz `from ai_router import _internal_user_id`, então vários testes já puxam
+# este módulo na coleta sem saber. Mover para dentro do teste esconderia o bug.
+import ai_router
+
+# Host reservado pela RFC 2606: se a chamada escapar do bloqueio, ela morre em
+# resolução de DNS em vez de bater em serviço real de alguém.
+ALVO = "http://host-que-nao-existe.invalid/x"
+
+
+def _bloqueado(fn) -> bool:
+    """True se o kill switch pegou; False se a chamada chegou a sair."""
+    try:
+        fn()
+    except RuntimeError as exc:
+        return "blocked" in str(exc).lower()
+    except Exception:
+        return False  # erro de rede == escapou do bloqueio
+    return False
+
+
+def test_httpx_client_sincrono_e_bloqueado():
+    """`httpx.Client` é a forma MAIS usada em produção (8 ocorrências) —
+    core/services/pluggy.py inteiro depende dela, com GET/POST/PATCH/DELETE
+    autenticados contra a conta bancária do usuário."""
+    def chamada():
+        with httpx.Client(timeout=1) as client:
+            client.get(ALVO)
+
+    assert _bloqueado(chamada), "httpx.Client escapou do kill switch"
+
+
+def test_httpx_client_bloqueia_todos_os_verbos():
+    """Bloquear verbo a verbo deixa buracos: o Pluggy usa PATCH e DELETE, que
+    não estavam na lista original. Client.get/post/... chamam self.request,
+    que chama self.send — o bloqueio no send cobre todos de uma vez."""
+    for verbo in ("get", "post", "put", "patch", "delete"):
+        def chamada(v=verbo):
+            with httpx.Client(timeout=1) as client:
+                getattr(client, v)(ALVO)
+
+        assert _bloqueado(chamada), f"httpx.Client.{verbo} escapou"
+
+
+def test_requests_session_e_bloqueada():
+    """`requests.Session()` mantém o mesmo furo do httpx.Client: os verbos do
+    módulo estavam cobertos, os da sessão não."""
+    def chamada():
+        with requests.Session() as s:
+            s.get(ALVO, timeout=1)
+
+    assert _bloqueado(chamada), "requests.Session escapou do kill switch"
+
+
+def test_openai_do_ai_router_e_o_dublê():
+    """`ai_router.py:20` faz `from openai import OpenAI`, o que copia o nome
+    para dentro do módulo no import. Trocar `openai.OpenAI` na fixture não
+    alcança essa cópia — o patch precisa ser no consumidor.
+
+    Sem isso, com OPENAI_API_KEY no ambiente, `_get_client()` constrói o
+    cliente real e a chamada é cobrada.
+    """
+    cliente = ai_router.OpenAI(api_key="sk-nao-usar")
+    assert type(cliente).__name__ == "_FakeOpenAIClient", (
+        f"ai_router.OpenAI construiu {type(cliente).__name__}, não o dublê"
+    )
+
+
+def test_openai_client_cacheado_nao_vaza_entre_testes():
+    """`_get_client()` guarda o cliente num global. Se um teste anterior o
+    tivesse preenchido com o cliente real, o patch da fixture não adiantaria
+    — ela precisa zerar o cache também."""
+    assert ai_router._client is None or type(ai_router._client).__name__ == "_FakeOpenAIClient"


### PR DESCRIPTION
## O que está em jogo

O `_block_outbound_network` (`tests/conftest.py`) é a trava que impede a suíte de sair para a internet. A própria docstring diz por quê:

> *"Sem isso, `register_auth_user` disparava welcome via Resend, o `ai_router` podia chamar OpenAI, `ipgeo` batia em ipapi.co. Cada execução do pytest gastava quota de APIs pagas e poluía dashboards de provedores."*

Ele cobria só parte dos caminhos. O furo é silencioso: nada falha, a chamada só sai.

## Inventário

Levantado do que produção usa de fato (`grep -rhoE "httpx\.(Client|AsyncClient|...)" --include=*.py`), não da lista escrita de memória:

| caminho | usos em produção | estava bloqueado? |
|---|---|---|
| `httpx.Client` | **8** | ❌ |
| `httpx.AsyncClient` | 5 | ✅ |
| `httpx.get/put/post/delete` | 6 | ✅ |
| `requests.Session` | **4** | ❌ |
| `requests.get/post/...` | 17 | ✅ |

**Três furos — um a mais do que a revisão do #84 apontou.**

## 1. `httpx.Client` — o mais grave

É a forma mais usada em produção. `core/services/pluggy.py` faz GET, POST, PATCH e DELETE autenticados **contra a conta bancária real do usuário** por ela (linhas 60, 75, 94, 114, 241).

Repare que **PATCH e DELETE nem constavam** da lista de verbos bloqueados do módulo — o que já mostra por que listar verbo a verbo não fecha o problema.

## 2. `requests.Session`

Mesmo furo do outro lado: os verbos do módulo estavam cobertos, os da sessão não.

Sendo justo sobre a gravidade: hoje `Session` só aparece em `scripts/post_deploy_deletion_check.py`, que roda **fora** da suíte. Então isto é defesa em profundidade, não correção de vazamento ativo.

## 3. `ai_router.OpenAI` — e é ativo, não latente

`ai_router.py:20` faz `from openai import OpenAI`, o que **copia** o nome para dentro do módulo no momento do import. Trocar `openai.OpenAI` na fixture não alcança essa cópia.

Cheguei a concluir que o furo seria só teórico, porque nenhum teste importa `ai_router` no topo. **Estava errado**: `core/handle_incoming.py:38` faz `from ai_router import _internal_user_id`, então o módulo já entra na coleta em vários testes. Medido com um teste que importa `ai_router` no topo:

```
ai_router.OpenAI construiu: OpenAI      ← o cliente REAL, não o dublê
```

Com `OPENAI_API_KEY` no ambiente, `_get_client()` constrói o cliente real e a chamada é cobrada. O patch agora vai no consumidor e zera o `_client` que o módulo cacheia.

## A decisão de design que importa

O bloqueio do httpx vai no **`send`**, não verbo a verbo: `get`/`post`/`put`/`patch`/`delete` chamam `request`, que chama `send`. Um ponto cobre todos — inclusive os que ninguém lembrar de listar depois.

**Mas o critério não pode ser "é um `httpx.Client`".** O `TestClient` do Starlette **herda** de `httpx.Client` e é como a suíte chama as próprias rotas. Minha primeira tentativa bloqueou por classe e **derrubou 125 testes** que não têm nada a ver com rede externa.

O que separa os dois é o **transporte**: só o `HTTPTransport` abre socket; o `_TestClientTransport` e os mocks rodam in-process. O guarda checa isso e delega ao `send` original quando a chamada é local.

## Verificação

`tests/test_killswitch_rede.py` prova cada furo, e foi conferido nos dois sentidos:

| | antes | depois |
|---|---|---|
| testes do kill switch | **3 de 5 falham** | 5 passam |
| suíte completa | 1053 passed, 4 skipped | **1058 passed, 4 skipped** |

O teste do `ai_router` importa o módulo **no topo** de propósito — é assim que o furo aparece de verdade. Movê-lo para dentro da função esconderia o bug (foi o que aconteceu na minha primeira versão, que passava sem corrigir nada).

Os testes usam `http://host-que-nao-existe.invalid/`, domínio reservado pela RFC 2606: se a chamada escapar do bloqueio, ela morre em DNS em vez de bater no serviço real de alguém.

## Não verificado

O CI — o GitHub Actions do repositório continua travado por cota (todo run morre em ~2s, sem runner atribuído, em todos os branches). A verificação aqui é a suíte local.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtWzacGdU7t8D8iXvobgyM)_