### PR TITLE
feat(app): puxar-pra-atualizar move o conteúdo (elástico nativo) na Início e no dashboard

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -737,9 +737,11 @@ html.pb-app .sidenav {
 html.pb-app .sidenav-backdrop.open { z-index: 750; }
 
 /* ─── Puxar pra atualizar ──────────────────────────────────────────────────
-   O indicador desce sozinho por cima da página — o conteúdo NÃO se mexe (ver
-   o porquê no app-mode.js, initPullToRefresh). Posição e escala vêm de lá;
-   aqui fica só a aparência.
+   Na Início e nas views do dashboard o CONTEÚDO (`.page`) desce junto com o
+   puxão e segura embaixo enquanto o refresh corre — estilo nativo do iOS — e o
+   indicador aparece no vão que abre sob o status bar. Nas demais telas (Ajustes,
+   O que pedir) só o indicador desce por cima da página. Posição e escala vêm do
+   app-mode.js (initPullToRefresh); aqui fica só a aparência.
 
    z-index 690: abaixo da tab bar (700) e dos modais (800/900), acima do
    conteúdo. Puxar com modal aberto não deve desenhar nada por cima dele. */

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -634,6 +634,12 @@
     }
 
     const damp = o => PTR.rubber * (1 - 1 / (o / PTR.rubber + 1));
+    // Inverso do damp: dado um `pull`, o deslocamento de dedo que o produz.
+    // Usado pra rebasear um puxão que começa em cima da molinha de recolher —
+    // o gesto novo continua do offset residual em vez de saltar (o damp sempre
+    // recebe pull < rubber, então o denominador nunca zera).
+    const dampInv = p => PTR.rubber * p / Math.max(1, PTR.rubber - p);
+    let startPullOffset = 0;   // dy virtual do residual retido no touchstart
     const atTop = () =>
       (window.scrollY || (document.scrollingElement || {}).scrollTop || 0) <= 0;
 
@@ -836,10 +842,22 @@
       // da digitação. Os campos vivem no fluxo normal; ownsGesture não os vê.
       if (ev.target.closest && ev.target.closest("input, textarea, select, [contenteditable]")) return;
       tracking = atTop();
+      startPullOffset = 0;
       // Retry rápido: se a molinha do ciclo anterior ainda está recolhendo,
       // o rAF dela seguiria empurrando pull pra zero por baixo do touchmove
       // — o puxão novo desabava no meio. Gesto aceito mata a molinha.
-      if (tracking && raf) { cancelAnimationFrame(raf); raf = 0; }
+      //
+      // Mas matar a molinha deixa `pull` no valor residual, e o primeiro
+      // touchmove o trocava por damp(dy)≈0 — com o `.page` inteiro descendo,
+      // isso é um salto visível de dezenas de px pra cima antes de seguir o
+      // dedo. Rebaseia: guarda o dy virtual do residual pra somar no touchmove,
+      // então o pull começa no residual e cresce contínuo. O offset entra SÓ no
+      // cálculo do pull — a classificação dx/dy usa o dy cru (senão o offset
+      // inflaria o dy e um swipe horizontal viraria puxão).
+      if (tracking && raf) {
+        cancelAnimationFrame(raf); raf = 0;
+        if (pull > 0) startPullOffset = dampInv(pull);
+      }
       dragged = false;
       startY = ev.touches[0].clientY;
       startX = ev.touches[0].clientX;
@@ -874,7 +892,7 @@
       if (ev.cancelable) ev.preventDefault();   // mata o elástico nativo
       if (!dragged) setDragging(true);          // primeira amostra: arma a camada de composição
       dragged = true;
-      pull = Math.min(PTR.max, damp(dy));
+      pull = Math.min(PTR.max, damp(dy + startPullOffset));
       draw();
     }, { passive: false });
 

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -594,6 +594,17 @@
     let dragged = false;    // este gesto puxou de verdade (tap nunca arma)
     let inFlight = null;    // PBRefresh pendente (o watchdog libera o ciclo, não o pedido)
 
+    // Nas telas de dados (Início e views do dashboard) o CONTEÚDO desce junto
+    // com o puxão — estilo nativo do iOS — e o indicador aparece no vão que
+    // abre sob o status bar. Nas outras (Ajustes, O que pedir) mantém o antigo:
+    // só o indicador desce por cima da página. O transform mora no `.page`, o
+    // único wrapper de conteúdo; foi verificado (grep) que nenhum position:fixed
+    // é descendente dele — dock, FAB, toasts e overlays são irmãos e ficam
+    // ancorados, então mover o `.page` não arrasta o chrome (e não abre faixa
+    // vazia embaixo). Ajustes fica de fora de propósito.
+    const moveContent = (page === "home" || page === "app");
+    const contentEl = moveContent ? document.querySelector(".page") : null;
+
     // Fetches pendentes DA PÁGINA (não do puxão): o fallback de reload não
     // pode atropelar um save em voo — o PATCH das preferências de notificação
     // dos Ajustes, por exemplo, seria abortado e a escolha recém-aceita pela
@@ -628,18 +639,44 @@
 
     function draw() {
       const p = Math.min(1, pull / PTR.threshold);
-      el.style.transform =
-        "translate3d(0," + pull.toFixed(1) + "px,0) scale(" + (0.5 + 0.5 * p).toFixed(3) + ")";
+      if (contentEl) {
+        // Conteúdo desce por inteiro (a molinha do rAF é quem anima).
+        contentEl.style.transform =
+          pull > 0 ? "translate3d(0," + pull.toFixed(1) + "px,0)" : "";
+        // Indicador fica no vão que abriu: sobe atrás do status bar quando o
+        // puxão é curto (translate negativo + opacity 0) e desce pra ~meio do
+        // vão conforme cresce. Metade da velocidade do conteúdo = "revelado"
+        // por trás dele, não colado ao topo do conteúdo.
+        el.style.transform =
+          "translate3d(0," + ((pull - 40) * 0.5).toFixed(1) + "px,0) scale(" +
+          (0.5 + 0.5 * p).toFixed(3) + ")";
+      } else {
+        el.style.transform =
+          "translate3d(0," + pull.toFixed(1) + "px,0) scale(" + (0.5 + 0.5 * p).toFixed(3) + ")";
+      }
       el.style.opacity = Math.min(1, p * 1.6).toFixed(2);
       if (!busy) arc.style.strokeDashoffset = (circ * (1 - p)).toFixed(1);
     }
 
+    // will-change só enquanto o puxão está vivo: manter uma camada de
+    // composição permanente no `.page` (subárvore inteira) é caro. Liga ao
+    // começar o gesto/refresh, desliga quando o conteúdo assenta em 0. O `.page`
+    // não tem transition no CSS, então a molinha do rAF anima sozinha.
+    function setDragging(on) {
+      if (!contentEl) return;
+      contentEl.style.willChange = on ? "transform" : "";
+    }
+
     function spring(goal) {
       if (raf) { cancelAnimationFrame(raf); raf = 0; }
-      if (!smooth) { pull = goal; draw(); return; }
+      // Assentou no zero: solta a camada de composição do `.page`. Só quando
+      // chega em 0 — no HOLD (refresh em curso) o conteúdo continua segurado
+      // embaixo.
+      const done = () => { if (goal === 0) setDragging(false); };
+      if (!smooth) { pull = goal; draw(); done(); return; }
       (function step() {
         pull += (goal - pull) * 0.22;
-        if (Math.abs(pull - goal) < 0.5) { pull = goal; raf = 0; draw(); return; }
+        if (Math.abs(pull - goal) < 0.5) { pull = goal; raf = 0; draw(); done(); return; }
         draw();
         raf = requestAnimationFrame(step);
       })();
@@ -835,6 +872,7 @@
       // de dy<=0 logo acima.
       if (!atTop()) { tracking = false; if (pull > 0) spring(0); return; }
       if (ev.cancelable) ev.preventDefault();   // mata o elástico nativo
+      if (!dragged) setDragging(true);          // primeira amostra: arma a camada de composição
       dragged = true;
       pull = Math.min(PTR.max, damp(dy));
       draw();

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,7 +81,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=23"></script>
+  <script src="/app-mode.js?v=24"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script defer src="/app-mode.js?v=23"></script>
+  <script defer src="/app-mode.js?v=24"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -382,7 +382,7 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=23"></script>
+  <script src="/app-mode.js?v=24"></script>
 </head>
 <body>
 

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1104,7 +1104,7 @@ a { color: inherit; text-decoration: none; }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=23"></script>
+  <script src="/app-mode.js?v=24"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## O quê

Refaz o puxar-pra-atualizar para o comportamento elástico nativo do iOS na **Início** e nas **views do dashboard**: ao puxar, o conteúdo inteiro desce, o ícone aparece no vão que abre sob o status bar, e o conteúdo **segura abaixado enquanto os dados carregam**, voltando ao normal ao concluir.

Antes, por decisão de projeto, só o indicador descia e o conteúdo ficava parado — porque um transform em `html`/`body` vira bloco de contenção e arrastaria todo `position:fixed` (dock, FAB, toasts).

## Por que agora é seguro

Inventário (grep, os dois arquivos): **todos os elementos fixos são irmãos do `.page`, não descendentes** — `.bg`, `.sidenav`, `#toast`, os ~20 `.overlay`, `#piggy-fab`/`#piggy-panel` e os toasts de sucesso ficam **fora** do `.page` (após o fechamento dele). Nenhum `position:fixed` é descendente do `.page` em `home.html` (`#page-root`, 396–525) nem em `dashboard.html` (`.page`, 112–823). Então transladar só o `.page`:
- move o conteúdo **sem** arrastar o chrome;
- **não** reabre a faixa vazia embaixo (a dock fica ancorada).

## Como funciona

- `moveContent = (page === "home" || page === "app")`; o transform mora no `.page`.
- `draw()` translada o `.page` por `pull` (amortecido, teto 150px) e ancora o ícone no vão a meia-velocidade: `(pull−40)×0.5` (revelado por trás, não colado ao topo).
- Ao soltar além do limiar, `run()` já segura em `HOLD` (66px) enquanto o `PBRefresh()` corre — só reaproveitei essa promise, que já existia (contrato do #64).
- `will-change` só enquanto o puxão está vivo (nada de camada de composição permanente na subárvore inteira do `.page`).

## Escopo

- **Dentro**: Início (home) + todas as views do dashboard (app).
- **Fora, de propósito**: Ajustes (settings) e "O que pedir" (comandos) mantêm o antigo — só o indicador desce por cima da página.
- Bump `app-mode.js` `?v=23 → v=24` nos 4 includes.

## O que foi medido (Chromium do painel, emulação mobile)

| Verificação | Resultado |
|---|---|
| Conteúdo desce amortecido (teto 150) | 60→49px, 160→102px, 330→150px |
| Ícone no vão `(pull−40)×0.5` | 4.7 / 30.9 / 55 — exato |
| **Segura em 66px** durante o refresh (busy=true) | `pageY=66` |
| Conclui → volta a 0, ícone recolhe, `will-change` limpo | `pageY=0`, busy=false |
| Não-regressão em "O que pedir" (fora do alvo) | `.page` fica `none`; só o indicador desce |

## O que **não** foi medido

- **Aparelho**: elástico nativo do WKWebView, `scrollY` travado em 0 no topo e `env(safe-area-inset-top)` real (vale 0 no headless — por isso o ícone aparece colado no topo no preview, em vez de abaixo da Dynamic Island). Só se confirma no build, no iPhone.
- **`/app` autenticado**: caiu no gate de auth do mock local. Caminho de código idêntico ao da Início (mesmo `.page`, mesmo booleano `moveContent`).
- **pytest**: mudança 100% frontend (nenhum `.py` tocado) — o pytest não exercita nada disso; o CI roda a suíte no PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)