### PR TITLE
Reduz atrito no onboarding e melhora entendimento da IA (WhatsApp)

### DIFF
--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -523,9 +523,14 @@ def process_message(message: InboundMessage) -> None:
                     user_id=uid,
                     details={"wa_id": message.wa_id},
                 )
+                # Onboarding: tutorial só pra cliente NOVO. status == "linked"
+                # significa que ele acabou de vincular NESTA primeira mensagem
+                # (quem já mandou mensagem antes cai em "already_linked" e não
+                # vê o tutorial). E só quando essa primeira mensagem é uma
+                # SAUDAÇÃO: se o cliente já abre com um comando ("saldo",
+                # "gastei 50..."), ele já sabe usar — a gente executa o comando
+                # e não interrompe com o tour.
                 if _is_greeting(message.text or ""):
-                    # Só interrompe para onboarding quando a mensagem era uma saudação.
-                    # Se o usuário mandou "saldo", "gastei..." etc., segue e executa o comando.
                     try:
                         send_welcome(reply_to, user_id=uid)
                     except Exception as e:

--- a/adapters/whatsapp/wa_tutorial.py
+++ b/adapters/whatsapp/wa_tutorial.py
@@ -40,7 +40,7 @@ _TTL = 3600  # 1 hora — tutorial expira após isso
 
 # ── IDs de botões que pertencem ao tutorial ─────────────────────────────────
 TUTORIAL_BUTTON_IDS: set[str] = {
-    "tut_start", "tut_skip",
+    "tut_start", "tut_skip", "tut_try",
     "tut_2", "tut_cc", "tut_3", "tut_4", "tut_5", "tut_6",
     "tut_done",
     "tut_back_1", "tut_back_2", "tut_back_cc",
@@ -266,9 +266,29 @@ def _step_skip(wa_id: str) -> None:
     )
 
 
+def _step_try(wa_id: str) -> None:
+    """Onboarding "aprender fazendo": convida o usuário a mandar o primeiro
+    lançamento agora. Não guarda estado — a próxima mensagem segue o fluxo
+    normal de lançamento, e o nudge pós-primeiro-lançamento (em
+    core/handlers/launches.py) fecha o loop comemorando."""
+    _STATE.pop(wa_id, None)
+    send_text(
+        to=wa_id,
+        body=(
+            "🐷 Show! Me conta seu último gasto do seu jeito — não precisa de comando.\n\n"
+            "Tenta assim:\n"
+            "• *gastei 20 no almoço*\n"
+            "• *paguei 50 de uber*\n\n"
+            "Pode mandar aqui embaixo. 👇"
+        ),
+    )
+
+
 # ── Mapa de ações ────────────────────────────────────────────────────────────
 
 _ACTION_MAP: dict[str, object] = {
+    # onboarding "aprender fazendo"
+    "tut_try":     _step_try,
     # avanço
     "tut_start":   _step_1,
     "tut_2":       _step_2,
@@ -309,31 +329,21 @@ def send_welcome(wa_id: str, user_id: int | None = None) -> None:
         except Exception as exc:
             logger.debug("send_welcome name lookup failed: %s", exc)
 
-    header = f"🎉 Bem-vindo, {first_name}!" if first_name else "🎉 Bem-vindo ao PigBank!"
-    intro = (
-        "Sou o Piggy, seu assistente financeiro pessoal no WhatsApp.\n\n"
-        if first_name
-        else "Sou seu assistente financeiro pessoal no WhatsApp.\n\n"
-    )
+    header = f"🐷 Bem-vindo, {first_name}!" if first_name else "🐷 Bem-vindo ao PigBank!"
 
     send_interactive_buttons(
         to=wa_id,
         header=header,
         body=(
-            f"{intro}"
-            "Com apenas uma mensagem de texto, você consegue:\n\n"
-            "💰 Registrar gastos e receitas\n"
-            "📊 Consultar seu saldo em tempo real\n"
-            "💳 Gerenciar cartões, crédito e parcelas\n"
-            "📦 Criar caixinhas de poupança\n"
-            "📈 Acompanhar investimentos com rendimento\n"
-            "🧾 Importar extratos bancários (.OFX)\n"
-            "🖥️ Acessar seu dashboard interativo\n\n"
-            "Quer um tour rápido de 2 minutos? 👇"
+            "Sou o Piggy, seu assistente de finanças aqui no WhatsApp. 💚\n\n"
+            "A melhor forma de aprender é fazendo — em 10 segundos você registra "
+            "seu primeiro gasto e vê como é simples.\n\n"
+            "Bora? 👇"
         ),
         footer="PigBank — seu dinheiro, sob controle",
         buttons=[
-            {"id": "tut_start", "title": "🚀 Começar tour!"},
+            {"id": "tut_try",   "title": "🚀 Meu 1º gasto"},
+            {"id": "tut_start", "title": "📋 Tour completo"},
             {"id": "tut_skip",  "title": "⚡ Usar direto"},
         ],
     )

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -527,6 +527,35 @@ def add_from_entities(
             f"todo mês)? Responda *sim* ou *não*."
         )
 
+    # Nudge de onboarding: no primeiríssimo lançamento do usuário no WhatsApp,
+    # aponta o próximo passo (aprender fazendo). Dispara UMA vez — a trava é o
+    # evento em system_event_logs; user_seq == 1 é só o pré-filtro barato pra não
+    # consultar o banco a cada lançamento (e o evento ainda cobre o caso de o
+    # user_seq voltar a 1 depois de um "apagar tudo"). Só pra lançamento real
+    # (não movimentação interna) e quando não há oferta de recorrente competindo
+    # pela atenção.
+    if platform == "whatsapp" and not is_int and not recurring_offer and user_seq == 1:
+        try:
+            from core.observability import recent_event_exists, log_system_event_sync
+            if not recent_event_exists("onboarding_first_launch_nudge", user_id, within_days=36500):
+                resposta += (
+                    "\n\n🎉 Esse foi seu primeiro lançamento — viu como é rápido?\n"
+                    "Agora tenta **saldo**. Quando quiser, tem caixinhas, cartões e "
+                    "dashboard: é só mandar **ajuda**."
+                )
+                log_system_event_sync(
+                    "info",
+                    "onboarding_first_launch_nudge",
+                    "Nudge de primeiro lançamento enviado no WhatsApp.",
+                    source="launches",
+                    user_id=user_id,
+                )
+        except Exception:
+            logger.warning(
+                "nudge de primeiro lançamento falhou (user %s) — seguindo sem ele",
+                user_id, exc_info=True,
+            )
+
     return resposta
 
 

--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -59,8 +59,18 @@ _EXACT: dict[str, str] = {
     "saldo da conta":           "balance.check",
     "conta":                    "balance.check",
     "saldo geral":              "balance.check",
+    "saldo atual":              "balance.check",
+    "meu saldo":                "balance.check",
+    "qual o saldo":             "balance.check",
+    "qual meu saldo":           "balance.check",
     "quanto tenho":             "balance.check",
     "quanto tem":               "balance.check",
+    "quanto eu tenho":          "balance.check",
+    "quanto de saldo":          "balance.check",
+    "quanto sobrou":            "balance.check",
+    "quanto me resta":          "balance.check",
+    "quanto resta":             "balance.check",
+    "ta quanto":                "balance.check",
     # lançamentos / gastos / despesas
     "meus lancamentos":         "launches.list",
     "meu historico":            "launches.list",
@@ -214,13 +224,38 @@ _EXACT: dict[str, str] = {
     "ajuda":                    "help",
     "help":                     "help",
     "tutorial":                 "help.tutorial",
-    # confirmações
+    # confirmações — sinais fortes de sim/não. Como o _EXACT é global (casa
+    # mesmo sem ação pendente), evitamos aqui acks ambíguos ("ok", "beleza",
+    # "certo") que a pessoa manda solto sem estar confirmando nada; esses ficam
+    # só no confirmations.py da IA, que só é consultado quando há pending.
     "sim":                      "confirm.yes",
     "s":                        "confirm.yes",
     "confirmar":                "confirm.yes",
+    "confirmo":                 "confirm.yes",
+    "confirmado":               "confirm.yes",
+    "isso":                     "confirm.yes",
+    "isso mesmo":               "confirm.yes",
+    "isso ai":                  "confirm.yes",
+    "e isso":                   "confirm.yes",
+    "aham":                     "confirm.yes",
+    "uhum":                     "confirm.yes",
+    "exato":                    "confirm.yes",
+    "exatamente":               "confirm.yes",
+    "com certeza":              "confirm.yes",
+    "pode sim":                 "confirm.yes",
+    "pode mandar":              "confirm.yes",
+    "manda bala":               "confirm.yes",
+    "positivo":                 "confirm.yes",
     "nao":                      "confirm.no",
     "nope":                     "confirm.no",
     "cancelar":                 "confirm.no",
+    "cancela":                  "confirm.no",
+    "negativo":                 "confirm.no",
+    "melhor nao":               "confirm.no",
+    "agora nao":                "confirm.no",
+    "deixa pra la":             "confirm.no",
+    "deixa quieto":             "confirm.no",
+    "nao quero":                "confirm.no",
     # desfazer
     "desfazer":                 "launches.undo",
 }
@@ -308,11 +343,11 @@ _ALIAS_PATTERNS: list[tuple[str, str]] = [
      "credit.handle"),
 
     # despesa / receita — detecta padrão sem chamar IA
-    (r"^(gastei|paguei|comprei|debitei|gasto|mandei|enviei|pixei)\b",
+    (r"^(gastei|paguei|comprei|debitei|gasto|mandei|enviei|pixei|torrei|queimei|gastando)\b",
      "launches.add"),
-    (r"^(recebi|ganhei|entrou|caiu)\b",
+    (r"^(recebi|ganhei|entrou|caiu|pingou|pinguei|embolsei)\b",
      "launches.add"),
-    (r"^(hoje|ontem|\d{1,2}[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?|dia\s+\d{1,2}(?:[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?)?)\b.*\b(gastei|paguei|comprei|debitei|gasto|mandei|enviei|pixei|recebi|ganhei|entrou|caiu)\b",
+    (r"^(hoje|ontem|\d{1,2}[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?|dia\s+\d{1,2}(?:[\/\-]\d{1,2}(?:[\/\-]\d{2,4})?)?)\b.*\b(gastei|paguei|comprei|debitei|gasto|mandei|enviei|pixei|torrei|queimei|recebi|ganhei|entrou|caiu|pingou|pinguei|embolsei)\b",
      "launches.add"),
 
     # cartões / crédito

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -72,7 +72,14 @@ OUT_OF_SCOPE_MSG = (
     "Digite *ajuda* para ver o que posso fazer."
 )
 
-NOT_UNDERSTOOD_MSG = "Não entendi. Pode reformular?\nDigite *ajuda* para ver exemplos."
+NOT_UNDERSTOOD_MSG = (
+    "Não entendi bem o que você quis fazer. 🤔\n"
+    "Tenta assim:\n"
+    "• *gastei 50 no mercado* — registrar um gasto\n"
+    "• *saldo* — ver quanto você tem\n"
+    "• *recebi 1000 de salário* — registrar uma receita\n\n"
+    "Ou digite *ajuda* pra ver tudo que eu faço."
+)
 
 
 def _contextual_help_message(text: str, platform: str) -> str:

--- a/core/services/ai_chat/confirmations.py
+++ b/core/services/ai_chat/confirmations.py
@@ -2,30 +2,64 @@
 core/services/ai_chat/confirmations.py — detecção de confirma/cancela.
 
 Quando há uma `ai_pending_actions` no DB, a próxima mensagem do user é testada
-contra estas listas antes de bater na OpenAI. Match exato (lowercase, strip),
-sem normalização de acentos — match parcial geraria falsos positivos no chat
-normal (o user pode dizer "não vou querer isso aqui" sem cancelar).
+contra estas listas antes de bater na OpenAI. Match por CONJUNTO (igualdade,
+não substring) sobre o texto normalizado.
+
+A normalização remove acentos e pontuação/emoji das bordas ("Sim!" → "sim",
+"não 👍" → "nao"), o que amplia bastante a cobertura sem abrir mão da segurança:
+seguimos exigindo igualdade exata com um item do conjunto, nunca `in`/substring —
+match parcial geraria falsos positivos no chat normal (o user pode dizer "não vou
+querer isso aqui" sem estar cancelando nada).
 """
 from __future__ import annotations
 
+import unicodedata
 
+
+# Conjuntos SEM acento — o texto é normalizado (sem acento) antes da comparação.
 _CONFIRM_EXACT: frozenset[str] = frozenset({
+    # núcleo
     "sim", "s", "yes", "y", "ok", "okay", "confirma", "confirmar", "confirmo",
-    "manda", "manda bala", "vai", "pode", "pode mandar", "blz", "beleza",
-    "ta", "tá", "ta bom", "tá bom", "feito", "claro",
+    "confirmado",
+    # imperativos de "manda ver"
+    "manda", "manda bala", "manda ver", "vai", "bora",
+    # "pode"
+    "pode", "pode sim", "pode mandar", "pode ir",
+    # aprovação informal
+    "blz", "beleza", "ta", "ta bom", "ta certo", "feito", "claro",
+    "perfeito", "fechado", "combinado",
+    # concordância
+    "isso", "isso mesmo", "isso ai", "isso ai mesmo", "e isso", "eh isso",
+    "aham", "uhum", "certo", "exato", "exatamente", "com certeza", "positivo",
 })
 
 
 _CANCEL_EXACT: frozenset[str] = frozenset({
-    "não", "nao", "n", "no", "cancela", "cancelar", "cancelo",
-    "deixa", "deixa pra lá", "deixa pra la", "não quero", "nao quero",
-    "esquece", "para", "pára",
+    # núcleo
+    "nao", "n", "no", "cancela", "cancelar", "cancelo", "cancelado",
+    "negativo",
+    # "deixa"
+    "deixa", "deixa pra la", "deixa quieto", "deixa isso",
+    # recusa
+    "nao quero", "nao quero nao", "esquece", "esquece isso", "para",
+    "para nao", "agora nao", "melhor nao", "nem", "nem vem",
 })
 
 
+def _normalize(text: str) -> str:
+    """lowercase + tira acento + colapsa qualquer não-alfanumérico (emoji,
+    pontuação, etc.) em espaço. Preserva palavras internas: "pode mandar!" →
+    "pode mandar"."""
+    t = (text or "").strip().lower()
+    t = unicodedata.normalize("NFKD", t)
+    t = "".join(c for c in t if not unicodedata.combining(c))
+    t = "".join(c if (c.isalnum() or c.isspace()) else " " for c in t)
+    return " ".join(t.split())
+
+
 def is_confirm(text: str) -> bool:
-    return (text or "").strip().lower() in _CONFIRM_EXACT
+    return _normalize(text) in _CONFIRM_EXACT
 
 
 def is_cancel(text: str) -> bool:
-    return (text or "").strip().lower() in _CANCEL_EXACT
+    return _normalize(text) in _CANCEL_EXACT


### PR DESCRIPTION
## Objetivo

Reduzir o atrito no onboarding do WhatsApp e fazer a IA entender mais rápido o que o usuário quer — foco especial no usuário **Free**, que hoje depende só do classificador determinístico (regex), sem a IA conversacional (que segue paga, sem mudança de custo).

## Mudanças

**Onboarding "aprender fazendo"** (`adapters/whatsapp/wa_tutorial.py`, `wa_runtime.py`, `core/handlers/launches.py`)
- Card de boas-vindas enxuto com botão **🚀 Meu 1º gasto** (aprender fazendo) em vez da lista de 7 features. Tour completo preservado atrás de **📋 Tour completo**.
- Disparo do tutorial **só para cliente novo** (`status == "linked"` = primeira mensagem que acabou de vincular) **e só em saudação**. Quem já abre com um comando executa direto; quem já mandou mensagem antes (`already_linked`) não vê o tutorial.
- Nudge pós-primeiro-lançamento (uma vez, travado via `system_event_logs`).

**Confirmação fuzzy** (`core/services/ai_chat/confirmations.py`)
- Normaliza acento/pontuação/emoji e amplia os conjuntos de sim/não ("isso", "aham", "pode mandar", "melhor não"…), mantendo **match por conjunto** (sem substring) para não gerar falso positivo.

**Vocabulário + mensagem "não entendi"** (`core/intent_classifier.py`, `core/intent_router.py`)
- Mais sinônimos de saldo ("meu saldo", "quanto sobrou", "ta quanto"…) e verbos de gasto/receita ("torrei", "queimei", "pingou"…).
- Mensagem "não entendi" com exemplos concretos em vez de "Pode reformular?".

## Validação

- `py_compile` em todos os arquivos.
- Sanity checks diretos + testes unitários mockados (confirmação, vocabulário, nudge, wiring dos botões).
- `tests_nfr/test_nfr_02_precisao_ia.py`: 6 passed, sem regressão.
- Testes de integração em `tests/` exigem `DATABASE_URL` (produção) e **não** foram rodados localmente — recomendo validar em staging antes do merge.

## Fora de escopo (decisões registradas)

- Gate `is_pro` da IA conversacional **não** foi tocado (IA segue paga).
- Não inclui robustezes opcionais do deep link (entrada determinística / fallback de código para WhatsApp ≠ telefone do cadastro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
