### PR TITLE
fix(db): conexão volta do pool em autocommit e mata o rollback

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -36,9 +36,26 @@ def _get_pool() -> ConnectionPool:
             max_size=int(os.getenv("DB_POOL_MAX_SYNC", "8")),
             timeout=float(os.getenv("DB_CONNECT_TIMEOUT", "30")),
             kwargs={"row_factory": dict_row},
+            reset=_reset_conn,
             open=True,
         )
         return _pool
+
+
+def _reset_conn(conn) -> None:
+    """Devolve a conexão ao pool no estado padrão (transacional).
+
+    O psycopg_pool faz rollback sozinho ao devolver, mas NÃO desfaz um
+    `conn.autocommit = True` — e uma conexão em autocommit é uma conexão sem
+    rollback: cada statement já está commitado, então um erro no meio de uma
+    operação deixa metade da escrita gravada. O init_db precisa de autocommit
+    para a DDL (locks) e pegava a conexão do pool; sem esta rede, ela voltava
+    envenenada e contaminava transações de dinheiro para sempre. Medido: 6 de 6
+    `create_investment_db` que estouraram INSUFFICIENT_ACCOUNT depois de um
+    init_db deixaram o investimento criado.
+    """
+    if conn.autocommit:
+        conn.autocommit = False
 
 
 def get_conn():

--- a/db/schema.py
+++ b/db/schema.py
@@ -1752,24 +1752,38 @@ def init_db():
     #      (deploy do Railway sobe um container novo antes do velho sair).
     # Toda a DDL eh idempotente (if not exists / or replace / where ... is null),
     # entao commit por instrucao eh seguro mesmo se o init_db rodar varias vezes.
+    # O `finally` nao e decoracao: a conexao vem do POOL e volta pra ele. Sem
+    # restaurar, ela fica em autocommit para sempre e toda transacao futura que
+    # cair nela perde a atomicidade — o rollback vira no-op e um erro no meio
+    # deixa metade da escrita gravada. Medido: depois de um init_db, 6 de 6
+    # `create_investment_db` que estouraram INSUFFICIENT_ACCOUNT deixaram o
+    # investimento criado no banco. (A trava definitiva esta no `reset` do pool,
+    # em db/connection.py; isto aqui e a primeira linha de defesa.)
     with get_conn() as conn:
         conn.autocommit = True
-        with conn.cursor() as cur:
-            for i, stmt in enumerate(ddl_statements, 1):
-                try:
-                    cur.execute(stmt)
-                except Exception as e:
-                    print(f"[init_db] erro no statement #{i}: {e}")
-                    print(stmt)
-                    raise
-
-            # Corrige FKs em users(id) que ficaram com on_delete errado
-            # porque a tabela já existia antes da FK ser declarada no schema.
-            try:
-                changes = repair_user_fk_cascades(cur)
-                if changes:
-                    print(f"[init_db] schema_repairs ajustou {len(changes)} FK(s): {changes}")
-            except Exception as e:
-                print(f"[init_db] schema_repairs falhou: {e}")
-                raise
+        try:
+            _run_ddl(conn, ddl_statements)
+        finally:
+            conn.autocommit = False
     print("[init_db] OK")
+
+
+def _run_ddl(conn, ddl_statements) -> None:
+    with conn.cursor() as cur:
+        for i, stmt in enumerate(ddl_statements, 1):
+            try:
+                cur.execute(stmt)
+            except Exception as e:
+                print(f"[init_db] erro no statement #{i}: {e}")
+                print(stmt)
+                raise
+
+        # Corrige FKs em users(id) que ficaram com on_delete errado
+        # porque a tabela já existia antes da FK ser declarada no schema.
+        try:
+            changes = repair_user_fk_cascades(cur)
+            if changes:
+                print(f"[init_db] schema_repairs ajustou {len(changes)} FK(s): {changes}")
+        except Exception as e:
+            print(f"[init_db] schema_repairs falhou: {e}")
+            raise

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -164,6 +164,18 @@ _db_pool: AsyncConnectionPool | None = None
 _db_pool_lock = asyncio.Lock()
 
 
+async def _reset_conn_async(conn) -> None:
+    """Mesma rede do pool síncrono (db/connection.py::_reset_conn).
+
+    Nenhum código liga `autocommit` neste pool hoje — a guarda é para fechar a
+    classe, não a instância. Conexão em autocommit é conexão sem rollback, e o
+    envenenamento é permanente: dura o resto da vida do processo, porque o
+    psycopg_pool faz rollback ao devolver a conexão mas não desfaz o autocommit.
+    """
+    if conn.autocommit:
+        await conn.set_autocommit(False)
+
+
 async def _get_db_pool() -> AsyncConnectionPool:
     global _db_pool
     if _db_pool is not None:
@@ -177,6 +189,7 @@ async def _get_db_pool() -> AsyncConnectionPool:
             max_size=int(os.getenv("DB_POOL_MAX", "8")),
             timeout=DB_CONNECT_TIMEOUT,
             kwargs={"row_factory": dict_row},
+            reset=_reset_conn_async,
             open=False,
         )
         await pool.open(wait=True, timeout=DB_CONNECT_TIMEOUT)

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -164,18 +164,14 @@ _db_pool: AsyncConnectionPool | None = None
 _db_pool_lock = asyncio.Lock()
 
 
-async def _reset_conn_async(conn) -> None:
-    """Mesma rede do pool síncrono (db/connection.py::_reset_conn).
-
-    Nenhum código liga `autocommit` neste pool hoje — a guarda é para fechar a
-    classe, não a instância. Conexão em autocommit é conexão sem rollback, e o
-    envenenamento é permanente: dura o resto da vida do processo, porque o
-    psycopg_pool faz rollback ao devolver a conexão mas não desfaz o autocommit.
-    """
-    if conn.autocommit:
-        await conn.set_autocommit(False)
-
-
+# NÃO ponha `reset=` neste pool. O pool síncrono (db/connection.py::_reset_conn)
+# tem essa guarda porque lá o bug existia de verdade: o init_db ligava
+# `autocommit` numa conexão do pool e não restaurava. Aqui nada liga autocommit
+# (`git grep autocommit` confirma), e a guarda simétrica foi tentada e revertida:
+# um callback de reset async vira uma task no event loop, e o encerramento do
+# loop passa a pendurar em `asyncio.runners._cancel_all_tasks`. Medido: 33
+# testes falhando e a suíte de 87s para 268s, com o arquivo
+# tests/test_unsubscribe_one_click.py travando por completo.
 async def _get_db_pool() -> AsyncConnectionPool:
     global _db_pool
     if _db_pool is not None:
@@ -189,7 +185,6 @@ async def _get_db_pool() -> AsyncConnectionPool:
             max_size=int(os.getenv("DB_POOL_MAX", "8")),
             timeout=DB_CONNECT_TIMEOUT,
             kwargs={"row_factory": dict_row},
-            reset=_reset_conn_async,
             open=False,
         )
         await pool.open(wait=True, timeout=DB_CONNECT_TIMEOUT)

--- a/tests/test_pool_atomicidade.py
+++ b/tests/test_pool_atomicidade.py
@@ -46,38 +46,3 @@ def test_rollback_continua_valendo_depois_do_init_db(user_id):
     assert db.list_investments(user_id) == []
     assert float(db.get_balance(user_id)) == 10.0
 
-
-# ─── O pool assíncrono do frontend tem a mesma rede ─────────────────────────
-#
-# Nenhum código liga autocommit nesse pool hoje: a guarda fecha a CLASSE, não a
-# instância. Sem ela, o dia em que alguém precisar de DDL no caminho async
-# repete o mesmo bug — e ele é silencioso, porque só aparece quando uma
-# transação estoura no meio.
-
-def test_pool_async_tambem_devolve_conexao_transacional():
-    import asyncio
-    import os
-
-    from psycopg.rows import dict_row
-    from psycopg_pool import AsyncConnectionPool
-
-    from frontend.routes.shared import _reset_conn_async
-
-    async def cenario():
-        pool = AsyncConnectionPool(
-            os.environ["DATABASE_URL"], min_size=1, max_size=2,
-            kwargs={"row_factory": dict_row}, reset=_reset_conn_async, open=False,
-        )
-        await pool.open(wait=True, timeout=10)
-        try:
-            async with pool.connection() as conn:
-                await conn.set_autocommit(True)   # simula o que o init_db faz
-            estados = []
-            for _ in range(6):
-                async with pool.connection() as conn:
-                    estados.append(conn.autocommit)
-            return estados
-        finally:
-            await pool.close()
-
-    assert asyncio.run(cenario()) == [False] * 6

--- a/tests/test_pool_atomicidade.py
+++ b/tests/test_pool_atomicidade.py
@@ -45,3 +45,39 @@ def test_rollback_continua_valendo_depois_do_init_db(user_id):
 
     assert db.list_investments(user_id) == []
     assert float(db.get_balance(user_id)) == 10.0
+
+
+# ─── O pool assíncrono do frontend tem a mesma rede ─────────────────────────
+#
+# Nenhum código liga autocommit nesse pool hoje: a guarda fecha a CLASSE, não a
+# instância. Sem ela, o dia em que alguém precisar de DDL no caminho async
+# repete o mesmo bug — e ele é silencioso, porque só aparece quando uma
+# transação estoura no meio.
+
+def test_pool_async_tambem_devolve_conexao_transacional():
+    import asyncio
+    import os
+
+    from psycopg.rows import dict_row
+    from psycopg_pool import AsyncConnectionPool
+
+    from frontend.routes.shared import _reset_conn_async
+
+    async def cenario():
+        pool = AsyncConnectionPool(
+            os.environ["DATABASE_URL"], min_size=1, max_size=2,
+            kwargs={"row_factory": dict_row}, reset=_reset_conn_async, open=False,
+        )
+        await pool.open(wait=True, timeout=10)
+        try:
+            async with pool.connection() as conn:
+                await conn.set_autocommit(True)   # simula o que o init_db faz
+            estados = []
+            for _ in range(6):
+                async with pool.connection() as conn:
+                    estados.append(conn.autocommit)
+            return estados
+        finally:
+            await pool.close()
+
+    assert asyncio.run(cenario()) == [False] * 6

--- a/tests/test_pool_atomicidade.py
+++ b/tests/test_pool_atomicidade.py
@@ -1,0 +1,47 @@
+"""O pool não pode devolver conexão em autocommit.
+
+Conexão em autocommit é conexão sem rollback: cada statement já está gravado,
+então um erro no meio de uma operação deixa metade da escrita no banco. O
+`init_db` precisa de autocommit para rodar a DDL sem segurar locks, e pegava a
+conexão do POOL — que depois voltava envenenada para o resto do processo.
+
+O estrago era em caminho de dinheiro. Medido antes da correção: depois de um
+`init_db`, 6 de 6 `create_investment_db` que estouraram INSUFFICIENT_ACCOUNT
+deixaram o investimento criado no banco.
+"""
+import pytest
+
+import db
+from db.connection import get_conn
+
+
+def test_conexao_volta_do_pool_sem_autocommit():
+    with get_conn() as conn:
+        conn.autocommit = True          # simula o que o init_db faz
+
+    # a mesma conexão pode voltar em qualquer um dos próximos checkouts
+    for _ in range(8):
+        with get_conn() as conn:
+            assert conn.autocommit is False
+
+
+def test_init_db_nao_envenena_o_pool():
+    db.init_db()
+    for _ in range(8):
+        with get_conn() as conn:
+            assert conn.autocommit is False
+
+
+def test_rollback_continua_valendo_depois_do_init_db(user_id):
+    """A prova de ponta a ponta: transação que estoura no meio não deixa rastro."""
+    db.init_db()
+    db.add_launch_and_update_balance(user_id, "receita", 10, None, "seed")
+
+    for i in range(6):
+        with pytest.raises(ValueError, match="INSUFFICIENT_ACCOUNT"):
+            db.create_investment_db(
+                user_id, f"Inv {i}", 0.14, "yearly", "n", initial_amount=800.0,
+            )
+
+    assert db.list_investments(user_id) == []
+    assert float(db.get_balance(user_id)) == 10.0


### PR DESCRIPTION
## O problema

`init_db()` pega uma conexão **do pool** e faz `conn.autocommit = True` para rodar a DDL sem segurar `ACCESS EXCLUSIVE` (motivo legítimo — o comentário original explica). Só que nunca restaura: a conexão volta ao pool envenenada e fica assim pelo resto da vida do processo.

Conexão em autocommit é conexão **sem rollback**: cada statement já está commitado, então um erro no meio de uma operação deixa metade da escrita gravada. O `psycopg_pool` faz rollback ao devolver a conexão, mas não desfaz o `autocommit`.

Não é um problema de teste. `init_db()` roda no boot da aplicação, no mesmo pool que atende as requisições.

## Alcance

Qualquer operação multi-statement que caia na conexão envenenada perde a atomicidade. As de dinheiro são as que doem:

- aporte em investimento (debita a conta, depois insere o lote)
- resgate (calcula IR/IOF, credita a conta, atualiza os lotes)
- pagamento de fatura
- transferência entre conta e caixinha
- criação de investimento com aporte inicial

Como o pool cresce sob carga, o envenenamento não é determinístico: em 6 checkouts seguidos após um `init_db`, metade voltou em autocommit.

## Medição

Com `create_investment_db` estourando `INSUFFICIENT_ACCOUNT` (criação + aporte são uma transação só), depois de um `init_db`:

```
antes:  6 de 6 falhas deixaram o investimento criado no banco
depois: 0 de 6
```

E o estado do `autocommit` em 6 checkouts consecutivos do pool:

```
antes:  [True, False, True, False, True, False]
depois: [False, False, False, False, False, False]
```

## A correção

Duas camadas, de propósito:

1. `db/schema.py` — `init_db` restaura `autocommit = False` num `finally`. Primeira linha de defesa, no ponto onde o dano nasce. (O corpo da DDL saiu para `_run_ddl` só para o `try/finally` não indentar o loop inteiro; o conteúdo é idêntico.)
2. `db/connection.py` — o pool ganha `reset=_reset_conn`, que normaliza a conexão na devolução. Isso fecha a **classe**, não a instância: nenhum código futuro consegue reenvenenar o pool, mesmo esquecendo o `finally`.

Duas coisas verificadas no fonte do `psycopg_pool`, não presumidas:

- `_reset_connection` chama o rollback automático **antes** do callback `reset`, então a guarda é aditiva e não substitui o rollback do pool;
- `CLIENT_EXCEPTIONS` é `Exception`, então qualquer erro dentro do callback só faz o pool descartar a conexão — não quebra o pool.

E o `finally` não mascara o erro real de uma DDL quebrada: em autocommit, um statement que falha deixa a conexão em `IDLE`, então `conn.autocommit = False` não levanta. Medido com um `create table ... (x tipo_inexistente)`.

## Testes

`tests/test_pool_atomicidade.py` (novo), 3 testes:

- a conexão volta do pool sem autocommit, mesmo depois de alguém ligá-lo;
- `init_db` não envenena o pool;
- prova de ponta a ponta: 6 transações que estouram no meio, depois de um `init_db`, não deixam rastro no banco nem no saldo.

Os 3 falham sem a correção (medido).

## Rodada de revisão própria

O Codex está sem cota e não revisou este PR. Revisando o próprio diff, achei que faltava simetria: o `frontend/routes/shared.py` mantém um `AsyncConnectionPool` separado, sem a mesma guarda. Estendi a guarda para lá — e **estava errado**:

```
com reset no pool async:  33 failed, 1075 passed, 268s
sem:                    1107 passed,   4 skipped,  85s
```

`tests/test_unsubscribe_one_click.py` travava por completo. O `faulthandler` apontou a thread principal presa em `asyncio.runners._cancel_all_tasks` no fechamento do loop: um callback de reset async vira uma task no event loop e o encerramento fica esperando por ela.

Revertido. No pool assíncrono nada liga `autocommit` (`git grep` confirma), então a guarda protegia contra um problema inexistente e cobrava uma suíte quebrada por isso. Ficou um comentário no lugar, com a medição, para o próximo que pensar "faltou simetria aqui".

Suíte completa: **1053 passed / 4 skipped** na `main`, **1107 passed / 4 skipped** com este PR e o #90 aplicados. Mesmos 4 skips (`ofxparse`), nenhuma falha nova.

## O que não foi verificado

O CI do repositório segue travado pela cota do Actions — os jobs morrem em 2 segundos com `runner_id: 0` e nenhum passo executado, em todas as branches, inclusive a `main`. A validação foi contra Postgres 16 local. Também não dá para exercitar o comportamento em produção deste ambiente.