### PR TITLE
fix(open finance): o Pig não debita a Carteira quando o dinheiro está no banco

### DIFF
--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -105,6 +105,54 @@ def _norm(txt: str) -> str:
 # "nao" e não "não".
 _NEGATIVAS = {"nao", "n", "cancelar", "cancela", "deixa", "esquece", "depois"}
 
+_AFIRMATIVAS = {
+    "sim", "s", "isso", "pode", "claro", "ok", "quero",
+    "registrar", "registra", "registrar mesmo assim", "mesmo assim", "cadastrar",
+}
+
+
+def _saldos(user_id: int) -> dict:
+    """Carteira, bancos conectados e o consolidado — os três números que o app mostra.
+
+    `manual` é `accounts.balance`, a Carteira: dinheiro FORA dos bancos conectados.
+    Ao conectar o primeiro banco o usuário zera a Carteira de propósito, senão o
+    mesmo dinheiro conta duas vezes (ver dashboard.js, "Ajustar carteira"). Por isso
+    quem tem Open Finance costuma ter Carteira = 0 e saldo na tela > 0.
+    """
+    try:
+        cb = db.get_consolidated_balance(user_id)
+    except Exception:
+        logger.exception("get_consolidated_balance falhou user=%s", user_id)
+        return {"carteira": 0.0, "banco": 0.0, "total": 0.0, "tem_banco": False}
+    carteira = float(cb.get("manual") or 0)
+    banco = float(cb.get("open_finance_bank") or 0)
+    return {
+        "carteira": carteira,
+        "banco": banco,
+        "total": carteira + banco,
+        "tem_banco": int(cb.get("of_bank_count") or 0) > 0,
+    }
+
+
+def _msg_saldo_insuficiente(user_id: int, amount: float, acao: str = "aporte") -> str:
+    """"Saldo insuficiente na conta" era o que mais confundia: o usuário via
+    R$ 1.387,76 na tela e o bot dizia que não tinha saldo. Agora a resposta diz
+    QUAL saldo faltou e quanto ele é."""
+    s = _saldos(user_id)
+    if s["tem_banco"]:
+        return (
+            f"Sua **Carteira** tem {fmt_brl(s['carteira'])} — e é dela que sai o {acao}.\n\n"
+            f"Os {fmt_brl(s['total'])} que aparecem como saldo somam a Carteira com os "
+            f"bancos conectados ({fmt_brl(s['banco'])}). O dinheiro que está no banco "
+            "quem movimenta é você, pelo app dele; a Carteira é o que está fora "
+            "(espécie e contas não conectadas).\n\n"
+            "Se esse valor saiu mesmo da Carteira, ajuste-a no dashboard."
+        )
+    return (
+        f"Saldo insuficiente: você tem {fmt_brl(s['carteira'])} na conta e o {acao} "
+        f"é de {fmt_brl(amount)}."
+    )
+
 
 def _casa_investimento(alvo: str, rows: list) -> list:
     """Investimentos cujo nome bate com `alvo` — exato primeiro, depois parcial.
@@ -137,8 +185,42 @@ def _pergunta_qual(user_id: int, amount: float, rows: list, texto: str, alvo: st
     )
 
 
+def _aviso_open_finance(user_id: int, amount: float, nome_sugerido: str, texto: str) -> str:
+    """Banco conectado + investimento novo: avisa ANTES de gravar.
+
+    O sync do Open Finance já traz as posições de renda fixa do banco
+    (`open_finance_investments`, tipo FIXED_INCOME), então cadastrar na mão um
+    ativo que é do próprio banco cria uma segunda linha do mesmo dinheiro. Não é
+    regra nova: a caixinha vinda do OF já é read-only pelo mesmo motivo
+    (`db/pockets.py`, OF_POCKET_READONLY).
+
+    O aviso só aparece quando o investimento NÃO existe no PigBank. Para um ativo
+    que o usuário cadastrou de propósito, dizer "ele entra sozinho pelo Open
+    Finance" seria falso — e avisar em todo aporte só treinaria o usuário a
+    ignorar o aviso.
+    """
+    pretty = _format_inv_name(nome_sugerido) if nome_sugerido else ""
+    db.set_pending_action(
+        user_id,
+        "investment_create",
+        {"amount": float(amount), "text": texto, "etapa": "of_aviso", "nome": pretty},
+        minutes=10,
+    )
+    alvo = f"**{pretty}**" if pretty else "esse investimento"
+    return (
+        "🏦 Vi que você tem banco conectado.\n\n"
+        f"Se {alvo} é no próprio banco, não precisa registrar aqui: ele entra sozinho "
+        "pelo Open Finance, com o saldo se atualizando junto. Cadastrar na mão criaria "
+        "uma segunda linha do mesmo dinheiro.\n\n"
+        "Se for fora do banco conectado (uma corretora, por exemplo), responda "
+        "*registrar mesmo assim*."
+    )
+
+
 def _oferece_criar(user_id: int, amount: float, nome_sugerido: str, texto: str) -> str:
     """Não há investimento que sirva: oferece criar, já com o nome que o usuário disse."""
+    if _saldos(user_id)["tem_banco"]:
+        return _aviso_open_finance(user_id, amount, nome_sugerido, texto)
     pretty = _format_inv_name(nome_sugerido) if nome_sugerido else ""
     db.set_pending_action(
         user_id,
@@ -186,6 +268,7 @@ def _cria_e_aporta(user_id: int, payload: dict, spec: dict) -> str:
             tax_profile=spec.get("tax_profile"),
             initial_amount=amount,
             initial_note=f"Aporte inicial em {nome}",
+            debit_account=not _saldos(user_id)["tem_banco"],
         )
     except ValueError as e:
         code = str(e)
@@ -196,9 +279,9 @@ def _cria_e_aporta(user_id: int, payload: dict, spec: dict) -> str:
             # "criei o cadastro" aqui seria mentira.
             db.clear_pending_action(user_id)
             return (
-                f"Não criei **{_format_inv_name(nome)}**: seu saldo em conta não cobre "
-                f"{fmt_brl(amount)}.\n"
-                "Manda de novo com um valor que caiba, ou deposite antes.\n\n"
+                f"Não criei **{_format_inv_name(nome)}**.\n\n"
+                + _msg_saldo_insuficiente(user_id, amount)
+                + "\n\n"
                 + _investment_dashboard_link(user_id)
             )
         logger.warning("criar investimento: código inesperado user=%s code=%s", user_id, code)
@@ -289,9 +372,27 @@ def resolve_pending(user_id: int, text: str, pending: dict) -> str | None:
     if tipo == "investment_create":
         etapa = payload.get("etapa")
 
+        if etapa == "of_aviso":
+            # Só uma afirmativa explícita passa pelo aviso. Texto solto NÃO vira
+            # consentimento — senão o gate cai justamente quando o usuário está
+            # confuso, que é quando ele mais serve. A negativa já foi tratada
+            # acima; o pendente expira em 10 min e o roteador solta a mensagem
+            # se ela for outro comando claro.
+            if _norm(resposta) not in _AFIRMATIVAS:
+                return (
+                    "Só para eu não duplicar o seu dinheiro: responda "
+                    "*registrar mesmo assim* se esse investimento é fora do banco "
+                    "conectado, ou *não* para deixar o Open Finance cuidar disso."
+                )
+            if payload.get("nome"):
+                return _pergunta_taxa(user_id, payload)
+            payload["etapa"] = "nome"
+            db.set_pending_action(user_id, "investment_create", payload, minutes=10)
+            return "Beleza. Qual nome você quer dar? (ex: *CDB XP*)"
+
         if etapa == "nome":
             # "sim" confirma o nome sugerido; qualquer outra coisa vira o nome
-            if _norm(resposta) in {"sim", "s", "isso", "pode", "claro", "ok"}:
+            if _norm(resposta) in _AFIRMATIVAS:
                 if not payload.get("nome"):
                     return "Qual nome você quer dar? (ex: *CDB Nubank*)"
             else:
@@ -354,9 +455,13 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     # Códigos vêm de db/investments.py como str(exc) — trate por TIPO e código
     # exato. Casar substring é frágil: "not found" nunca casou com
     # "INV_NOT_FOUND" (espaço × underscore) e o código cru vazava pro WhatsApp.
+    # Com banco conectado o dinheiro está no banco, não na Carteira (que fica
+    # zerada de propósito) — debitar dali inventaria uma saída. Ver
+    # investment_deposit_from_account.
     try:
         launch_id, _new_acc, _new_inv, canon = db.investment_deposit_from_account(
-            user_id, investment_name, float(amount), text
+            user_id, investment_name, float(amount), text,
+            debit_account=not _saldos(user_id)["tem_banco"],
         )
     except LookupError:
         # Corrida rara: sumiu entre a checagem acima e o aporte.
@@ -364,7 +469,7 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     except ValueError as e:
         code = str(e)
         if code == "INSUFFICIENT_ACCOUNT":
-            return "Saldo insuficiente na conta para esse aporte.\n\n" + _investment_dashboard_link(user_id)
+            return _msg_saldo_insuficiente(user_id, float(amount)) + "\n\n" + _investment_dashboard_link(user_id)
         if code == "AMOUNT_INVALID":
             return "Valor inválido para aporte. Tente: *aportar 500 no CDB Nubank*."
         logger.warning("deposit: código inesperado user=%s inv=%s code=%s", user_id, investment_name, code)
@@ -436,6 +541,7 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
             investment_name,
             None if want_all else float(amount),
             text,
+            credit_account=not _saldos(user_id)["tem_banco"],
             withdraw_all=want_all,
         )
     except LookupError:

--- a/core/handlers/pockets.py
+++ b/core/handlers/pockets.py
@@ -72,9 +72,14 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     if not amount or float(amount) <= 0:
         return "Qual o valor? Tente: *coloquei 200 na caixinha viagem*"
 
+    # Com banco conectado o dinheiro está no banco, não na Carteira — mesma regra
+    # do aporte em investimento (core/handlers/investments.py::_saldos).
+    from core.handlers.investments import _saldos, _msg_saldo_insuficiente
+
     try:
         launch_id, new_acc, new_pocket, canon = db.pocket_deposit_from_account(
-            user_id, pocket_name, float(amount), text
+            user_id, pocket_name, float(amount), text,
+            debit_account=not _saldos(user_id)["tem_banco"],
         )
         return (
             f"✅ Depósito na caixinha **{canon}**: +{fmt_brl(float(amount))}\n"
@@ -87,7 +92,7 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
         if "OF_POCKET_READONLY" in str(e):
             return "Essa caixinha é sincronizada com seu banco — mova o dinheiro pelo app do banco."
         if "INSUFFICIENT_ACCOUNT" in str(e):
-            return "Saldo insuficiente na conta para esse depósito."
+            return _msg_saldo_insuficiente(user_id, float(amount), acao="depósito")
         return "Valor inválido."
     except Exception as e:
         return f"Erro ao depositar: {e}"
@@ -148,6 +153,8 @@ def _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, l
 
 
 def withdraw(user_id: int, text: str, entities: dict) -> str:
+    from core.handlers.investments import _saldos
+
     pocket_name = entities.get("pocket_name")
     amount      = entities.get("amount")
     want_all    = bool(_WITHDRAW_ALL_RX.search(text or ""))
@@ -169,7 +176,8 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
     if want_all:
         try:
             launch_id, new_acc, new_pocket, canon, taxes = db.pocket_withdraw_to_account(
-                user_id, pocket_name, None, text, withdraw_all=True
+                user_id, pocket_name, None, text, withdraw_all=True,
+                credit_account=not _saldos(user_id)["tem_banco"],
             )
         except LookupError:
             return f"Caixinha **{pocket_name}** não encontrada. Use *listar caixinhas* para ver as disponíveis."
@@ -189,7 +197,8 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
 
     try:
         launch_id, new_acc, new_pocket, canon, taxes = db.pocket_withdraw_to_account(
-            user_id, pocket_name, float(amount), text
+            user_id, pocket_name, float(amount), text,
+            credit_account=not _saldos(user_id)["tem_banco"],
         )
     except LookupError:
         return f"Caixinha **{pocket_name}** não encontrada. Use *listar caixinhas* para ver as disponíveis."

--- a/core/services/ai_chat/tools/investments.py
+++ b/core/services/ai_chat/tools/investments.py
@@ -24,6 +24,8 @@ from typing import Any
 import db
 from utils_text import fmt_rate
 
+from core.handlers.investments import _msg_saldo_insuficiente, _saldos
+
 from ._base import Tool
 
 
@@ -174,13 +176,16 @@ def _create_investment_execute(user_id: int, args: dict[str, Any]) -> str:
             "Criado pelo chat do Pig",
             initial_amount=initial_amount or None,
             initial_note=f"Aporte inicial em {name}" if initial_amount else None,
+            # Com banco conectado o dinheiro está no banco, não na Carteira —
+            # mesma regra do handler (core/handlers/investments.py::_saldos).
+            debit_account=not _saldos(user_id)["tem_banco"],
         )
     except ValueError as e:
         if str(e) == "INSUFFICIENT_ACCOUNT":
             # criação + aporte são uma transação só: sem saldo, nada foi gravado
             return (
-                f'🐷 Não criei "{name}": o saldo da conta não cobre '
-                f"R$ {initial_amount:.2f} de aporte. Manda um valor menor."
+                f'🐷 Não criei "{name}". '
+                + _msg_saldo_insuficiente(user_id, initial_amount)
             )
         return f"🐷 Não consegui criar: {e}"
     except Exception as e:
@@ -224,7 +229,10 @@ def _investment_deposit_execute(user_id: int, args: dict[str, Any]) -> str:
     if not name or amount <= 0:
         return "🐷 Faltou o nome do investimento ou o valor."
     try:
-        db.investment_deposit_from_account(user_id, name, amount)
+        db.investment_deposit_from_account(
+            user_id, name, amount,
+            debit_account=not _saldos(user_id)["tem_banco"],
+        )
         return f'✅ Aporte de R$ {amount:.2f} no "{name}" registrado.'
     except LookupError:
         # INV_NOT_FOUND. Mandar pro dashboard aqui era um beco: o user está no
@@ -252,7 +260,7 @@ def _investment_deposit_execute(user_id: int, args: dict[str, Any]) -> str:
         )
     except ValueError as e:
         if "INSUFFICIENT_ACCOUNT" in str(e):
-            return "🐷 Saldo insuficiente na conta pra esse aporte."
+            return "🐷 " + _msg_saldo_insuficiente(user_id, amount)
         return "🐷 Valor inválido pra aporte."
     except Exception as e:
         from core.services.plan_limits import PlanLimitExceeded
@@ -287,6 +295,7 @@ def _investment_withdraw_execute(user_id: int, args: dict[str, Any]) -> str:
     try:
         _lid, _acc, _inv, canon, taxes = db.investment_withdraw_to_account(
             user_id, name, None if withdraw_all else amount, withdraw_all=withdraw_all,
+            credit_account=not _saldos(user_id)["tem_banco"],
         )
         gross = float(taxes.get("gross", 0)) if taxes else 0.0
         tax = (float(taxes.get("ir", 0)) + float(taxes.get("iof", 0))) if taxes else 0.0

--- a/db/investments.py
+++ b/db/investments.py
@@ -849,6 +849,7 @@ def create_investment_db(
     tax_profile: str | None = None,
     initial_amount: float | Decimal | None = None,
     initial_note: str | None = None,
+    debit_account: bool = True,
 ):
     """
     Cria investimento (suporta period='cdi'). Retorna (launch_id, inv_id, canon_name).
@@ -943,13 +944,16 @@ def create_investment_db(
                 acc = cur.fetchone()
                 if not acc:
                     raise RuntimeError("ACCOUNT_MISSING")
-                if acc["balance"] < initial:
+                # debit_account=False: dinheiro está no banco conectado, não na
+                # Carteira (ver investment_deposit_from_account).
+                if debit_account and acc["balance"] < initial:
                     raise ValueError("INSUFFICIENT_ACCOUNT")
 
-                cur.execute(
-                    "update accounts set balance = balance - %s where user_id=%s",
-                    (initial, user_id),
-                )
+                if debit_account:
+                    cur.execute(
+                        "update accounts set balance = balance - %s where user_id=%s",
+                        (initial, user_id),
+                    )
                 lot_opened_at = purchase_date or today
                 lot_id = _insert_investment_lot(
                     cur, user_id, inv_id, initial, lot_opened_at, lot_opened_at,
@@ -958,7 +962,7 @@ def create_investment_db(
                 _sync_investment_from_lots(cur, user_id, inv_id)
 
                 deposit_effects = {
-                    "delta_conta": -float(initial), "delta_pocket": None,
+                    "delta_conta": -float(initial) if debit_account else 0, "delta_pocket": None,
                     "delta_invest": {"nome": canon, "delta": float(initial)},
                     "create_pocket": None, "create_investment": None,
                     "investment_lot_create": {"lot_id": lot_id, "investment_id": inv_id},
@@ -1233,8 +1237,18 @@ def investment_deposit_from_account(
     rate: float | Decimal | None = None,
     period: str | None = None,
     purchase_date: date | str | None = None,
+    debit_account: bool = True,
 ):
     """Conta → Investimento (com accrual antes). Retorna (launch_id, new_acc, new_inv, canon).
+
+    `debit_account=False` registra o aporte SEM tirar da Carteira (`accounts.balance`)
+    e grava `delta_conta: 0`. É o caso de quem tem banco conectado por Open Finance: o
+    dinheiro está no banco, não na Carteira (que fica zerada de propósito, senão o
+    mesmo dinheiro conta 2x — ver dashboard.js, "Ajustar carteira"). Debitar dali
+    inventaria uma saída que não existe. Mesmo padrão do `import_open_finance_launches`,
+    que também grava `delta_conta: 0` justamente para não mexer no saldo manual.
+    O `delta_conta` zerado é o que mantém o desfazer correto: `delete_launch_and_rollback`
+    só estorna a conta quando ele é diferente de zero (db/accounts.py:743).
 
     Parâmetros opcionais (kwargs) para suportar ativos cuja taxa muda por compra
     (Tesouro IPCA+/Prefixado, Debêntures, CRI/CRA IPCA+, CDB prefixado):
@@ -1277,7 +1291,7 @@ def investment_deposit_from_account(
             acc = cur.fetchone()
             if not acc:
                 raise RuntimeError("ACCOUNT_MISSING")
-            if acc["balance"] < v:
+            if debit_account and acc["balance"] < v:
                 raise ValueError("INSUFFICIENT_ACCOUNT")
 
             cur.execute(
@@ -1294,11 +1308,14 @@ def investment_deposit_from_account(
             # Como o lote novo abre hoje, ele não retroage.
             accrue_investment_db(cur, user_id, inv_id, today=today)
 
-            cur.execute(
-                "update accounts set balance = balance - %s where user_id=%s returning balance",
-                (v, user_id),
-            )
-            new_acc = cur.fetchone()["balance"]
+            if debit_account:
+                cur.execute(
+                    "update accounts set balance = balance - %s where user_id=%s returning balance",
+                    (v, user_id),
+                )
+                new_acc = cur.fetchone()["balance"]
+            else:
+                new_acc = acc["balance"]
 
             # Se rate==0 foi passado para selic_spread, repassa explicitamente;
             # senão, None deixa o _insert herdar do investimento.
@@ -1311,7 +1328,7 @@ def investment_deposit_from_account(
             new_inv = _sync_investment_from_lots(cur, user_id, inv_id)
 
             efeitos = {
-                "delta_conta": -float(v), "delta_pocket": None,
+                "delta_conta": -float(v) if debit_account else 0, "delta_pocket": None,
                 "delta_invest": {"nome": canon, "delta": +float(v)},
                 "create_pocket": None, "create_investment": None,
                 "investment_lot_create": {
@@ -1341,8 +1358,14 @@ def investment_withdraw_to_account(
     nota: str | None = None,
     *,
     withdraw_all: bool = False,
+    credit_account: bool = True,
 ):
     """Investimento → Conta via PEPS/FIFO. Retorna (launch_id, new_acc, new_inv, canon, tax_summary).
+
+    `credit_account=False` é o espelho do `debit_account` do aporte: com banco
+    conectado por Open Finance o dinheiro volta para o BANCO, não para a Carteira.
+    Creditar a Carteira inflaria o saldo consolidado (Carteira + bancos) com o mesmo
+    dinheiro que o sync do banco vai trazer.
 
     Se ``withdraw_all=True``, resgata o saldo cheio pós-rendimento (zera o investimento
     de forma atômica) e ignora ``amount``. Caso contrário resgata ``amount``; mas se o
@@ -1488,11 +1511,18 @@ def investment_withdraw_to_account(
 
             new_inv = _sync_investment_from_lots(cur, user_id, inv_id)
 
-            cur.execute(
-                "update accounts set balance = balance + %s where user_id=%s returning balance",
-                (total_net, user_id),
-            )
-            new_acc = cur.fetchone()["balance"]
+            # Espelho do aporte: com banco conectado o dinheiro volta PARA O BANCO,
+            # não para a Carteira. Creditar aqui inflaria o consolidado
+            # (Carteira + bancos) com o mesmo dinheiro que o sync vai trazer.
+            if credit_account:
+                cur.execute(
+                    "update accounts set balance = balance + %s where user_id=%s returning balance",
+                    (total_net, user_id),
+                )
+                new_acc = cur.fetchone()["balance"]
+            else:
+                cur.execute("select balance from accounts where user_id=%s", (user_id,))
+                new_acc = cur.fetchone()["balance"]
 
             tax_summary = {
                 "gross": float(total_gross),
@@ -1504,7 +1534,7 @@ def investment_withdraw_to_account(
                 "lots": breakdown,
             }
             efeitos = {
-                "delta_conta": +float(total_net), "delta_pocket": None,
+                "delta_conta": +float(total_net) if credit_account else 0, "delta_pocket": None,
                 "delta_invest": {"nome": canon, "delta": -float(total_gross)},
                 "create_pocket": None, "create_investment": None,
                 "investment_lot_withdrawals": lot_effects,

--- a/db/pockets.py
+++ b/db/pockets.py
@@ -308,8 +308,12 @@ def pocket_withdraw_to_account(
     nota: str | None = None,
     *,
     withdraw_all: bool = False,
+    credit_account: bool = True,
 ):
     """Caixinha → Conta via FIFO. Retorna (launch_id, new_acc, new_pocket, canon, tax_summary).
+
+    `credit_account=False`: ver investment_withdraw_to_account — com banco conectado
+    o dinheiro volta para o banco, não para a Carteira.
 
     Se ``withdraw_all=True``, saca o saldo cheio pós-rendimento (zera a caixinha de
     forma atômica) e ignora ``amount``. Caso contrário saca ``amount``; mas se o valor
@@ -461,11 +465,17 @@ def pocket_withdraw_to_account(
             new_pocket = _sync_pocket_from_lots(cur, user_id, pocket_id)
 
             cur.execute("select balance from accounts where user_id=%s for update", (user_id,))
-            cur.execute(
-                "update accounts set balance = balance + %s where user_id=%s returning balance",
-                (total_net, user_id),
-            )
-            new_acc = cur.fetchone()["balance"]
+            # Ver investment_withdraw_to_account: com banco conectado o dinheiro
+            # volta para o banco, não para a Carteira.
+            if credit_account:
+                cur.execute(
+                    "update accounts set balance = balance + %s where user_id=%s returning balance",
+                    (total_net, user_id),
+                )
+                new_acc = cur.fetchone()["balance"]
+            else:
+                cur.execute("select balance from accounts where user_id=%s", (user_id,))
+                new_acc = cur.fetchone()["balance"]
 
             tax_summary = {
                 "gross": float(total_gross),
@@ -477,7 +487,7 @@ def pocket_withdraw_to_account(
                 "lots": breakdown,
             }
             efeitos = {
-                "delta_conta": float(+total_net),
+                "delta_conta": float(+total_net) if credit_account else 0,
                 "delta_pocket": {"nome": canon, "delta": float(-total_gross)},
                 "delta_invest": None, "create_pocket": None, "create_investment": None,
                 "pocket_lot_withdrawals": lot_effects,
@@ -583,9 +593,15 @@ def create_pocket(
 
 
 def pocket_deposit_from_account(
-    user_id: int, pocket_name: str, amount: float, nota: str | None = None
+    user_id: int, pocket_name: str, amount: float, nota: str | None = None,
+    *, debit_account: bool = True,
 ):
-    """Conta → Caixinha. Retorna (launch_id, new_account_balance, new_pocket_balance, canon_name)."""
+    """Conta → Caixinha. Retorna (launch_id, new_account_balance, new_pocket_balance, canon_name).
+
+    `debit_account=False`: mesma regra do aporte em investimento
+    (ver investment_deposit_from_account) — com banco conectado por Open Finance o
+    dinheiro está no banco e não na Carteira, então não há o que debitar aqui.
+    """
     ensure_user(user_id)
     v = Decimal(str(amount))
     if v <= 0:
@@ -599,7 +615,7 @@ def pocket_deposit_from_account(
             acc = cur.fetchone()
             if not acc:
                 raise RuntimeError("ACCOUNT_MISSING")
-            if Decimal(str(acc["balance"])) < v:
+            if debit_account and Decimal(str(acc["balance"])) < v:
                 raise ValueError("INSUFFICIENT_ACCOUNT")
 
             cur.execute(
@@ -617,17 +633,20 @@ def pocket_deposit_from_account(
             pocket_id, canon = p["id"], p["name"]
             accrue_pocket_db(cur, user_id, pocket_id, today=criado_em.date())
 
-            cur.execute(
-                "update accounts set balance = balance - %s where user_id=%s returning balance",
-                (v, user_id),
-            )
-            new_acc = cur.fetchone()["balance"]
+            if debit_account:
+                cur.execute(
+                    "update accounts set balance = balance - %s where user_id=%s returning balance",
+                    (v, user_id),
+                )
+                new_acc = cur.fetchone()["balance"]
+            else:
+                new_acc = acc["balance"]
 
             lot_id = _insert_pocket_lot(cur, user_id, pocket_id, v, criado_em.date(), criado_em.date())
             new_pocket = _sync_pocket_from_lots(cur, user_id, pocket_id)
 
             efeitos = {
-                "delta_conta": float(-v),
+                "delta_conta": float(-v) if debit_account else 0,
                 "delta_pocket": {"nome": canon, "delta": float(+v)},
                 "delta_invest": None, "create_pocket": None, "create_investment": None,
                 "pocket_lot_create": {"lot_id": lot_id, "pocket_id": pocket_id},

--- a/tests/test_aporte_open_finance.py
+++ b/tests/test_aporte_open_finance.py
@@ -1,0 +1,324 @@
+"""Aporte e caixinha quando o dinheiro está num banco conectado (Open Finance).
+
+O bug relatado: o app mostrava R$ 1.387,76 de saldo e o bot respondia "Saldo
+insuficiente na conta" a um aporte de R$ 800. Os dois estavam certos e falando de
+coisas diferentes — o saldo da tela é Carteira + bancos conectados, e o aporte
+debitava só a Carteira, que fica zerada de propósito quando há banco conectado
+(senão o mesmo dinheiro conta duas vezes).
+
+Regra adotada: com banco conectado o Pig NÃO debita a Carteira. E antes de
+cadastrar um investimento novo ele avisa que o Open Finance já traz as posições do
+banco — mesma doutrina que a caixinha vinda do OF já seguia (OF_POCKET_READONLY).
+"""
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+import db
+from core.handlers import investments as h_investments
+
+
+def _connect_fake_bank(user_id: int, balance: str = "1387.76") -> int:
+    connection = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": f"item-of-{user_id}", "connector": {"id": 612, "name": "Nubank"}, "status": "UPDATED"},
+    )
+    db.save_open_finance_sync(
+        connection["id"],
+        [{
+            "provider_account_id": f"acc-of-{user_id}",
+            "name": "Nubank Conta",
+            "type": "BANK",
+            "subtype": "CHECKING_ACCOUNT",
+            "currency": "BRL",
+            "balance": Decimal(balance),
+            "raw": {},
+            "transactions": [],
+        }],
+    )
+    return connection["id"]
+
+
+# ─── a detecção ─────────────────────────────────────────────────────────────
+
+def test_saldos_sem_banco_conectado(user_id):
+    db.add_launch_and_update_balance(user_id, "receita", 500, None, "seed")
+    s = h_investments._saldos(user_id)
+    assert s["tem_banco"] is False
+    assert s["carteira"] == 500.0 and s["banco"] == 0.0
+
+
+def test_saldos_com_banco_conectado(user_id):
+    _connect_fake_bank(user_id)
+    s = h_investments._saldos(user_id)
+    assert s["tem_banco"] is True
+    assert s["carteira"] == 0.0
+    assert s["banco"] == 1387.76
+    assert s["total"] == 1387.76
+
+
+def test_saldos_nao_derruba_o_fluxo_se_a_consulta_falhar(user_id):
+    """A detecção é acessória — se ela quebrar, o aporte não pode quebrar junto."""
+    with patch("core.handlers.investments.db.get_consolidated_balance",
+               side_effect=RuntimeError("boom")):
+        s = h_investments._saldos(user_id)
+    assert s["tem_banco"] is False   # fail-safe: volta ao comportamento antigo
+
+
+# ─── o débito ───────────────────────────────────────────────────────────────
+
+def test_aporte_com_banco_conectado_nao_debita_a_carteira(user_id):
+    """O caso do print: Carteira R$ 0,00, banco com R$ 1.387,76, aporte de R$ 800."""
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+
+    msg = h_investments.deposit(
+        user_id, "Investi 800 na renda fixa",
+        {"investment_name": "Renda Fixa", "amount": 800},
+    )
+
+    assert "✅" in msg
+    assert "insuficiente" not in msg.lower()
+    invs = {i["name"]: float(i["balance"]) for i in db.list_investments(user_id)}
+    assert invs["Renda Fixa"] == 800.0
+    assert float(db.get_balance(user_id)) == 0.0   # a Carteira não foi tocada
+
+
+def test_aporte_sem_banco_conectado_continua_debitando(user_id):
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+    db.add_launch_and_update_balance(user_id, "receita", 1000, None, "seed")
+
+    h_investments.deposit(
+        user_id, "Investi 800 na renda fixa",
+        {"investment_name": "Renda Fixa", "amount": 800},
+    )
+
+    assert float(db.get_balance(user_id)) == 200.0
+
+
+def test_aporte_sem_debito_grava_delta_conta_zero(user_id):
+    """`delta_conta` é o que o desfazer usa para estornar. Se ficasse -800 sem o
+    débito ter acontecido, desfazer CRIARIA R$ 800 do nada na Carteira."""
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+
+    launch_id, _acc, _inv, _canon = db.investment_deposit_from_account(
+        user_id, "Renda Fixa", 800, "t", debit_account=False,
+    )
+
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select efeitos from launches where id=%s", (launch_id,))
+        assert cur.fetchone()["efeitos"]["delta_conta"] == 0
+
+    db.delete_launch_and_rollback(user_id, launch_id)
+    assert float(db.get_balance(user_id)) == 0.0   # desfazer não inventou dinheiro
+
+
+def test_caixinha_com_banco_conectado_nao_debita_a_carteira(user_id):
+    from core.handlers import pockets as h_pockets
+
+    _connect_fake_bank(user_id)
+    db.create_pocket(user_id, "Viagem")
+
+    msg = h_pockets.deposit(user_id, "coloquei 200 na caixinha viagem",
+                            {"pocket_name": "Viagem", "amount": 200})
+
+    assert "✅" in msg
+    assert float(db.get_balance(user_id)) == 0.0
+    pockets = {p["name"]: float(p["balance"]) for p in db.list_pockets(user_id)}
+    assert pockets["Viagem"] == 200.0
+
+
+# ─── a mensagem que enganou ─────────────────────────────────────────────────
+
+def test_mensagem_de_saldo_sem_banco_mostra_o_numero(user_id):
+    db.add_launch_and_update_balance(user_id, "receita", 50, None, "seed")
+    msg = h_investments._msg_saldo_insuficiente(user_id, 800)
+    assert "R$ 50,00" in msg and "R$ 800,00" in msg
+    assert "Saldo insuficiente na conta para esse aporte." not in msg
+
+
+def test_mensagem_de_saldo_com_banco_explica_a_diferenca(user_id):
+    _connect_fake_bank(user_id)
+    msg = h_investments._msg_saldo_insuficiente(user_id, 800)
+    assert "Carteira" in msg
+    assert "R$ 0,00" in msg          # a Carteira
+    assert "R$ 1.387,76" in msg      # o que ele vê na tela
+    assert "banco" in msg.lower()
+
+
+# ─── o aviso antes de cadastrar ─────────────────────────────────────────────
+
+def test_investimento_novo_com_banco_conectado_avisa_antes(user_id):
+    _connect_fake_bank(user_id)
+
+    msg = h_investments.deposit(
+        user_id, "Investi 800 na renda fixa",
+        {"investment_name": "renda fixa", "amount": 800},
+    )
+
+    assert "Open Finance" in msg
+    assert "registrar mesmo assim" in msg
+    pend = db.get_pending_action(user_id)
+    assert pend["action_type"] == "investment_create"
+    assert pend["payload"]["etapa"] == "of_aviso"
+    assert db.list_investments(user_id) == []   # nada gravado ainda
+
+
+def test_investimento_novo_sem_banco_nao_avisa(user_id):
+    msg = h_investments.deposit(
+        user_id, "Investi 800 na renda fixa",
+        {"investment_name": "renda fixa", "amount": 800},
+    )
+    assert "Open Finance" not in msg
+    assert db.get_pending_action(user_id)["payload"]["etapa"] == "nome"
+
+
+def test_investimento_que_ja_existe_nao_avisa(user_id):
+    """O aviso diz "ele entra sozinho pelo Open Finance". Para um ativo que o
+    usuário cadastrou de propósito isso é falso — e avisar em todo aporte só
+    treinaria o usuário a ignorar o aviso."""
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "CDB XP", 0.12, "yearly")
+
+    msg = h_investments.deposit(
+        user_id, "Investi 800 no cdb xp",
+        {"investment_name": "CDB XP", "amount": 800},
+    )
+
+    assert "Open Finance" not in msg
+    assert "✅" in msg
+
+
+@pytest.mark.parametrize("resposta", ["registrar mesmo assim", "sim", "registrar"])
+def test_aviso_afirmativa_segue_para_a_taxa(user_id, resposta):
+    pend = {"action_type": "investment_create",
+            "payload": {"amount": 800.0, "etapa": "of_aviso", "nome": "Renda Fixa", "text": "x"}}
+    with patch("core.handlers.investments.db.set_pending_action") as sp:
+        msg = h_investments.resolve_pending(user_id, resposta, pend)
+    assert "rende" in msg.lower()
+    assert sp.call_args[0][2]["etapa"] == "taxa"
+
+
+def test_aviso_texto_solto_nao_vale_como_consentimento(user_id):
+    """O gate serve justamente para quem está em dúvida — não pode cair sozinho."""
+    pend = {"action_type": "investment_create",
+            "payload": {"amount": 800.0, "etapa": "of_aviso", "nome": "Renda Fixa", "text": "x"}}
+    with patch("core.handlers.investments.db.set_pending_action") as sp, \
+         patch("core.handlers.investments.db.create_investment_db") as create:
+        msg = h_investments.resolve_pending(user_id, "como assim?", pend)
+    create.assert_not_called()
+    sp.assert_not_called()                       # continua na mesma etapa
+    assert "registrar mesmo assim" in msg
+
+
+def test_aviso_negativa_cancela(user_id):
+    pend = {"action_type": "investment_create",
+            "payload": {"amount": 800.0, "etapa": "of_aviso", "nome": "Renda Fixa", "text": "x"}}
+    with patch("core.handlers.investments.db.clear_pending_action") as clear, \
+         patch("core.handlers.investments.db.create_investment_db") as create:
+        msg = h_investments.resolve_pending(user_id, "não", pend)
+    create.assert_not_called()
+    clear.assert_called_once_with(user_id)
+    assert "cancelei" in msg.lower()
+
+
+def test_aviso_sem_nome_sugerido_pergunta_o_nome(user_id):
+    pend = {"action_type": "investment_create",
+            "payload": {"amount": 800.0, "etapa": "of_aviso", "nome": "", "text": "x"}}
+    with patch("core.handlers.investments.db.set_pending_action") as sp:
+        msg = h_investments.resolve_pending(user_id, "registrar mesmo assim", pend)
+    assert "nome" in msg.lower()
+    assert sp.call_args[0][2]["etapa"] == "nome"
+
+
+def test_fluxo_completo_insistindo_cria_sem_debitar(user_id):
+    """Ponta a ponta: aviso → insiste → nome já sugerido → taxa → criado."""
+    _connect_fake_bank(user_id)
+
+    h_investments.deposit(user_id, "Investi 800 na renda fixa",
+                          {"investment_name": "renda fixa", "amount": 800})
+    h_investments.resolve_pending(user_id, "registrar mesmo assim",
+                                  db.get_pending_action(user_id))
+    msg = h_investments.resolve_pending(user_id, "100% do CDI",
+                                        db.get_pending_action(user_id))
+
+    assert "✅" in msg
+    invs = {i["name"]: float(i["balance"]) for i in db.list_investments(user_id)}
+    assert invs["Renda Fixa"] == 800.0
+    assert float(db.get_balance(user_id)) == 0.0   # Carteira intacta
+    assert db.get_pending_action(user_id) is None
+
+
+# ─── o resgate é o espelho: não pode creditar a Carteira ────────────────────
+#
+# Sem isto a correção ficaria meio torta: o aporte não debita, mas o resgate
+# creditaria — inflando o consolidado (Carteira + bancos) com o mesmo dinheiro
+# que o sync do banco vai trazer de volta.
+
+def test_resgate_com_banco_conectado_nao_credita_a_carteira(user_id):
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+    db.investment_deposit_from_account(user_id, "Renda Fixa", 800, "t", debit_account=False)
+    assert float(db.get_balance(user_id)) == 0.0
+
+    msg = h_investments.withdraw(user_id, "resgatei 300 da renda fixa",
+                                 {"investment_name": "Renda Fixa", "amount": 300})
+
+    assert "📤" in msg or "✅" in msg
+    assert float(db.get_balance(user_id)) == 0.0   # não inventou dinheiro na Carteira
+
+
+def test_resgate_sem_banco_continua_creditando(user_id):
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+    db.add_launch_and_update_balance(user_id, "receita", 1000, None, "seed")
+    h_investments.deposit(user_id, "investi 800 na renda fixa",
+                          {"investment_name": "Renda Fixa", "amount": 800})
+    assert float(db.get_balance(user_id)) == 200.0
+
+    h_investments.withdraw(user_id, "resgatei 300 da renda fixa",
+                           {"investment_name": "Renda Fixa", "amount": 300})
+
+    assert float(db.get_balance(user_id)) > 200.0
+
+
+def test_caixinha_resgate_com_banco_conectado_nao_credita(user_id):
+    from core.handlers import pockets as h_pockets
+
+    _connect_fake_bank(user_id)
+    db.create_pocket(user_id, "Viagem")
+    db.pocket_deposit_from_account(user_id, "Viagem", 200, "t", debit_account=False)
+
+    h_pockets.withdraw(user_id, "retirei 50 da caixinha viagem",
+                       {"pocket_name": "Viagem", "amount": 50})
+
+    assert float(db.get_balance(user_id)) == 0.0
+
+
+# ─── o caminho da IA segue a mesma regra ────────────────────────────────────
+
+def test_ia_aporta_sem_debitar_com_banco_conectado(user_id):
+    from core.services.ai_chat.tools.investments import _investment_deposit_execute
+
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+
+    out = _investment_deposit_execute(user_id, {"name": "Renda Fixa", "amount": 800})
+
+    assert "✅" in out
+    assert float(db.get_balance(user_id)) == 0.0
+    invs = {i["name"]: float(i["balance"]) for i in db.list_investments(user_id)}
+    assert invs["Renda Fixa"] == 800.0
+
+
+def test_ia_mensagem_de_saldo_tambem_ficou_certeira(user_id):
+    from core.services.ai_chat.tools.investments import _investment_deposit_execute
+
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+    db.add_launch_and_update_balance(user_id, "receita", 50, None, "seed")
+
+    out = _investment_deposit_execute(user_id, {"name": "Renda Fixa", "amount": 800})
+
+    assert "Saldo insuficiente na conta pra esse aporte." not in out
+    assert "R$ 50,00" in out and "R$ 800,00" in out

--- a/tests/test_investments_handler.py
+++ b/tests/test_investments_handler.py
@@ -168,17 +168,23 @@ def test_deposit_inv_not_found_em_corrida_oferece_criar():
     assert pend.call_args[0][1] == "investment_create"
 
 
-def test_deposit_saldo_insuficiente_continua_com_mensagem_propria():
+def test_deposit_saldo_insuficiente_diz_quanto_falta():
+    """"Saldo insuficiente na conta" era vago e foi o que enganou o usuário que
+    via R$ 1.387,76 na tela. A resposta agora nomeia o saldo e mostra o número
+    (a explicação Carteira x Bancos tem teste próprio em test_aporte_open_finance)."""
     with patch("core.handlers.investments.db.investment_deposit_from_account",
                side_effect=ValueError("INSUFFICIENT_ACCOUNT")), \
          patch("core.handlers.investments.db.accrue_all_investments",
                return_value=_CARTEIRA_TESOURO), \
+         patch("core.handlers.investments.db.get_consolidated_balance",
+               return_value={"manual": 50, "open_finance_bank": 0, "of_bank_count": 0}), \
          patch("core.handlers.investments.build_dashboard_link", return_value="https://app.test/d/abc"):
         msg = h_investments.deposit(
             123, "investi 999999 no tesouro direto",
             {"investment_name": "Tesouro Direto", "amount": 999999},
         )
-    assert "Saldo insuficiente na conta" in msg
+    assert "R$ 50,00" in msg
+    assert "R$ 999.999,00" in msg
 
 
 def test_deposit_sucesso_responde_com_id():


### PR DESCRIPTION
## O relato

App mostrando **R$ 1.387,76** de saldo. "Investi 800 na renda fixa" → **"Saldo insuficiente na conta para esse aporte."**

Os dois estavam certos e falando de coisas diferentes:

| | valor |
|---|---|
| `accounts.balance` — a **Carteira** (dinheiro manual) | **R$ 0,00** |
| Open Finance — **Bancos** conectados | R$ 1.387,76 |
| "Saldo atual" na tela = soma dos dois | R$ 1.387,76 |
| O que o aporte checava (`db/investments.py`) | **só a Carteira** |

A Carteira fica zerada **de propósito** quando há banco conectado — o próprio código explica (`dashboard.js:9029`): *"Ao conectar o 1º banco o usuário zera aqui o que era controle manual daquele banco, senão o mesmo dinheiro conta 2x."*

## A regra

Com banco conectado, o Pig não movimenta a Carteira: o dinheiro está no banco, e quem o move é o usuário pelo app dele.

Não é regra nova. A caixinha vinda do Open Finance **já** é read-only pelo mesmo motivo (`db/pockets.py`, `OF_POCKET_READONLY`): *"o dinheiro está no banco, não no Pig — mover por aqui criaria saldo mentiroso que o sync sobrescreve."* Investimento é que tinha ficado de fora da doutrina.

`debit_account` / `credit_account` nas quatro operações de dinheiro. Quando falso, nada toca `accounts.balance` e o `efeitos` grava `delta_conta: 0` — o mesmo padrão que o `import_open_finance_launches` já adotava (`db/open_finance.py:1186`).

**Esse zero não é cosmético.** `delete_launch_and_rollback` só estorna a conta quando `delta_conta != 0` (`db/accounts.py:743`). Se gravássemos `-800` sem o débito ter acontecido, desfazer o aporte **criaria R$ 800 na Carteira do nada**. Tem teste.

## O aviso antes de cadastrar

Antes de criar um investimento **novo** com banco conectado:

> 🏦 Vi que você tem banco conectado.
>
> Se **Renda Fixa** é no próprio banco, não precisa registrar aqui: ele entra sozinho pelo Open Finance, com o saldo se atualizando junto. Cadastrar na mão criaria uma segunda linha do mesmo dinheiro.
>
> Se for fora do banco conectado (uma corretora, por exemplo), responda *registrar mesmo assim*.

O sync realmente traz as posições — `open_finance_investments` existe e sincroniza `FIXED_INCOME`/`CDB`.

Duas decisões que vale explicitar:

- **O aviso não aparece para investimento que já existe no PigBank.** Ali a frase "ele entra sozinho pelo Open Finance" seria falsa (o usuário cadastrou de propósito), e avisar em todo aporte só treinaria a pessoa a ignorar o aviso.
- **Texto solto não vale como consentimento** na etapa do aviso. O gate serve justamente para quem está em dúvida; se qualquer resposta passasse, ele cairia exatamente na hora em que é útil.

## A mensagem que enganou

`"Saldo insuficiente na conta"` era vago — e foi ele que fez o usuário achar que o bot estava errado. Agora diz **qual** saldo e **quanto**:

**Sem banco conectado**
> Saldo insuficiente: você tem R$ 50,00 na conta e o aporte é de R$ 800,00.

**Com banco conectado**
> Sua **Carteira** tem R$ 0,00 — e é dela que sai o aporte.
>
> Os R$ 1.387,76 que aparecem como saldo somam a Carteira com os bancos conectados (R$ 1.387,76). O dinheiro que está no banco quem movimenta é você, pelo app dele; a Carteira é o que está fora (espécie e contas não conectadas).

## Alcance

Fechei a categoria, não a instância:

| | entrada | saída |
|---|---|---|
| investimento | `debit_account` | `credit_account` |
| caixinha | `debit_account` | `credit_account` |
| handler de intents | ✅ | ✅ |
| chat da IA | ✅ | ✅ |

Corrigir só o aporte deixaria a correção torta: o resgate creditaria a Carteira, inflando o consolidado (Carteira + bancos) com o mesmo dinheiro que o sync devolve ao banco. Esses dois eu achei revisando o próprio diff, depois de já ter dado o trabalho por pronto.

A detecção (`_saldos`) é **fail-safe**: se `get_consolidated_balance` estourar, devolve `tem_banco=False` e vale o comportamento antigo. Ela também **não** passa pelo gate `consolidated_balance_enabled` de propósito — esse gate é sobre *exibir* o saldo somado; ter banco conectado é um fato, e é ele que decide se há o que debitar.

## Testes

`tests/test_aporte_open_finance.py` (novo), 24 testes contra Postgres real com banco fake conectado: detecção, débito/crédito nos dois sentidos, `delta_conta: 0` e o desfazer, as duas mensagens, as transições do aviso, e o fluxo completo ponta a ponta.

**16 dos 24 falham sem esta mudança.** Os outros 8 são guarda de não-regressão do caminho sem Open Finance — se algum deles quebrar, quem não tem banco conectado foi afetado.

Suíte: **1107 passed / 4 skipped** antes → **1131 / 4** depois. Mesmos 4 skips (`ofxparse`).

## O que não foi verificado

- Não rodou no WhatsApp real nem no CI — o Actions segue travado pela cota (jobs morrem em 2s com `runner_id: 0`, em todas as branches). Validação contra Postgres 16 local.
- **Custo:** `_saldos` roda em toda operação de dinheiro, e `get_consolidated_balance` faz duas queries + `ensure_user`. São ~3 round-trips a mais por aporte/resgate. Idempotente e barato, mas dá para cachear por turno se pesar.
- Não toquei em despesa comum debitando a Carteira: o `import_open_finance_launches` já trata gastos com `delta_conta: 0`, então aquele caminho tem tratamento próprio.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtWzacGdU7t8D8iXvobgyM)_