### PR TITLE
feat(open finance): avisar que o saldo se ajusta no próximo sync

### DIFF
--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -134,6 +134,26 @@ def _saldos(user_id: int) -> dict:
     }
 
 
+def _nota_sync_of(saida: bool = True) -> str:
+    """Aviso obrigatório quando o Pig registra só metade da movimentação.
+
+    Com banco conectado o Pig anota o lado do investimento na hora, mas o lado
+    do dinheiro só aparece quando o Open Finance sincronizar. Entre uma coisa e
+    outra o patrimônio fica alto (no aporte) ou baixo (no resgate) pelo valor da
+    operação — e sem este aviso o usuário vê o número errado sem entender por quê.
+
+    Também avisa da segunda linha: a transação do banco entra como um lançamento
+    próprio e a reconciliação não a funde com o aporte (ela só casa despesa/receita
+    não-interna com lançamento manual — ver db/open_finance.py::_find_manual_candidates).
+    """
+    movimento = "saída" if saida else "entrada"
+    return (
+        f"🔄 Anotei só o lado do investimento. A {movimento} do dinheiro aparece "
+        "quando o Open Finance sincronizar — até lá o saldo do banco fica como está, "
+        "e a transação pode surgir como uma segunda linha no extrato."
+    )
+
+
 def _msg_saldo_insuficiente(user_id: int, amount: float, acao: str = "aporte") -> str:
     """"Saldo insuficiente na conta" era o que mais confundia: o usuário via
     R$ 1.387,76 na tela e o bot dizia que não tinha saldo. Agora a resposta diz
@@ -256,6 +276,7 @@ def _cria_e_aporta(user_id: int, payload: dict, spec: dict) -> str:
     """Cria o investimento e lança o aporte na mesma transação."""
     nome = payload["nome"]
     amount = float(payload["amount"])
+    tem_banco = _saldos(user_id)["tem_banco"]
     try:
         launch_id, _inv_id, canon = db.create_investment_db(
             user_id,
@@ -268,7 +289,7 @@ def _cria_e_aporta(user_id: int, payload: dict, spec: dict) -> str:
             tax_profile=spec.get("tax_profile"),
             initial_amount=amount,
             initial_note=f"Aporte inicial em {nome}",
-            debit_account=not _saldos(user_id)["tem_banco"],
+            debit_account=not tem_banco,
         )
     except ValueError as e:
         code = str(e)
@@ -314,7 +335,9 @@ def _cria_e_aporta(user_id: int, payload: dict, spec: dict) -> str:
     return (
         f"✅ **{_format_inv_name(canon)}** criado ({taxa_txt}) "
         f"com aporte de **{fmt_brl(amount)}**. ID #{db.display_id_for(user_id, launch_id)}.\n\n"
-        "Ele já aparece no seu dashboard.\n\n" + _investment_dashboard_link(user_id)
+        "Ele já aparece no seu dashboard.\n\n"
+        + (_nota_sync_of() + "\n\n" if tem_banco else "")
+        + _investment_dashboard_link(user_id)
     )
 
 
@@ -458,10 +481,11 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     # Com banco conectado o dinheiro está no banco, não na Carteira (que fica
     # zerada de propósito) — debitar dali inventaria uma saída. Ver
     # investment_deposit_from_account.
+    tem_banco = _saldos(user_id)["tem_banco"]
     try:
         launch_id, _new_acc, _new_inv, canon = db.investment_deposit_from_account(
             user_id, investment_name, float(amount), text,
-            debit_account=not _saldos(user_id)["tem_banco"],
+            debit_account=not tem_banco,
         )
     except LookupError:
         # Corrida rara: sumiu entre a checagem acima e o aporte.
@@ -481,7 +505,8 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
         return "Não consegui registrar esse aporte agora. Tente de novo em instantes."
 
     display_id = db.display_id_for(user_id, launch_id)
-    return f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**. ID #{display_id}."
+    msg = f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**. ID #{display_id}."
+    return msg + ("\n\n" + _nota_sync_of() if tem_banco else "")
 
 
 def check_cdi() -> str:
@@ -535,13 +560,15 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
     if not want_all and (not amount or float(amount) <= 0):
         return list_investments(user_id, "Qual valor você quer resgatar?")
 
+    tem_banco = _saldos(user_id)["tem_banco"]
+
     try:
         launch_id, _new_acc, _new_inv, canon, taxes = db.investment_withdraw_to_account(
             user_id,
             investment_name,
             None if want_all else float(amount),
             text,
-            credit_account=not _saldos(user_id)["tem_banco"],
+            credit_account=not tem_banco,
             withdraw_all=want_all,
         )
     except LookupError:
@@ -578,4 +605,10 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
     if taxes and float(taxes.get("iof", 0) or 0) + float(taxes.get("ir", 0) or 0) > 0:
         tax_note = f" Líquido: **{fmt_brl(float(taxes.get('net', 0)))}**."
     verb = "Resgate total" if want_all else "Resgate"
-    return f"✅ {verb} de **{fmt_brl(gross)}** de **{canon}**.{tax_note} ID #{db.display_id_for(user_id, launch_id)}.\n\n" + list_investments(user_id)
+    nota_sync = _nota_sync_of(saida=False) + "\n\n" if tem_banco else ""
+    return (
+        f"✅ {verb} de **{fmt_brl(gross)}** de **{canon}**.{tax_note} "
+        f"ID #{db.display_id_for(user_id, launch_id)}.\n\n"
+        + nota_sync
+        + list_investments(user_id)
+    )

--- a/core/handlers/pockets.py
+++ b/core/handlers/pockets.py
@@ -74,17 +74,19 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
 
     # Com banco conectado o dinheiro está no banco, não na Carteira — mesma regra
     # do aporte em investimento (core/handlers/investments.py::_saldos).
-    from core.handlers.investments import _saldos, _msg_saldo_insuficiente
+    from core.handlers.investments import _saldos, _msg_saldo_insuficiente, _nota_sync_of
 
+    tem_banco = _saldos(user_id)["tem_banco"]
     try:
         launch_id, new_acc, new_pocket, canon = db.pocket_deposit_from_account(
             user_id, pocket_name, float(amount), text,
-            debit_account=not _saldos(user_id)["tem_banco"],
+            debit_account=not tem_banco,
         )
         return (
             f"✅ Depósito na caixinha **{canon}**: +{fmt_brl(float(amount))}\n"
             f"🏦 Conta: {fmt_brl(float(new_acc))} • 📦 Caixinha: {fmt_brl(float(new_pocket))}\n"
             f"ID: **#{db.display_id_for(user_id, launch_id)}**"
+            + ("\n\n" + _nota_sync_of() if tem_banco else "")
         )
     except LookupError:
         return f"Caixinha **{pocket_name}** não encontrada. Use *criar caixinha {pocket_name}*."
@@ -136,7 +138,7 @@ def _pocket_name_from_text(text: str):
     return pocket or None
 
 
-def _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id, *, emptied=False):
+def _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id, *, emptied=False, nota_sync=""):
     tax_note = ""
     if taxes and (taxes.get("iof", 0) or taxes.get("ir", 0)):
         tax_note = f" • IR/IOF: {fmt_brl(float(taxes.get('ir', 0) + taxes.get('iof', 0)))}"
@@ -149,11 +151,12 @@ def _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, l
         f"{head}\n"
         f"🏦 Conta: {fmt_brl(float(new_acc))} • 📦 Caixinha: {fmt_brl(float(new_pocket))}{tax_note}\n"
         f"ID: **#{db.display_id_for(user_id, launch_id)}**"
+        + nota_sync
     )
 
 
 def withdraw(user_id: int, text: str, entities: dict) -> str:
-    from core.handlers.investments import _saldos
+    from core.handlers.investments import _saldos, _nota_sync_of
 
     pocket_name = entities.get("pocket_name")
     amount      = entities.get("amount")
@@ -190,7 +193,10 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
         except Exception as e:
             return f"Erro ao retirar: {e}"
         sacado = float(taxes.get("gross", 0)) if taxes else 0.0
-        return _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id, emptied=True)
+        return _format_withdraw_reply(
+            user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id, emptied=True,
+            nota_sync="\n\n" + _nota_sync_of(saida=False) if _saldos(user_id)["tem_banco"] else "",
+        )
 
     if not amount or float(amount) <= 0:
         return "Qual o valor? Tente: *retirei 100 da caixinha viagem*"
@@ -212,4 +218,7 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
         return f"Erro ao retirar: {e}"
     # o backend pode sacar um pouco mais que o pedido (tolerância de zeragem)
     sacado = float(taxes.get("gross", amount)) if taxes else float(amount)
-    return _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id)
+    return _format_withdraw_reply(
+        user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id,
+        nota_sync="\n\n" + _nota_sync_of(saida=False) if _saldos(user_id)["tem_banco"] else "",
+    )

--- a/core/services/ai_chat/tools/investments.py
+++ b/core/services/ai_chat/tools/investments.py
@@ -24,7 +24,7 @@ from typing import Any
 import db
 from utils_text import fmt_rate
 
-from core.handlers.investments import _msg_saldo_insuficiente, _saldos
+from core.handlers.investments import _msg_saldo_insuficiente, _nota_sync_of, _saldos
 
 from ._base import Tool
 
@@ -233,7 +233,8 @@ def _investment_deposit_execute(user_id: int, args: dict[str, Any]) -> str:
             user_id, name, amount,
             debit_account=not _saldos(user_id)["tem_banco"],
         )
-        return f'✅ Aporte de R$ {amount:.2f} no "{name}" registrado.'
+        nota = "\n\n" + _nota_sync_of() if _saldos(user_id)["tem_banco"] else ""
+        return f'✅ Aporte de R$ {amount:.2f} no "{name}" registrado.' + nota
     except LookupError:
         # INV_NOT_FOUND. Mandar pro dashboard aqui era um beco: o user está no
         # WhatsApp querendo aportar. A pergunta vai NA MENSAGEM, não como

--- a/tests/test_aporte_open_finance.py
+++ b/tests/test_aporte_open_finance.py
@@ -171,7 +171,7 @@ def test_investimento_novo_sem_banco_nao_avisa(user_id):
         user_id, "Investi 800 na renda fixa",
         {"investment_name": "renda fixa", "amount": 800},
     )
-    assert "Open Finance" not in msg
+    assert "registrar mesmo assim" not in msg
     assert db.get_pending_action(user_id)["payload"]["etapa"] == "nome"
 
 
@@ -187,7 +187,10 @@ def test_investimento_que_ja_existe_nao_avisa(user_id):
         {"investment_name": "CDB XP", "amount": 800},
     )
 
-    assert "Open Finance" not in msg
+    # o aviso de CADASTRO não aparece (é o que este teste cobre); o aviso do
+    # SYNC aparece sim, e tem teste próprio — são coisas diferentes.
+    assert "registrar mesmo assim" not in msg
+    assert "não precisa registrar aqui" not in msg
     assert "✅" in msg
 
 
@@ -322,3 +325,89 @@ def test_ia_mensagem_de_saldo_tambem_ficou_certeira(user_id):
 
     assert "Saldo insuficiente na conta pra esse aporte." not in out
     assert "R$ 50,00" in out and "R$ 800,00" in out
+
+
+# ─── o aviso do sync ────────────────────────────────────────────────────────
+#
+# Com banco conectado o Pig anota só metade da movimentação: o lado do
+# investimento entra na hora, o lado do dinheiro só quando o banco sincronizar.
+# Nesse intervalo o patrimônio fica alto (aporte) ou baixo (resgate) pelo valor
+# da operação. Sem o aviso, o usuário vê o número errado sem entender por quê —
+# foi exatamente a dúvida que apareceu no primeiro teste real.
+
+def _tem_aviso(msg: str) -> bool:
+    return "Open Finance sincronizar" in msg
+
+
+def test_aporte_com_banco_avisa_do_sync(user_id):
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+
+    msg = h_investments.deposit(user_id, "Investi 800 na renda fixa",
+                                {"investment_name": "Renda Fixa", "amount": 800})
+
+    assert _tem_aviso(msg)
+    assert "saída" in msg          # no aporte o que falta aparecer é a saída
+    assert "segunda linha" in msg  # e a transação do banco vem como linha própria
+
+
+def test_aporte_sem_banco_nao_avisa(user_id):
+    """Sem Open Finance a Carteira é debitada na hora — não há nada a sincronizar,
+    e o aviso só confundiria."""
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+    db.add_launch_and_update_balance(user_id, "receita", 1000, None, "seed")
+
+    msg = h_investments.deposit(user_id, "Investi 800 na renda fixa",
+                                {"investment_name": "Renda Fixa", "amount": 800})
+
+    assert not _tem_aviso(msg)
+
+
+def test_resgate_com_banco_avisa_da_entrada(user_id):
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+    db.investment_deposit_from_account(user_id, "Renda Fixa", 800, "t", debit_account=False)
+
+    msg = h_investments.withdraw(user_id, "resgatei 300 da renda fixa",
+                                 {"investment_name": "Renda Fixa", "amount": 300})
+
+    assert _tem_aviso(msg)
+    assert "entrada" in msg        # no resgate é a entrada que falta
+
+
+def test_criacao_com_aporte_tambem_avisa(user_id):
+    _connect_fake_bank(user_id)
+
+    h_investments.deposit(user_id, "Investi 800 na renda fixa",
+                          {"investment_name": "renda fixa", "amount": 800})
+    h_investments.resolve_pending(user_id, "registrar mesmo assim",
+                                  db.get_pending_action(user_id))
+    msg = h_investments.resolve_pending(user_id, "100% do CDI",
+                                        db.get_pending_action(user_id))
+
+    assert _tem_aviso(msg)
+
+
+def test_caixinha_avisa_nos_dois_sentidos(user_id):
+    from core.handlers import pockets as h_pockets
+
+    _connect_fake_bank(user_id)
+    db.create_pocket(user_id, "Viagem")
+
+    dep = h_pockets.deposit(user_id, "coloquei 200 na caixinha viagem",
+                            {"pocket_name": "Viagem", "amount": 200})
+    saq = h_pockets.withdraw(user_id, "retirei 50 da caixinha viagem",
+                             {"pocket_name": "Viagem", "amount": 50})
+
+    assert _tem_aviso(dep) and "saída" in dep
+    assert _tem_aviso(saq) and "entrada" in saq
+
+
+def test_ia_tambem_avisa(user_id):
+    from core.services.ai_chat.tools.investments import _investment_deposit_execute
+
+    _connect_fake_bank(user_id)
+    db.create_investment(user_id, "Renda Fixa", 0.14, "yearly")
+
+    out = _investment_deposit_execute(user_id, {"name": "Renda Fixa", "amount": 800})
+    assert _tem_aviso(out)


### PR DESCRIPTION
## Por que

Com banco conectado o Pig anota **metade** da movimentação: o lado do investimento entra na hora, o lado do dinheiro só quando o banco sincronizar. Nesse intervalo o patrimônio fica alto (no aporte) ou baixo (no resgate) pelo valor da operação.

Isso apareceu no primeiro teste real logo depois do #92: patrimônio saltou de **R$ 52.108,23** para **R$ 52.908,23** após um aporte de R$ 800, e a pergunta veio na hora — *"de onde vem o dinheiro então?"*. O número não estava errado, estava **adiantado** — mas não havia como saber disso pela tela.

## O aviso

> ✅ Aporte de **R$ 800,00** em **Reserva de Emergencia**. ID #2.
>
> 🔄 Anotei só o lado do investimento. A **saída** do dinheiro aparece quando o Open Finance sincronizar — até lá o saldo do banco fica como está, e a transação pode surgir como uma segunda linha no extrato.

No resgate a palavra vira **entrada**, que é o lado que falta aparecer.

## A segunda frase não é enfeite

A transação do banco entra como lançamento próprio e a reconciliação **não** a funde com o aporte. `_find_manual_candidates` (`db/open_finance.py:1094`) só considera candidatos com:

```sql
and tipo = %s                      -- o tipo da transação OF (despesa/receita)
and is_internal_movement = false
```

O aporte é `tipo='aporte_investimento'` e `is_internal_movement=true` — falha nos **dois** critérios, então nunca é candidato. Enquanto isso não mudar, a segunda linha vai aparecer no extrato, e é mais honesto avisar do que deixar o usuário descobrir sozinho.

## Alcance

Aporte, resgate, depósito e saque de caixinha; handler de intents e chat da IA.

**Sem banco conectado o aviso não aparece** — ali a Carteira é debitada na hora, não há nada a sincronizar, e o aviso só confundiria.

## Testes

6 novos, em `tests/test_aporte_open_finance.py`: aporte avisa (com "saída"), resgate avisa (com "entrada"), criação-com-aporte avisa, caixinha avisa nos dois sentidos, chat da IA avisa, e o caminho sem Open Finance **não** avisa.

Um teste antigo precisou ficar mais específico. Ele afirmava `"Open Finance" not in msg` para checar a ausência do aviso de **cadastro**, e passou a colidir com o aviso de **sync** — agora casa a frase do aviso certo (`"registrar mesmo assim"`). Isso é falha do teste antigo, não da mudança: ele estava casando um termo genérico demais para o que queria provar.

Suíte: **1131 passed / 4 skipped** → **1137 / 4**.

## O que continua em aberto

O aviso descreve a duplicidade; não a resolve. O conserto de verdade é deixar o aporte reconciliável — aceitar movimentos internos e os tipos `aporte_investimento`/`deposito_caixinha` em `_find_manual_candidates` quando a transação OF também é interna. Mexe no motor de reconciliação e ficou de fora deste PR de propósito.

CI segue travado pela cota do Actions; validação contra Postgres 16 local.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtWzacGdU7t8D8iXvobgyM)_