### PR TITLE
fix(dashboard): corrige quebra de layout no banner de avisos

### DIFF
--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -975,7 +975,9 @@ body.light #alert-banner.exceeded { background:rgba(220,38,38,.04); border-color
 body.light #alert-banner.warning  { background:rgba(245,158,11,.04); border-color:rgba(245,158,11,.18); }
 #alert-banner .alert-banner-head { display:flex;align-items:flex-start;justify-content:space-between;gap:12px; }
 #alert-banner .alert-banner-body { flex:1;min-width:0; }
-.alert-row { display:flex;align-items:center;gap:8px;padding:2px 0; }
+.alert-row { display:block;line-height:1.45;padding:2px 0;overflow-wrap:break-word; }
+.alert-row > b { font-weight:600; }
+.alert-row button { vertical-align:baseline; }
 .alert-close {
   appearance:none;background:transparent;border:none;color:inherit;cursor:pointer;
   font-size:1rem;line-height:1;padding:2px 4px;border-radius:6px;opacity:.72;flex-shrink:0;


### PR DESCRIPTION
## Problema

No banner de avisos do dashboard (`#alert-banner`), o texto dos lançamentos aparecia empilhado em colunas espremidas — ex.: `Railway` quebrava como `Railw / ay`, e "Piggy lançou", o valor e os `✕` ficavam cada um em uma coluna.

**Causa:** `.alert-row` usava `display:flex`. Num flex container, cada trecho de texto solto vira um *flex item* independente; sem espaço horizontal, cada item encolhe até o mínimo e quebra palavra por palavra.

## Correção

`.alert-row` passa a usar `display:block` (fluxo de texto normal), com `line-height:1.45` e `overflow-wrap:break-word`. A frase corre em linha e quebra naturalmente; o botão de dispensar volta a ficar inline no fim do texto.

```diff
-.alert-row { display:flex;align-items:center;gap:8px;padding:2px 0; }
+.alert-row { display:block;line-height:1.45;padding:2px 0;overflow-wrap:break-word; }
+.alert-row > b { font-weight:600; }
+.alert-row button { vertical-align:baseline; }
```

Afeta as três variações que usam `.alert-row`: lançamento recorrente, recebimento recorrente e estouro de orçamento.

## Teste

Só CSS. Validado em preview com: aviso normal, nome de conta longo e múltiplos avisos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)