### PR TITLE
feat(app): bolinha do chat arrastável + aba Notícias no rodapé (Pro)

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -463,6 +463,11 @@ html.pb-app body.pb-page-home .header-right {
 html.pb-app body.pb-page-home { padding-top: env(safe-area-inset-top); }
 html.pb-app footer { display: none !important; }
 
+/* ─── Notícias (/changelog) como aba do app ────────────────────────────── */
+/* .nav e footer já somem (regras globais). Ajusta só o topo pro app. */
+html.pb-app body.pb-page-changelog { padding-top: env(safe-area-inset-top); }
+html.pb-app body.pb-page-changelog .section { padding-top: 14px !important; }
+
 /* ─── Dashboard ────────────────────────────────────────────────────────── */
 /* Header compacto: ☰ + marca | mês centrado | conta. Import/export são
    fluxos de desktop. */

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -41,14 +41,15 @@
     "/home":         "home",
     "/app":          "app",
     "/comandos-app": "comandos",
+    "/changelog":    "changelog",
     "/settings":     "settings",
   };
   // Variantes do preview local (mock serve arquivos .html e o dash na raiz)
   if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
     Object.assign(PAGES, {
       "/home.html": "home", "/dashboard.html": "app",
-      "/comandos-app.html": "comandos", "/settings.html": "settings",
-      "/": "app",
+      "/comandos-app.html": "comandos", "/changelog.html": "changelog",
+      "/settings.html": "settings", "/": "app",
     });
   }
   const path = location.pathname.replace(/\/+$/, "") || "/";
@@ -71,6 +72,45 @@
     { href: "/settings", label: "Ajustes", icon:
       '<svg viewBox="0 0 24 24" width="24" height="24"><circle cx="12" cy="12" r="3.2"/><path d="M19.4 15a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-1.8-.3 1.6 1.6 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.6 1.6 0 0 0-1-1.5 1.6 1.6 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0 .3-1.8 1.6 1.6 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.6 1.6 0 0 0 1.5-1 1.6 1.6 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3h.1a1.6 1.6 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 1 1.5h.1a1.6 1.6 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8v.1a1.6 1.6 0 0 0 1.5 1h.1a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/></svg>' },
   ];
+
+  // 4º lugar da tab bar: "Notícias" (/changelog) é recurso Pro. Se o plano
+  // libera, ela assume esse lugar (no lugar de "O que pedir") e some do menu
+  // lateral. Free mantém "O que pedir". A decisão fica em cache (localStorage)
+  // pra montar instantâneo; /auth/me só reconcilia depois.
+  const NEWS_TAB = { href: "/changelog", label: "Notícias", icon:
+    '<svg viewBox="0 0 24 24" width="24" height="24"><path d="M3 6a1 1 0 0 1 1-1h13a1 1 0 0 1 1 1v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><path d="M18 9h2a1 1 0 0 1 1 1v8a2 2 0 0 1-2 2"/><path d="M7 9h7M7 12h7M7 15h4"/></svg>' };
+  function newsAllowed() {
+    try { return localStorage.getItem("pbNewsTab") === "1"; } catch (_) { return false; }
+  }
+  function fourthTab() { return newsAllowed() ? NEWS_TAB : TABS[2]; } // TABS[2] = "O que pedir"
+
+  // Pergunta o plano e reconcilia o 4º tab + o item do menu lateral. Como o
+  // swap não muda posição nem quantidade de abas, atualiza o tab NO LUGAR
+  // (sem remexer no dock). Pro: "Notícias" no rodapé, fora do menu.
+  function syncNewsTab(bar) {
+    fetch("/auth/me", { credentials: "same-origin" })
+      .then(r => (r.ok ? r.json() : null))
+      .then(me => {
+        if (!me) return;
+        const isPro = ((me.plan || "free") + "").trim().toLowerCase() === "pro";
+        let prev = false;
+        try { prev = localStorage.getItem("pbNewsTab") === "1"; } catch (_) {}
+        try { localStorage.setItem("pbNewsTab", isPro ? "1" : "0"); } catch (_) {}
+        const sidenavNews = document.querySelector('.sidenav-item[href="/changelog"]');
+        if (sidenavNews) sidenavNews.style.display = isPro ? "none" : "";
+        if (isPro === prev) return; // cache já estava certo
+        const t = fourthTab();
+        const a = bar.querySelector('.pb-tab[href="/comandos-app"], .pb-tab[href="/changelog"]');
+        if (!a) return;
+        a.setAttribute("href", t.href);
+        const ico = a.querySelector(".pb-tab-ico"); if (ico) ico.innerHTML = t.icon;
+        const lbl = a.querySelector("span:last-child"); if (lbl) lbl.textContent = t.label;
+        const active = PAGES[t.href] === page;
+        a.classList.toggle("active", active);
+        if (active) a.setAttribute("aria-current", "page"); else a.removeAttribute("aria-current");
+      })
+      .catch(() => {});
+  }
 
   // Lançamento: no dashboard abre o modal direto; nas outras páginas navega
   // pro dashboard com ?lancar=1 (o init lá embaixo dispara o modal).
@@ -116,11 +156,12 @@
       "</linearGradient></defs>" +
       '<path class="pb-dock-fill" fill="url(#pbDockPlate)" stroke="url(#pbDockRim)" stroke-width="1"/>' +
       "</svg>" +
-      tabHtml(TABS[0]) + tabHtml(TABS[1]) + fabHtml + tabHtml(TABS[2]) + tabHtml(TABS[3]) +
+      tabHtml(TABS[0]) + tabHtml(TABS[1]) + fabHtml + tabHtml(fourthTab()) + tabHtml(TABS[3]) +
       '<span class="pb-dock-bead" aria-hidden="true"><span class="pb-dock-bead-ico"></span></span>';
     bar.querySelector(".pb-tab-fab").addEventListener("click", fabLaunch);
     document.body.appendChild(bar);
     initDock(bar);
+    syncNewsTab(bar);
   }
 
   // ─── Dock "menisco" ──────────────────────────────────────────────────────

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,8 +16,8 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=23"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script src="/app-mode.js?v=26"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -13,6 +13,8 @@
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script src="/app-mode.js?v=26"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,8 +80,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=24"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script src="/app-mode.js?v=26"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard-chat.js
+++ b/frontend/dashboard-chat.js
@@ -189,4 +189,90 @@
       if (panel && panel.classList.contains("open")) closePiggy();
     }
   });
+
+  // ── Bolinha: clique abre o chat + arrasto (só no app/PWA) ───────────────
+  (function initFab() {
+    const fab = document.getElementById("piggy-fab");
+    if (!fab) return;
+
+    let justDragged = false;
+
+    // Toque/click abre o chat — em QUALQUER contexto (site e app). Também cobre
+    // teclado (Enter/Espaço no botão dispara click). Substitui o onclick inline.
+    fab.addEventListener("click", (e) => {
+      if (justDragged) { e.preventDefault(); e.stopPropagation(); return; }
+      if (typeof window.togglePiggy === "function") window.togglePiggy();
+    });
+
+    // Arrasto: SÓ no app/PWA. No desktop/site a bolinha fica fixa.
+    if (!document.documentElement.classList.contains("pb-app")) return;
+
+    const KEY = "pbFabPos", MARGIN = 14, THRESHOLD = 6;
+    const size = () => fab.offsetWidth || 58;
+    // Deixa espaço pra tab bar embaixo e pro notch/status em cima.
+    const RESERVE_BOTTOM = 92, MIN_TOP = 54;
+    const clampTop = (y) => Math.max(MIN_TOP, Math.min(y, window.innerHeight - size() - RESERVE_BOTTOM));
+
+    // setProperty com 'important' pra vencer as regras !important do app-mode.css
+    function place(side, top) {
+      fab.style.setProperty("top", clampTop(top) + "px", "important");
+      fab.style.setProperty("bottom", "auto", "important");
+      fab.style.setProperty(side === "left" ? "left" : "right", MARGIN + "px", "important");
+      fab.style.setProperty(side === "left" ? "right" : "left", "auto", "important");
+    }
+    function save(side, top) { try { localStorage.setItem(KEY, JSON.stringify({ side, top })); } catch (_) {} }
+    function load() { try { return JSON.parse(localStorage.getItem(KEY)); } catch (_) { return null; } }
+
+    // Restaura posição salva (se houver)
+    const saved = load();
+    if (saved && (saved.side === "left" || saved.side === "right")) place(saved.side, saved.top);
+
+    let active = false, moved = false, sx = 0, sy = 0, ox = 0, oy = 0;
+
+    fab.addEventListener("pointerdown", (e) => {
+      active = true; moved = false;
+      const r = fab.getBoundingClientRect();
+      sx = e.clientX; sy = e.clientY; ox = e.clientX - r.left; oy = e.clientY - r.top;
+      try { fab.setPointerCapture(e.pointerId); } catch (_) {}
+    });
+
+    fab.addEventListener("pointermove", (e) => {
+      if (!active) return;
+      if (!moved && Math.hypot(e.clientX - sx, e.clientY - sy) < THRESHOLD) return;
+      moved = true;
+      fab.classList.add("pb-dragging");
+      const s = size();
+      const left = Math.max(4, Math.min(e.clientX - ox, window.innerWidth - s - 4));
+      fab.style.setProperty("left", left + "px", "important");
+      fab.style.setProperty("right", "auto", "important");
+      fab.style.setProperty("top", clampTop(e.clientY - oy) + "px", "important");
+      fab.style.setProperty("bottom", "auto", "important");
+      e.preventDefault();
+    });
+
+    function end(e) {
+      if (!active) return;
+      active = false;
+      try { fab.releasePointerCapture(e.pointerId); } catch (_) {}
+      if (!moved) return; // toque curto → o click acima abre o chat
+      fab.classList.remove("pb-dragging");
+      const r = fab.getBoundingClientRect();
+      const side = (r.left + r.width / 2) < window.innerWidth / 2 ? "left" : "right";
+      // Anima o "encaixe" na lateral, depois solta a transição pro hover voltar
+      fab.style.transition = "top .18s ease, left .18s ease, right .18s ease";
+      place(side, r.top);
+      save(side, r.top);
+      setTimeout(() => { fab.style.transition = ""; }, 220);
+      justDragged = true;
+      setTimeout(() => { justDragged = false; }, 0);
+    }
+    fab.addEventListener("pointerup", end);
+    fab.addEventListener("pointercancel", end);
+
+    // Reposiciona ao virar a tela / redimensionar (re-clampa nos limites novos)
+    window.addEventListener("resize", () => {
+      const p = load();
+      if (p && (p.side === "left" || p.side === "right")) place(p.side, p.top);
+    });
+  })();
 })();

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -1997,6 +1997,13 @@ textarea.modal-inp { resize:vertical;min-height:60px;font-family:inherit; }
 }
 #piggy-fab:hover { transform: translateY(-3px) scale(1.05); box-shadow: 0 16px 36px rgba(255,45,142,.55); }
 #piggy-fab.open { transform: rotate(360deg); }
+/* Arrastável só no app/PWA: touch-action none pro gesto não rolar a página.
+   No desktop/site a bolinha fica fixa (arrasto desligado no JS). */
+html.pb-app #piggy-fab { touch-action: none; }
+#piggy-fab.pb-dragging { transition: none !important; cursor: grabbing; }
+/* A imagem interna não intercepta ponteiro: o botão é o único alvo e evita o
+   drag nativo de imagem no desktop. */
+#piggy-fab img { pointer-events: none; -webkit-user-drag: none; user-select: none; }
 #piggy-fab .fab-badge {
   position: absolute; top: -4px; right: -4px;
   background: #ef4444; color: #fff; font-size: .58rem; font-weight: 800;

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,8 +26,8 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script defer src="/app-mode.js?v=24"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script defer src="/app-mode.js?v=26"></script>
 </head>
 <body class="has-sidenav">
 
@@ -1552,7 +1552,7 @@
 
 <!-- ─── Chat IA widget (Piggy) — Item #49 ──────────────────────────────── -->
 
-<button id="piggy-fab" type="button" aria-label="Abrir Piggy IA" onclick="togglePiggy()">
+<button id="piggy-fab" type="button" aria-label="Abrir Piggy IA">
   <span aria-hidden="true"><img src="/brand/stickers/hello.webp" alt=""></span>
   <span class="fab-badge" id="piggy-fab-badge"></span>
 </button>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -404,8 +404,8 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=24"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script src="/app-mode.js?v=26"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,8 +15,8 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=23"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script src="/app-mode.js?v=26"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1103,8 +1103,8 @@ a { color: inherit; text-decoration: none; }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=25" />
-  <script src="/app-mode.js?v=24"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=26" />
+  <script src="/app-mode.js?v=26"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## O que muda

Duas melhorias no **modo app/PWA** (nada muda no site desktop):

### 🐷 Bolinha do chat arrastável (só no app/PWA)
A `#piggy-fab` cobria conteúdo no canto. Agora, **no app**, o usuário pode arrastá-la e ela **gruda na lateral** mais próxima; a posição fica **salva** (`localStorage`) e é restaurada. No **desktop/site** ela continua **fixa** (o arrasto é desligado via `pb-app`).
- Toque curto **abre o chat**; arrasto **não** abre (limiar de 6px).
- Ponteiro unificado (dedo + mouse); `touch-action:none` só no app; imagem interna com `pointer-events:none` (evita o drag nativo de imagem no desktop).
- No app, a bolinha nunca desce por baixo do dock nem sobe no notch (clamp).

### 📰 Aba "Notícias" no rodapé (Pro)
Hoje "Notícias" (`/changelog`) fica escondida no menu lateral. Agora, para contas **Pro**, ela **assume o 4º lugar da tab bar** no lugar de "O que pedir" e **some do menu lateral** (sem duplicar). Contas **Free** mantêm "O que pedir".
- Decisão do plano em cache (montagem instantânea) + reconciliação por `/auth/me`; o swap é **in-place**, sem remexer no dock de menisco.
- `/changelog` passa a renderizar como **tela de app** (tab bar, sem a nav/footer do site).

Bump `app-mode.js`/`app-mode.css` → `v26`.

## Como foi testado
Servindo o front estático com `/auth/me` mockado:
- **Pro:** 4º tab = Notícias→/changelog, item some do menu, cache=1. **Free:** O que pedir→/comandos-app, item no menu, cache=0. **Swap de ida e volta** ao trocar de plano.
- **/changelog no app:** tab bar com "Notícias" ativa, nav/footer ocultos.
- **Arrasto (app):** arrasta, snap na lateral, salva/restaura; toque abre, arrasto não abre; imagem protegida. **Desktop:** sem arrasto, posição fixa, clique abre.
- Sintaxe (`node --check`) e console sem erros.

> Nota: a troca da imagem "torta" da bolinha no site **já foi resolvida na main** (usa o sticker `hello.webp`), então este PR não mexe nisso. A mascote de corpo inteiro no fab **do app** (via `hardenGlyphs`) segue como está — dá pra ajustar num PR separado se quiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
