### PR TITLE
fix(app): fab do chat usa o mesmo sticker do site (some a mascote torta)

### DIFF
--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -399,13 +399,9 @@
         'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
         '<circle cx="12" cy="8" r="3.6"/><path d="M5 20a7 7 0 0 1 14 0"/></svg>';
     });
-    // FAB do chat: mascote 3D (a logo rosa sumia no círculo rosa)
-    const fabIcon = document.querySelector("#piggy-fab span[aria-hidden]");
-    if (fabIcon) {
-      fabIcon.innerHTML =
-        '<img src="/brand/mascot.webp" alt="" style="width:52px;height:52px;' +
-        'display:block;object-fit:contain" />';
-    }
+    // FAB do chat: usa a mesma imagem do site (sticker "hello", já no HTML). O
+    // override antigo trocava pela mascote de corpo inteiro (mascot.webp), que
+    // ficava pequena e torta dentro do círculo — removido pra unificar site/app.
   }
 
   // ── Visão geral estilo app: seção "Próximos vencimentos" + cabeçalho de

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -17,7 +17,7 @@
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=26"></script>
+  <script src="/app-mode.js?v=27"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=26"></script>
+  <script src="/app-mode.js?v=27"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,7 +81,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=26"></script>
+  <script src="/app-mode.js?v=27"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script defer src="/app-mode.js?v=26"></script>
+  <script defer src="/app-mode.js?v=27"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -405,7 +405,7 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=26"></script>
+  <script src="/app-mode.js?v=27"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=26"></script>
+  <script src="/app-mode.js?v=27"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1104,7 +1104,7 @@ a { color: inherit; text-decoration: none; }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=26"></script>
+  <script src="/app-mode.js?v=27"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## O que muda
No **app**, a bolinha do chat (`#piggy-fab`) mostrava a **mascote de corpo inteiro** (`mascot.webp`, 321×520) — o `hardenGlyphs` do `app-mode.js` sobrescrevia o ícone do fab com ela. Num círculo de ~58px, uma imagem retrato fica pequena e **descentralizada** (a "torta" que aparecia no app).

Este PR **remove esse override**: o app passa a usar a **mesma imagem do site** — o sticker `hello.webp` que já está no HTML do fab — centralizada via a regra `#piggy-fab img` existente. Site e app ficam consistentes.

- `app-mode.js`: removido o bloco que trocava o ícone do fab por `mascot.webp`.
- Bump `app-mode.js` → `v27`.

## Antes / depois (app)
- **Antes:** `mascot.webp` (corpo inteiro) → pequena e torta no círculo.
- **Depois:** `hello.webp` (busto, igual ao site) → preenche e centraliza.

## Teste
Servindo o front estático com `?pbapp=1`: o `#piggy-fab img` resolve para `/brand/stickers/hello.webp` (não mais `mascot.webp`); sem erros de console. `node --check` OK.

## Notas
- Se preferirem **outra** imagem só pro app (ex.: `avatar.webp`), é trocar uma linha — mas o padrão aqui é unificar com o site.
- Toca `app-mode.js` como o #96 (bump de versão): se ambos forem mergeados, há um conflito trivial só nas linhas `?v=` — resolve pegando a maior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
