### PR TITLE
feat(dashboard): botão de olho para esconder o saldo

### DIFF
--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -2244,14 +2244,24 @@ html.pb-app #piggy-fab { touch-action: none; }
 
 /* ── Esconder saldo (olho) ────────────────────────────────────────────────
    Borra todos os valores em R$ menos a lista de lançamentos (data-num="lnc_…")
-   e as categorias do mês (data-num="cat_…"), que continuam visíveis. */
+   e as categorias do mês (data-num="cat_…"), que continuam visíveis.
+   Modais e a view de Cartões não usam data-num, então são cobertos por
+   seletores próprios abaixo (escopados pra não borrar transações/lançamentos). */
 #hide-balance-btn { font-size: 1rem; line-height: 1; }
 body.balance-hidden [data-num]:not([data-num^="cat_"]):not([data-num^="lnc_"]),
 body.balance-hidden #pkt-hist-balance,
 body.balance-hidden #pay-bill-balance,
+body.balance-hidden #receipt-amount,
 body.balance-hidden #receipt-balance,
+body.balance-hidden #receipt-open,
 body.balance-hidden #invest-summary .chip-val,
-body.balance-hidden #invest-list .val {
+body.balance-hidden #invest-list .val,
+/* View de Cartões: stats agregados + valores por cartão (totais, limites,
+   faturas). A lista de compras da fatura fica de fora — ver #bill-detail-tx. */
+body.balance-hidden #cards-view .stat-value,
+body.balance-hidden #cards-view .val,
+/* Modal de detalhe da fatura: só os totais do resumo, não as compras. */
+body.balance-hidden #bill-detail-summary .v {
   filter: blur(8px);
   -webkit-filter: blur(8px);
   user-select: none;

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -2241,3 +2241,19 @@ html.pb-app #piggy-fab { touch-action: none; }
 .ag-event-body { min-width: 0; }
 .ag-event-msg { margin: 0; font-size: 13.5px; line-height: 1.45; }
 .ag-event-when { margin: 3px 0 0; font-size: 11.5px; color: var(--text-3); }
+
+/* ── Esconder saldo (olho) ────────────────────────────────────────────────
+   Borra todos os valores em R$ menos a lista de lançamentos (data-num="lnc_…")
+   e as categorias do mês (data-num="cat_…"), que continuam visíveis. */
+#hide-balance-btn { font-size: 1rem; line-height: 1; }
+body.balance-hidden [data-num]:not([data-num^="cat_"]):not([data-num^="lnc_"]),
+body.balance-hidden #pkt-hist-balance,
+body.balance-hidden #pay-bill-balance,
+body.balance-hidden #receipt-balance,
+body.balance-hidden #invest-summary .chip-val,
+body.balance-hidden #invest-list .val {
+  filter: blur(8px);
+  -webkit-filter: blur(8px);
+  user-select: none;
+  transition: filter .15s ease;
+}

--- a/frontend/dashboard.css
+++ b/frontend/dashboard.css
@@ -2256,10 +2256,12 @@ body.balance-hidden #receipt-balance,
 body.balance-hidden #receipt-open,
 body.balance-hidden #invest-summary .chip-val,
 body.balance-hidden #invest-list .val,
-/* View de Cartões: stats agregados + valores por cartão (totais, limites,
-   faturas). A lista de compras da fatura fica de fora — ver #bill-detail-tx. */
+/* View de Cartões: stats agregados (todos em R$) + só os valores monetários
+   por cartão, marcados com .cc-money no dashboard.js (fatura, limite, próxima
+   fatura, limite usado). Os campos de dia (Melhor dia/Fecha/Vence em) usam .val
+   puro e NÃO borram. A lista de compras da fatura fica de fora — ver #bill-detail-tx. */
 body.balance-hidden #cards-view .stat-value,
-body.balance-hidden #cards-view .val,
+body.balance-hidden #cards-view .val.cc-money,
 /* Modal de detalhe da fatura: só os totais do resumo, não as compras. */
 body.balance-hidden #bill-detail-summary .v {
   filter: blur(8px);

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -129,6 +129,7 @@
         <div id="dot" class="connecting"></div>
         <span id="status-text">Conectando…</span>
       </div>
+      <button class="hbtn" id="hide-balance-btn" type="button" onclick="toggleHideBalance()" aria-pressed="false" title="Esconder saldo"><i class="ph ph-eye" aria-hidden="true"></i></button>
       <button class="hbtn" id="refresh-btn" onclick="sendRefresh()"><span id="ref-icon"><i class="ph ph-arrows-clockwise" aria-hidden="true"></i></span> Atualizar</button>
       <button class="hbtn" data-pro-feature="ofx_import" onclick="openOfxImport()"><i class="ph ph-download-simple" aria-hidden="true"></i> Importar OFX</button>
       <input type="file" id="ofx-file-input" accept=".ofx" style="display:none" onchange="handleOfxFileSelected(event)" />

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -6014,6 +6014,28 @@ function toggleTheme() {
   applyTheme(saved);
 })();
 
+// ── Esconder saldo (olho) ────────────────────────────────────────────────
+function applyHideBalance(hidden){
+  document.body.classList.toggle("balance-hidden", hidden);
+  const btn = document.getElementById("hide-balance-btn");
+  if (btn){
+    const ico = btn.querySelector("i");
+    if (ico) ico.className = hidden ? "ph ph-eye-slash" : "ph ph-eye";
+    btn.setAttribute("aria-pressed", hidden ? "true" : "false");
+    btn.title = hidden ? "Mostrar saldo" : "Esconder saldo";
+  }
+}
+function toggleHideBalance(){
+  const hidden = !document.body.classList.contains("balance-hidden");
+  try { localStorage.setItem("pigbank_hide_balance", hidden ? "1" : "0"); } catch(_){}
+  applyHideBalance(hidden);
+}
+(function initHideBalance(){
+  let v = "0";
+  try { v = localStorage.getItem("pigbank_hide_balance") || "0"; } catch(_){}
+  applyHideBalance(v === "1");
+})();
+
 // ── Pro gates (visivel + desabilitado por feature) ───────────────────────
 // A fonte da verdade é o BACKEND: /auth/dashboard-profile devolve feature_gates
 // já resolvido (get_user_limits + is_pro cobrem assinatura expirada com webhook

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -873,16 +873,16 @@ function _renderCardItem(c, idx = 0) {
       </summary>
       <div class="cc-detail-body">
         <div class="cc-meta" style="margin:0">
-          <div class="row"><span class="label">Fatura aberta</span><span class="val ${openColor}">${_fmtBRL(openDue)}</span></div>
-          <div class="row"><span class="label">Limite</span><span class="val">${lim != null ? _fmtBRL(lim) : "—"}</span></div>
+          <div class="row"><span class="label">Fatura aberta</span><span class="val cc-money ${openColor}">${_fmtBRL(openDue)}</span></div>
+          <div class="row"><span class="label">Limite</span><span class="val cc-money">${lim != null ? _fmtBRL(lim) : "—"}</span></div>
           <div class="row"><span class="label">Melhor dia</span><span class="val">${_bestPurchaseDay(c.closing_day)}</span></div>
           <div class="row"><span class="label">Fecha em</span><span class="val">${c.closing_day ? "dia " + c.closing_day : "—"}</span></div>
           <div class="row"><span class="label">Vence em</span><span class="val">${c.due_day ? "dia " + c.due_day : "—"}</span></div>
-          <div class="row"><span class="label">Próxima fatura</span><span class="val">${_fmtBRL(c.next_bill?.total || 0)}</span></div>
+          <div class="row"><span class="label">Próxima fatura</span><span class="val cc-money">${_fmtBRL(c.next_bill?.total || 0)}</span></div>
         </div>
         ${lim != null ? `
           <div class="bar-body" style="margin-top:12px">
-            <div class="bar-head"><span class="name">Limite usado</span><span class="val">${_fmtBRL(used)} / ${_fmtBRL(lim)}</span></div>
+            <div class="bar-head"><span class="name">Limite usado</span><span class="val cc-money">${_fmtBRL(used)} / ${_fmtBRL(lim)}</span></div>
             <div class="bar-track"><div class="bar-fill ${fillClass}" style="width:${usePct.toFixed(1)}%"></div></div>
           </div>` : ""}
         <div class="cc-detail-actions">

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -136,6 +136,11 @@ header h1 { font-size:1.1rem; font-weight:650; letter-spacing:-.02em; }
   font-size:.66rem; font-weight:700; letter-spacing:.1em;
   text-transform:uppercase; color:var(--text-3); margin:28px 4px 10px;
 }
+/* Esconder saldo (olho): borra os valores do Resumo */
+body.balance-hidden .bignum {
+  filter: blur(8px); -webkit-filter: blur(8px);
+  user-select: none; transition: filter .15s ease;
+}
 
 /* Free banner — CTA pra Pro, aparece só pra users no plano free */
 .free-banner {
@@ -487,7 +492,11 @@ footer a:hover { color:var(--text); }
       <a class="btn-pill primary" href="/app?action=launch">+ Lançar agora</a>
     </div>
 
-    <div class="section-title">Resumo</div>
+    <div class="section-title" style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+      <span>Resumo</span>
+      <button id="hide-balance-btn" type="button" onclick="toggleHideBalance()" aria-pressed="false" title="Esconder saldo"
+        style="background:none;border:0;cursor:pointer;font-size:1rem;line-height:1;padding:2px 4px;color:var(--text-2)"><i class="ph ph-eye" aria-hidden="true"></i></button>
+    </div>
     <div class="stats-grid">
       <a class="stat-card" href="/app">
         <div class="stat-head"><span class="stat-icon green"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7V5a2 2 0 0 0-2-2H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v3m0 4v3a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/></svg></span>Saldo</div>
@@ -565,6 +574,28 @@ footer a:hover { color:var(--text); }
 const API = window.location.origin;
 const PT_MONTHS = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"];
 let USER_ID = 0;
+
+/* ─── Esconder saldo (olho) ───────────────────────────────────────────── */
+function applyHideBalance(hidden){
+  document.body.classList.toggle("balance-hidden", hidden);
+  const btn = document.getElementById("hide-balance-btn");
+  if (btn){
+    const ico = btn.querySelector("i");
+    if (ico) ico.className = hidden ? "ph ph-eye-slash" : "ph ph-eye";
+    btn.setAttribute("aria-pressed", hidden ? "true" : "false");
+    btn.title = hidden ? "Mostrar saldo" : "Esconder saldo";
+  }
+}
+function toggleHideBalance(){
+  const hidden = !document.body.classList.contains("balance-hidden");
+  try { localStorage.setItem("pigbank_hide_balance", hidden ? "1" : "0"); } catch(_){}
+  applyHideBalance(hidden);
+}
+(function initHideBalance(){
+  let v = "0";
+  try { v = localStorage.getItem("pigbank_hide_balance") || "0"; } catch(_){}
+  applyHideBalance(v === "1");
+})();
 
 /* ─── Helpers ─────────────────────────────────────────────────────────── */
 function fmtBRL(n) {

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -630,6 +630,10 @@ a { color: inherit; text-decoration: none; }
 }
 .positive { color: var(--green); }
 .negative { color: var(--red); }
+/* Esconder saldo (olho): respeita a preferência ligada em outra tela */
+body.balance-hidden .account-balance {
+  filter: blur(8px); -webkit-filter: blur(8px); user-select: none;
+}
 
 /* ─── Transactions ───────────────────────────── */
 .tx-list { display: flex; flex-direction: column; }
@@ -1732,6 +1736,13 @@ a { color: inherit; text-decoration: none; }
 <div id="toast"></div>
 
 <script>
+/* ── Esconder saldo (olho): aplica a preferência ligada em outra tela ── */
+(function initHideBalance(){
+  let v = "0";
+  try { v = localStorage.getItem("pigbank_hide_balance") || "0"; } catch(_){}
+  document.body.classList.toggle("balance-hidden", v === "1");
+})();
+
 /* ── Config ──────────────────────────────────── */
 const API = window.location.origin;
 const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## O que faz

Adiciona um botão de **olho** (👁 / 🙈) que borra os valores em R$, igual aos apps de banco, para o usuário abrir o PigBank em público sem expor quanto tem.

## Onde aparece

- **Dashboard** (`/app`): botão no header, ao lado de "Atualizar".
- **Início** (`/home`): botão ao lado do título "Resumo".
- **Configurações** (`/settings`): respeita a preferência (borra os saldos das conexões Open Finance).

## Como funciona

- Toggle persiste em `localStorage` (`pigbank_hide_balance`), no mesmo padrão do toggle de tema (`pigbank_theme`). **Sincroniza** entre as três telas.
- Máscara via classe no `<body>` (`balance-hidden`) + CSS `filter: blur` — sobrevive automaticamente aos re-renders do grid e ao `animateCounters()`, sem reaplicar nada.
- Ícone Phosphor `ph-eye` / `ph-eye-slash`, consistente com o resto da UI.

## Escopo (decidido com o solicitante)

**Esconde:** saldo, patrimônio, sobrou/déficit, gastos, receitas, caixinhas, cartões, saldos dos modais (caixinha, pagar boleto, recibo) e a carteira de investimentos.

**Mantém visível:** a lista de lançamentos/transações (`data-num="lnc_"`) e as categorias do mês (`data-num="cat_"`).

## Notas

- 100% client-side — **nenhuma** mudança de backend ou banco.
- As parcelas de "Próximos vencimentos" (card injetado no app mobile) não são borradas (são valores de contas, não saldo).

## Verificação

- [x] Seletor CSS validado em harness isolado: saldo/patrimônio/caixinha/cartão/investimentos borram; categorias/lançamentos/extrato ficam nítidos.
- [ ] Testar com dados reais em `/app`: alternar o olho, atualizar, trocar de mês e recarregar (persistência).

🤖 Generated with [Claude Code](https://claude.com/claude-code)