### PR TITLE
fix(aporte): entender o nome escrito na frase, e ouvir a resposta da pergunta

### DIFF
--- a/core/handle_incoming.py
+++ b/core/handle_incoming.py
@@ -69,6 +69,7 @@ _RESUMABLE_PENDING_TYPES: frozenset[str] = frozenset({
     "installment_pending",
     "pay_bill_choice",
     "funding_source_choice",
+    "investment_pick",
 })
 
 

--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -10,6 +10,93 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _norm_nome(txt: str) -> str:
+    """Comparação de nomes tolerante a acento e caixa."""
+    import unicodedata
+
+    base = unicodedata.normalize("NFD", (txt or "").strip().lower())
+    return "".join(c for c in base if unicodedata.category(c) != "Mn")
+
+
+def _casa_investimento(alvo: str, rows: list) -> list:
+    """Investimentos cujo nome bate com `alvo` — exato primeiro, depois parcial.
+
+    1 item = escolha clara; vários = ambíguo (quem decide é o usuário, porque aportar
+    no investimento errado só se desfaz com resgate, que recolhe IR/IOF); 0 = não achou.
+    """
+    alvo_n = _norm_nome(alvo)
+    if not alvo_n:
+        return []
+    exatos = [r for r in rows if _norm_nome(r["name"]) == alvo_n]
+    if exatos:
+        return exatos
+    return [r for r in rows if alvo_n in _norm_nome(r["name"]) or _norm_nome(r["name"]) in alvo_n]
+
+
+def _pergunta_qual_investimento(user_id: int, amount: float, rows: list, texto: str) -> str:
+    """Pergunta em qual investimento aportar — e ARMA a pendência para ouvir a resposta.
+
+    Antes o bot perguntava "Em qual investimento você quer aportar?" e não guardava
+    nada: a resposta do usuário virava mensagem nova, era reclassificada do zero e — se
+    ele tivesse uma caixinha de mesmo nome — caía na caixinha. Pergunta sem pendência é
+    beco sem saída.
+    """
+    db.set_pending_action(
+        user_id,
+        "investment_pick",
+        {"amount": float(amount), "text": texto,
+         "nomes": [r["name"] for r in rows]},
+        minutes=10,
+    )
+    linhas = [f"{i}. **{_format_inv_name(r['name'])}**" for i, r in enumerate(rows, start=1)]
+    return (
+        f"Em qual investimento você quer aportar {fmt_brl(float(amount))}?\n\n"
+        + "\n".join(linhas)
+        + "\n\nResponda com o número (ex: *1*) ou o nome. Para desistir, *cancelar*."
+    )
+
+
+def resolve_investment_pick(user_id: int, text: str, pending: dict) -> str | None:
+    """Resposta à pergunta "em qual investimento?".
+
+    Devolve None quando a mensagem não é resposta a esta pergunta — aí o roteador
+    segue o caminho normal em vez de prender o usuário.
+    """
+    from utils_text import normalize_text
+
+    if pending.get("action_type") != "investment_pick":
+        return None
+
+    payload = dict(pending.get("payload") or {})
+    resposta = (text or "").strip()
+    norm = normalize_text(resposta)
+
+    if norm in ("nao", "n", "cancelar", "cancela"):
+        db.clear_pending_action(user_id)
+        return "❌ Beleza, cancelei o aporte."
+
+    nomes = payload.get("nomes") or []
+    escolhido = None
+    if norm.isdigit() and 1 <= int(norm) <= len(nomes):
+        escolhido = nomes[int(norm) - 1]
+    else:
+        achados = _casa_investimento(resposta, [{"name": n} for n in nomes])
+        if len(achados) == 1:
+            escolhido = achados[0]["name"]
+
+    if escolhido is None:
+        linhas = [f"{i}. **{_format_inv_name(n)}**" for i, n in enumerate(nomes, start=1)]
+        return ("Não entendi qual. Responda com o número:\n\n"
+                + "\n".join(linhas) + "\n\nOu *cancelar*.")
+
+    db.clear_pending_action(user_id)
+    return deposit(
+        user_id,
+        payload.get("text") or resposta,
+        {"investment_name": escolhido, "amount": float(payload.get("amount") or 0)},
+    )
+
+
 def _pergunta_origem(user_id: int, fontes: list, amount: float, retomar: dict) -> str:
     """Mais de um saldo cobre o valor: o usuário escolhe de onde sai.
 
@@ -225,10 +312,26 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     investment_name = entities.get("investment_name")
     amount = entities.get("amount")
 
-    if not investment_name:
-        return list_investments(user_id, "Em qual investimento você quer aportar?")
     if not amount or float(amount) <= 0:
         return list_investments(user_id, "Qual valor você quer aportar?")
+
+    # Resolve o NOME antes de qualquer coisa. Sem nome, ou com nome que não bate,
+    # o bot pergunta E FICA ESPERANDO (pendência armada) — antes ele perguntava e
+    # não ouvia, e a resposta solta era reclassificada do zero.
+    rows = db.accrue_all_investments(user_id)
+    achados = _casa_investimento(investment_name, rows) if investment_name else []
+    if len(achados) == 1:
+        investment_name = achados[0]["name"]
+    elif rows and len(achados) > 1:
+        return _pergunta_qual_investimento(user_id, float(amount), achados, text)
+    elif rows:
+        # nome não bateu com nada: mostra a carteira inteira e espera a escolha
+        intro = (f"Não encontrei **{_format_inv_name(investment_name)}**."
+                 if investment_name else "")
+        msg = _pergunta_qual_investimento(user_id, float(amount), rows, text)
+        return f"{intro}\n\n{msg}" if intro else msg
+    elif not investment_name:
+        return list_investments(user_id, "Em qual investimento você quer aportar?")
 
     from core.services import funding
 

--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -716,6 +716,18 @@ def _try_alias(norm: str, original: str) -> IntentResult | None:
                 if m:
                     entities["pocket_name"] = m.group(1).strip()
 
+            # Sem este ramo o Tier 2 reconhecia o aporte com 0.95 e devolvia
+            # `entities={}` — o handler caía em "em qual investimento?" mesmo com o
+            # nome escrito na frase, e a confiança alta impedia a IA (Tier 3) de ver
+            # a mensagem. Medido: nenhum aporte determinístico completava.
+            elif intent == "investments.deposit":
+                from utils_text import parse_investment_deposit_natural
+                _amt, _nome = parse_investment_deposit_natural(original)
+                if _amt is not None:
+                    entities["amount"] = _amt
+                if _nome:
+                    entities["investment_name"] = _nome
+
             elif intent == "investments.create":
                 m = re.search(r"^criar\s+investimento\s+(.+)$", norm)
                 if m:

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -162,6 +162,19 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
     # escolha qualquer texto poderia virar resposta, então vale a mesma regra do
     # guard anti-órfão logo abaixo: outro comando claro abandona a pergunta e
     # limpa a pendência. confirm.yes/no seguem para o fluxo (podem cancelar).
+    # Resposta à pergunta "em qual investimento?" — mesma escotilha de escape do
+    # guard anti-órfão: outro comando claro abandona a pergunta.
+    if pending and pending.get("action_type") == "investment_pick":
+        if (confidence >= 0.55 and intent != "out_of_scope"
+                and intent not in ("confirm.yes", "confirm.no")
+                and not intent.startswith("investments.")):
+            db.clear_pending_action(user_id)
+            pending = None
+        else:
+            resp = h_investments.resolve_investment_pick(user_id, text, pending)
+            if resp is not None:
+                return resp
+
     if pending and pending.get("action_type") == "funding_source_choice":
         abandonou = (
             confidence >= 0.55

--- a/tests/test_aporte_entende_o_nome.py
+++ b/tests/test_aporte_entende_o_nome.py
@@ -1,0 +1,178 @@
+"""O aporte precisa entender o nome que o usuário escreveu — e ouvir a resposta.
+
+Três falhas reais, relatadas com print da conversa:
+
+1. "investi 80 em reserva de emergencia" devolvia a lista de investimentos, mesmo com
+   o nome escrito na frase. Causa: o Tier 2 do classificador reconhecia
+   `investments.deposit` com 0.95 de confiança e devolvia `entities={}` — não havia
+   ramo de extração para esse intent. E, pela confiança alta, a mensagem nunca chegava
+   na IA (Tier 3) que saberia extrair. Nenhum aporte determinístico completava.
+
+2. "Em qual investimento você quer aportar?" era pergunta sem pendência: o bot
+   perguntava e não guardava nada.
+
+3. Como consequência de (2), a resposta solta era reclassificada do zero — e o usuário,
+   que tem uma CAIXINHA com o mesmo nome de um INVESTIMENTO, recebia o extrato da
+   caixinha em vez do aporte.
+"""
+import uuid
+
+import pytest
+
+import db
+from core.handlers import investments as h_investments
+from core.intent_classifier import classify
+from utils_text import parse_investment_deposit_natural
+
+
+CARTEIRA = [
+    ("Reserva de Emergencia", 1.0, "cdi"),
+    ("Tesouro IPCA+ 2032", 0.0762, "yearly"),
+    ("Tesouro Prefixado 2032", 0.1378, "yearly"),
+    ("Fabiana", 1.0, "cdi"),
+]
+
+
+@pytest.fixture()
+def carteira(user_id):
+    """Replica a carteira do relato, incluindo a caixinha de nome repetido."""
+    db.add_launch_and_update_balance(user_id, "receita", 5000, None, "seed")
+    for nome, taxa, periodo in CARTEIRA:
+        db.create_investment_db(user_id, nome, taxa, periodo, "seed", initial_amount=100)
+    db.create_pocket(user_id, "Reserva de Emergência")   # mesmo nome, outro tipo
+    return user_id
+
+
+# ─── 1. entender o nome ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("frase,valor,nome", [
+    ("investi 80 em reserva de emergencia", 80.0, "reserva de emergencia"),
+    ("Investi 800 na renda fixa", 800.0, "renda fixa"),
+    ("aportei 500 no investimento CDB Nubank", 500.0, "cdb nubank"),
+    ("investi 1.200 no tesouro ipca+ 2032", 1200.0, "tesouro ipca+ 2032"),
+    ("apliquei 300 na Fabiana", 300.0, "fabiana"),
+])
+def test_parser_extrai_valor_e_nome(frase, valor, nome):
+    assert parse_investment_deposit_natural(frase) == (valor, nome)
+
+
+@pytest.mark.parametrize("frase", ["investi 80", "oi tudo bem", "quanto gastei hoje"])
+def test_parser_nao_inventa(frase):
+    assert parse_investment_deposit_natural(frase) == (None, None)
+
+
+def test_classificador_entrega_as_entidades():
+    """Era aqui que quebrava: intent certo, confiança alta, `entities` vazio."""
+    r = classify("investi 80 em reserva de emergencia")
+    assert r.intent == "investments.deposit"
+    assert r.entities == {"amount": 80.0, "investment_name": "reserva de emergencia"}
+
+
+def test_nome_escrito_na_frase_aporta_direto(carteira):
+    """O caso do print: nome correto na mensagem tem que virar aporte, não pergunta."""
+    r = classify("investi 80 em reserva de emergencia", user_id=carteira)
+    msg = h_investments.deposit(carteira, "investi 80 em reserva de emergencia", r.entities)
+
+    assert "✅" in msg
+    assert "Reserva de Emergencia" in msg
+    assert "Em qual investimento" not in msg
+    invs = {i["name"]: float(i["balance"]) for i in db.list_investments(carteira)}
+    assert invs["Reserva de Emergencia"] == 180.0     # 100 do seed + 80
+
+
+# ─── 2. a pergunta precisa esperar a resposta ────────────────────────────────
+
+def test_nome_desconhecido_pergunta_e_arma_pendencia(carteira):
+    msg = h_investments.deposit(
+        carteira, "investi 800 na carteira azul",
+        {"investment_name": "carteira azul", "amount": 800},
+    )
+
+    assert "Não encontrei" in msg
+    assert "Em qual investimento" in msg
+    pend = db.get_pending_action(carteira)
+    assert pend is not None and pend["action_type"] == "investment_pick"
+    assert pend["payload"]["amount"] == 800.0
+
+
+def test_sem_pendencia_a_pergunta_seria_beco_sem_saida(carteira):
+    """Guarda explícita do bug 2: perguntar sem armar pendência é o defeito."""
+    h_investments.deposit(carteira, "investi 800 na carteira azul",
+                          {"investment_name": "carteira azul", "amount": 800})
+    assert db.get_pending_action(carteira) is not None
+
+
+def test_ambiguidade_lista_so_os_candidatos(carteira):
+    msg = h_investments.deposit(
+        carteira, "investi 300 no tesouro", {"investment_name": "tesouro", "amount": 300},
+    )
+    assert "Tesouro IPCA+ 2032" in msg and "Tesouro Prefixado 2032" in msg
+    assert "Fabiana" not in msg          # só os que casam
+    assert db.get_pending_action(carteira)["action_type"] == "investment_pick"
+
+
+# ─── 3. a resposta não pode virar a caixinha ─────────────────────────────────
+
+def test_resposta_pelo_nome_vai_pro_investimento_nao_pra_caixinha(carteira):
+    """O erro do print: o usuário tem CAIXINHA e INVESTIMENTO com o mesmo nome.
+    Respondendo à pergunta, tem que valer o investimento."""
+    h_investments.deposit(carteira, "investi 800 na carteira azul",
+                          {"investment_name": "carteira azul", "amount": 800})
+
+    msg = h_investments.resolve_investment_pick(
+        carteira, "Reserva de Emergencia", db.get_pending_action(carteira))
+
+    assert "✅" in msg
+    assert "caixinha" not in msg.lower()
+    invs = {i["name"]: float(i["balance"]) for i in db.list_investments(carteira)}
+    assert invs["Reserva de Emergencia"] == 900.0        # 100 + 800
+    pockets = {p["name"]: float(p["balance"]) for p in db.list_pockets(carteira)}
+    assert pockets["Reserva de Emergência"] == 0.0       # a caixinha não foi tocada
+
+
+def test_resposta_pelo_numero(carteira):
+    h_investments.deposit(carteira, "investi 800 na carteira azul",
+                          {"investment_name": "carteira azul", "amount": 800})
+    pend = db.get_pending_action(carteira)
+    primeiro = pend["payload"]["nomes"][0]
+
+    msg = h_investments.resolve_investment_pick(carteira, "1", pend)
+
+    assert "✅" in msg and primeiro in msg
+    assert db.get_pending_action(carteira) is None
+
+
+def test_resposta_ilegivel_repergunta_sem_lancar(carteira):
+    h_investments.deposit(carteira, "investi 800 na carteira azul",
+                          {"investment_name": "carteira azul", "amount": 800})
+
+    msg = h_investments.resolve_investment_pick(
+        carteira, "sei lá", db.get_pending_action(carteira))
+
+    assert "Não entendi qual" in msg
+    assert db.get_pending_action(carteira) is not None    # pendência preservada
+    invs = {i["name"]: float(i["balance"]) for i in db.list_investments(carteira)}
+    assert invs["Reserva de Emergencia"] == 100.0         # nada lançado
+
+
+def test_cancelar_limpa(carteira):
+    h_investments.deposit(carteira, "investi 800 na carteira azul",
+                          {"investment_name": "carteira azul", "amount": 800})
+    msg = h_investments.resolve_investment_pick(
+        carteira, "cancelar", db.get_pending_action(carteira))
+
+    assert "cancelei" in msg.lower()
+    assert db.get_pending_action(carteira) is None
+
+
+def test_pendencia_alheia_e_ignorada(carteira):
+    assert h_investments.resolve_investment_pick(
+        carteira, "1", {"action_type": "delete_launch", "payload": {}}) is None
+
+
+def test_pendencia_bloqueia_o_fallback_de_ia():
+    """Sem isso, a resposta "1" cai como baixa confiança e a IA sequestra o turno
+    (core/handle_incoming.py), que foi como a caixinha entrou na conversa."""
+    pytest.importorskip("ofxparse", reason="ausente localmente; presente no CI")
+    from core.handle_incoming import _RESUMABLE_PENDING_TYPES
+    assert "investment_pick" in _RESUMABLE_PENDING_TYPES

--- a/utils_text.py
+++ b/utils_text.py
@@ -1095,6 +1095,48 @@ def parse_expense_income_natural(text: str):
 
     return {"kind": kind, "amount": amount, "note": note, "category": category}
 
+def parse_investment_deposit_natural(text: str):
+    """Retorna (amount, investment_name) de "investi 80 em reserva de emergencia".
+
+    Espelha `parse_pocket_deposit_natural`, mas para aporte em investimento. Existe
+    porque o Tier 2 do classificador reconhece o comando de aporte com 95% de
+    confiança e NÃO extraía entidade nenhuma — devolvia `entities={}`, o handler caía
+    em "em qual investimento?" e, pela confiança alta, a mensagem nunca chegava na IA
+    que saberia extrair. Resultado medido: nenhum aporte pelo caminho determinístico
+    conseguia completar, mesmo com o nome escrito na frase.
+
+    Aceita "no/na/em/pra/para <nome>" e o prefixo opcional "investimento".
+    """
+    raw = normalize_spaces(text.lower())
+
+    if not re.search(r"\b(investi|apliquei|aportei|aplicar|aportar|investir)\b", raw):
+        return None, None
+
+    amount = parse_money(raw)
+    if amount is None:
+        return None, None
+
+    # "investi 500 no investimento X" → o nome vem depois da palavra
+    if "investimento" in raw:
+        nome = raw.split("investimento", 1)[1].strip()
+        nome = re.sub(r"^(da|do|de|na|no|em|pra|para)\s+", "", nome).strip()
+        nome = re.sub(r"\b(hoje|ontem)\b.*$", "", nome).strip()
+        if nome:
+            return amount, nome
+
+    # "investi 80 em reserva de emergencia"
+    m = re.search(r"\b(na|no|em|pra|para)\s+([a-z0-9_\-+áàâãéèêíìîóòôõúùûç ]+)", raw)
+    if m:
+        nome = m.group(2).strip()
+        nome = re.sub(r"\b(hoje|ontem)\b.*$", "", nome).strip()
+        # corta se emendar outro comando
+        nome = re.split(r"\b(saldo|caixinha|coloquei|depositei)\b", nome)[0].strip()
+        if nome:
+            return amount, nome
+
+    return None, None
+
+
 def parse_pocket_deposit_natural(text: str):
     """
     Retorna (amount: float, pocket_name: str) ou (None, None)


### PR DESCRIPTION
Três falhas relatadas com print da conversa. Duas foram identificadas no relato; a terceira é **anterior às duas** e explica a conversa inteira.

## 1. O nome estava na frase e era ignorado

```
'investi 80 em reserva de emergencia'
   intent=investments.deposit   conf=0.95   entities={}
```

O regex `^(apliquei|aportei|investi)\s+\d` do Tier 2 reconhecia o comando com 95% de confiança, mas `_try_alias` **não tinha ramo de extração para esse intent** — devolvia `entities` vazio. O handler caía no primeiro `if not investment_name` e respondia com a lista.

E, pela confiança alta, a mensagem **nunca chegava no Tier 3 (IA)**, que saberia extrair. O Tier 2 roubava a mensagem e não entregava nada.

**Consequência medida: nenhum aporte pelo caminho determinístico completava**, mesmo com nome e valor escritos na frase.

`parse_investment_deposit_natural` espelha o `parse_pocket_deposit_natural` que já existia — mesmo formato, mesma tolerância a `no/na/em/pra/para` e ao prefixo "investimento".

## 2. A pergunta não esperava resposta

*"Em qual investimento você quer aportar?"* era feita **sem armar pendência**: o bot perguntava e não guardava nada. A resposta virava mensagem nova e era reclassificada do zero. Pergunta sem pendência é beco sem saída.

Agora arma `investment_pick` com os nomes e o valor, aceita **número ou nome**, repergunta em vez de adivinhar quando não entende, e tem a mesma escotilha de escape do guard anti-órfão (outro comando claro abandona a pergunta). Entra em `_RESUMABLE_PENDING_TYPES` — sem isso a resposta "1" cai como baixa confiança e o fallback de IA sequestra o turno.

**Restaurei só o perguntar-e-ouvir.** O fluxo de criação do #91 fica de fora de propósito: ele estava entrelaçado com a decisão da ponte (etapa 3), e foi lá que moraram os erros que motivaram a reversão.

## 3. A caixinha aparecendo no lugar do investimento

Consequência da anterior, como o relato já tinha identificado corretamente. O usuário tem uma **caixinha** e um **investimento** com o mesmo nome ("Reserva de Emergência"); sem pendência, a resposta solta foi reclassificada e casou com a caixinha.

Com a pendência armada, a resposta é resolvida contra a lista de investimentos da pergunta. Há teste afirmando que a caixinha continua **intocada**.

## Medição

A conversa do print, ponta a ponta, depois das correções:

| mensagem | antes | depois |
|---|---|---|
| `investi 80 em reserva de emergencia` | a lista | ✅ Aporte de R$ 80,00 |
| `investi 800 na carteira azul` | pergunta órfã | Não encontrei + pergunta + **pendência armada** |
| `Reserva de Emergencia` | extrato da **caixinha** | ✅ Aporte de R$ 800,00 no **investimento** |

**18 testes novos; 10 falham sem estas correções.** Os 8 que passam nos dois estados são o parser puro (código novo) e as guardas de não-regressão — medido revertendo só os arquivos de comportamento e mantendo o parser, para a falha ser de comportamento e não de import.

Suíte: **1094 passed / 5 skipped** → **1122 / 6**. O skip novo é o teste que importa `handle_incoming`, bloqueado localmente pela falta de `ofxparse` (CLAUDE.md §6); no CI roda.

## Fora de escopo

`"Investi 800 na renda fixa"` continua indo para a IA: `"renda fixa"` está em `_RECURRENCE_MARKERS` (`intent_classifier.py`), lista de marcadores de "receita fixa"/"gasto fixo", o que desvia a mensagem para o Tier 3. É falso positivo, mas a IA resolve bem e mexer naquela lista é risco sem retorno claro — fica registrado aqui em vez de virar mudança silenciosa.

## O que não foi verificado

Não rodou no WhatsApp real nem no CI — o Actions segue travado pela cota. Validação contra Postgres 16 local, com a carteira do relato replicada (quatro investimentos + a caixinha de nome repetido).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtWzacGdU7t8D8iXvobgyM)_