### PR TITLE
fix(app-mode): dock encosta na borda inferior da tela

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -154,7 +154,7 @@ html.pb-app .pb-tabbar {
   /* laterais: 10px normais, mas nunca por baixo do notch/cantos (landscape) */
   left: max(10px, env(safe-area-inset-left));
   right: max(10px, env(safe-area-inset-right));
-  bottom: max(8px, calc(env(safe-area-inset-bottom) - 14px));
+  bottom: 0;
   /* Abaixo dos overlays de modal (800/900): modal aberto cobre a tab bar */
   z-index: 700;
   display: flex;


### PR DESCRIPTION
## O que muda

A tab bar flutuante do app mode ficava descolada da base da tela, deixando um vão embaixo onde o conteúdo da página aparecia. Este PR desce a barra até o fim da tela para tampar o conteúdo atrás dela.

Mudança de **uma linha** em `frontend/app-mode.css` (regra `html.pb-app .pb-tabbar`):

```css
/* antes */
bottom: max(8px, calc(env(safe-area-inset-bottom) - 14px));
/* depois */
bottom: 0;
```

## O que NÃO muda

- **Altura** (66px), **espaçamento lateral** (`left/right: max(10px, env(safe-area-inset-*))`), cantos e a chapa SVG do dock — intocados.
- Body `padding-bottom: calc(84px + env(safe-area-inset-bottom))` — sem mudança; com o dock agora ocupando `0→66px` da base (antes ia até `safe-area+52`), a reserva continua sobrando folga.
- `frontend/app-mode.js` — sem mudança (a bolha arrastável e o efeito de "derreter" continuam iguais).

## Validação

- Validado num preview interativo que reusa a geometria real do dock (`socketPath`), com a safe area simulada em 34px: a barra desce ~20px, encosta na borda inferior e tampa o conteúdo de baixo, mantendo altura e laterais.
- **Não verificado neste ambiente:** `env(safe-area-inset-*)` vale 0 no Chromium headless e o comportamento nativo do WKWebView (elástico, home indicator) não é reproduzível aqui. O encaixe fino acima do home indicator do iPhone só se confirma no aparelho, depois do build. Vale conferir no device se a barra não fica colada demais na barrinha; se ficar, dá pra reintroduzir um respiro mínimo de safe area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDyzxpzjHXmxsWjxvsL5m9)_