### PR TITLE
security: SRI hashes, pin Actions by SHA, Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Janela de segurança: espera N dias após publicação antes de abrir PR,
+    # pra não puxar uma versão recém-comprometida (supply-chain).
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -26,6 +31,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     labels:
       - "dependencies"
     commit-message:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
           cache: pip
@@ -72,10 +72,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
           cache: pip

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 <meta name="theme-color" content="#07121d" />
 <title>PigBank — Monitoramento</title>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw==" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <style>
 * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -17,7 +17,7 @@
      bloqueante do parse, mas ainda pré-carrega durante a ociosidade, ficando
      pronto quando os dados chegam. Sortable NÃO entra aqui: é carregado sob
      demanda (ensureSortable) só quando o usuário reordena cartões. -->
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js" integrity="sha512-CQBWl4fJHWbryGE+Pc7UAxWMUMNMWzWxF4SQo9CgkJIN1kx6djDQZjh3Y8SZ1d+6I+1zze6Z7kHXO7q3UyZAWw==" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/dashboard.css?v=7" />

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -10,7 +10,7 @@
      (openPluggyConnect). defer tira o download do caminho bloqueante do parse;
      o factory (window.PluggyConnect) já estará pronto muito antes do clique. -->
 <link rel="preconnect" href="https://cdn.pluggy.ai" crossorigin />
-<script defer src="https://cdn.pluggy.ai/pluggy-connect/v2.7.0/pluggy-connect.js"></script>
+<script defer src="https://cdn.pluggy.ai/pluggy-connect/v2.7.0/pluggy-connect.js" integrity="sha384-EfJtVYPBw2vssrS8cou8sSUccnxm72OwXqa4V+b1injWH0avP4mtCJr2XM6Sb2/7" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="/brand.css" />
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <style>


### PR DESCRIPTION
## Summary
Rodei `semgrep --config auto .` (84 findings) e investiguei cada um individualmente (3 agentes em paralelo, lendo o código ao redor de cada linha, não só a linha isolada). 79 eram falso positivo; 3 categorias eram reais e foram corrigidas:

- **SRI ausente** (3 de 13 findings — os outros 10 são `<link rel="canonical">`, que o navegador nunca busca): adicionado `integrity` + `crossorigin="anonymous"` nos 3 `<script>` de CDN (2x Chart.js 4.4.1 do cdnjs, pluggy-connect v2.7.0 do cdn.pluggy.ai). Hashes conferidos baixando cada arquivo real e recalculando com `openssl dgst` — não foram adivinhados.
- **GitHub Actions em tag mutável** (`actions/checkout@v7`, `actions/setup-python@v7`): pinado ao SHA de commit que a tag `v7` resolve hoje (consultado via API do GitHub), com comentário da versão.
- **Dependabot sem cooldown**: adicionado `cooldown: { default-days: 7, semver-major-days: 14 }` nas 2 entradas (`pip`, `github-actions`) — janela de segurança antes de abrir PR pra versão recém-publicada.

Nada de comportamento de app mudou: são atributos HTML adicionados (não removidos/trocados), SHA que já é o que a tag resolve, e timing de PR do Dependabot.

## Test plan
- [x] `semgrep --config auto .`: 84 → 75 findings. As 3 categorias reais (`missing-integrity` nos 3 scripts, `github-actions-mutable-action-tag`, `dependabot-missing-cooldown`) zeraram; as 79 de falso positivo continuam idênticas (nada nelas foi tocado).
- [x] Hashes SRI verificados por 3 fontes independentes (API do cdnjs, WebFetch, `openssl dgst` sobre o arquivo baixado) — bateram exatamente.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` nos 2 YAML editados — parseiam ok.
- [x] `git diff` revisado linha a linha — só os atributos/blocos planejados foram tocados.
- [x] Suíte completa: `.venv/bin/python -m pytest -q` → 1214 passed, 2 failed. As 2 falhas (`test_conversa_aporte_e2e.py::test_conversa_ambiguidade`, `test_db_investments.py::test_resgate_usa_peps_e_calcula_ir_por_lote`) são pré-existentes e alheias a esta mudança: confirmei rodando os mesmos 2 testes com as mudanças desta PR removidas (stash) e o erro é idêntico (mesmos valores) — são testes de juros/data que dependem de "hoje", não regressão desta PR.
- [ ] Não verificado neste ambiente: renderização real do Chart.js/pluggy-connect no navegador com o `integrity` (CDN bloqueado no sandbox local, conforme CLAUDE.md §6) — o hash bate contra o arquivo real da CDN, mas o carregamento em si só é confirmável em deploy/aparelho real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)