### PR TITLE
fix(app): elimina piscada de cor ao abrir /settings no WebView

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -33,7 +33,19 @@ html.pb-app body {
 html.pb-app.pb-root-app,
 html.pb-app.pb-root-home,
 html.pb-app.pb-root-comandos { background-color: #2E111F; }
-html.pb-app.pb-root-settings { background-color: #0B0B0D; }
+/* Paleta do Ajustes no <html> (não no body): pb-root-settings vem do <head> e
+   pega o 1º paint; body.pb-page-settings só chega no DOMContentLoaded e piscava.
+   As vars herdam pro body. */
+html.pb-app.pb-root-settings {
+  --page:         #0B0B0D;
+  --surface:      #141416;
+  --surface-2:    #1B1B1F;
+  --border:       rgba(255, 255, 255, 0.07);
+  --border-hover: rgba(255, 255, 255, 0.14);
+  --muted:        rgba(255, 255, 255, 0.55);
+  --faint:        rgba(255, 255, 255, 0.34);
+  background-color: #0B0B0D;
+}
 /* Modo claro do dashboard: o applyTheme espelha a classe no <html> por causa
    desta regra. Sem ela o canvas continuaria ameixa enquanto a página vira
    #F6F4F1 — a mesma faixa, invertida. Tom medido no claro: #E8E4E2.
@@ -593,23 +605,13 @@ html.pb-app .upgrade-toast {
 }
 
 /* ─── Settings ─────────────────────────────────────────────────────────── */
-/* Topbar (logo + atalhos) redundante com a tab bar */
-html.pb-app body.pb-page-settings .topbar { display: none !important; }
+/* Topbar redundante com a tab bar. Escondida pelo pb-root-* (1º paint), senão a
+   barra azulada piscava junto com a paleta. */
+html.pb-app.pb-root-settings .topbar { display: none !important; }
 html.pb-app body.pb-page-settings { padding-top: env(safe-area-inset-top); }
 
 /* ─── Settings vira "Minha conta" (estilo app) ─────────────────────────── */
-/* Paleta: o settings tem tema próprio cinza-azulado (#16181d/#1e2128) que
-   destoa do preto da marca — no app, escurece pro tom do resto do produto */
-html.pb-app body.pb-page-settings {
-  --page:         #0B0B0D;
-  --surface:      #141416;
-  --surface-2:    #1B1B1F;
-  --border:       rgba(255, 255, 255, 0.07);
-  --border-hover: rgba(255, 255, 255, 0.14);
-  --muted:        rgba(255, 255, 255, 0.55);
-  --faint:        rgba(255, 255, 255, 0.34);
-  background: #0B0B0D !important;
-}
+/* Paleta movida pra html.pb-app.pb-root-settings (1º paint); aqui só estrutural. */
 
 /* Cabeçalho original (breadcrumb + título por seção) sai; entra o header
    fixo "Minha conta" + banner de segurança injetados pelo app-mode.js */

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -55,6 +55,10 @@
   const path = location.pathname.replace(/\/+$/, "") || "/";
   const page = PAGES[path];
 
+  // pb-root-* no <html> aqui no <head> (síncrono) = paleta por página já no 1º
+  // paint. Só no buildTabbar (DOMContentLoaded) fazia o Ajustes piscar de cor.
+  if (page) root.classList.add("pb-root-" + page);
+
   // Viewport de app: safe areas + zoom travado (pinch/auto-zoom estica o
   // layout e "come" texto nas bordas; app nativo não tem zoom de UI)
   function fixViewport() {

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,8 +16,8 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script src="/app-mode.js?v=28"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -13,8 +13,8 @@
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script src="/app-mode.js?v=28"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,8 +80,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script src="/app-mode.js?v=28"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,8 +26,8 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script defer src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script defer src="/app-mode.js?v=28"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -409,8 +409,8 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script src="/app-mode.js?v=28"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,8 +15,8 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script src="/app-mode.js?v=28"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1107,8 +1107,8 @@ body.balance-hidden .account-balance {
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=26" />
-  <script src="/app-mode.js?v=27"></script>
+  <link rel="stylesheet" href="/app-mode.css?v=27" />
+  <script src="/app-mode.js?v=28"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Paleta e topbar do Ajustes eram escopadas em body.pb-page-settings, aplicada so no DOMContentLoaded — depois do 1o paint. A tela pintava com a paleta azulada do settings-web e trocava pra #0B0B0D logo em seguida.

- pb-root-<page> no <html> de forma sincrona no <head> (ja existe no 1o paint)
- paleta + topbar do Ajustes reescopadas pra html.pb-app.pb-root-settings
- bump ?v= (css 27, js 28) nas 7 paginas do modo-app pro WebView pegar o novo