### PR TITLE
perf(app): troca de aba mais responsiva (corta delay do melt 190->60ms)

### DIFF
--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -333,7 +333,11 @@
       start();
       if (navigate && i !== home) {
         const href = tabs[i].getAttribute("href");
-        if (smooth) setTimeout(() => { location.href = href; }, 190);
+        // 60ms (era 190): o delay do melt somava ao tempo já parado da recarga
+        // — com o cross-fade das View Transitions, o quadro velho fica congelado
+        // durante a navegação, então quanto menos espera antes de começar,
+        // menos "trava". A bolha ainda começa a deslizar; só não espera terminar.
+        if (smooth) setTimeout(() => { location.href = href; }, 60);
         else location.href = href;
       }
     }

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -17,7 +17,7 @@
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=28"></script>
+  <script src="/app-mode.js?v=29"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=28"></script>
+  <script src="/app-mode.js?v=29"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,7 +81,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=28"></script>
+  <script src="/app-mode.js?v=29"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script defer src="/app-mode.js?v=28"></script>
+  <script defer src="/app-mode.js?v=29"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -422,7 +422,7 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=28"></script>
+  <script src="/app-mode.js?v=29"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=28"></script>
+  <script src="/app-mode.js?v=29"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1108,7 +1108,7 @@ body.balance-hidden .account-balance {
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=28"></script>
+  <script src="/app-mode.js?v=29"></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Contexto

O PR #111 ligou o cross-fade nativo (View Transitions). No aparelho, a troca de aba deixou de piscar branco, mas passou a **"congelar e trocar"**: o WebKit segura o quadro da tela velha, recarrega a página e só então faz o fade. Esse congelamento é o **tempo de carga** da recarga de documento — o cross-fade não deixa a navegação mais rápida.

## O que este PR faz (caminho 1, paliativo)

Corta o delay do "melt" da bolha de **190ms → 60ms** antes de navegar (`app-mode.js`, `goTo`).

Hoje, ao tocar numa aba, a bolha desliza 190ms **antes** de a navegação começar — e esse tempo soma ao congelamento. Reduzindo, o toque responde ~0,13s mais rápido. A bolha ainda começa a deslizar; só não espera terminar.

- Não remove a carga da página (isso é limite do MPA no WebView; sem prerender no iOS).
- Bump `app-mode.js ?v=29` nas 7 páginas.

## Verificação

- **Não medi aqui** — o WKWebView não é reproduzível fora do aparelho (`CLAUDE.md §6`). **Só no iPhone dá pra dizer se ficou bom.**
- Se ainda "travar", o gargalo é a **carga da página** em si, não o melt — aí o caminho é navegação client-side (mudança grande, discutida à parte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
