### PR TITLE
feat(home): ☰ abre a gaveta lateral do dashboard (não o menu de conta)

### DIFF
--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10265,8 +10265,12 @@ function _showAccessError(title, msg) {
 	    // Os demais abrem via navigateTo — mas só se o item do sidenav existir
 	    // e estiver visível, respeitando os beta-gates (ex.: agents_ui_enabled)
 	    // e o pro-gate, igual ao clique manual.
+	    // affiliate fica de fora: seu item (#sidenav-affiliate) só vira visível
+	    // depois do initAffiliateNav() (fire-and-forget, abaixo), então o check
+	    // de visibilidade correria com ele. A gaveta da /home não linka affiliate,
+	    // e ele nunca foi deep-linkável por URL — manter fora não regride nada.
 	    if (view === "investments") setMainView("investments");
-	    else if (view && view !== "overview") {
+	    else if (view && view !== "overview" && view !== "affiliate") {
 	      const navEl = document.querySelector(`[data-nav="${view}"]`);
 	      if (navEl && navEl.style.display !== "none") navigateTo(view);
 	    }

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10260,13 +10260,15 @@ function _showAccessError(title, msg) {
 	  // do profile resolver.
 	  connect();
 	  loadUserMenuState().then(() => {
+	    // Deep-link por ?view=X (gaveta da /home aponta pra cá). investments
+	    // mantém o caminho antigo (setMainView direto); overview é o default.
+	    // Os demais abrem via navigateTo — mas só se o item do sidenav existir
+	    // e estiver visível, respeitando os beta-gates (ex.: agents_ui_enabled)
+	    // e o pro-gate, igual ao clique manual.
 	    if (view === "investments") setMainView("investments");
-	    // Deep-link da galeria pública /agents (botão "Ver meus agentes"):
-	    // abre a aba de agentes — só se ela estiver visível (respeita o
-	    // beta-gate agents_ui_enabled, que esconde o item acima).
-	    else if (view === "agentes") {
-	      const agNav = document.querySelector('[data-nav="agentes"]');
-	      if (agNav && agNav.style.display !== "none") navigateTo("agentes");
+	    else if (view && view !== "overview") {
+	      const navEl = document.querySelector(`[data-nav="${view}"]`);
+	      if (navEl && navEl.style.display !== "none") navigateTo(view);
 	    }
 	  });
 	  // Wizard: abre auto se conta virgem (não bloqueante).

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -830,12 +830,14 @@ function toggleSidenav(force) {
   if (bd) bd.classList.toggle("open", open);
   const tog = document.querySelector(".sidenav-toggle");
   if (tog) tog.setAttribute("aria-expanded", String(open));
-  // Foco preso na gaveta: enquanto aberta, o resto da página (#page-root, que
-  // inclui o header/☰) fica inert — o Tab não escapa pro fundo coberto e, ao
-  // passar do último item, volta pro primeiro. Fechar libera o fundo ANTES de
-  // devolver o foco pro ☰ (que mora dentro do #page-root).
-  const root = document.getElementById("page-root");
-  if (root) root.toggleAttribute("inert", open);
+  // Foco preso na gaveta: enquanto aberta, TODO o resto (irmãos do body — o
+  // #page-root com o header/☰, e a .pb-tabbar que o app-mode.js injeta direto
+  // no body) fica inert. Assim o Tab não escapa pro fundo coberto e, ao passar
+  // do último item, volta pro primeiro. Fechar libera tudo ANTES de devolver o
+  // foco pro ☰ (que mora dentro do #page-root).
+  Array.from(document.body.children).forEach(el => {
+    if (el !== nav && el !== bd) el.toggleAttribute("inert", open);
+  });
   // Foco segue a gaveta: abrir → 1º item; fechar (backdrop/ESC) → ☰.
   if (open) {
     const first = nav.querySelector(".sidenav-item");

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -484,7 +484,7 @@ footer a:hover { color:var(--text); }
      abre fica escondido na web. Os itens são as views do dashboard, então
      deep-linkam pra /app?view=X (o dashboard.js abre a view certa no load). -->
 <div class="sidenav-backdrop" id="sidenav-backdrop" onclick="toggleSidenav(false)"></div>
-<aside class="sidenav" id="sidenav" aria-label="Navegação principal">
+<aside class="sidenav" id="sidenav" aria-label="Navegação principal" inert>
   <div class="sidenav-brand">
     <img class="logo" src="/brand/icon.png?v=1" alt="" />
     <div class="brand-text">
@@ -497,7 +497,7 @@ footer a:hover { color:var(--text); }
   <a class="sidenav-item" href="/app?view=overview"><span class="sn-icon" style="color:#3B82F6"><i class="ph ph-chart-bar" aria-hidden="true"></i></span><span class="sn-label">Visão Geral</span></a>
   <a class="sidenav-item" href="/app?view=analytics"><span class="sn-icon" style="color:#06B6D4"><i class="ph ph-chart-line-up" aria-hidden="true"></i></span><span class="sn-label">Análises</span></a>
   <a class="sidenav-item" href="/app?view=history"><span class="sn-icon" style="color:#94A3B8"><i class="ph ph-clock-counter-clockwise" aria-hidden="true"></i></span><span class="sn-label">Histórico</span></a>
-  <a class="sidenav-item" href="/app?view=agentes"><span class="sn-icon" style="color:#FF2D8E"><i class="ph ph-piggy-bank" aria-hidden="true"></i></span><span class="sn-label">Agentes</span><span class="sn-tag new">novo</span></a>
+  <a class="sidenav-item" data-nav="agentes" href="/app?view=agentes"><span class="sn-icon" style="color:#FF2D8E"><i class="ph ph-piggy-bank" aria-hidden="true"></i></span><span class="sn-label">Agentes</span><span class="sn-tag new">novo</span></a>
 
   <div class="sidenav-section">Planejamento</div>
   <a class="sidenav-item" href="/app?view=fixed"><span class="sn-icon" style="color:#14B8A6"><i class="ph ph-arrows-clockwise" aria-hidden="true"></i></span><span class="sn-label">Recorrentes</span></a>
@@ -824,6 +824,9 @@ function toggleSidenav(force) {
   if (!nav) return;
   const open = (typeof force === "boolean") ? force : !nav.classList.contains("open");
   nav.classList.toggle("open", open);
+  // Fechada, a gaveta só sai da tela (translateX) — sem inert, seus links
+  // continuariam no tab order. inert tira do foco/AT quando fechada.
+  nav.toggleAttribute("inert", !open);
   if (bd) bd.classList.toggle("open", open);
   const tog = document.querySelector(".sidenav-toggle");
   if (tog) tog.setAttribute("aria-expanded", String(open));
@@ -886,6 +889,11 @@ async function loadProfile() {
     document.getElementById("user-label").textContent = displayLabel(PROFILE_DISPLAY_NAME, PROFILE_EMAIL);
     document.getElementById("user-email").textContent = PROFILE_EMAIL || "Minha conta";
     document.getElementById("user-plan").textContent  = planLabel(plan);
+    // Beta-gate dos Agentes: esconde o item da gaveta quando desligado
+    // (mesma regra do dashboard.js — freio de emergência / allowlist).
+    if (data.agents_ui_enabled === false) {
+      document.querySelectorAll('[data-nav="agentes"]').forEach(el => { el.style.display = "none"; });
+    }
   } catch {}
 }
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -523,7 +523,7 @@ footer a:hover { color:var(--text); }
 
   <header>
     <div class="header-left">
-      <button class="sidenav-toggle" type="button" aria-label="Abrir menu" aria-controls="sidenav" onclick="toggleSidenav(true)"><i class="ph ph-list" aria-hidden="true"></i></button>
+      <button class="sidenav-toggle" type="button" aria-label="Abrir menu" aria-controls="sidenav" aria-expanded="false" onclick="toggleSidenav(true)"><i class="ph ph-list" aria-hidden="true"></i></button>
       <img class="logo-img" src="/brand/icon.png?v=1" alt="Piggy" />
       <h1>PigBank</h1>
       <div class="nav-links">
@@ -825,6 +825,8 @@ function toggleSidenav(force) {
   const open = (typeof force === "boolean") ? force : !nav.classList.contains("open");
   nav.classList.toggle("open", open);
   if (bd) bd.classList.toggle("open", open);
+  const tog = document.querySelector(".sidenav-toggle");
+  if (tog) tog.setAttribute("aria-expanded", String(open));
 }
 document.addEventListener("keydown", e => {
   if (e.key === "Escape") {

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -830,6 +830,15 @@ function toggleSidenav(force) {
   if (bd) bd.classList.toggle("open", open);
   const tog = document.querySelector(".sidenav-toggle");
   if (tog) tog.setAttribute("aria-expanded", String(open));
+  // Foco segue a gaveta: ao abrir vai pro 1º item; ao fechar (backdrop/ESC)
+  // volta pro ☰ — senão o Tab passeia pela página coberta, e o ESC deixaria
+  // o foco preso num link que acabou de virar inert.
+  if (open) {
+    const first = nav.querySelector(".sidenav-item");
+    if (first) first.focus();
+  } else if (tog) {
+    tog.focus();
+  }
 }
 document.addEventListener("keydown", e => {
   if (e.key === "Escape") {

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -73,6 +73,39 @@ header {
 }
 .sidenav-toggle:hover { background:rgba(255,255,255,.08); color:var(--text); }
 html.pb-app body.pb-page-home .sidenav-toggle { display:inline-flex; }
+
+/* ─── Gaveta lateral (portada da dashboard.css) ───────────────────────── */
+.sidenav {
+  position:fixed; top:0; left:0; bottom:0; width:260px; box-sizing:border-box;
+  z-index:60; display:flex; flex-direction:column; padding:18px 14px 14px;
+  padding-top:calc(18px + env(safe-area-inset-top));
+  padding-bottom:calc(14px + env(safe-area-inset-bottom));
+  background:#0f1422; box-shadow:4px 0 24px rgba(0,0,0,.5);
+  overflow-y:auto; transform:translateX(-100%); transition:transform .25s var(--ease);
+}
+.sidenav.open { transform:translateX(0); }
+.sidenav::-webkit-scrollbar { width:6px; }
+.sidenav::-webkit-scrollbar-thumb { background:rgba(255,255,255,.08); border-radius:3px; }
+.sidenav-brand { display:flex; align-items:center; gap:10px; padding:6px 8px 16px; border-bottom:1px solid var(--div); margin-bottom:12px; }
+.sidenav-brand .logo { width:38px; height:38px; object-fit:contain; display:block; background:none; box-shadow:none; border-radius:0; }
+.sidenav-brand .brand-text { display:flex; flex-direction:column; line-height:1.15; min-width:0; }
+.sidenav-brand .brand-name { font-size:.92rem; font-weight:700; color:var(--text); letter-spacing:-.01em; }
+.sidenav-brand .brand-sub  { font-size:.66rem; color:var(--text-3); text-transform:uppercase; letter-spacing:.08em; }
+.sidenav-section { font-size:.62rem; text-transform:uppercase; letter-spacing:.1em; color:var(--text-3); padding:14px 10px 6px; }
+.sidenav-item {
+  display:flex; align-items:center; gap:11px; width:100%; padding:9px 11px; margin:1px 0;
+  background:transparent; border:1px solid transparent; border-radius:10px;
+  color:var(--text-2); font-size:.83rem; font-weight:500; text-align:left;
+  cursor:pointer; transition:all .18s var(--ease); text-decoration:none; font-family:inherit;
+}
+.sidenav-item:hover:not([disabled]) { background:rgba(255,255,255,.06); color:var(--text); border-color:rgba(255,255,255,.07); }
+.sidenav-item .sn-icon { width:22px; height:22px; border-radius:7px; display:inline-flex; align-items:center; justify-content:center; font-size:.92rem; flex-shrink:0; background:rgba(255,255,255,.04); color:var(--text-2); }
+.sidenav-item .sn-label { flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sidenav-item .sn-tag { font-size:.55rem; font-weight:700; padding:2px 6px; border-radius:6px; letter-spacing:.06em; text-transform:uppercase; background:rgba(251,191,36,.18); color:#fbbf24; }
+.sidenav-item .sn-tag.new { background:rgba(198,241,26,.18); color:#C6F11A; }
+.sidenav-footer { margin-top:auto; padding-top:12px; border-top:1px solid var(--div); display:flex; flex-direction:column; gap:2px; }
+.sidenav-backdrop { display:none; }
+.sidenav-backdrop.open { display:block; position:fixed; inset:0; z-index:59; background:rgba(0,0,0,.55); backdrop-filter:blur(1px); }
 header h1 { font-size:1.1rem; font-weight:650; letter-spacing:-.02em; }
 
 .nav-links { display:flex; gap:4px; margin-left:8px; flex-wrap:wrap; }
@@ -447,11 +480,50 @@ footer a:hover { color:var(--text); }
   <div class="orb orb-4"></div>
 </div>
 
+<!-- Gaveta lateral (igual à do dashboard). Só é alcançável no app: o ☰ que a
+     abre fica escondido na web. Os itens são as views do dashboard, então
+     deep-linkam pra /app?view=X (o dashboard.js abre a view certa no load). -->
+<div class="sidenav-backdrop" id="sidenav-backdrop" onclick="toggleSidenav(false)"></div>
+<aside class="sidenav" id="sidenav" aria-label="Navegação principal">
+  <div class="sidenav-brand">
+    <img class="logo" src="/brand/icon.png?v=1" alt="" />
+    <div class="brand-text">
+      <span class="brand-name">PigBank</span>
+      <span class="brand-sub">Assistente financeiro</span>
+    </div>
+  </div>
+
+  <div class="sidenav-section">Geral</div>
+  <a class="sidenav-item" href="/app?view=overview"><span class="sn-icon" style="color:#3B82F6"><i class="ph ph-chart-bar" aria-hidden="true"></i></span><span class="sn-label">Visão Geral</span></a>
+  <a class="sidenav-item" href="/app?view=analytics"><span class="sn-icon" style="color:#06B6D4"><i class="ph ph-chart-line-up" aria-hidden="true"></i></span><span class="sn-label">Análises</span></a>
+  <a class="sidenav-item" href="/app?view=history"><span class="sn-icon" style="color:#94A3B8"><i class="ph ph-clock-counter-clockwise" aria-hidden="true"></i></span><span class="sn-label">Histórico</span></a>
+  <a class="sidenav-item" href="/app?view=agentes"><span class="sn-icon" style="color:#FF2D8E"><i class="ph ph-piggy-bank" aria-hidden="true"></i></span><span class="sn-label">Agentes</span><span class="sn-tag new">novo</span></a>
+
+  <div class="sidenav-section">Planejamento</div>
+  <a class="sidenav-item" href="/app?view=fixed"><span class="sn-icon" style="color:#14B8A6"><i class="ph ph-arrows-clockwise" aria-hidden="true"></i></span><span class="sn-label">Recorrentes</span></a>
+  <a class="sidenav-item" href="/app?view=budgets"><span class="sn-icon" style="color:#F59E0B"><i class="ph ph-note-pencil" aria-hidden="true"></i></span><span class="sn-label">Orçamentos</span><span class="sn-tag new">novo</span></a>
+  <a class="sidenav-item" href="/app?view=goals"><span class="sn-icon" style="color:#10B981"><i class="ph ph-target" aria-hidden="true"></i></span><span class="sn-label">Caixinhas e metas</span><span class="sn-tag new">novo</span></a>
+  <a class="sidenav-item" href="/app?view=categories"><span class="sn-icon" style="color:#A855F7"><i class="ph ph-tag" aria-hidden="true"></i></span><span class="sn-label">Categorias</span></a>
+
+  <div class="sidenav-section">Crédito</div>
+  <a class="sidenav-item" href="/app?view=installments"><span class="sn-icon" style="color:#FB923C"><i class="ph ph-credit-card" aria-hidden="true"></i></span><span class="sn-label">Parcelamentos</span></a>
+  <a class="sidenav-item" href="/app?view=cards"><span class="sn-icon" style="color:#6366F1"><i class="ph ph-cards" aria-hidden="true"></i></span><span class="sn-label">Cartões</span><span class="sn-tag new">novo</span></a>
+  <a class="sidenav-item" href="/app?view=investments"><span class="sn-icon" style="color:#22C55E"><i class="ph ph-chart-line-up" aria-hidden="true"></i></span><span class="sn-label">Investimentos</span><span class="sn-tag">Pro</span></a>
+
+  <div class="sidenav-footer">
+    <div class="sidenav-section" style="padding-top:0">Conta</div>
+    <a class="sidenav-item" href="/settings?view=security"><span class="sn-icon" style="color:#94A3B8"><i class="ph ph-user" aria-hidden="true"></i></span><span class="sn-label">Conta</span></a>
+    <a class="sidenav-item" href="/suporte" target="_blank" rel="noopener"><span class="sn-icon" style="color:#60A5FA"><i class="ph ph-question" aria-hidden="true"></i></span><span class="sn-label">Suporte</span></a>
+    <a class="sidenav-item" href="/changelog"><span class="sn-icon" style="color:#F59E0B"><i class="ph ph-newspaper" aria-hidden="true"></i></span><span class="sn-label">Notícias</span><span class="sn-tag">Pro</span></a>
+    <button class="sidenav-item" type="button" onclick="connectWhatsAppFromHome(event)"><span class="sn-icon" style="color:#22c55e"><i class="ph ph-whatsapp-logo" aria-hidden="true"></i></span><span class="sn-label">WhatsApp</span></button>
+  </div>
+</aside>
+
 <div class="page" id="page-root">
 
   <header>
     <div class="header-left">
-      <button class="sidenav-toggle" type="button" aria-label="Abrir menu" aria-haspopup="menu" onclick="toggleUserMenu(event)"><i class="ph ph-list" aria-hidden="true"></i></button>
+      <button class="sidenav-toggle" type="button" aria-label="Abrir menu" aria-controls="sidenav" onclick="toggleSidenav(true)"><i class="ph ph-list" aria-hidden="true"></i></button>
       <img class="logo-img" src="/brand/icon.png?v=1" alt="Piggy" />
       <h1>PigBank</h1>
       <div class="nav-links">
@@ -744,6 +816,22 @@ document.addEventListener("click", e => {
   if (m && !m.contains(e.target)) closeUserMenu();
 });
 document.addEventListener("keydown", e => { if (e.key === "Escape") closeUserMenu(); });
+
+/* ─── Gaveta lateral (mesma lógica do dashboard.js) ───────────────────── */
+function toggleSidenav(force) {
+  const nav = document.getElementById("sidenav");
+  const bd  = document.getElementById("sidenav-backdrop");
+  if (!nav) return;
+  const open = (typeof force === "boolean") ? force : !nav.classList.contains("open");
+  nav.classList.toggle("open", open);
+  if (bd) bd.classList.toggle("open", open);
+}
+document.addEventListener("keydown", e => {
+  if (e.key === "Escape") {
+    const nav = document.getElementById("sidenav");
+    if (nav && nav.classList.contains("open")) toggleSidenav(false);
+  }
+});
 
 /* ─── Logout / Connect WhatsApp ───────────────────────────────────────── */
 async function logoutFromHome() {

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -830,9 +830,13 @@ function toggleSidenav(force) {
   if (bd) bd.classList.toggle("open", open);
   const tog = document.querySelector(".sidenav-toggle");
   if (tog) tog.setAttribute("aria-expanded", String(open));
-  // Foco segue a gaveta: ao abrir vai pro 1º item; ao fechar (backdrop/ESC)
-  // volta pro ☰ — senão o Tab passeia pela página coberta, e o ESC deixaria
-  // o foco preso num link que acabou de virar inert.
+  // Foco preso na gaveta: enquanto aberta, o resto da página (#page-root, que
+  // inclui o header/☰) fica inert — o Tab não escapa pro fundo coberto e, ao
+  // passar do último item, volta pro primeiro. Fechar libera o fundo ANTES de
+  // devolver o foco pro ☰ (que mora dentro do #page-root).
+  const root = document.getElementById("page-root");
+  if (root) root.toggleAttribute("inert", open);
+  // Foco segue a gaveta: abrir → 1º item; fechar (backdrop/ESC) → ☰.
   if (open) {
     const first = nav.querySelector(".sidenav-item");
     if (first) first.focus();
@@ -898,12 +902,16 @@ async function loadProfile() {
     document.getElementById("user-label").textContent = displayLabel(PROFILE_DISPLAY_NAME, PROFILE_EMAIL);
     document.getElementById("user-email").textContent = PROFILE_EMAIL || "Minha conta";
     document.getElementById("user-plan").textContent  = planLabel(plan);
-    // Beta-gate dos Agentes: esconde o item da gaveta quando desligado
-    // (mesma regra do dashboard.js — freio de emergência / allowlist).
-    if (data.agents_ui_enabled === false) {
-      document.querySelectorAll('[data-nav="agentes"]').forEach(el => { el.style.display = "none"; });
-    }
   } catch {}
+}
+
+// Beta-gate dos Agentes (freio de emergência / allowlist). O flag vem do
+// /auth/me — NÃO do /auth/dashboard-profile, que só traz feature_gates de
+// plano. Esconde o item da gaveta quando off, igual ao dashboard.js:10215.
+function applyAgentsGate(me) {
+  if (me && me.agents_ui_enabled === false) {
+    document.querySelectorAll('[data-nav="agentes"]').forEach(el => { el.style.display = "none"; });
+  }
 }
 
 /* ─── Render: greeting ────────────────────────────────────────────────── */
@@ -1505,6 +1513,7 @@ let _homeMe = null;   // /auth/me da abertura, reusado pelas recargas
   // 3 e 4) Busca + render moram em loadHomeData() porque o "puxar pra
   // atualizar" do app (app-mode.js) precisa refazer exatamente este pedaço.
   _homeMe = me;
+  applyAgentsGate(me);
   await loadHomeData({ initial: true });
 })();
 


### PR DESCRIPTION
## Contexto
O #109 foi mergeado (squash `4f199fc`) capturando só os 2 primeiros commits (header com ☰ + esconder ☰ na web). Os 2 últimos — a **gaveta lateral** e o **aria-expanded** — foram enviados depois do merge e ficaram de fora. Resultado: na `main` o ☰ da home ainda abre o **menu de conta** (comportamento errado), sem gaveta. Este PR traz o que faltou.

## O que muda
- **☰** na home passa a abrir a **gaveta lateral (sidenav) igual à do dashboard** — GERAL / PLANEJAMENTO / CRÉDITO / CONTA, com backdrop — em vez do dropdown de conta.
- Itens da gaveta são views do dashboard → deep-linkam pra `/app?view=X`.
- `dashboard.js`: load passa a honrar `?view=` de **qualquer** view (antes só `investments`/`agentes`), via `navigateTo` se o item existir e estiver visível (respeita beta/pro-gate).
- ☰ com `aria-controls="sidenav"` + `aria-expanded` sincronizado a cada abre/fecha (☰, backdrop, ESC).

## Escopo
- `frontend/home.html`: gaveta + backdrop, CSS portada da `dashboard.css`, `toggleSidenav`, ESC fecha, aria. (Cherry-pick de `282d234`+`caa9ec6` sobre a `main` atual; conflito resolvido mantendo `app-mode.css?v=28` do #111.)
- `frontend/dashboard.js`: deep-link genérico por `?view=`.

## Verificação
- **Medido:** preview isolado app-mode — ☰ abre a gaveta (transform final `translateX(0)`, backdrop `display:block`), layout idêntico ao dashboard. `node --check dashboard.js` OK.
- **Não medido (só no aparelho, pós-deploy):** navegação real `/home → /app?view=X` (gate de auth impede exercitar aqui); WKWebView nativo. Só front (HTML/CSS/JS) — pytest não se aplica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)