### PR TITLE
revert(app): volta delay do melt pra 190ms (desfaz #113)

### DIFF
--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -333,11 +333,7 @@
       start();
       if (navigate && i !== home) {
         const href = tabs[i].getAttribute("href");
-        // 60ms (era 190): o delay do melt somava ao tempo já parado da recarga
-        // — com o cross-fade das View Transitions, o quadro velho fica congelado
-        // durante a navegação, então quanto menos espera antes de começar,
-        // menos "trava". A bolha ainda começa a deslizar; só não espera terminar.
-        if (smooth) setTimeout(() => { location.href = href; }, 60);
+        if (smooth) setTimeout(() => { location.href = href; }, 190);
         else location.href = href;
       }
     }

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -17,7 +17,7 @@
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=29"></script>
+  <script src="/app-mode.js?v=30"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=29"></script>
+  <script src="/app-mode.js?v=30"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,7 +81,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=29"></script>
+  <script src="/app-mode.js?v=30"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script defer src="/app-mode.js?v=29"></script>
+  <script defer src="/app-mode.js?v=30"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -422,7 +422,7 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=29"></script>
+  <script src="/app-mode.js?v=30"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=29"></script>
+  <script src="/app-mode.js?v=30"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1108,7 +1108,7 @@ body.balance-hidden .account-balance {
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=28" />
-  <script src="/app-mode.js?v=29"></script>
+  <script src="/app-mode.js?v=30"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Cortar o melt pra 60ms (#113) fez a bolha do dock **congelar no meio do caminho** no aparelho — a navegacao comecava antes de o melt terminar. Restaura os 190ms originais e bump pp-mode.js ?v=30.

Nao mexe no #111 (View Transitions segue como esta). Testado: nao pude medir aqui (WKWebView so no device, CLAUDE.md 6).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>