### PR TITLE
fix(app): duracao visivel no cross-fade entre telas

### DIFF
--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -21,8 +21,16 @@
    carregam este CSS, no app E no site web (desktop/mobile) — aceito de
    propósito. Progressive enhancement: sem suporte, navega igual. */
 @view-transition { navigation: auto; }
+/* Duração explícita: o padrão do WebView vinha ~instantâneo (~15ms medido no
+   device) — o fade não dava pra ver. E o quadro VELHO fica opaco embaixo
+   (animation: none) enquanto o NOVO entra por cima (fade-in). Não é o cross-fade
+   simétrico dos dois meio-transparentes — assim não há o "dip" escuro no meio,
+   e o velho segura por cima do vão preto de ~1 frame da recarga. */
+::view-transition-old(root) { animation: none; }
+::view-transition-new(root) { animation: pb-vt-fade .32s ease both; }
+@keyframes pb-vt-fade { from { opacity: 0; } to { opacity: 1; } }
 @media (prefers-reduced-motion: reduce) {
-  ::view-transition-group(*) { animation-duration: 0s !important; }
+  ::view-transition-new(root) { animation-duration: .001s; }
 }
 
 /* ─── Base: página nunca rola de lado (app não arrasta lateral) ────────── */

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=30"></script>
 </head>
 <body>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=30"></script>
 </head>
 <body>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -80,7 +80,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=30"></script>
 </head>
 <body>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -26,7 +26,7 @@
      dashboard.js. Nenhum script inline depende deles durante o parse. -->
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script defer src="/app-mode.js?v=30"></script>
 </head>
 <body class="has-sidenav">

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -421,7 +421,7 @@ footer a:hover { color:var(--text); }
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=30"></script>
 </head>
 <body>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -15,7 +15,7 @@
   .auth-error.show { display: block; }
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=30"></script>
 </head>
 <body>

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1107,7 +1107,7 @@ body.balance-hidden .account-balance {
 </style>
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
-  <link rel="stylesheet" href="/app-mode.css?v=28" />
+  <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=30"></script>
 </head>
 <body>


### PR DESCRIPTION
## Diagnóstico (confirmado no aparelho)

Gravação de tela quadro a quadro no iPhone: **o View Transitions engata no WebView** — o fade velho→nova existe. Mas a **duração padrão vinha ~instantânea (~15ms)**, então o efeito não dava pra perceber a olho nu. "Reduzir Movimento" estava **desligado**, então não era o guard de acessibilidade.

## Correção

- **Duração explícita de .32s** no cross-fade da raiz (antes: default do WebView, ~15ms).
- **Velho fica opaco embaixo, novo entra por cima (fade-in)** em vez do cross-fade simétrico dos dois meio-transparentes: mata o "dip" escuro no meio do fade **e** o velho cobre o vão preto de ~1 frame da recarga (que você reportou).
- **reduce-motion** segue respeitado (fade instantâneo pra quem tem a opção ligada).
- Bump `app-mode.css ?v=29`.

## Verificação

- **Só no aparelho** confirma (WKWebView não reproduz aqui, `CLAUDE.md §6`). O CI valida que não quebrou o resto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
