### PR TITLE
feat(app): navegacao client-side entre abas — Fase 1 (motor + POC)

### DIFF
--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -333,8 +333,12 @@
       start();
       if (navigate && i !== home) {
         const href = tabs[i].getAttribute("href");
-        if (smooth) setTimeout(() => { location.href = href; }, 190);
-        else location.href = href;
+        // pb-nav (se ativo e a rota é convertida) troca a tela sem recarregar;
+        // o onNavigate lá embaixo sincroniza o dock quando o mount terminar.
+        // Senão, navegação de documento igual sempre foi.
+        const nav = () => { if (!(window.PBNav && PBNav.go(href))) location.href = href; };
+        if (smooth) setTimeout(nav, 190);
+        else nav();
       }
     }
 
@@ -384,6 +388,26 @@
     window.addEventListener("orientationchange", () => setTimeout(measure, 120));
     // Fontes/ícones chegando depois mudam a largura das abas → remede
     if (document.fonts && document.fonts.ready) document.fonts.ready.then(measure).catch(() => {});
+
+    // Navegação client-side (pb-nav.js): o motor troca a tela sem recarregar,
+    // então o dock é o MESMO objeto vivo — aqui ele se sincroniza ao fim de
+    // cada mount (tap ou botão voltar): bolha, aba ativa e "home" (a aba da
+    // página atual, referência do pointercancel e do clique-na-mesma-aba).
+    if (window.PBNav && PBNav.enabled) {
+      PBNav.onNavigate = key => {
+        const i = tabs.findIndex(a => PAGES[a.getAttribute("href")] === key);
+        if (i < 0) return;
+        home = i;
+        setLive(i);
+        target = stops[i];
+        start();
+        tabs.forEach((a, k) => {
+          a.classList.toggle("active", k === i);
+          if (k === i) a.setAttribute("aria-current", "page");
+          else a.removeAttribute("aria-current");
+        });
+      };
+    }
   }
 
   // Glifos de texto (☰, 🐷) viram SVG/imagem — WebView pode não ter as fontes

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -241,7 +241,10 @@
     const smooth = !(window.matchMedia &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches);
 
-    const home = Math.max(0, tabs.findIndex(a => a.classList.contains("active")));
+    // let, não const: o onNavigate do pb-nav reaponta a "aba da página atual"
+    // a cada swap client-side. Com const a atribuição lançava TypeError
+    // (engolido), home ficava na aba de boot e voltar pra ela não navegava.
+    let home = Math.max(0, tabs.findIndex(a => a.classList.contains("active")));
     let W = 0, stops = [], x = 0, target = 0, vel = 0, prev = 0;
     let live = home, raf = 0, running = false, drag = null;
 
@@ -402,6 +405,9 @@
     if (window.PBNav && PBNav.enabled) {
       PBNav.onNavigate = key => {
         livePage = key;   // callbacks assíncronos (syncNewsTab) leem a página viva
+        // Glifos de texto (☰, ▾) da página recém-montada: o hardenGlyphs do
+        // boot não alcança DOM que chegou por swap — re-roda (é idempotente).
+        hardenGlyphs();
         const i = tabs.findIndex(a => PAGES[a.getAttribute("href")] === key);
         if (i < 0) return;
         home = i;

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -54,6 +54,12 @@
   }
   const path = location.pathname.replace(/\/+$/, "") || "/";
   const page = PAGES[path];
+  // A página VIVA: igual a `page` no load, atualizada pelo pb-nav a cada troca
+  // client-side. Callback assíncrono que decide "aba ativa" (o /auth/me do
+  // syncNewsTab) tem que olhar pra cá — o const de boot fica velho depois de
+  // um swap e reconciliava contra a página errada (Codex, #118). Antes do SPA
+  // o reload descartava o callback pendente; agora ele sobrevive à troca.
+  let livePage = page;
 
   // pb-root-* no <html> aqui no <head> (síncrono) = paleta por página já no 1º
   // paint. Só no buildTabbar (DOMContentLoaded) fazia o Ajustes piscar de cor.
@@ -109,7 +115,7 @@
         a.setAttribute("href", t.href);
         const ico = a.querySelector(".pb-tab-ico"); if (ico) ico.innerHTML = t.icon;
         const lbl = a.querySelector("span:last-child"); if (lbl) lbl.textContent = t.label;
-        const active = PAGES[t.href] === page;
+        const active = PAGES[t.href] === livePage; // viva, não a de boot (SPA)
         a.classList.toggle("active", active);
         if (active) a.setAttribute("aria-current", "page"); else a.removeAttribute("aria-current");
       })
@@ -395,6 +401,7 @@
     // página atual, referência do pointercancel e do clique-na-mesma-aba).
     if (window.PBNav && PBNav.enabled) {
       PBNav.onNavigate = key => {
+        livePage = key;   // callbacks assíncronos (syncNewsTab) leem a página viva
         const i = tabs.findIndex(a => PAGES[a.getAttribute("href")] === key);
         if (i < 0) return;
         home = i;

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -17,7 +17,7 @@
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=30"></script>
+  <script src="/app-mode.js?v=31"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -17,7 +17,7 @@
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=31"></script>
+  <script src="/app-mode.js?v=32"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -17,7 +17,7 @@
   .field .hint { font-size: .74rem; color: var(--ink-3); margin-top: 6px; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=32"></script>
+  <script src="/app-mode.js?v=33"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=32"></script>
+  <script src="/app-mode.js?v=33"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=31"></script>
+  <script src="/app-mode.js?v=32"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -14,7 +14,7 @@
 <link rel="stylesheet" href="/site.css?v=4" />
 <script src="/safe-area.js?v=1"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=30"></script>
+  <script src="/app-mode.js?v=31"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -82,7 +82,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=31"></script>
-  <script src="/pb-nav.js?v=1"></script>
+  <script src="/pb-nav.js?v=2"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,8 +81,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=31"></script>
-  <script src="/pb-nav.js?v=2"></script>
+  <script src="/app-mode.js?v=32"></script>
+  <script src="/pb-nav.js?v=3"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,8 +81,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=32"></script>
-  <script src="/pb-nav.js?v=3"></script>
+  <script src="/app-mode.js?v=33"></script>
+  <script src="/pb-nav.js?v=4"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -81,7 +81,8 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 @media(max-width:660px){.page{padding-inline:14px}.hero{padding:24px 4px 18px}.nav-links{width:100%;justify-content:center}}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=30"></script>
+  <script src="/app-mode.js?v=31"></script>
+  <script src="/pb-nav.js?v=1"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>
@@ -121,6 +122,12 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 </div>
 
 <script>
+/* Contrato pb-nav: o código da página vive num init re-chamável — sem
+   let/const no topo do script (re-execução no mesmo documento estoura
+   SyntaxError de redeclaração). No load MPA o PBNav.boot roda os inits;
+   num mount client-side é o motor quem roda. */
+window.PBPages = window.PBPages || {};
+(PBPages.comandos = PBPages.comandos || { inits: [] }).inits.push(function () {
 const API = window.location.origin;
 
 function showAccessError() {
@@ -207,6 +214,8 @@ function renderCatalog(catalog, snap, plan) {
 
   renderCatalog(catalog, snap, plan);
 })();
+});
 </script>
+<script data-pb-boot>window.PBNav ? PBNav.boot("comandos") : PBPages.comandos.inits.forEach(f => f());</script>
 </body>
 </html>

--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -82,7 +82,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=33"></script>
-  <script src="/pb-nav.js?v=4"></script>
+  <script src="/pb-nav.js?v=5"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script defer src="/app-mode.js?v=32"></script>
+  <script defer src="/app-mode.js?v=33"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script defer src="/app-mode.js?v=31"></script>
+  <script defer src="/app-mode.js?v=32"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -27,7 +27,7 @@
 <script defer src="/static/auth-refresh.js"></script>
 <script defer src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script defer src="/app-mode.js?v=30"></script>
+  <script defer src="/app-mode.js?v=31"></script>
 </head>
 <body class="has-sidenav">
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -455,8 +455,8 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=32"></script>
-  <script src="/pb-nav.js?v=3"></script>
+  <script src="/app-mode.js?v=33"></script>
+  <script src="/pb-nav.js?v=4"></script>
 </head>
 <body>
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -456,7 +456,7 @@ footer a:hover { color:var(--text); }
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=33"></script>
-  <script src="/pb-nav.js?v=4"></script>
+  <script src="/pb-nav.js?v=5"></script>
 </head>
 <body>
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -455,7 +455,8 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=30"></script>
+  <script src="/app-mode.js?v=31"></script>
+  <script src="/pb-nav.js?v=1"></script>
 </head>
 <body>
 
@@ -657,6 +658,12 @@ footer a:hover { color:var(--text); }
 </div>
 
 <script>
+/* Contrato pb-nav: o código da página vive num init re-chamável — sem
+   let/const no topo do script (re-execução no mesmo documento estoura
+   SyntaxError de redeclaração). No load MPA o PBNav.boot roda os inits;
+   num mount client-side é o motor quem roda. */
+window.PBPages = window.PBPages || {};
+(PBPages.home = PBPages.home || { inits: [] }).inits.push(function () {
 const API = window.location.origin;
 const PT_MONTHS = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"];
 let USER_ID = 0;
@@ -1628,6 +1635,14 @@ async function mfaOnboardingDismiss() {
   await _markMfaOnboardingSeen();
   closeMfaOnboardingOverlay();
 }
+
+/* Handlers chamados por onclick= no HTML: dentro do init eles deixaram de
+   nascer globais — expõe exatamente os que o markup usa. */
+Object.assign(window, {
+  toggleHideBalance, toggleSidenav, logoutFromHome, connectWhatsAppFromHome,
+  mfaOnboardingActivate, mfaOnboardingDismiss,
+});
+});
 </script>
 
 <!-- ── MFA Onboarding overlay ─────────────────────────────────────────────── -->
@@ -1882,6 +1897,10 @@ async function mfaOnboardingDismiss() {
 <div class="upgrade-toast" id="upgrade-cancel-toast" role="status"></div>
 
 <script>
+/* Contrato pb-nav (mesmo esquema do script de cima; este e o de cima só
+   conversam pelo evento pb:checkout-confirmado, então cada um vira um init). */
+window.PBPages = window.PBPages || {};
+(PBPages.home = PBPages.home || { inits: [] }).inits.push(function () {
 /* O modal é um dialog de verdade agora: prende o Esc, o clique fora e devolve o
    foco pra quem o tinha antes. Sair daqui NUNCA cobra nada e nunca muda plano,
    só decide se a pessoa vai pro dashboard ou fica na Início. */
@@ -2140,7 +2159,12 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
     setTimeout(() => toast.classList.remove("show"), 9350);
   }
 })();
+
+/* Handlers de onclick= deste script (modal de boas-vindas Pro). */
+Object.assign(window, { dismissWelcomePro, goExplorePro });
+});
 </script>
+<script data-pb-boot>window.PBNav ? PBNav.boot("home") : PBPages.home.inits.forEach(f => f());</script>
 
 </body>
 </html>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -455,8 +455,8 @@ footer a:hover { color:var(--text); }
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=31"></script>
-  <script src="/pb-nav.js?v=2"></script>
+  <script src="/app-mode.js?v=32"></script>
+  <script src="/pb-nav.js?v=3"></script>
 </head>
 <body>
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -456,7 +456,7 @@ footer a:hover { color:var(--text); }
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
   <script src="/app-mode.js?v=31"></script>
-  <script src="/pb-nav.js?v=1"></script>
+  <script src="/pb-nav.js?v=2"></script>
 </head>
 <body>
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=30"></script>
+  <script src="/app-mode.js?v=31"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=32"></script>
+  <script src="/app-mode.js?v=33"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -16,7 +16,7 @@
   .auth-error.ok { background: rgba(0,240,120,.1); border-color: rgba(0,240,120,.3); color: #93f7c4; }
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=31"></script>
+  <script src="/app-mode.js?v=32"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -1,0 +1,258 @@
+/**
+ * pb-nav.js — navegação client-side entre as abas do modo app (Fase 1).
+ *
+ * O porquê: trocar de aba por location.href recarrega o documento, e o vão
+ * entre descartar a página velha e pintar a nova aparece como piscada preta
+ * no WKWebView — nenhum CSS alcança esse instante. Aqui a troca acontece
+ * DENTRO de um documento só (fetch + swap em startViewTransition): sem
+ * navegação de documento, o vão não existe.
+ *
+ * Ativação (POC): modo app (html.pb-app) + flag pbspa. Liga com ?pbspa=1
+ * (persiste em localStorage, igual ao pbapp), desliga com ?pbspa=0.
+ * Teste no iPhone: Safari → https://pigbankai.com/home?pbapp=1&pbspa=1
+ *
+ * Contrato por página (só as ROUTES abaixo):
+ *   - scripts inline embrulhados em (PBPages.<key> ||= {inits:[]}).inits.push(fn)
+ *   - último script da página (marcado data-pb-boot, que o motor NÃO executa):
+ *     PBNav.boot("<key>") — no load MPA roda os inits; em mount SPA é o motor
+ *     que os roda.
+ *   - window.PBRefresh continua o contrato de refresh: o motor o salva/restaura
+ *     por página e o chama em background ao voltar pra uma aba cacheada.
+ *
+ * Fallback sempre-navega: qualquer erro (fetch, timeout 5s, redirect de
+ * auth/gate, rota não convertida) cai em location.href — o pior caso é o
+ * comportamento de hoje, nunca tela travada.
+ *
+ * Limitações conhecidas da Fase 1 (documentadas no PR):
+ *   - listeners globais de uma página desmontada seguem vivos (mexem em DOM
+ *     desanexado: no-op visual); evicção com AbortSignal fica pra quando
+ *     houver pressão de memória medida.
+ *   - o puxar-pra-atualizar do app-mode captura o .page da página de boot;
+ *     após um swap ele opera no modo simples (só indicador). Fase 2.
+ */
+(() => {
+  "use strict";
+
+  const qs = new URLSearchParams(location.search);
+  if (qs.get("pbspa") === "0") { try { localStorage.removeItem("pbSpa"); } catch (_) {} }
+  if (qs.get("pbspa") === "1") { try { localStorage.setItem("pbSpa", "1"); } catch (_) {} }
+  let flag = null;
+  try { flag = localStorage.getItem("pbSpa"); } catch (_) {}
+
+  // pb-app já está no <html> (app-mode.js roda antes, síncrono no head)
+  const enabled = document.documentElement.classList.contains("pb-app") &&
+    flag === "1" &&
+    typeof document.startViewTransition === "function" &&
+    typeof DOMParser === "function";
+
+  // Rotas convertidas — as chaves batem com o PAGES do app-mode.js
+  const ROUTES = { "/home": "home", "/comandos-app": "comandos" };
+  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+    Object.assign(ROUTES, { "/home.html": "home", "/comandos-app.html": "comandos" });
+  }
+
+  window.PBPages = window.PBPages || {};
+
+  const cache = {};        // key → {nodes, styles, title, scrollY, refresh, bodyClass}
+  const booted = new Set(); // keys cujos scripts inline já executaram (nunca 2x: let/const)
+  let currentKey = null;
+  let seq = 0;             // geração: só a navegação mais recente monta
+
+  // Base neutra quando a origem é opaca (preview/data:): só o pathname importa.
+  const norm = href => {
+    const base = location.origin && location.origin !== "null" ? location.origin : "http://pb.local";
+    try { return new URL(href, base).pathname.replace(/\/+$/, "") || "/"; }
+    catch (_) { return null; }
+  };
+
+  const hard = path => { location.href = path; };
+
+  // Nós do shell (vivem no body mas pertencem ao app, não à página)
+  const isShell = n => n.nodeType === 1 &&
+    (n.classList.contains("pb-tabbar") || n.classList.contains("pb-ptr"));
+
+  function runInits(key) {
+    const p = window.PBPages[key];
+    ((p && p.inits) || []).forEach(f => { try { f(); } catch (e) { console.error("[pb-nav] init " + key, e); } });
+  }
+
+  function setRootClass(key) {
+    const root = document.documentElement;
+    root.className = root.className.replace(/\bpb-root-\S+/g, "").replace(/\s+/g, " ").trim();
+    root.classList.add("pb-root-" + key);
+  }
+
+  // Desmonta a página atual pro cache: nós do body (menos shell), estilos
+  // marcados, título, rolagem e o PBRefresh dela. DOM fica VIVO desanexado —
+  // estado (um passo de MFA aberto, um campo digitado) sobrevive ao vaivém.
+  function unmountCurrent() {
+    if (!currentKey) return;
+    const e = {
+      nodes: document.createDocumentFragment(),
+      styles: [],
+      title: document.title,
+      scrollY: window.scrollY,
+      refresh: window.PBRefresh,
+      bodyClass: document.body.className,
+    };
+    document.querySelectorAll('head style[data-pb-page="' + currentKey + '"]')
+      .forEach(s => { e.styles.push(s); s.remove(); });
+    Array.prototype.slice.call(document.body.childNodes)
+      .forEach(n => { if (!isShell(n)) e.nodes.appendChild(n); });
+    cache[currentKey] = e;
+    window.PBRefresh = undefined;
+  }
+
+  function mountPoint() { return document.querySelector(".pb-tabbar"); }
+
+  const swap = mutate =>
+    document.startViewTransition(mutate).finished.catch(() => {});
+
+  function finish(key, path, push) {
+    currentKey = key;
+    // try/catch: histórico lança em origem opaca (preview/embeds) — a troca
+    // de tela nunca pode morrer por causa do pushState.
+    if (push) { try { history.pushState({ pb: key }, "", path + location.hash); } catch (_) {} }
+    if (window.PBNav.onNavigate) { try { window.PBNav.onNavigate(key); } catch (_) {} }
+  }
+
+  async function mountCached(key, path, push, my) {
+    await swap(() => {
+      if (my !== seq) return;
+      unmountCurrent();
+      const e = cache[key];
+      e.styles.forEach(s => document.head.appendChild(s));
+      document.body.insertBefore(e.nodes, mountPoint());
+      document.title = e.title;
+      document.body.className = e.bodyClass;
+      setRootClass(key);
+      window.PBRefresh = e.refresh;
+      window.scrollTo(0, e.scrollY);
+    });
+    if (my !== seq) return;
+    finish(key, path, push);
+    // Dado fresco em background, reusando o contrato do puxar-pra-atualizar:
+    // dado velho na tela agora, dado novo repintando quando chegar.
+    if (window.PBRefresh) { try { window.PBRefresh(); } catch (_) {} }
+  }
+
+  // Scripts externos da página nova que o documento ainda não tem (dedupe por
+  // URL absoluta). Externos definem globals uma vez — nunca re-executam.
+  function ensureExternalScripts(doc) {
+    const have = new Set(Array.prototype.map.call(document.scripts, s => s.src).filter(Boolean));
+    const need = Array.prototype.slice.call(doc.querySelectorAll("script[src]"))
+      .map(s => new URL(s.getAttribute("src"), location.origin).href)
+      .filter(u => !have.has(u));
+    return Promise.all(need.map(u => new Promise((ok, bad) => {
+      const s = document.createElement("script");
+      s.src = u; s.onload = ok; s.onerror = () => bad(new Error("script " + u));
+      document.head.appendChild(s);
+    })));
+  }
+
+  async function mountNew(key, path, html, push, my) {
+    const doc = new DOMParser().parseFromString(html, "text/html");
+
+    await ensureExternalScripts(doc);
+    if (my !== seq) return;
+
+    // Executa os scripts inline UMA vez por página (data-pb-boot fica de fora:
+    // boot é do load MPA; aqui quem roda os inits é o motor, dentro do swap).
+    if (!booted.has(key)) {
+      booted.add(key);
+      doc.querySelectorAll("script:not([src]):not([data-pb-boot])").forEach(s => {
+        const el = document.createElement("script");
+        el.textContent = s.textContent;
+        document.body.appendChild(el);
+        el.remove();
+      });
+    }
+
+    const newStyles = Array.prototype.map.call(
+      doc.head.querySelectorAll("style"),
+      s => {
+        const c = document.createElement("style");
+        c.textContent = s.textContent;
+        c.setAttribute("data-pb-page", key);
+        return c;
+      });
+    const bodyClass = doc.body.getAttribute("class") || "";
+    const title = doc.title;
+
+    await swap(() => {
+      if (my !== seq) return;
+      unmountCurrent();
+      newStyles.forEach(s => document.head.appendChild(s));
+      const frag = document.createDocumentFragment();
+      Array.prototype.slice.call(doc.body.childNodes).forEach(n => frag.appendChild(document.importNode(n, true)));
+      frag.querySelectorAll("script").forEach(s => s.remove());
+      document.body.insertBefore(frag, mountPoint());
+      document.title = title;
+      document.body.className = (bodyClass ? bodyClass + " " : "") + "pb-page-" + key;
+      setRootClass(key);
+      window.scrollTo(0, 0);
+      runInits(key);          // síncrono entra no snapshot; o resto é async normal
+    });
+    if (my !== seq) return;
+    finish(key, path, push);
+  }
+
+  async function navigate(path, key, push) {
+    const my = ++seq;                            // só a navegação mais recente monta
+    if (cache[key]) return mountCached(key, path, push, my);
+    try {
+      const r = await fetch(path, {
+        credentials: "same-origin",
+        headers: { Accept: "text/html" },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (my !== seq) return;                    // um tap mais novo venceu
+      // Redirect = auth/gate (login, /precos): fluxo de verdade, navegação real
+      if (r.redirected || !r.ok) { hard(path); return; }
+      const html = await r.text();
+      if (my !== seq) return;
+      await mountNew(key, path, html, push, my);
+    } catch (_) {
+      if (my === seq) hard(path);                // timeout/rede: cai no MPA
+    }
+  }
+
+  window.addEventListener("popstate", () => {
+    if (!enabled || !currentKey) return;
+    const path = norm(location.pathname);
+    const key = ROUTES[path];
+    if (!key) { location.reload(); return; }     // URL não convertida: MPA
+    if (key === currentKey) return;
+    navigate(path, key, false);
+  });
+
+  window.PBNav = {
+    enabled,
+    onNavigate: null,   // o dock do app-mode se pendura aqui pra sincronizar
+
+    // true = o motor assume esta navegação; false = chame location.href
+    go(href) {
+      if (!enabled) return false;
+      const path = norm(href);
+      const key = path && ROUTES[path];
+      if (!key) return false;
+      if (key === currentKey) return true;       // já está nela
+      navigate(path, key, true);
+      return true;
+    },
+
+    // Chamado pelo load MPA da própria página (script data-pb-boot).
+    boot(key) {
+      if (enabled) {
+        currentKey = key;
+        booted.add(key);
+        try { history.scrollRestoration = "manual"; } catch (_) {}
+        try { history.replaceState({ pb: key }, "", location.pathname + location.search + location.hash); } catch (_) {}
+        // marca os estilos de head desta página pra viajarem com ela no swap
+        document.querySelectorAll("head style:not([data-pb-page])")
+          .forEach(s => s.setAttribute("data-pb-page", key));
+      }
+      runInits(key);
+    },
+  };
+})();

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -231,16 +231,21 @@
     const t0 = performance.now();
     const log = via => console.log("[pb-nav]", key, via,
       Math.round(performance.now() - t0) + "ms");
-    if (cache[key]) { await mountCached(key, path, push, my); log("cache"); return; }
-    if (warm[key]) {                             // prefetch pronto: sem rede no tap
-      const html = warm[key];
-      delete warm[key];
-      await mountNew(key, path, html, push, my);
-      log("warm");
-      setTimeout(warmUp, 400);
-      return;
-    }
+    // O try cobre TODOS os ramos (cache, warm e fetch): mountNew também rejeita
+    // fora da rede do tap — ex.: script externo da página nova falhando ao
+    // carregar (home puxa auth-refresh/modals quando o boot foi no comandos).
+    // Sem isso o ramo warm deixava o usuário preso na tela velha, porque o
+    // go() já tinha assumido a navegação (apontamento do Codex no #118).
     try {
+      if (cache[key]) { await mountCached(key, path, push, my); log("cache"); return; }
+      if (warm[key]) {                           // prefetch pronto: sem rede no tap
+        const html = warm[key];
+        delete warm[key];
+        await mountNew(key, path, html, push, my);
+        log("warm");
+        setTimeout(warmUp, 400);
+        return;
+      }
       const r = await fetch(path, {
         credentials: "same-origin",
         headers: { Accept: "text/html" },
@@ -255,7 +260,7 @@
       log("fetch");
       setTimeout(warmUp, 400);
     } catch (_) {
-      if (my === seq) hard(path);                // timeout/rede: cai no MPA
+      if (my === seq) hard(path);                // qualquer falha: cai no MPA
     }
   }
 

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -121,7 +121,12 @@
     // try/catch: histórico lança em origem opaca (preview/embeds) — a troca
     // de tela nunca pode morrer por causa do pushState.
     if (push) { try { history.pushState({ pb: key }, "", path + location.hash); } catch (_) {} }
-    if (window.PBNav.onNavigate) { try { window.PBNav.onNavigate(key); } catch (_) {} }
+    // erro do hook NÃO derruba a navegação, mas também não é engolido mudo:
+    // um catch vazio escondeu um TypeError que quebrava o dock (Codex, #118)
+    if (window.PBNav.onNavigate) {
+      try { window.PBNav.onNavigate(key); }
+      catch (e) { console.error("[pb-nav] onNavigate", e); }
+    }
   }
 
   async function mountCached(key, path, push, my) {

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -82,9 +82,14 @@
     root.classList.add("pb-root-" + key);
   }
 
-  // Desmonta a página atual pro cache: nós do body (menos shell), estilos
-  // marcados, título, rolagem e o PBRefresh dela. DOM fica VIVO desanexado —
-  // estado (um passo de MFA aberto, um campo digitado) sobrevive ao vaivém.
+  // Desmonta a página atual: nós do body (menos shell), estilos marcados,
+  // título, rolagem e o PBRefresh dela. Só vai pro CACHE se a init assentou —
+  // a prova é o window.PBRefresh presente (o contrato é exposto no FIM da
+  // carga; ver home.html). Cachear página inacabada congelava o esqueleto pra
+  // sempre: a init em voo morre ao consultar DOM desanexado e nunca é re-rodada
+  // (apontamento do Codex no #118). Página sem o contrato (comandos) nunca
+  // cacheia: remonta fresca — os listeners dela são todos de nó, re-init limpa.
+  // DOM cacheado fica VIVO desanexado — estado (campo digitado) sobrevive.
   function unmountCurrent() {
     if (!currentKey) return;
     const e = {
@@ -99,7 +104,7 @@
       .forEach(s => { e.styles.push(s); s.remove(); });
     Array.prototype.slice.call(document.body.childNodes)
       .forEach(n => { if (!isShell(n)) e.nodes.appendChild(n); });
-    cache[currentKey] = e;
+    if (e.refresh) cache[currentKey] = e;   // assentou: pode voltar do cache
     window.PBRefresh = undefined;
   }
 
@@ -108,8 +113,11 @@
   const swap = mutate =>
     document.startViewTransition(mutate).finished.catch(() => {});
 
+  // currentKey NÃO é setado aqui: ele muda dentro do callback do swap, atômico
+  // com a mutação do DOM. Setar só depois do .finished abria uma janela (os
+  // ~320ms do fade) em que um tap novo desmontava com a chave velha e gravava
+  // o DOM da página nova no cache da antiga (apontamento do Codex no #118).
   function finish(key, path, push) {
-    currentKey = key;
     // try/catch: histórico lança em origem opaca (preview/embeds) — a troca
     // de tela nunca pode morrer por causa do pushState.
     if (push) { try { history.pushState({ pb: key }, "", path + location.hash); } catch (_) {} }
@@ -121,6 +129,7 @@
       if (my !== seq) return;
       unmountCurrent();
       const e = cache[key];
+      delete cache[key];             // os nós voltam pro DOM; a entrada morreu
       e.styles.forEach(s => document.head.appendChild(s));
       document.body.insertBefore(e.nodes, mountPoint());
       document.title = e.title;
@@ -128,6 +137,7 @@
       setRootClass(key);
       window.PBRefresh = e.refresh;
       window.scrollTo(0, e.scrollY);
+      currentKey = key;              // atômico com o DOM (ver finish)
     });
     if (my !== seq) return;
     finish(key, path, push);
@@ -191,15 +201,45 @@
       document.body.className = (bodyClass ? bodyClass + " " : "") + "pb-page-" + key;
       setRootClass(key);
       window.scrollTo(0, 0);
+      currentKey = key;       // atômico com o DOM (ver finish)
       runInits(key);          // síncrono entra no snapshot; o resto é async normal
     });
     if (my !== seq) return;
     finish(key, path, push);
   }
 
+  // Prefetch: o HTML das outras abas é aquecido em background logo após o
+  // load e a cada troca. Sem isso, o fetch acontecia NO tap — a rede que a
+  // recarga escondia atrás da piscada virava tela parada (medido no GATE 1:
+  // "demora muito"). Com o texto já baixado, o mount é imediato. O HTML é só
+  // o shell (esqueleto); dado vivo vem da init/PBRefresh — não fica velho.
+  const warm = {};   // key → html (null = em voo)
+  function warmUp() {
+    Object.keys(ROUTES).forEach(path => {
+      const key = ROUTES[path];
+      if (key === currentKey || cache[key] || warm[key] !== undefined) return;
+      warm[key] = null;
+      fetch(path, { credentials: "same-origin", headers: { Accept: "text/html" } })
+        .then(r => (r.ok && !r.redirected ? r.text() : Promise.reject()))
+        .then(html => { warm[key] = html; })
+        .catch(() => { delete warm[key]; });
+    });
+  }
+
   async function navigate(path, key, push) {
     const my = ++seq;                            // só a navegação mais recente monta
-    if (cache[key]) return mountCached(key, path, push, my);
+    const t0 = performance.now();
+    const log = via => console.log("[pb-nav]", key, via,
+      Math.round(performance.now() - t0) + "ms");
+    if (cache[key]) { await mountCached(key, path, push, my); log("cache"); return; }
+    if (warm[key]) {                             // prefetch pronto: sem rede no tap
+      const html = warm[key];
+      delete warm[key];
+      await mountNew(key, path, html, push, my);
+      log("warm");
+      setTimeout(warmUp, 400);
+      return;
+    }
     try {
       const r = await fetch(path, {
         credentials: "same-origin",
@@ -212,6 +252,8 @@
       const html = await r.text();
       if (my !== seq) return;
       await mountNew(key, path, html, push, my);
+      log("fetch");
+      setTimeout(warmUp, 400);
     } catch (_) {
       if (my === seq) hard(path);                // timeout/rede: cai no MPA
     }
@@ -251,6 +293,8 @@
         // marca os estilos de head desta página pra viajarem com ela no swap
         document.querySelectorAll("head style:not([data-pb-page])")
           .forEach(s => s.setAttribute("data-pb-page", key));
+        // aquece as outras abas depois que a carga da página assentar
+        setTimeout(warmUp, 1200);
       }
       runInits(key);
     },

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -113,11 +113,14 @@
   const swap = mutate =>
     document.startViewTransition(mutate).finished.catch(() => {});
 
-  // currentKey NÃO é setado aqui: ele muda dentro do callback do swap, atômico
-  // com a mutação do DOM. Setar só depois do .finished abria uma janela (os
-  // ~320ms do fade) em que um tap novo desmontava com a chave velha e gravava
-  // o DOM da página nova no cache da antiga (apontamento do Codex no #118).
-  function finish(key, path, push) {
+  // Roda DENTRO do callback do swap, atômico com a mutação do DOM: currentKey,
+  // histórico e dock mudam juntos ou não mudam nada. Qualquer um deixado pra
+  // depois do .finished abria janela de ~320ms em que um tap novo supersede e
+  // o estado racha — a chave velha envenenava o cache (rodada 2 do Codex) e o
+  // pushState nunca registrado deixava a navegação seguinte empurrar URL
+  // duplicada, quebrando o Back (rodada 4).
+  function commit(key, path, push) {
+    currentKey = key;
     // try/catch: histórico lança em origem opaca (preview/embeds) — a troca
     // de tela nunca pode morrer por causa do pushState.
     if (push) { try { history.pushState({ pb: key }, "", path + location.hash); } catch (_) {} }
@@ -142,13 +145,11 @@
       setRootClass(key);
       window.PBRefresh = e.refresh;
       window.scrollTo(0, e.scrollY);
-      currentKey = key;              // atômico com o DOM (ver finish)
+      commit(key, path, push);
+      // Dado fresco em background, reusando o contrato do puxar-pra-atualizar:
+      // dado velho na tela agora, dado novo repintando quando chegar.
+      if (window.PBRefresh) { try { window.PBRefresh(); } catch (_) {} }
     });
-    if (my !== seq) return;
-    finish(key, path, push);
-    // Dado fresco em background, reusando o contrato do puxar-pra-atualizar:
-    // dado velho na tela agora, dado novo repintando quando chegar.
-    if (window.PBRefresh) { try { window.PBRefresh(); } catch (_) {} }
   }
 
   // Scripts externos da página nova que o documento ainda não tem (dedupe por
@@ -206,11 +207,9 @@
       document.body.className = (bodyClass ? bodyClass + " " : "") + "pb-page-" + key;
       setRootClass(key);
       window.scrollTo(0, 0);
-      currentKey = key;       // atômico com o DOM (ver finish)
       runInits(key);          // síncrono entra no snapshot; o resto é async normal
+      commit(key, path, push);
     });
-    if (my !== seq) return;
-    finish(key, path, push);
   }
 
   // Prefetch: o HTML das outras abas é aquecido em background logo após o

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -377,6 +377,18 @@ async def serve_app_mode_css():
     )
 
 
+@router.get("/pb-nav.js")
+async def serve_pb_nav_js():
+    """Navegação client-side entre as abas do modo app (troca de tela sem
+    recarregar o documento — elimina a piscada da navegação no WebView).
+    Inerte sem a flag pbspa; carregado só pelas páginas convertidas."""
+    return FileResponse(
+        FRONTEND_DIR / "pb-nav.js",
+        media_type="application/javascript",
+        headers={"Cache-Control": "public, max-age=300"},
+    )
+
+
 @router.get("/safe-area.js")
 async def serve_safe_area_js():
     """Reserva de safe area para as páginas fora do modo app (precos, landing,

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1108,7 +1108,7 @@ body.balance-hidden .account-balance {
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=31"></script>
+  <script src="/app-mode.js?v=32"></script>
 </head>
 <body>
 

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1108,7 +1108,7 @@ body.balance-hidden .account-balance {
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=30"></script>
+  <script src="/app-mode.js?v=31"></script>
 </head>
 <body>
 

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1108,7 +1108,7 @@ body.balance-hidden .account-balance {
 <script src="/static/auth-refresh.js"></script>
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=29" />
-  <script src="/app-mode.js?v=32"></script>
+  <script src="/app-mode.js?v=33"></script>
 </head>
 <body>
 

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -73,6 +73,15 @@ def test_auth_refresh_js_com_cache_publico():
     assert resp.headers["cache-control"] == "public, max-age=300"
 
 
+def test_pb_nav_js_com_cache_publico():
+    resp = client.get("/pb-nav.js")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/javascript")
+    assert resp.headers["cache-control"] == "public, max-age=300"
+    # o motor exige o contrato: sem PBNav.boot as páginas convertidas não iniciam
+    assert "PBNav" in resp.text and "boot" in resp.text
+
+
 def test_service_worker_headers():
     resp = client.get("/service-worker.js")
     assert resp.status_code == 200


### PR DESCRIPTION
## Fase 1 do plano [Navegação Sem Recarga](https://claude.ai/code/artifact/77a41c6c-eed2-4d5c-a7be-3a86f0afd4df) — motor + POC

A piscada preta ao trocar de aba é o **vão da recarga de documento** — o instante em que o WebView descartou a página velha e ainda não pintou a nova; CSS não alcança esse momento. Este PR troca a tela **dentro do documento** (fetch + swap em `startViewTransition`): sem navegação de documento, o vão não existe, por construção.

## O que entra

- **`pb-nav.js` (novo, ~260 linhas)** — o motor: rotas convertidas (`/home`, `/comandos-app`), cache de DOM por aba (estado sobrevive ao vaivém — um campo digitado continua lá), `PBRefresh` em background ao voltar pra aba cacheada (reusa o contrato do puxar-pra-atualizar), `pushState`/`popstate`, geração de navegação (o último tap vence), e **fallback sempre-navega**: fetch falhou, timeout 5s, redirect de auth/gate, rota não convertida → `location.href`. O pior caso é o comportamento de hoje, nunca tela travada.
- **Contrato por página** — os scripts inline de `/home` (2) e `/comandos-app` (1) embrulhados em `PBPages.<key>.inits` (sem `let`/`const` no topo: re-execução no mesmo documento estoura `SyntaxError`); os 8 handlers de `onclick=` expostos explicitamente; um `<script data-pb-boot>` roda os inits no load MPA e **nunca** via motor.
- **`app-mode.js`** — `goTo` delega pro motor quando ativo; o dock sincroniza bolha/aba ativa/`home` via `PBNav.onNavigate` (cobre tap e botão voltar).
- Rota `/pb-nav.js` no `static_pages.py` + teste (`test_pb_nav_js_com_cache_publico`).

## Desligado por padrão

O motor só ativa com **`?pbspa=1`** (persiste em localStorage, igual ao `pbapp`); `?pbspa=0` desliga. Sem a flag, nada muda pra ninguém — todo o caminho MPA continua o oficial.

## O que foi medido (harness no Chromium, 19 asserts, todos verdes)

Gating de rotas (não convertida/href inválido recusados) · boot MPA roda os inits · swap com VT: página nova entra, velha sai pro cache, **estilo entra/sai junto**, título troca, **dock permanece** · init roda **exatamente 1x** por página · `data-pb-boot` não executa via motor · volta do cache restaura DOM + estilo **sem re-executar** init · `PBRefresh` chamado em background no re-mount.

Também validado (previews das páginas reais): os embrulhos não introduzem erro de sintaxe e o caminho MPA (fallback do boot) executa os inits — na `/home`, os 2 inits rodam e as 8 globais de `onclick=` existem; na `/comandos-app`, o init roda até o `showAccessError` (fetch de sessão falha em `file://`, esperado).

## O que NÃO foi medido (GATE 1 — no aparelho)

Fluidez e ausência de piscada no WKWebView: **só no iPhone**. Teste do gate, depois do deploy:

1. Safari do iPhone → `https://pigbankai.com/home?pbapp=1&pbspa=1`
2. Alternar **Início ↔ O que pedir** várias vezes (as duas rotas da POC; as outras abas seguem MPA até as fases 3/4)
3. Critério: **zero piscada preta** — gravação de tela sem frame vazio

Se o gate falhar, paramos com custo de 1 PR contido (fallback: tweak nativo de cor, §1 do plano).

## Limitações conhecidas da Fase 1 (documentadas no pb-nav.js)

- Listeners globais de página desmontada seguem vivos (mexem em DOM desanexado: no-op visual); evicção com AbortSignal só se houver pressão de memória medida (Fase 4).
- O puxar-pra-atualizar captura o `.page` da página de boot; após um swap opera no modo simples (só indicador). Fase 2.
- Service worker não é registrado em mount SPA da `/home` (o `window load` já disparou) — inofensivo: já registrado em qualquer visita MPA anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
