### PR TITLE
fix(frontend): cache-buster de asset por hash de conteúdo (mata o merge conflict do ?v=)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,15 @@ O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView c
   precisa reservar a área segura por conta própria.
 - **Paisagem está habilitada no iPhone** (`mobile/ios/App/App/Info.plist`), então os
   insets laterais contam. Não trate área segura como assunto de topo.
+- **O cache-buster `?v=N` de CSS/JS é reescrito no serve-time — não bumpe à mão.**
+  `stamp_asset_versions` (`frontend/routes/shared.py`) troca o `?v=N` de qualquer
+  `*.css`/`*.js` de `frontend/` por um hash do conteúdo do arquivo, em toda saída de
+  HTML (o funil `html_file`, `/suporte`, `/blog/{slug}` e as duas páginas geradas em
+  Python). O número hardcoded no `<head>` (ex.: `app-mode.css?v=29`) é **ignorado** —
+  está lá só como resquício; mexer nele não faz nada. A invalidação passou a ser
+  automática (muda o arquivo → muda o hash). Antes cada asset era bumpado à mão em
+  ~8 HTMLs por PR e `v=31` vs `v=33` na mesma linha dava merge conflict a cada duas
+  PRs paralelas. Asset servido de fora de `frontend/` fica intacto.
 
 ### Componentes fragmentados
 

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -116,6 +116,7 @@ from frontend.routes.shared import (
     raise_if_account_scheduled_for_deletion as _raise_if_account_scheduled_for_deletion,
     resolve_analytics_window as _resolve_analytics_window,
     resolve_dashboard_user_id as _resolve_dashboard_user_id,
+    stamp_asset_versions as _stamp_asset_versions,
 )
 from frontend.routes.static_pages import router as static_pages_router
 
@@ -4719,7 +4720,7 @@ Solicite um novo link digitando <strong style="color:rgba(255,255,255,.8)">dashb
 Os links expiram em __MAGIC_LINK_MINUTES__ minutos e funcionam uma única vez.</p>
 <a href="/">← Página inicial</a>
 </div></body></html>""".replace("__MAGIC_LINK_MINUTES__", str(DASHBOARD_MAGIC_LINK_MINUTES))
-        return HTMLResponse(content=expired_html, status_code=401)
+        return HTMLResponse(content=_stamp_asset_versions(expired_html), status_code=401)
 
     # next: rotas internas permitidas pra evitar open-redirect. Tem prioridade sobre view.
     _ALLOWED_NEXT_PREFIXES = ("/precos", "/conta", "/app", "/home", "/settings")
@@ -4822,7 +4823,7 @@ async def unsubscribe(uid: int, token: str):
     if not await _apply_unsubscribe(uid, token):
         return HTMLResponse("<h2>Link inválido ou expirado.</h2>", status_code=400)
 
-    return HTMLResponse("""
+    return HTMLResponse(_stamp_asset_versions("""
 <!DOCTYPE html>
 <html lang="pt-BR">
 <head>
@@ -4851,7 +4852,7 @@ async def unsubscribe(uid: int, token: str):
   </div>
 </body>
 </html>
-""")
+"""))
 
 
 # ─── HTTP API routes ─────────────────────────────────────────────────────────

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -9,17 +9,20 @@ chamam via atributo de módulo, ex: `shared.authorize_dashboard_access`).
 """
 
 import asyncio
+import functools
+import hashlib
 import json
 import logging
 import os
 import pathlib
+import re
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any
 
 import jwt as pyjwt
 from fastapi import HTTPException, Request
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import Response
 from fastapi.security import HTTPAuthorizationCredentials
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
@@ -99,6 +102,42 @@ def inject_meta_pixel(html_text: str) -> str:
     return html_text[:idx] + snippet + html_text[idx:]
 
 
+# ─── Cache-buster dos assets (?v=) ───────────────────────────────────────────
+# Antes o `?v=N` de app-mode.css/js, pb-nav.js etc. era hardcoded no <head> de
+# cada HTML e bumpado à mão a cada deploy — o que dava merge conflict toda vez
+# que duas PRs mexiam no mesmo asset em paralelo (v=31 vs v=33 na mesma linha).
+# Agora o número no HTML é ignorado: reescrevemos `?v=N` no serve-time com um
+# hash do conteúdo do próprio arquivo. Zero bump manual → zero conflito, e a
+# invalidação passa a ser exata (só muda quando o arquivo muda de verdade).
+_ASSET_VER_RE = re.compile(r"(/[A-Za-z0-9_.-]+\.(?:css|js))\?v=\d+")
+
+
+@functools.lru_cache(maxsize=256)
+def _asset_hash(name: str, _mtime_ns: int) -> str:
+    # `_mtime_ns` entra na chave do cache só pra forçar recomputo quando o
+    # arquivo muda em disco (dev sem restart); não é usado no corpo.
+    data = (FRONTEND_DIR / name).read_bytes()
+    return hashlib.blake2b(data, digest_size=6).hexdigest()
+
+
+def stamp_asset_versions(html_text: str) -> str:
+    """Troca o `?v=N` de cada CSS/JS de frontend/ por um hash do conteúdo.
+
+    Aplicado em TODA saída de HTML (template, gerado em Python, montado à mão) —
+    ver os call sites em static_pages.py e no monólito. Assets fora de
+    FRONTEND_DIR ficam intactos.
+    """
+    def repl(m: "re.Match[str]") -> str:
+        url = m.group(1)             # ex: /app-mode.css
+        try:
+            mtime_ns = (FRONTEND_DIR / url[1:]).stat().st_mtime_ns
+        except OSError:
+            return m.group(0)        # arquivo não existe aqui → deixa como está
+        return f"{url}?v={_asset_hash(url[1:], mtime_ns)}"
+
+    return _ASSET_VER_RE.sub(repl, html_text)
+
+
 def html_file(path: pathlib.Path, pixel: bool = True) -> Response:
     """Serve um .html do frontend com cache desligado.
 
@@ -106,11 +145,11 @@ def html_file(path: pathlib.Path, pixel: bool = True) -> Response:
     <head>. As páginas da área logada (dashboard, settings, onboarding) passam
     `pixel=False` — o rastreio de marketing fica só nas páginas públicas.
     """
+    text = path.read_text(encoding="utf-8")
     if pixel and META_PIXEL_ID:
-        text = inject_meta_pixel(path.read_text(encoding="utf-8"))
-        response: Response = Response(content=text, media_type="text/html; charset=utf-8")
-    else:
-        response = FileResponse(path, media_type="text/html")
+        text = inject_meta_pixel(text)
+    response = Response(content=stamp_asset_versions(text),
+                        media_type="text/html; charset=utf-8")
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
     return response

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -19,6 +19,7 @@ from frontend.routes.shared import (
     inject_meta_pixel,
     limiter,
     public_site_url,
+    stamp_asset_versions,
 )
 
 router = APIRouter()
@@ -159,7 +160,7 @@ async def serve_blog_guide(slug: str, request: Request):
         .replace("{{BODY}}", guide["body"])            # HTML confiável (nosso)
         .replace("{{MORE_GUIDES}}", more)
     )
-    return Response(content=page, media_type="text/html; charset=utf-8")
+    return Response(content=stamp_asset_versions(page), media_type="text/html; charset=utf-8")
 
 
 @router.get("/whatsapp")
@@ -262,7 +263,7 @@ async def serve_suporte():
     # Mesmos headers de cache das demais páginas HTML (html_file): o /suporte é
     # montado à mão (injeta o FAQ), então precisa setar no-store explicitamente.
     # /suporte é público → recebe o Meta Pixel como as demais páginas públicas.
-    page = inject_meta_pixel(template.replace("{{FAQ}}", faq))
+    page = stamp_asset_versions(inject_meta_pixel(template.replace("{{FAQ}}", faq)))
     return Response(content=page,
                     media_type="text/html; charset=utf-8",
                     headers={"Cache-Control": "no-store", "Pragma": "no-cache"})

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -5,9 +5,12 @@ registrada no app e respondendo com o mesmo status/content-type/headers.
 Nenhuma toca banco — TestClient sem lifespan basta.
 """
 
+import re
+
 from fastapi.testclient import TestClient
 
 import frontend.finance_bot_websocket_custom as dashboard
+from frontend.routes.shared import FRONTEND_DIR, _asset_hash, stamp_asset_versions
 
 client = TestClient(dashboard.app)
 
@@ -36,6 +39,31 @@ def test_html_pages_respondem_com_no_store():
         assert resp.status_code == 200, path
         assert resp.headers["content-type"].startswith("text/html"), path
         assert resp.headers["cache-control"] == "no-store", path
+
+
+def test_stamp_asset_versions_usa_hash_de_conteudo():
+    # Número hardcoded no HTML é ignorado e trocado pelo hash do arquivo real.
+    mtime = (FRONTEND_DIR / "app-mode.css").stat().st_mtime_ns
+    esperado = _asset_hash("app-mode.css", mtime)
+    out = stamp_asset_versions('<link href="/app-mode.css?v=29">')
+    assert f"/app-mode.css?v={esperado}" in out
+    assert "?v=29" not in out
+    # Assets distintos → hashes distintos (não é um número global compartilhado).
+    js = re.search(r"/app-mode\.js\?v=(\w+)", stamp_asset_versions('"/app-mode.js?v=1"'))
+    assert js and js.group(1) != esperado
+    # Asset que não existe em frontend/ fica intacto.
+    assert stamp_asset_versions('"/naoexiste.js?v=7"') == '"/naoexiste.js?v=7"'
+
+
+def test_home_serve_app_mode_com_cache_buster_de_hash():
+    # A página logada real: o ?v= servido tem que ser hash, nunca o v=29 do arquivo.
+    html = client.get("/home").text
+    m = re.search(r"/app-mode\.css\?v=([0-9a-f]+)", html)
+    assert m, "app-mode.css deveria aparecer com ?v=<hash>"
+    assert m.group(1) != "29"
+    assert m.group(1) == _asset_hash(
+        "app-mode.css", (FRONTEND_DIR / "app-mode.css").stat().st_mtime_ns
+    )
 
 
 def test_health():


### PR DESCRIPTION
## Problema

O cache-buster `?v=N` de `app-mode.css`, `app-mode.js` e `pb-nav.js` (e outros CSS/JS) estava **hardcoded no `<head>` de ~8 HTMLs** e precisava ser bumpado à mão em todos eles a cada mudança do asset. Duas PRs em paralelo bumpando o mesmo asset viravam `v=31` vs `v=33` **na mesma linha** — o git não auto-mergeia e dá conflito toda vez (3 rounds na #112, vs #111/#114/#118).

## Solução

`stamp_asset_versions` (`frontend/routes/shared.py`) reescreve o `?v=N` de qualquer `*.css`/`*.js` de `frontend/` por um **hash blake2b do conteúdo do arquivo**, calculado no serve-time. O número que está no HTML passa a ser **ignorado** (fica só como resquício).

- **Zero bump manual → zero conflito.**
- **Invalidação automática e exata:** muda o arquivo → muda o hash; não muda → mesmo hash (browser reusa cache).
- Hash cacheado por `(nome, mtime_ns)` — recomputa quando o arquivo muda em disco (dev sem restart também).
- Asset servido de fora de `frontend/` fica intacto.

### Cobertura de todas as saídas de HTML
Aplicado em **todo** caminho que emite HTML, inclusive os gerados fora de template (CLAUDE.md §5):
- funil `html_file` (dashboard, home, settings, login, cadastro, comandos-app, changelog…);
- `/suporte` e `/blog/{slug}` (montados à mão);
- as **2 páginas geradas em Python** no monólito: link expirado `/d/{code}` e descadastro.

`html_file` deixou de usar `FileResponse` no ramo `pixel=False` (agora sempre `Response` com texto) pra o stamp poder rodar — inócuo, o HTML já era `no-store`.

## Testes
- Baseline local antes: **1217 passed**. Depois: **1219 passed** (+2 novos, 0 regressão).
- Novos testes em `tests/test_static_pages_routes.py`: unit de `stamp_asset_versions` (hash de conteúdo, hashes distintos por asset, asset inexistente intacto) + integração no `/home`.
- Render conferido manualmente em `/home`, `/comandos-app` e `/app`: cada asset com hash próprio e consistente entre páginas; `v=29/33/5` sumiram do HTML servido.

## Não verificado aqui
Comportamento de cache real no WKWebView (iOS) só no aparelho, depois do build — este ambiente não reproduz o WebView nem acessa produção. A aritmética de invalidação (hash muda ⇔ conteúdo muda) está coberta pelos testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)