### PR TITLE
feat(landing): meta de verificação de domínio do Facebook na página inicial

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
 <meta name="theme-color" content="#0c0c0d" />
+<meta name="facebook-domain-verification" content="bkhplpcvt5kouph3e1b9y8jk8aiqsu" />
 <meta property="og:type" content="website" />
 <script>
 /* PWA instalada (start_url antiga "/"): entra pelo app, não pela landing —


### PR DESCRIPTION
## O que muda

Adiciona a meta tag de verificação de domínio da Meta/Facebook no `<head>` da página inicial (`frontend/index.html`), logo antes do `og:type`:

```html
<meta name="facebook-domain-verification" content="bkhplpcvt5kouph3e1b9y8jk8aiqsu" />
```

Só a `index.html` recebe a tag: a verificação da Meta busca a tag na URL raiz do domínio, servida pela rota `/` (`frontend/routes/static_pages.py:35-37`). O site não é Next.js — o frontend é HTML estático — então a tag entra direto no HTML.

## Validação

- Suíte completa rodada **com e sem** a mudança no ambiente remoto: 1094 passed / 57 failed nas duas execuções, com **listas de falhas idênticas nome a nome** — as 57 são preexistentes do ambiente local (versões de pacote), não regressão desta mudança. O CI, com o `requirements.txt` completo, é a confirmação.
- Não verificável daqui: a produção (`pigbankai.com`) é inacessível neste ambiente. A verificação no Meta Business Manager (Configurações do negócio → Segurança da marca → Domínios → "Verificar") só pode ser feita depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3kuyHEv6uhcQAhwkF7KKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3kuyHEv6uhcQAhwkF7KKU)_