### PR TITLE
fix(app): generation guard uniforme nos loaders de Ajustes (fecha a classe)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,37 @@ jobs:
         run: |
           PYTHONPATH=. pytest -q
 
+  # Testes de frontend (tests/frontend/): Playwright + Chromium contra as páginas
+  # reais de frontend/. Job SEPARADO de propósito — não depende de Postgres nem
+  # das deps de Python, e roda em paralelo sem somar um segundo ao `pytest`.
+  #
+  # BLOQUEANTE, de propósito: o download do Chromium (~95 MB) é rede externa e
+  # não foi exercitado neste CI ainda. Se ele quebrar, o CI fica vermelho e a
+  # gente descobre na hora — falha ruidosa vale mais que um job que sinaliza
+  # sozinho e ninguém lê.
+  frontend:
+    runs-on: ubuntu-latest
+    # Sem isto o default é 360 min: um download de Chromium travado queimaria
+    # 6 horas de runner antes de desistir.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Playwright + Chromium
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run frontend tests
+        run: npm run test:frontend
+
   # Varredura de CVE nas dependências. Não-bloqueante: sinaliza sem travar
   # o merge/deploy (uma CVE sem fix disponível não deve segurar a main).
   # O Dependabot (.github/dependabot.yml) abre os PRs de correção.

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ register_whatsapp.json
 # o ~/.claude/ de ninguém.
 !.claude/skills/baseline-testes/
 skills-lock.json
+
+# Harness de testes de frontend (tests/frontend/): dependência local, não viaja.
+node_modules/

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -2298,10 +2298,12 @@ function applyNotificationSettings(data) {
   ].join(" · ");
 }
 
-// Geração: reachable só quando um pull-to-refresh cai em cima do primeiro load
-// da aba (o PTR já encadeia atrás de _notifSave). Guard uniforme com os demais
-// loaders: o load antigo não repinta nem tinge o PTR de âmbar. O finally
-// (reabilitação dos controles) segue rodando sempre, idempotente sobre o DOM.
+// Geração: reachable quando um pull-to-refresh cai em cima do primeiro load da
+// aba (o PTR já encadeia atrás de _notifSave). O load antigo não repinta, não
+// tinge o PTR de âmbar E não reabilita os controles — este último importa
+// porque a reabilitação é o que sustenta o invariante "no máximo um save":
+// reabilitar cedo (com o GET novo ainda em voo) deixaria um PATCH concorrente
+// ser sobrescrito pelo GET pré-PATCH. Só a geração corrente restaura.
 let _notifGen = 0;
 async function loadNotificationSettings({ propagate = false } = {}) {
   if (!USER_ID) {
@@ -2328,18 +2330,25 @@ async function loadNotificationSettings({ propagate = false } = {}) {
     else if (propagate) refreshErr = err;
     else showToast(err.message || "Erro ao carregar notificações", "error");
   } finally {
-    const daily = document.getElementById("notif-daily-report")?.checked;
-    const anyScheduled = daily
-      || document.getElementById("notif-weekly-report")?.checked
-      || document.getElementById("notif-monthly-report")?.checked;
-    const destinationText = document.getElementById("notif-email-value")?.textContent || "";
-    const hasEmail = !destinationText.startsWith("E-mail não vinculado");
-    const hasWhatsapp = !destinationText.includes("WhatsApp não vinculado");
-    setNotificationControlsDisabled(false);
-    document.getElementById("notif-tip-email").disabled = !hasEmail;
-    document.getElementById("notif-insight-email").disabled = !hasEmail;
-    document.getElementById("notif-whatsapp-updates").disabled = !hasWhatsapp;
-    document.getElementById("notif-daily-hour").disabled = !anyScheduled;
+    // Só a geração corrente reabilita os controles. Um load superado NÃO pode
+    // reabilitar enquanto o GET mais novo ainda está em voo — senão o usuário
+    // dispara um PATCH cujos controles/estado o GET pré-PATCH sobrescreveria,
+    // furando o invariante "no máximo um save". O load mais novo restaura no
+    // próprio finally (e, como é o último a assentar, sempre restaura).
+    if (myGen === _notifGen) {
+      const daily = document.getElementById("notif-daily-report")?.checked;
+      const anyScheduled = daily
+        || document.getElementById("notif-weekly-report")?.checked
+        || document.getElementById("notif-monthly-report")?.checked;
+      const destinationText = document.getElementById("notif-email-value")?.textContent || "";
+      const hasEmail = !destinationText.startsWith("E-mail não vinculado");
+      const hasWhatsapp = !destinationText.includes("WhatsApp não vinculado");
+      setNotificationControlsDisabled(false);
+      document.getElementById("notif-tip-email").disabled = !hasEmail;
+      document.getElementById("notif-insight-email").disabled = !hasEmail;
+      document.getElementById("notif-whatsapp-updates").disabled = !hasWhatsapp;
+      document.getElementById("notif-daily-hour").disabled = !anyScheduled;
+    }
   }
   if (refreshErr) throw refreshErr;   // PTR: propaga a falha depois do finally
 }

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1977,6 +1977,12 @@ async function awaitAllPropagate(promises) {
   if (failed) throw failed.reason;
 }
 
+// Geração: saveSecurityContact e o reset de senha (:2235) recarregam a segurança
+// fora do PTR; puxar no meio deixa dois loads em voo e o antigo repintava os
+// campos por último. Os filhos (atividade/sessões) têm geração própria — aqui só
+// gato a pintura do painel de segurança. Superado pula o fan-out: o load mais
+// novo o refaz, e não deixo a falha de um load velho tingir o PTR de âmbar.
+let _securityGen = 0;
 async function loadSecuritySettings({ propagate = false } = {}) {
   if (!USER_ID) {
     if (propagate) throw new Error("Sessão inválida");
@@ -1984,12 +1990,15 @@ async function loadSecuritySettings({ propagate = false } = {}) {
     showToast("Sessão inválida. Faça login novamente", "error");
     return;
   }
+  const myGen = ++_securityGen;
   try {
     const resp = await fetch(`${API}/settings/${USER_ID}/security`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) throw new Error(await readApiError(resp));
     const data = await resp.json();
+    if (myGen !== _securityGen) return;   // superado: não pinta (o load mais novo refaz o fan-out)
     applySecuritySettings(data);
   } catch (err) {
+    if (myGen !== _securityGen) return;   // superado: não repinta nem propaga
     if (propagate) throw err;
     applySecuritySettings({});
     showToast(err.message || "Erro ao carregar segurança", "error");
@@ -2062,21 +2071,30 @@ function renderActivityList(events, containerId, opts = {}) {
 
 let _activityCache = [];
 
+// Geração (par do _sessionsGen): loadSecuritySettings dispara atividade E sessões
+// juntas, e uma ação de segurança que recarrega no meio de um pull-to-refresh
+// deixa dois loads em voo; o antigo, chegando por último, re-renderizava um
+// _activityCache stale — que também alimenta o modal (openActivityModal). Só a
+// geração mais nova pinta.
+let _activityGen = 0;
 async function loadActivityLog({ propagate = false } = {}) {
   const container = document.getElementById("activity-list");
   if (!USER_ID || !container) return;
   // No refresh (propagate) NÃO troca por "Carregando…": preserva o conteúdo
   // atual, pra uma falha transitória não apagar dado válido antes de propagar.
   if (!propagate) container.innerHTML = '<div class="activity-loading">Carregando…</div>';
+  const myGen = ++_activityGen;
   try {
     const resp = await fetch(`${API}/settings/${USER_ID}/activity?limit=10`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) throw new Error(await readApiError(resp));
     const data = await resp.json();
+    if (myGen !== _activityGen) return;   // superado por um load mais novo: não pinta
     _activityCache = Array.isArray(data.events) ? data.events : [];
     renderActivityList(_activityCache, "activity-list", { limit: 3 });
     const showAllBtn = document.getElementById("activity-show-all-btn");
     if (showAllBtn) showAllBtn.hidden = _activityCache.length <= 3;
   } catch (err) {
+    if (myGen !== _activityGen) return;   // superado: não mexe no DOM nem propaga
     if (propagate) throw err;   // refresh: preserva conteúdo, PTR vira âmbar
     container.innerHTML = '<div class="activity-empty">Não foi possível carregar a atividade.</div>';
   }
@@ -2280,24 +2298,34 @@ function applyNotificationSettings(data) {
   ].join(" · ");
 }
 
+// Geração: reachable só quando um pull-to-refresh cai em cima do primeiro load
+// da aba (o PTR já encadeia atrás de _notifSave). Guard uniforme com os demais
+// loaders: o load antigo não repinta nem tinge o PTR de âmbar. O finally
+// (reabilitação dos controles) segue rodando sempre, idempotente sobre o DOM.
+let _notifGen = 0;
 async function loadNotificationSettings({ propagate = false } = {}) {
   if (!USER_ID) {
     if (propagate) throw new Error("Sessão inválida");
     showToast("Sessão inválida. Faça login novamente", "error");
     return;
   }
+  const myGen = ++_notifGen;
   setNotificationControlsDisabled(true);
   let refreshErr = null;
   try {
     const resp = await fetch(`${API}/settings/${USER_ID}/notifications`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) throw new Error(await readApiError(resp));
     const data = await resp.json();
-    applyNotificationSettings(data);
-    notificationSettingsLoaded = true;
+    if (myGen === _notifGen) {   // só a geração mais nova pinta
+      applyNotificationSettings(data);
+      notificationSettingsLoaded = true;
+    }
   } catch (err) {
+    // Superado por um load mais novo: não repinta nem transforma o PTR em âmbar.
+    if (myGen !== _notifGen) { /* segue pro finally, refreshErr fica null */ }
     // propagate (PTR): guarda o erro e re-lança DEPOIS do finally, pra o
     // indicador virar âmbar sem pular a reabilitação dos controles.
-    if (propagate) refreshErr = err;
+    else if (propagate) refreshErr = err;
     else showToast(err.message || "Erro ao carregar notificações", "error");
   } finally {
     const daily = document.getElementById("notif-daily-report")?.checked;
@@ -2840,18 +2868,25 @@ async function loadData({ propagate = false } = {}) {
    do PigBank pro Banqueiro detectar os aportes. */
 let _caixMetas = [];
 
+// Geração: chamado pelo loadData (que já checa _dataGen, mas o fetch próprio
+// reabre a janela) e pelo bind (:2910); puxar no meio deixa dois em voo e o
+// antigo re-renderizava o card stale (ou escondia um recém-mostrado). Só a
+// geração mais nova mexe no card.
+let _caixGen = 0;
 async function loadCaixinhas({ propagate = false } = {}) {
   const card = document.getElementById("caixinhas-card");
   if (!USER_ID || !card) return;
+  const myGen = ++_caixGen;
   let data;
   try {
     const resp = await fetch(`${API}/open-finance/${USER_ID}/caixinhas`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) {
-      if (resp.status === 404) { card.style.display = "none"; return; }  // 404 = fora do beta (legítimo)
+      if (resp.status === 404) { if (myGen === _caixGen) card.style.display = "none"; return; }  // 404 = fora do beta (legítimo)
       throw new Error("HTTP " + resp.status);                            // 5xx/transitório
     }
     data = await resp.json();
   } catch (err) {
+    if (myGen !== _caixGen) return;   // superado: não mexe no card nem propaga
     // No refresh (propagate) preserva o card já renderizado e propaga — sem
     // isso uma falha transitória escondia caixinhas válidas. No load normal,
     // mantém o comportamento antigo (esconde).
@@ -2859,6 +2894,7 @@ async function loadCaixinhas({ propagate = false } = {}) {
     card.style.display = "none";
     return;
   }
+  if (myGen !== _caixGen) return;   // superado por um load mais novo: não pinta
   const cx = data.caixinhas || [];
   if (!cx.length) { card.style.display = "none"; return; }
   _caixMetas = data.metas || [];
@@ -3082,12 +3118,21 @@ async function disconnectAll() {
 /* ── MFA (TOTP) ──────────────────────────────── */
 let _mfaStatus = { enabled: false, has_pending_secret: false, backup_codes_remaining: 0 };
 
+// Geração: enable/disable/regenerate (:3184,:3232,:3271) recarregam o status;
+// puxar-pra-atualizar no meio deixa dois GETs em voo e o antigo, por último,
+// sobrescrevia _mfaStatus — que decide qual modal o toggle abre (onMfaToggleClick),
+// não só o texto. Só a geração mais nova assenta.
+let _mfaGen = 0;
 async function loadMfaStatus({ propagate = false } = {}) {
+  const myGen = ++_mfaGen;
   try {
     const resp = await fetch(`${API}/auth/mfa/status`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) throw new Error(await readApiError(resp));
-    _mfaStatus = await resp.json();
+    const status = await resp.json();
+    if (myGen !== _mfaGen) return;   // superado: não assenta (preserva o load mais novo)
+    _mfaStatus = status;
   } catch (err) {
+    if (myGen !== _mfaGen) return;   // superado: não mexe no estado nem propaga
     // No refresh (propagate) preserva _mfaStatus e propaga: sem isso, um erro
     // transitório no /auth/mfa/status virava "MFA desativado" na tela (oferecendo
     // ativar de novo) e o PTR ainda reportava sucesso.

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1903,6 +1903,12 @@ async function saveSecurityContact(kind) {
     // o input ficava com o texto pré-save (ex.: com espaços) e o valor
     // canonicalizado do backend só apareceria no rótulo, não ao reabrir.
     toggleSecurityEdit(kind, false);
+    // Invalida qualquer loadSecuritySettings em voo: os inputs de segurança NÃO
+    // ficam disabled durante o load (diferente de notificações), então um GET
+    // do "↻ Atualizar" ou do PTR pode ter partido antes deste PATCH e chegar
+    // por último. Sem bumpar a geração, esse GET veria myGen === _securityGen e
+    // repintaria o contato pré-PATCH por cima do que acabou de ser salvo.
+    ++_securityGen;
     applySecuritySettings(data);
     const labels = { email: "E-mail atualizado", phone: "Telefone atualizado", name: value ? "Nome atualizado" : "Nome removido" };
     showToast(labels[kind] || "Dado atualizado", "ok");

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1909,6 +1909,20 @@ async function saveSecurityContact(kind) {
     // por último. Sem bumpar a geração, esse GET veria myGen === _securityGen e
     // repintaria o contato pré-PATCH por cima do que acabou de ser salvo.
     ++_securityGen;
+    // Bumpar a geração cancela o fan-out do load em voo (ele retorna ANTES de
+    // loadActivityLog/loadSessionsList) e este save não dispara load novo pra
+    // refazê-lo — sem isto os dois painéis ficariam presos em "Carregando…" até
+    // um refresh manual. Refazer aqui também é freshness legítima: trocar
+    // e-mail/telefone escreve um evento na atividade. Sem await e sem propagate:
+    // os filhos têm geração própria e um erro aqui não pode virar rejeição solta.
+    // ANTES do applySecuritySettings: se o apply estourasse no meio, o catch
+    // abaixo engolia em toast e o fan-out do load invalidado nunca seria refeito.
+    // Inerte hoje (o apply só toca ids que existem nesta página, e nenhum teste
+    // cobre o cenário); é de graça e tira a dependência. Ordem não muda nada:
+    // os filhos são async e não tocam em nenhum #security-* (pintam
+    // #activity-list / #sessions-list e os botões deles).
+    loadActivityLog();
+    loadSessionsList();
     applySecuritySettings(data);
     const labels = { email: "E-mail atualizado", phone: "Telefone atualizado", name: value ? "Nome atualizado" : "Nome removido" };
     showToast(labels[kind] || "Dado atualizado", "ok");
@@ -1983,11 +1997,22 @@ async function awaitAllPropagate(promises) {
   if (failed) throw failed.reason;
 }
 
-// Geração: saveSecurityContact e o reset de senha (:2235) recarregam a segurança
-// fora do PTR; puxar no meio deixa dois loads em voo e o antigo repintava os
-// campos por último. Os filhos (atividade/sessões) têm geração própria — aqui só
-// gato a pintura do painel de segurança. Superado pula o fan-out: o load mais
-// novo o refaz, e não deixo a falha de um load velho tingir o PTR de âmbar.
+// Geração: saveSecurityContact, o reset de senha (sendPasswordResetEmail) e o
+// "↻ Atualizar" do card "Dados da conta" recarregam a segurança fora do PTR; puxar no
+// meio deixa dois loads em voo e o antigo repintava os campos por último. Os
+// filhos (atividade/sessões) têm geração própria — aqui só gato a pintura do
+// painel de segurança.
+//
+// Invariante: O BUMPER MAIS RECENTE DE _securityGen É DONO DO FAN-OUT
+// (atividade + sessões) E DO DESFECHO. Dois lugares bumpam: saveSecurityContact
+// e este load. Um load superado sai calado nos três pontos de saída — o guard do
+// sucesso, o do catch, e a re-checagem depois do fan-out: não pinta e não
+// propaga erro. Nos dois primeiros ele sai ANTES do fan-out, e quem o superou é
+// quem dispara os filhos; no terceiro os filhos já rodaram.
+// Sem isso os dois painéis ficavam presos no "Carregando…" estático de
+// #activity-list / #sessions-list até troca de seção — era o que acontecia
+// quando a geração corrente saía por throw (propagate) antes do fan-out,
+// deixando o load superado sem ninguém pra refazê-lo.
 let _securityGen = 0;
 async function loadSecuritySettings({ propagate = false } = {}) {
   if (!USER_ID) {
@@ -1997,22 +2022,38 @@ async function loadSecuritySettings({ propagate = false } = {}) {
     return;
   }
   const myGen = ++_securityGen;
+  let ownErr = null;
   try {
     const resp = await fetch(`${API}/settings/${USER_ID}/security`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) throw new Error(await readApiError(resp));
     const data = await resp.json();
-    if (myGen !== _securityGen) return;   // superado: não pinta (o load mais novo refaz o fan-out)
+    if (myGen !== _securityGen) return;   // superado: não pinta nem dispara os filhos (quem superou faz os dois)
     applySecuritySettings(data);
   } catch (err) {
     if (myGen !== _securityGen) return;   // superado: não repinta nem propaga
-    if (propagate) throw err;
-    applySecuritySettings({});
-    showToast(err.message || "Erro ao carregar segurança", "error");
+    // propagate (PTR): não zera a tela (preserva o conteúdo atual), guarda o erro
+    // e re-lança DEPOIS do fan-out, pro indicador virar âmbar sem deixar os
+    // filhos órfãos. Sair por throw aqui quebrava o invariante acima — esta
+    // geração é a dona do fan-out e ninguém mais o refaria.
+    if (propagate) ownErr = err;
+    else {
+      applySecuritySettings({});
+      showToast(err.message || "Erro ao carregar segurança", "error");
+    }
   }
   // Espera atividade E sessões assentarem (não só a 1ª a falhar) e então
   // propaga a falha — senão o indicador soltava com uma delas ainda em voo,
   // que podia repintar por cima depois. {propagate} preserva o conteúdo atual.
-  await awaitAllPropagate([loadActivityLog({ propagate }), loadSessionsList({ propagate })]);
+  // Erro do pai ganha do erro do filho (é mais informativo).
+  await awaitAllPropagate([loadActivityLog({ propagate }), loadSessionsList({ propagate })])
+    .catch(function (childErr) { if (!ownErr) ownErr = childErr; });
+  // Re-checa a geração: o fan-out são mais dois GETs, e um ↻/save no meio pode
+  // ter superado este load. É a outra metade da regra que os guards
+  // acima já aplicam — eles descartam o SUCESSO de um load superado, este
+  // descarta o ERRO. Limite aceito: a geração nova pode não pintar (em voo, ou
+  // falhando também) e aí o PTR resolve verde com a tela possivelmente zerada —
+  // o toast de erro do caminho propagate:false é o sinal que sobra.
+  if (ownErr && myGen === _securityGen) throw ownErr;
 }
 
 const ACTIVITY_ICONS = {
@@ -2849,11 +2890,12 @@ async function loadData({ propagate = false } = {}) {
     return;
   }
   const myGen = ++_dataGen;
+  let ownErr = null;
   try {
     const resp = await fetch(`${API}/open-finance/${USER_ID}`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) throw new Error(await readApiError(resp));
     const data = await resp.json();
-    if (myGen !== _dataGen) return;   // superado por um loadData mais novo: não pinta
+    if (myGen !== _dataGen) return;   // superado: não pinta nem chama o caixinhas (quem superou faz os dois)
     const c = data.connections  || [];
     const a = data.accounts     || [];
     const t = data.transactions || [];
@@ -2862,19 +2904,33 @@ async function loadData({ propagate = false } = {}) {
     renderAccounts(a);
     renderTransactions(t);
     if (c.length > 0) setStep(3);
-    // await + propaga: sem isso o loadData soltava o indicador do PTR antes do
-    // caixinhas assentar (segundo pull podia sobrepor) e uma falha transitória
-    // escondia o card já renderizado com o refresh reportando sucesso.
-    await loadCaixinhas({ propagate });
   } catch (err) {
     if (myGen !== _dataGen) return;   // superado: não mexe no DOM nem propaga
-    // propagate (PTR): preserva o que está renderizado e rejeita (âmbar). Sem
-    // isso, uma falha transitória apagava conexões/contas/transações da tela.
-    if (propagate) throw err;
-    updateStats([], [], []);
-    renderConnections([]); renderAccounts([]); renderTransactions([]);
-    showToast(err.message || "Erro ao carregar dados", "error");
+    // propagate (PTR): preserva o que está renderizado e guarda o erro pra
+    // rejeitar DEPOIS do caixinhas (âmbar). Sem isso, uma falha transitória
+    // apagava conexões/contas/transações da tela.
+    if (propagate) ownErr = err;
+    else {
+      updateStats([], [], []);
+      renderConnections([]); renderAccounts([]); renderTransactions([]);
+      showToast(err.message || "Erro ao carregar dados", "error");
+    }
   }
+  // Caixinhas FORA do try — mesmo invariante do fan-out de segurança (documentado
+  // acima de loadSecuritySettings): o bumper mais recente de _dataGen é dono do
+  // loadCaixinhas e do desfecho, e loadData é o único que bumpa. Dentro do try ele
+  // ficava órfão quando esta geração falhava com propagate (sai por throw antes) e
+  // a anterior caía no guard de geração — ninguém o chamava.
+  // await + propaga: sem isso o loadData soltava o indicador do PTR antes do
+  // caixinhas assentar (segundo pull podia sobrepor) e uma falha transitória
+  // escondia o card já renderizado com o refresh reportando sucesso.
+  // Erro do pai ganha do erro do filho (é mais informativo).
+  await loadCaixinhas({ propagate }).catch(function (childErr) { if (!ownErr) ownErr = childErr; });
+  // Re-checa a geração pelo mesmo motivo do loadSecuritySettings: o await acima é
+  // mais um GET, e um loadData mais novo (2º pull, disconnectAll) que
+  // tenha superado este é o dono do desfecho — o erro desta geração morta não
+  // pode tingir o PTR de âmbar por cima do dado fresco que a nova pintou.
+  if (ownErr && myGen === _dataGen) throw ownErr;
 }
 
 /* ── Caixinhas ↔ metas (Banqueiro, beta) ─────────
@@ -2884,37 +2940,51 @@ async function loadData({ propagate = false } = {}) {
 let _caixMetas = [];
 
 // Geração: chamado pelo loadData (que já checa _dataGen, mas o fetch próprio
-// reabre a janela) e pelo bind (:2910); puxar no meio deixa dois em voo e o
-// antigo re-renderizava o card stale (ou escondia um recém-mostrado). Só a
-// geração mais nova mexe no card.
+// reabre a janela) e pelo bindCaixinha (o onchange do <select> de cada linha do
+// card); puxar no meio deixa dois em voo e o antigo re-renderizava o card stale
+// (ou escondia um recém-mostrado). Só a geração mais nova mexe no card.
 let _caixGen = 0;
 async function loadCaixinhas({ propagate = false } = {}) {
   const card = document.getElementById("caixinhas-card");
   if (!USER_ID || !card) return;
   const myGen = ++_caixGen;
-  let data;
+  // A pintura fica DENTRO do try (como no loadData e no loadSecuritySettings):
+  // fora dela um throw do renderCaixinhas subia pro catch do loadData e, com
+  // propagate:false, apagava conexões/contas/transações que tinham acabado de
+  // renderizar com sucesso; com o caixinhas já fora do try do loadData, viraria
+  // rejeição solta.
+  // O preço: com propagate:false um bug no renderCaixinhas cai no mesmo catch de
+  // um GET que falhou e vira "esconde o card". Sem toast de propósito — este card
+  // é beta e só aparece pra uma allowlist; um toast de erro numa tela onde o card
+  // nem devia existir é pior que a ausência dele, e o fetch com propagate:false
+  // já era silencioso desde antes. Mas erro de render é BUG, não falha
+  // transitória: vai pro console.error abaixo. Com propagate:true nada muda —
+  // rejeita e o PTR fica âmbar.
   try {
     const resp = await fetch(`${API}/open-finance/${USER_ID}/caixinhas`, authOptions({ headers: authHeaders() }));
     if (!resp.ok) {
       if (resp.status === 404) { if (myGen === _caixGen) card.style.display = "none"; return; }  // 404 = fora do beta (legítimo)
       throw new Error("HTTP " + resp.status);                            // 5xx/transitório
     }
-    data = await resp.json();
+    const data = await resp.json();
+    if (myGen !== _caixGen) return;   // superado por um load mais novo: não pinta
+    const cx = data.caixinhas || [];
+    if (!cx.length) { card.style.display = "none"; return; }
+    _caixMetas = data.metas || [];
+    renderCaixinhas(cx);
+    card.style.display = "";
   } catch (err) {
     if (myGen !== _caixGen) return;   // superado: não mexe no card nem propaga
     // No refresh (propagate) preserva o card já renderizado e propaga — sem
     // isso uma falha transitória escondia caixinhas válidas. No load normal,
-    // mantém o comportamento antigo (esconde).
+    // mantém o comportamento antigo (esconde) + console.error, pro throw de
+    // render não sumir sem deixar rastro. _caixMetas pode ter ficado com as metas
+    // novas e o card escondido: inerte, renderCaixinhas é o único leitor e o
+    // loadCaixinhas reatribui _caixMetas antes de cada render.
     if (propagate) throw err;
+    console.error("loadCaixinhas:", err);
     card.style.display = "none";
-    return;
   }
-  if (myGen !== _caixGen) return;   // superado por um load mais novo: não pinta
-  const cx = data.caixinhas || [];
-  if (!cx.length) { card.style.display = "none"; return; }
-  _caixMetas = data.metas || [];
-  renderCaixinhas(cx);
-  card.style.display = "";
 }
 
 function renderCaixinhas(list) {
@@ -3133,7 +3203,7 @@ async function disconnectAll() {
 /* ── MFA (TOTP) ──────────────────────────────── */
 let _mfaStatus = { enabled: false, has_pending_secret: false, backup_codes_remaining: 0 };
 
-// Geração: enable/disable/regenerate (:3184,:3232,:3271) recarregam o status;
+// Geração: mfaSetupStep2Submit/mfaDisableSubmit/mfaRegenerateSubmit recarregam o status;
 // puxar-pra-atualizar no meio deixa dois GETs em voo e o antigo, por último,
 // sobrescrevia _mfaStatus — que decide qual modal o toggle abre (onMfaToggleClick),
 // não só o texto. Só a geração mais nova assenta.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "pigbank-frontend-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pigbank-frontend-tests",
+      "devDependencies": {
+        "playwright": "^1.56.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pigbank-frontend-tests",
+  "private": true,
+  "description": "Só o harness de testes de frontend (tests/frontend/). O site é HTML estático servido pelo backend; não há build de JS.",
+  "scripts": {
+    "test:frontend": "node --test tests/frontend/*.test.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.56.0"
+  }
+}

--- a/tests/frontend/settings_security_fanout.test.mjs
+++ b/tests/frontend/settings_security_fanout.test.mjs
@@ -1,0 +1,413 @@
+/**
+ * Concorrência do fan-out em frontend/settings.html.
+ *
+ * UM invariante, e cada teste abaixo existe pra discriminar uma forma de
+ * quebrá-lo (rodar contra a versão sabotada correspondente tem que dar VERMELHO
+ * — asserção que passa nas duas versões é peso morto):
+ *
+ *   FAN-OUT: o bumper MAIS RECENTE da geração é dono dos filhos (_securityGen →
+ *   atividade + sessões; _dataGen → caixinhas) E do desfecho. Um load superado
+ *   pula o fan-out porque quem o superou é o dono — então a geração corrente NÃO
+ *   pode sair por throw antes de disparar os filhos, e tem que ESPERAR eles
+ *   assentarem antes de soltar o PTR, propagando a falha (do pai, se houver) sem
+ *   rejeição solta. A recíproca vale: uma geração superada DURANTE o fan-out
+ *   também não propaga — quem a superou é o dono do desfecho.
+ *
+ * Fora de escopo de propósito: o placeholder estático ("Carregando…") dos
+ * painéis quando o GET falha com propagate. O comportamento aceito é preservar o
+ * conteúdo atual — que no primeiro load É o placeholder.
+ *
+ * Rodar:  npm run test:frontend
+ * Precisa de `npm ci` na raiz (playwright) + `npx playwright install chromium`.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+const PORT = Number(process.env.PB_TEST_PORT || 8899);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const json = (body) => ({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+const err500 = (detail) => ({ status: 500, contentType: "application/json", body: JSON.stringify({ detail }) });
+
+async function startServer() {
+  const proc = spawn("python3", ["-m", "http.server", String(PORT), "--bind", "127.0.0.1", "--directory", FRONTEND],
+    { stdio: "ignore" });
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    // Porta ocupada por outro processo: o python morre na hora ("Address already
+    // in use"). Sem esta checagem a sonda adotava o servidor alheio em silêncio.
+    if (proc.exitCode !== null) throw new Error(`http.server morreu (porta ${PORT} ocupada?)`);
+    try { if ((await fetch(`${ORIGIN}/settings.html`)).ok) return proc; } catch { /* ainda subindo */ }
+  }
+  proc.kill();
+  throw new Error(`http.server não subiu em ${ORIGIN}`);
+}
+
+/** Espera cond() virar true; estoura em vez de pendurar o teste pra sempre. */
+async function waitFor(cond, what, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return;
+    await sleep(50);
+  }
+  throw new Error(`timeout esperando: ${what}`);
+}
+
+let server, browser;
+before(async () => { server = await startServer(); browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/**
+ * Página com o baseline de rotas. Catch-all registrado PRIMEIRO = menor
+ * prioridade no Playwright (casa na ordem inversa de registro): asset com
+ * extensão vai pro http.server, o resto é API e vira {} — assim nenhum 404 gera
+ * ruído. Cada teste registra DEPOIS as rotas que quer controlar.
+ */
+async function newPage() {
+  const page = await browser.newPage();
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin !== ORIGIN) return route.abort();          // CDN (pluggy) bloqueado
+    if (/\.[a-z0-9]+$/i.test(url.pathname)) return route.continue();
+    return route.fulfill(json({}));
+  });
+  // /static/auth-refresh.js: o path servido é /static/, o arquivo mora na raiz de frontend/.
+  await page.route("**/static/auth-refresh.js", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript",
+                    body: readFileSync(join(FRONTEND, "auth-refresh.js"), "utf8") }));
+  await page.route("**/auth/validate", (route) => route.fulfill(json({ user_id: 1 })));
+  await page.route("**/auth/me", (route) => route.fulfill(json({})));
+  await page.addInitScript(() => {
+    window.__unhandled = [];
+    window.addEventListener("unhandledrejection", (e) =>
+      window.__unhandled.push(String((e.reason && e.reason.message) || e.reason)));
+  });
+  return page;
+}
+
+/** Dispara o PTR guardando o desfecho em window.__done (null = ainda em voo). */
+const startPtr = (page) => page.evaluate(() => {
+  window.__done = null;
+  window.PBRefresh().then(() => "resolved", (e) => "rejected:" + ((e && e.message) || e))
+    .then((v) => { window.__done = v; });
+});
+
+const SECURITY_OK = { email: "a@b.com", phone: "5511999999999", plan: "pro", display_name: "Japa" };
+const ONE_EVENT = { events: [{ event_type: "login_from_new_ip", created_at: new Date().toISOString() }] };
+const ONE_SESSION = { sessions: [{ jti: "a", is_current: true, user_agent: "Chrome", created_at: new Date().toISOString() }] };
+
+/**
+ * O cenário do relato original — pai falhando COM um load anterior em voo:
+ *   1. GET /security da abertura da aba (geração 1) fica SEGURADO;
+ *   2. PBRefresh() dispara a geração 2 com propagate:true;
+ *   3. o GET da geração 2 responde 500;
+ *   4. só então a geração 1 é liberada com 200 (chega superada, não pinta).
+ *
+ * Sem o `ownErr` (a geração 2 saindo por throw direto do catch): 0 chamadas a
+ * /activity e /sessions, e os dois painéis ficam órfãos no "Carregando…" —
+ * ninguém mais vai refazer o fan-out, porque a geração 1 é a superada.
+ */
+test("segurança: GET que falha durante um load em voo não deixa os filhos órfãos", async () => {
+  const page = await newPage();
+  const counts = { activity: 0, sessions: 0 };
+  const securityCalls = [];   // route objects, na ordem de chegada
+  try {
+    await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+    await page.route("**/settings/1/activity*", (route) => { counts.activity++; route.fulfill(json(ONE_EVENT)); });
+    await page.route("**/settings/1/sessions", (route) => { counts.sessions++; route.fulfill(json(ONE_SESSION)); });
+    // Fila: 1ª chamada segurada (liberada à mão lá embaixo), 2ª responde 500.
+    await page.route("**/settings/1/security", (route) => {
+      securityCalls.push(route);
+      if (securityCalls.length === 2) route.fulfill(err500("boom"));
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=security`);
+
+    // (1) geração 1 em voo, segurada.
+    await waitFor(() => securityCalls.length === 1, "o GET de segurança da abertura da aba");
+    assert.equal(counts.activity, 0, "fan-out não pode ter rodado antes do GET de segurança assentar");
+
+    // (2) pull-to-refresh → geração 2.
+    await startPtr(page);
+
+    // (3) geração 2 chega e leva 500 do handler acima.
+    await waitFor(() => securityCalls.length === 2, "o GET de segurança do pull-to-refresh");
+
+    // (4) só agora libera a geração 1 com sucesso — chega por último e é superada.
+    await securityCalls[0].fulfill(json(SECURITY_OK));
+
+    await waitFor(() => page.evaluate(() => window.__done !== null), "PBRefresh assentar");
+    await sleep(300);   // deixa a geração 1 (superada) terminar de não fazer nada
+
+    const dom = await page.evaluate(() => {
+      const txt = (id) => (document.getElementById(id) || {}).textContent || "";
+      return {
+        activity: txt("activity-list"), sessions: txt("sessions-list"),
+        done: window.__done, unhandled: window.__unhandled,
+      };
+    });
+
+    // alguém chamou os filhos, exatamente uma vez — sem duplicar.
+    assert.equal(counts.activity, 1, "GETs de /activity (esperado 1, o fan-out da geração dona)");
+    assert.equal(counts.sessions, 1, "GETs de /sessions (esperado 1, o fan-out da geração dona)");
+    assert.ok(!dom.activity.includes("Carregando"), `#activity-list preso: ${dom.activity.trim()}`);
+    assert.ok(!dom.sessions.includes("Carregando"), `#sessions-list preso: ${dom.sessions.trim()}`);
+
+    // contrato do PTR: continua rejeitando pro indicador virar âmbar.
+    assert.match(dom.done, /^rejected:/, `PBRefresh devia rejeitar, deu: ${dom.done}`);
+    assert.deepEqual(dom.unhandled, [], "rejeição solta na página");
+  } finally { await page.close(); }
+});
+
+/**
+ * Com o FILHO falhando — o furo que a versão anterior deste arquivo não
+ * cobria. Pai 200, /sessions do PTR segurado e depois 500.
+ *
+ * Contra a sabotagem "fire-and-forget" (fan-out sem await, `if (ownErr) throw`):
+ *   - o PTR settla com o filho ainda em voo  → assert de __done === null falha;
+ *   - o PTR reporta SUCESSO                  → assert /^rejected:/ falha;
+ *   - a falha do filho vira rejeição solta   → assert de __unhandled falha.
+ */
+test("segurança: PTR não solta o indicador com filho em voo e propaga a falha dele", async () => {
+  const page = await newPage();
+  const counts = { security: 0, activity: 0, sessions: 0 };
+  const heldSessions = [];
+  try {
+    await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+    await page.route("**/settings/1/security", (route) => { counts.security++; route.fulfill(json(SECURITY_OK)); });
+    await page.route("**/settings/1/activity*", (route) => { counts.activity++; route.fulfill(json(ONE_EVENT)); });
+    // 1ª (load inicial) OK; 2ª (PTR) fica segurada e depois falha.
+    await page.route("**/settings/1/sessions", (route) => {
+      counts.sessions++;
+      if (counts.sessions === 1) return route.fulfill(json(ONE_SESSION));
+      heldSessions.push(route);
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=security`);
+    await waitFor(() => counts.sessions === 1, "load inicial da aba");
+
+    await startPtr(page);
+    // Tudo do PTR já assentou, MENOS o filho segurado: se o indicador soltar
+    // agora, soltou com um GET em voo (que podia repintar por cima depois).
+    await waitFor(() => counts.security === 2 && counts.activity === 2 && heldSessions.length === 1,
+      "o PTR chegar em todos os GETs, com /sessions segurado");
+    await sleep(250);
+    assert.equal(await page.evaluate(() => window.__done), null,
+      "PBRefresh settlou com /sessions ainda em voo");
+
+    await heldSessions[0].fulfill(err500("FILHO-SESSIONS-500"));
+    await waitFor(() => page.evaluate(() => window.__done !== null), "PBRefresh assentar após o filho");
+    await sleep(200);
+
+    const out = await page.evaluate(() => ({ done: window.__done, unhandled: window.__unhandled }));
+    assert.equal(out.done, "rejected:FILHO-SESSIONS-500",
+      `falha do filho tinha que virar rejeição do PTR, deu: ${out.done}`);
+    assert.deepEqual(out.unhandled, [], "rejeição solta na página");
+  } finally { await page.close(); }
+});
+
+/**
+ * Regra "erro do pai ganha do erro do filho": pai 500 E filho 500 juntos.
+ * Contra a sabotagem `ownErr = childErr` (sem o `if (!ownErr)`) o PTR rejeita
+ * com FILHO-SESSIONS-500 e este assert fica vermelho.
+ */
+test("segurança: com pai e filho falhando, o PTR rejeita com o erro do pai", async () => {
+  const page = await newPage();
+  const counts = { security: 0, sessions: 0 };
+  try {
+    await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+    await page.route("**/settings/1/activity*", (route) => route.fulfill(json(ONE_EVENT)));
+    await page.route("**/settings/1/security", (route) => {
+      counts.security++;
+      route.fulfill(counts.security === 1 ? json(SECURITY_OK) : err500("PAI-SECURITY-500"));
+    });
+    await page.route("**/settings/1/sessions", (route) => {
+      counts.sessions++;
+      route.fulfill(counts.sessions === 1 ? json(ONE_SESSION) : err500("FILHO-SESSIONS-500"));
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=security`);
+    await waitFor(() => counts.sessions === 1, "load inicial da aba");
+
+    await startPtr(page);
+    await waitFor(() => page.evaluate(() => window.__done !== null), "PBRefresh assentar");
+    await sleep(200);
+
+    const out = await page.evaluate(() => ({
+      done: window.__done, unhandled: window.__unhandled,
+      sessions: document.getElementById("sessions-list").textContent,
+    }));
+    assert.equal(out.done, "rejected:PAI-SECURITY-500", `erro do pai devia ganhar, deu: ${out.done}`);
+    assert.deepEqual(out.unhandled, [], "rejeição solta na página");
+    // propagate preserva conteúdo real: a sessão do load inicial continua lá.
+    assert.ok(out.sessions.includes("Esta sessão"), `filho apagou conteúdo bom: ${out.sessions.trim()}`);
+  } finally { await page.close(); }
+});
+
+/**
+ * No Open Finance — mesmo defeito de forma do fan-out de segurança, outro
+ * loader: loadData é o único que bumpa _dataGen, logo é dono do loadCaixinhas.
+ * Com o loadCaixinhas DENTRO do try, a geração que falha com propagate sai por
+ * throw antes dele e a geração superada cai no guard: ninguém o chama.
+ */
+test("open finance: caixinhas não fica órfão quando o loadData falha com um load em voo", async () => {
+  const page = await newPage();
+  const counts = { caixinhas: 0 };
+  const ofCalls = [];
+  try {
+    // of_ui_enabled: sem isso o initSettings tira "open-finance" das views
+    // permitidas e reescreve a URL pra ?view=security — o PBRefresh lê a URL e
+    // cairia na branch errada (o loadData nem seria chamado).
+    await page.route("**/auth/me", (route) => route.fulfill(json({ of_ui_enabled: true })));
+    await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+    await page.route("**/open-finance/1/caixinhas", (route) => { counts.caixinhas++; route.fulfill(json({ caixinhas: [], metas: [] })); });
+    // Fila igual à do teste de segurança: 1ª segurada, 2ª (a do PTR) 500.
+    await page.route("**/open-finance/1", (route) => {
+      ofCalls.push(route);
+      if (ofCalls.length === 2) route.fulfill(err500("of boom"));
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => ofCalls.length === 1, "o GET de open-finance da abertura");
+    assert.equal(counts.caixinhas, 0, "caixinhas não pode rodar antes do loadData assentar");
+
+    await startPtr(page);
+    await waitFor(() => ofCalls.length === 2, "o GET de open-finance do pull-to-refresh");
+    await ofCalls[0].fulfill(json({ connections: [], accounts: [], transactions: [] }));
+
+    await waitFor(() => page.evaluate(() => window.__done !== null), "PBRefresh assentar");
+    await sleep(300);
+
+    assert.equal(counts.caixinhas, 1, "GETs de /caixinhas (esperado 1, o da geração dona)");
+    const out = await page.evaluate(() => ({ done: window.__done, unhandled: window.__unhandled }));
+    assert.match(out.done, /^rejected:/, `PBRefresh devia rejeitar, deu: ${out.done}`);
+    assert.deepEqual(out.unhandled, [], "rejeição solta na página");
+  } finally { await page.close(); }
+});
+
+/**
+ * A recíproca: geração superada DURANTE o fan-out não tinge o PTR.
+ *   1. abertura da aba (geração 1) OK;
+ *   2. PBRefresh → geração 2, /security 500 (erro guardado), filhos SEGURADOS;
+ *   3. usuário clica "↻ Atualizar" → geração 3, /security 200 com e-mail novo,
+ *      pinta a tela e supera a geração 2 no meio do await dela;
+ *   4. libera os filhos da geração 2.
+ * Sem a re-checagem de geração antes do throw, o PTR rejeita com o erro da
+ * geração 2 (morta) enquanto a tela mostra o dado fresco da 3 — indicador âmbar
+ * com dado certo. Com ela, o PTR resolve.
+ */
+test("segurança: load superado durante o fan-out não tinge o PTR de âmbar", async () => {
+  const page = await newPage();
+  const c = { security: 0, activity: 0, sessions: 0 };
+  const held = [];   // filhos da geração 2
+  const FRESCO = { ...SECURITY_OK, email: "fresco@b.com" };
+  try {
+    await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+    await page.route("**/settings/1/security", (route) => {
+      c.security++;
+      if (c.security === 2) return route.fulfill(err500("PAI-GERACAO-2-500"));   // o GET do PTR
+      route.fulfill(json(c.security === 1 ? SECURITY_OK : FRESCO));              // abertura / ↻
+    });
+    await page.route("**/settings/1/activity*", (route) => {
+      c.activity++;
+      if (c.activity === 2) return held.push(route);
+      route.fulfill(json(ONE_EVENT));
+    });
+    await page.route("**/settings/1/sessions", (route) => {
+      c.sessions++;
+      if (c.sessions === 2) return held.push(route);
+      route.fulfill(json(ONE_SESSION));
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=security`);
+    await waitFor(() => c.sessions === 1, "load inicial da aba");
+
+    await startPtr(page);
+    await waitFor(() => held.length === 2, "os filhos da geração 2 segurados");
+    await sleep(200);
+    assert.equal(await page.evaluate(() => window.__done), null,
+      "PBRefresh settlou com o fan-out ainda em voo");
+
+    // (3) o ↻ Atualizar: geração 3 completa inteira (pai + filhos) e pinta.
+    await page.evaluate(() => window.loadSecuritySettings());
+    await waitFor(() => c.security === 3 && c.activity === 3 && c.sessions === 3, "a geração 3 do ↻");
+
+    // (4) só agora os filhos da geração 2 respondem — ela já está superada.
+    for (const route of held) await route.fulfill(json(ONE_EVENT));
+    await waitFor(() => page.evaluate(() => window.__done !== null), "PBRefresh assentar");
+    await sleep(200);
+
+    const out = await page.evaluate(() => ({
+      done: window.__done, unhandled: window.__unhandled,
+      email: document.getElementById("security-email-value").textContent,
+    }));
+    assert.equal(out.email, "fresco@b.com", `a geração 3 devia estar pintada, tela mostra: ${out.email}`);
+    assert.equal(out.done, "resolved",
+      `geração superada não pode tingir o PTR com dado fresco na tela, deu: ${out.done}`);
+    assert.deepEqual(out.unhandled, [], "rejeição solta na página");
+  } finally { await page.close(); }
+});
+
+/**
+ * Mesma recíproca no outro loader (a mesma classe, não a mesma instância):
+ * dois pulls seguidos. O 1º pega 500 no /open-finance e fica preso no await do
+ * caixinhas; o 2º responde 200 inteiro e supera o 1º nesse meio. Sem a
+ * re-checagem de _dataGen antes do throw, o 1º PTR rejeita com o erro da
+ * geração morta.
+ */
+test("open finance: loadData superado durante o caixinhas não tinge o PTR", async () => {
+  const page = await newPage();
+  const c = { of: 0, caix: 0 };
+  const held = [];   // caixinhas da geração 2
+  try {
+    await page.route("**/auth/me", (route) => route.fulfill(json({ of_ui_enabled: true })));
+    await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+    await page.route("**/open-finance/1/caixinhas", (route) => {
+      c.caix++;
+      if (c.caix === 2) return held.push(route);
+      route.fulfill(json({ caixinhas: [], metas: [] }));
+    });
+    await page.route("**/open-finance/1", (route) => {
+      c.of++;
+      if (c.of === 2) return route.fulfill(err500("OF-GERACAO-2-500"));   // o GET do 1º pull
+      route.fulfill(json({ connections: [], accounts: [], transactions: [] }));
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => c.caix === 1, "load inicial da aba");
+
+    await page.evaluate(() => {
+      window.__p1 = null;
+      window.PBRefresh().then(() => "resolved", (e) => "rejected:" + ((e && e.message) || e))
+        .then((v) => { window.__p1 = v; });
+    });
+    await waitFor(() => held.length === 1, "o caixinhas da geração 2 segurado");
+    await sleep(200);
+    assert.equal(await page.evaluate(() => window.__p1), null, "o 1º PTR settlou com o caixinhas em voo");
+
+    // 2º pull: geração 3 completa e supera a 2 no meio do await dela.
+    await page.evaluate(() => {
+      window.__p2 = null;
+      window.PBRefresh().then(() => "resolved", (e) => "rejected:" + ((e && e.message) || e))
+        .then((v) => { window.__p2 = v; });
+    });
+    await waitFor(() => c.of === 3 && c.caix === 3, "a geração 3 do 2º pull");
+
+    for (const route of held) await route.fulfill(json({ caixinhas: [], metas: [] }));
+    await waitFor(() => page.evaluate(() => window.__p1 !== null && window.__p2 !== null), "os dois PTR assentarem");
+    await sleep(200);
+
+    const out = await page.evaluate(() => ({ p1: window.__p1, p2: window.__p2, unhandled: window.__unhandled }));
+    assert.equal(out.p2, "resolved", `o 2º PTR (a geração viva) devia resolver, deu: ${out.p2}`);
+    assert.equal(out.p1, "resolved", `geração superada não pode tingir o PTR, deu: ${out.p1}`);
+    assert.deepEqual(out.unhandled, [], "rejeição solta na página");
+  } finally { await page.close(); }
+});


### PR DESCRIPTION
## Problema

O pull-to-refresh da aba **Ajustes** deixou todos os loaders re-disparáveis, mas só `loadSessionsList` (`_sessionsGen`) e `loadData` (`_dataGen`) tinham generation guard. Os irmãos expostos à **mesma race** ficaram sem — classe aberta (CLAUDE.md §4: "corrigir a instância e não a classe").

**A race:** um GET disparado antes de uma mutação chega por último e sobrescreve estado novo. Ex. (MFA): PTR chama `loadMfaStatus` (captura "ativado") → você toca "Desativar" → DELETE + `loadMfaStatus` (captura "desativado") → o GET #2 pinta desativado, o GET #1 do PTR volta por último e **reverte pra "ativado"**.

O caso mais gritante: `loadSecuritySettings` faz fan-out em `loadActivityLog` + `loadSessionsList` na mesma linha — e só sessões tinha o guard; atividade, o par literal dele, não.

## Correção

Mesmo padrão de 2 linhas já revisado em `_sessionsGen`/`_dataGen`, aplicado aos descobertos:

| Loader | Guard | Além da pintura |
|---|---|---|
| `loadActivityLog` | `_activityGen` | `_activityCache` alimenta o modal |
| `loadSecuritySettings` | `_securityGen` | gato só o painel; filhos têm geração própria |
| `loadMfaStatus` | `_mfaGen` | `_mfaStatus.enabled` decide qual modal o toggle abre |
| `loadCaixinhas` | `_caixGen` | `_caixMetas` alimenta o bind; gatei 404/erro/vazio/render |
| `loadNotificationSettings` | `_notifGen` | uniformidade (race rara: só PTR no 1º load) |

Carimba `++_gen` na entrada; `if (myGen !== _gen) return` antes de escrever global/DOM e no `catch` (não pinta nem tinge o PTR de âmbar).

## Severidade

Baixa: janela estreita (PTR no exato reload de uma mutação), consequência é UI transitoriamente stale que se auto-corrige. Não é perda de dado nem vazamento entre usuários.

## Verificação

- ✅ Sintaxe: bloco `<script>` extraído, `node --check` passa.
- ✅ Revisão linha a linha (método do CLAUDE.md §3 para classes cegas ao teste headless). Fan-out de segurança nunca se perde: o load mais novo nunca é superado e sempre chega ao próprio fan-out, inclusive no erro non-propagate.
- ❌ **Não verificado no aparelho** — a race só se manifesta no timing nativo do WKWebView, estruturalmente irreproduzível neste ambiente (CLAUDE.md §3/§6). Teste headless replicando o shape seria tautológico.
- ⚪ Suíte pytest não rodada: frontend puro, o backend não exercita `settings.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)