### PR TITLE
perf(pb-nav): tira o service worker do caminho da troca + cronometro por fase

### DIFF
--- a/frontend/comandos-app.html
+++ b/frontend/comandos-app.html
@@ -82,7 +82,7 @@ header h1{font-size:1.05rem;font-weight:650;letter-spacing:-.02em}
 </style>
   <link rel="stylesheet" href="/app-mode.css?v=34" />
   <script src="/app-mode.js?v=34"></script>
-  <script src="/pb-nav.js?v=5"></script>
+  <script src="/pb-nav.js?v=6"></script>
 </head>
 <body>
 <div class="bg"><div class="orb orb-1"></div><div class="orb orb-2"></div><div class="orb orb-3"></div></div>

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -456,7 +456,7 @@ footer a:hover { color:var(--text); }
 <script src="/modals.js"></script>
   <link rel="stylesheet" href="/app-mode.css?v=34" />
   <script src="/app-mode.js?v=34"></script>
-  <script src="/pb-nav.js?v=5"></script>
+  <script src="/pb-nav.js?v=6"></script>
 </head>
 <body>
 

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -110,6 +110,50 @@
 
   function mountPoint() { return document.querySelector(".pb-tabbar"); }
 
+  // ── Cronômetro por fase ────────────────────────────────────────────────
+  // "demora ~5s" não diz ONDE. Cada troca mede rede (ter o HTML), scripts
+  // (externos da página nova), mutate (DOM + inits, síncrono) e vt (a
+  // animação inteira até .finished). Com ?pbdebug=1 o resultado aparece na
+  // PRÓPRIA tela — o aparelho é o único lugar onde isso se mede, e nem sempre
+  // há Mac com o Web Inspector do lado.
+  const debug = (() => {
+    if (qs.get("pbdebug") === "0") { try { localStorage.removeItem("pbDebug"); } catch (_) {} }
+    if (qs.get("pbdebug") === "1") { try { localStorage.setItem("pbDebug", "1"); } catch (_) {} }
+    try { return localStorage.getItem("pbDebug") === "1"; } catch (_) { return false; }
+  })();
+
+  function stopwatch(key) {
+    const t0 = performance.now();
+    let last = t0;
+    const parts = [];
+    return {
+      mark(name) {
+        const now = performance.now();
+        parts.push(name + " " + Math.round(now - last));
+        last = now;
+      },
+      done(via) {
+        const total = Math.round(performance.now() - t0);
+        const line = "[pb-nav] " + key + " " + via + " " + total + "ms (" + parts.join(", ") + ")";
+        console.log(line);
+        if (debug) showDebug(line);
+      },
+    };
+  }
+
+  function showDebug(line) {
+    let box = document.getElementById("pb-nav-debug");
+    if (!box) {
+      box = document.createElement("div");
+      box.id = "pb-nav-debug";
+      box.style.cssText = "position:fixed;left:8px;right:8px;top:env(safe-area-inset-top,8px);" +
+        "z-index:99999;background:rgba(0,0,0,.86);color:#C6F11A;font:600 11px/1.45 ui-monospace,monospace;" +
+        "padding:8px 10px;border-radius:10px;pointer-events:none;white-space:pre-wrap;";
+      document.documentElement.appendChild(box);   // fora do body: sobrevive ao swap
+    }
+    box.textContent = line;
+  }
+
   const swap = mutate =>
     document.startViewTransition(mutate).finished.catch(() => {});
 
@@ -132,7 +176,7 @@
     }
   }
 
-  async function mountCached(key, path, push, my) {
+  async function mountCached(key, path, push, my, sw) {
     await swap(() => {
       if (my !== seq) return;
       unmountCurrent();
@@ -146,10 +190,12 @@
       window.PBRefresh = e.refresh;
       window.scrollTo(0, e.scrollY);
       commit(key, path, push);
+      sw.mark("mutate");
       // Dado fresco em background, reusando o contrato do puxar-pra-atualizar:
       // dado velho na tela agora, dado novo repintando quando chegar.
       if (window.PBRefresh) { try { window.PBRefresh(); } catch (_) {} }
     });
+    sw.mark("vt");
   }
 
   // Scripts externos da página nova que o documento ainda não tem (dedupe por
@@ -166,10 +212,12 @@
     })));
   }
 
-  async function mountNew(key, path, html, push, my) {
+  async function mountNew(key, path, html, push, my, sw) {
     const doc = new DOMParser().parseFromString(html, "text/html");
+    sw.mark("parse");
 
     await ensureExternalScripts(doc);
+    sw.mark("scripts");
     if (my !== seq) return;
 
     // Executa os scripts inline UMA vez por página (data-pb-boot fica de fora:
@@ -209,7 +257,9 @@
       window.scrollTo(0, 0);
       runInits(key);          // síncrono entra no snapshot; o resto é async normal
       commit(key, path, push);
+      sw.mark("mutate");
     });
+    sw.mark("vt");
   }
 
   // Prefetch: o HTML das outras abas é aquecido em background logo após o
@@ -217,36 +267,45 @@
   // recarga escondia atrás da piscada virava tela parada (medido no GATE 1:
   // "demora muito"). Com o texto já baixado, o mount é imediato. O HTML é só
   // o shell (esqueleto); dado vivo vem da init/PBRefresh — não fica velho.
-  const warm = {};   // key → html (null = em voo)
+  const warm = {};       // key → html pronto (null = ainda em voo)
+  const inflight = {};   // key → promise do html em voo (o tap espera ESTA)
   function warmUp() {
     Object.keys(ROUTES).forEach(path => {
       const key = ROUTES[path];
       if (key === currentKey || cache[key] || warm[key] !== undefined) return;
       warm[key] = null;
-      fetch(path, { credentials: "same-origin", headers: { Accept: "text/html" } })
+      inflight[key] = fetch(path, { credentials: "same-origin", headers: { Accept: "text/html" } })
         .then(r => (r.ok && !r.redirected ? r.text() : Promise.reject()))
-        .then(html => { warm[key] = html; })
-        .catch(() => { delete warm[key]; });
+        .then(html => { warm[key] = html; delete inflight[key]; return html; })
+        .catch(() => { delete warm[key]; delete inflight[key]; return null; });
     });
   }
 
   async function navigate(path, key, push) {
     const my = ++seq;                            // só a navegação mais recente monta
-    const t0 = performance.now();
-    const log = via => console.log("[pb-nav]", key, via,
-      Math.round(performance.now() - t0) + "ms");
+    const sw = stopwatch(key);
     // O try cobre TODOS os ramos (cache, warm e fetch): mountNew também rejeita
     // fora da rede do tap — ex.: script externo da página nova falhando ao
     // carregar (home puxa auth-refresh/modals quando o boot foi no comandos).
     // Sem isso o ramo warm deixava o usuário preso na tela velha, porque o
     // go() já tinha assumido a navegação (apontamento do Codex no #118).
     try {
-      if (cache[key]) { await mountCached(key, path, push, my); log("cache"); return; }
-      if (warm[key]) {                           // prefetch pronto: sem rede no tap
-        const html = warm[key];
+      if (cache[key]) {
+        await mountCached(key, path, push, my, sw);
+        sw.done("cache");
+        return;
+      }
+      // Prefetch: pronto OU em voo. Esperar o pedido que já está na rede é
+      // sempre melhor que abrir um segundo — antes, `warm[key]` null (em voo)
+      // era falsy e caía no fetch, duplicando a rede no tap.
+      if (warm[key] !== undefined) {
+        const html = await Promise.resolve(warm[key] || inflight[key]);
+        sw.mark("net(warm)");
         delete warm[key];
-        await mountNew(key, path, html, push, my);
-        log("warm");
+        if (my !== seq) return;
+        if (!html) { hard(path); return; }
+        await mountNew(key, path, html, push, my, sw);
+        sw.done("warm");
         setTimeout(warmUp, 400);
         return;
       }
@@ -259,9 +318,10 @@
       // Redirect = auth/gate (login, /precos): fluxo de verdade, navegação real
       if (r.redirected || !r.ok) { hard(path); return; }
       const html = await r.text();
+      sw.mark("net");
       if (my !== seq) return;
-      await mountNew(key, path, html, push, my);
-      log("fetch");
+      await mountNew(key, path, html, push, my, sw);
+      sw.done("fetch");
       setTimeout(warmUp, 400);
     } catch (_) {
       if (my === seq) hard(path);                // qualquer falha: cai no MPA

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -11,7 +11,7 @@
  * once the network is restored.
  */
 
-const CACHE_NAME = "pigbank-v7";
+const CACHE_NAME = "pigbank-v8";  // v8: limpa HTML de pagina logada que o v7 cacheou
 
 // Resources to pre-cache on install
 const PRECACHE = [
@@ -24,8 +24,15 @@ const PRECACHE = [
 // Never cache these (API calls, WebSocket upgrades, dados financeiros).
 // Open Finance e histórico trazem saldo/transações do banco: nunca cachear
 // (privacidade no dispositivo + evita mostrar dado velho depois de um sync).
+// /home e /comandos-app entram aqui por causa do pb-nav: navegação de
+// documento chega como mode "navigate" e o handler abaixo já a ignora, mas o
+// fetch do motor client-side NÃO — sem esta linha o SW interceptava a troca de
+// aba (latência de acordar o worker) e ainda guardava HTML de página logada
+// no cache, contra o "HTML / auth: never cached" do topo deste arquivo.
 const SKIP_CACHE = [
   "/app",
+  "/home",
+  "/comandos-app",
   "/settings",
   "/auth/",
   "/ws/",


### PR DESCRIPTION
## Contexto

GATE 1 no aparelho: a **piscada preta morreu** ✅, mas a troca de aba leva **~5s**. Já errei duas vezes chutando causa sem medir (#113, #116), então este PR faz **um achado concreto + instrumentação**, e não promete resolver os 5s.

## 1. Achado concreto: o service worker estava no caminho

O handler do SW ignora navegação real (`request.mode === "navigate"`), mas o fetch do pb-nav **não é** `navigate` — então caía no `network-first`: pagava a latência de acordar o worker e ainda **guardava HTML de página logada no cache**, contra o `HTML / auth: never cached` do próprio cabeçalho do arquivo.

- `/home` e `/comandos-app` entram no `SKIP_CACHE`.
- `CACHE_NAME` → `pigbank-v8`, pra limpar o que o v7 já cacheou.

Isso é correção legítima por si só (privacidade + o SW não deve tocar troca de aba), independente de ser ou não o gargalo dos 5s.

## 2. Instrumentação: "demora 5s" não diz ONDE

Cada troca agora mede as fases separadamente — `net`, `parse`, `scripts`, `mutate`, `vt`:

```
[pb-nav] home warm 480ms (net(warm) 12, parse 30, scripts 5, mutate 180, vt 250)
```

Com **`?pbdebug=1`** o breakdown aparece **na própria tela** (o overlay vive no `<html>`, sobrevive ao swap) — dá pra medir no iPhone sem depender de um Mac com o Web Inspector.

## 3. De quebra: prefetch em voo era ignorado

`warm[key] = null` (em voo) é *falsy*, então o tap caía no ramo do `fetch` e abria um **segundo** pedido do mesmo HTML — duas conexões competindo pelo mesmo recurso. Agora o tap **aguarda o pedido que já está na rede** (`inflight[key]`).

## Verificação

- Harness no Chromium: **19/19**, zero asserts falsos; o cronômetro emite o breakdown por fase corretamente.
- **Não medido aqui:** se isto derruba os 5s — só no aparelho. O próximo passo é ler o breakdown com `?pbdebug=1` e atacar a fase que dominar o tempo, com número em vez de hipótese.

## Como testar

```
https://pigbankai.com/home?pbapp=1&pbspa=1&pbdebug=1
```

Alternar Início ↔ O que pedir e ler a faixa no topo. A fase com o maior número é o gargalo real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
