### PR TITLE
chore(categoria): script pra limpar regras de categoria envenenadas

### DIFF
--- a/scripts/cleanup_poisoned_category_rules.py
+++ b/scripts/cleanup_poisoned_category_rules.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Limpa regras de categoria ENVENENADAS em user_category_rules.
+
+Uma regra está envenenada quando o keyword dela colide com o token distintivo
+de uma categoria CUSTOM do próprio usuário, mas aponta pra uma categoria
+DIFERENTE. Como a regra de usuário (passo B em infer_category) vence a categoria
+custom (passo B2), todo lançamento que menciona aquele token era sequestrado pra
+categoria errada.
+
+Contexto: antes do fix (commit 2013c17), o auto-aprendizado gravava regras como
+`namorada -> lazer` mesmo o usuário tendo a categoria custom "gastos com
+namorada" (o gatilho foi "namorada cinema", que casa cinema->lazer nas
+LOCAL_RULES). O guard novo impede NOVAS regras assim; este script varre as que
+já foram gravadas — em qualquer cliente que criou categoria custom antes do fix.
+
+Reusa `custom_category_match` — a MESMA função do guard — então detecta
+exatamente a classe que o guard previne, sem reimplementar a heurística em SQL.
+
+ATENÇÃO: `user_category_rules` não registra proveniência — não dá pra saber, pela
+linha, se uma regra foi auto-aprendida (veneno) ou criada DE PROPÓSITO pelo
+usuário via "linkar" (que não passa pelo guard). Uma regra deliberada
+`cinema -> lazer` de quem tem a custom "cinema da família" apareceria aqui como
+colisão, mas apagá-la seria perder config do usuário. Por isso `--apply` exige
+`--user`: rode global em dry-run, revise a lista, e só então aplique cliente a
+cliente conferindo que nenhuma daquelas regras é intencional.
+
+Uso:
+    .venv/bin/python -m scripts.cleanup_poisoned_category_rules              # dry-run global (só reporta)
+    .venv/bin/python -m scripts.cleanup_poisoned_category_rules --user 314149836            # dry-run de 1 user
+    .venv/bin/python -m scripts.cleanup_poisoned_category_rules --user 314149836 --apply    # deleta (revisado)
+"""
+from __future__ import annotations
+
+import argparse
+
+import db
+from db.categories import list_user_category_rules
+from core.services.category_service import custom_category_match
+from utils_text import normalize_text
+
+
+def _all_user_ids() -> list[int]:
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select id from users order by id")
+        rows = cur.fetchall() or []
+    return [r["id"] if isinstance(r, dict) else r[0] for r in rows]
+
+
+def find_poisoned(user_id: int) -> list[tuple[str, str, str]]:
+    """[(keyword, categoria_da_regra, categoria_custom_que_ela_rouba)]."""
+    out: list[tuple[str, str, str]] = []
+    for keyword, category in list_user_category_rules(user_id):
+        custom = custom_category_match(user_id, normalize_text(keyword))
+        if custom and normalize_text(custom) != normalize_text(category or ""):
+            out.append((keyword, category, custom))
+    return out
+
+
+def _delete_rule(user_id: int, keyword: str) -> None:
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "delete from user_category_rules where user_id=%s and keyword=%s",
+            (user_id, keyword),
+        )
+        conn.commit()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true",
+                    help="deleta de verdade (sem isso, só reporta — dry-run)")
+    ap.add_argument("--user", type=int, help="limita a um único user_id")
+    args = ap.parse_args()
+
+    # Segurança: apagar exige escopo de 1 user (revisão manual), porque uma regra
+    # colidente pode ter sido criada de propósito e não há como distinguir em lote.
+    if args.apply and not args.user:
+        ap.error("--apply exige --user: revise a lista global (dry-run) e aplique "
+                 "cliente a cliente, conferindo que nenhuma regra é intencional.")
+
+    user_ids = [args.user] if args.user else _all_user_ids()
+    total = 0
+    afetados = 0
+    for uid in user_ids:
+        poisoned = find_poisoned(uid)
+        if not poisoned:
+            continue
+        afetados += 1
+        print(f"user {uid}:")
+        for keyword, cat, custom in poisoned:
+            total += 1
+            print(f"  '{keyword}' -> '{cat}'  (rouba a categoria custom '{custom}')")
+            if args.apply:
+                _delete_rule(uid, keyword)
+
+    verbo = "deletada(s)" if args.apply else "encontrada(s) — dry-run, nada foi deletado"
+    print(f"\n{total} regra(s) envenenada(s) {verbo} em {afetados} cliente(s).")
+    if total and not args.apply:
+        print("Rode de novo com --apply pra deletar.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_poisoned_category_rules.py
+++ b/scripts/cleanup_poisoned_category_rules.py
@@ -24,6 +24,11 @@ colisão, mas apagá-la seria perder config do usuário. Por isso `--apply` exig
 `--user`: rode global em dry-run, revise a lista, e só então aplique cliente a
 cliente conferindo que nenhuma daquelas regras é intencional.
 
+O dry-run é READ-ONLY de verdade: nenhuma das duas leituras (`_all_user_ids`,
+`_rules_somente_leitura`) escreve, e `--user` inexistente aborta em vez de ser
+criado. Sem isso o próprio conselho de segurança deste script ("rode o dry-run
+primeiro") criava dado em produção.
+
 Uso:
     .venv/bin/python -m scripts.cleanup_poisoned_category_rules              # dry-run global (só reporta)
     .venv/bin/python -m scripts.cleanup_poisoned_category_rules --user 314149836            # dry-run de 1 user
@@ -34,7 +39,6 @@ from __future__ import annotations
 import argparse
 
 import db
-from db.categories import list_user_category_rules
 from core.services.category_service import custom_category_match
 from utils_text import normalize_text
 
@@ -46,10 +50,46 @@ def _all_user_ids() -> list[int]:
     return [r["id"] if isinstance(r, dict) else r[0] for r in rows]
 
 
+def _user_existe(user_id: int) -> bool:
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select 1 from users where id=%s", (user_id,))
+        return cur.fetchone() is not None
+
+
+def _rules_somente_leitura(user_id: int) -> list[tuple[str, str]]:
+    """As regras do usuário, SEM `ensure_user`. Mesma query, sem o write.
+
+    `list_user_category_rules` (db/categories.py) abre com `ensure_user`, que
+    INSERE linha em `users` E em `accounts` e commita antes de devolver lista
+    nenhuma. Num script cujo argumento de segurança inteiro é "rode o dry-run
+    primeiro", isso significava que o dry-run CRIAVA em produção o cliente que o
+    operador digitou errado — e reportava "0 regras", com cara de nada a fazer.
+
+    Não é caso isolado do `--user`: todo leitor de regra do repo passa pelo
+    mesmo `ensure_user` (`list_category_rules`, `get_memorized_category`,
+    `list_user_category_rules`), não existe versão read-only pra reusar. Por
+    isso a query mora aqui, e é a ÚNICA porta de leitura do script.
+    """
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "select keyword, category from user_category_rules "
+            "where user_id=%s order by length(keyword) desc",
+            (user_id,),
+        )
+        rows = cur.fetchall() or []
+    return [
+        (
+            (r["keyword"] if isinstance(r, dict) else r[0]) or "",
+            (r["category"] if isinstance(r, dict) else r[1]) or "",
+        )
+        for r in rows
+    ]
+
+
 def find_poisoned(user_id: int) -> list[tuple[str, str, str]]:
     """[(keyword, categoria_da_regra, categoria_custom_que_ela_rouba)]."""
     out: list[tuple[str, str, str]] = []
-    for keyword, category in list_user_category_rules(user_id):
+    for keyword, category in _rules_somente_leitura(user_id):
         custom = custom_category_match(user_id, normalize_text(keyword))
         if custom and normalize_text(custom) != normalize_text(category or ""):
             out.append((keyword, category, custom))
@@ -77,6 +117,12 @@ def main() -> None:
     if args.apply and not args.user:
         ap.error("--apply exige --user: revise a lista global (dry-run) e aplique "
                  "cliente a cliente, conferindo que nenhuma regra é intencional.")
+
+    # `--user` digitado errado não pode virar "0 regras, nada a fazer": aborta.
+    # (O write que ele causava morreu em `_rules_somente_leitura`; isto é o
+    # aviso, pra não confundir "cliente limpo" com "cliente que não existe".)
+    if args.user is not None and not _user_existe(args.user):
+        ap.error(f"user {args.user} não existe — confira o id.")
 
     user_ids = [args.user] if args.user else _all_user_ids()
     total = 0

--- a/tests/test_cleanup_poisoned_category_rules.py
+++ b/tests/test_cleanup_poisoned_category_rules.py
@@ -1,0 +1,52 @@
+"""Testes do script de limpeza de regras envenenadas.
+
+Separado de `test_custom_category_infer.py` porque o script vive em PR próprio:
+ele é operação destrutiva rodada à mão em produção, e o resto daquele arquivo
+cobre o caminho de consulta, que é verificável aqui.
+
+`find_poisoned` é o predicado que SELECIONA linhas para DELETE — e é testável
+localmente, ao contrário do `_delete_rule`, que só se prova em produção.
+"""
+import pytest
+
+from db.categories import create_user_category
+
+
+def test_cleanup_script_apply_exige_user(monkeypatch):
+    # Codex P1: --apply global apagaria regras criadas de propósito (sem coluna
+    # de proveniência). --apply exige --user pra forçar revisão cliente a cliente.
+    import sys
+    from scripts.cleanup_poisoned_category_rules import main
+    monkeypatch.setattr(sys, "argv", ["cleanup", "--apply"])
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_find_poisoned_seleciona_so_a_regra_que_rouba_a_custom(pro_user_id):
+    # Observação 4 do Manager: `find_poisoned` é o predicado que SELECIONA linhas
+    # pro DELETE de scripts/cleanup_poisoned_category_rules.py e não tinha teste
+    # nenhum. Só o `_delete_rule` depende de produção; a seleção roda aqui.
+    from db.categories import upsert_category_rule
+    from scripts.cleanup_poisoned_category_rules import find_poisoned
+
+    create_user_category(pro_user_id, "gastos com minha namorada")
+    upsert_category_rule(pro_user_id, "namorada", "lazer")          # VENENO
+    upsert_category_rule(pro_user_id, "cinema", "lazer")            # neutra
+    upsert_category_rule(
+        pro_user_id, "namorada jantar", "gastos com minha namorada"  # aponta pra própria
+    )
+
+    achados = find_poisoned(pro_user_id)
+    assert [(kw, cat) for kw, cat, _ in achados] == [("namorada", "lazer")], achados
+    assert achados[0][2] == "gastos com minha namorada"
+
+
+def test_find_poisoned_vazio_sem_categoria_custom(pro_user_id):
+    # Sem categoria custom não há o que roubar: nenhuma regra é selecionada.
+    # Guarda contra a pior falha possível num script de DELETE — selecionar demais.
+    from db.categories import upsert_category_rule
+    from scripts.cleanup_poisoned_category_rules import find_poisoned
+
+    upsert_category_rule(pro_user_id, "namorada", "lazer")
+    upsert_category_rule(pro_user_id, "cinema", "lazer")
+    assert find_poisoned(pro_user_id) == []

--- a/tests/test_cleanup_poisoned_category_rules.py
+++ b/tests/test_cleanup_poisoned_category_rules.py
@@ -50,3 +50,72 @@ def test_find_poisoned_vazio_sem_categoria_custom(pro_user_id):
     upsert_category_rule(pro_user_id, "namorada", "lazer")
     upsert_category_rule(pro_user_id, "cinema", "lazer")
     assert find_poisoned(pro_user_id) == []
+
+
+def _conta(tabela: str) -> int:
+    import db
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(f"select count(*) as n from {tabela}")
+        r = cur.fetchone()
+    return r["n"] if isinstance(r, dict) else r[0]
+
+
+def _existe(user_id: int) -> bool:
+    # SELECT local de propósito: importar o `_user_existe` do script faria o
+    # teste morrer de ImportError antes de chegar na asserção que interessa —
+    # e ImportError não prova nada sobre escrita no banco.
+    import db
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select 1 from users where id=%s", (user_id,))
+        return cur.fetchone() is not None
+
+
+def _id_inexistente() -> int:
+    import db
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select coalesce(max(id), 0) as m from users")
+        r = cur.fetchone()
+    m = r["m"] if isinstance(r, dict) else r[0]
+    return int(m) + 1000          # sempre livre, mesmo depois de um run sujo
+
+
+def test_dry_run_com_user_inexistente_nao_escreve(monkeypatch):
+    # Codex P2: `list_user_category_rules` chama `ensure_user`, que INSERE em
+    # `users` e em `accounts` e commita. O dry-run — a única defesa deste script
+    # destrutivo — criava em produção o cliente que o operador digitou errado.
+    import sys
+    from scripts.cleanup_poisoned_category_rules import main
+
+    fantasma = _id_inexistente()
+    assert not _existe(fantasma)
+    antes = (_conta("users"), _conta("accounts"))
+
+    monkeypatch.setattr(sys, "argv", ["cleanup", "--user", str(fantasma)])
+    try:
+        main()
+        abortou = False
+    except SystemExit:
+        abortou = True
+
+    assert not _existe(fantasma), "o dry-run CRIOU o usuário inexistente"
+    assert (_conta("users"), _conta("accounts")) == antes, "o dry-run ESCREVEU no banco"
+    assert abortou, "--user inexistente tem que abortar, não reportar '0 regras'"
+
+
+def test_dry_run_global_nao_escreve(monkeypatch, pro_user_id):
+    # A varredura global é o outro caminho do mesmo `ensure_user` — não corrigir
+    # só a instância que o revisor citou. Este já passava ANTES (`_all_user_ids`
+    # só devolve id que existe, e o insert é `on conflict do nothing`): é guarda
+    # de que a varredura continue read-only, não discriminante do P2.
+    import sys
+    from db.categories import upsert_category_rule
+    from scripts.cleanup_poisoned_category_rules import main
+
+    create_user_category(pro_user_id, "gastos com minha namorada")
+    upsert_category_rule(pro_user_id, "namorada", "lazer")
+    antes = (_conta("users"), _conta("accounts"), _conta("user_category_rules"))
+
+    monkeypatch.setattr(sys, "argv", ["cleanup"])
+    main()
+
+    assert (_conta("users"), _conta("accounts"), _conta("user_category_rules")) == antes


### PR DESCRIPTION
Separado do #123 por verificabilidade (CLAUDE.md §4): o efeito real deste script só se mede em produção, enquanto o resto daquele PR é coberto por 1316 testes locais.

## O que ele apaga

Linhas de `user_category_rules` — **regras de aprendizado** ("sempre que aparecer X, use Y").

**Não** apaga lançamento, **não** apaga categoria, **não** mexe em nenhum valor em reais.

## O problema que ele resolve

Uma regra está *envenenada* quando o keyword dela colide com o token distintivo de uma categoria **custom** do próprio usuário, mas aponta pra categoria **diferente**. Como regra de usuário vence categoria custom na inferência (`infer_category`: explícito → ticker → **regra** → **categoria custom** → regras locais → IA), todo lançamento com aquele token era sequestrado.

Caso real que originou isto: um cliente criou a categoria `gastos com minha namorada` e o auto-aprendizado gravou `namorada → lazer` a partir de um lançamento "namorada cinema" (que casa `cinema→lazer` nas regras locais). Nove lançamentos foram parar em "lazer"; o dashboard mostrava 1 na categoria certa.

O guard que impede regras **novas** assim está no #123. Este script varre as que **já foram gravadas**.

## Segurança

- `dry-run` é o padrão
- **`--apply` exige `--user`**

O motivo do segundo: uma regra pode ter sido criada **de propósito** pelo usuário e coincidir com a colisão — apagá-la seria perder configuração dele. Por isso a aplicação é cliente a cliente, com revisão manual da lista global antes. (Este guard veio de um P1 do Codex numa revisão anterior.)

## Testes

`find_poisoned` — o predicado que **seleciona** as linhas pro DELETE — ganhou cobertura:
- seleciona só a regra que rouba a custom
- não seleciona nada quando não há categoria custom
- mais o guard de argparse

`_delete_rule` **não** tem teste: esse só se prova em produção.

## Não verificado

Nada foi rodado contra dado de cliente. Quantas regras existem, em quantos clientes, e se são todas mesmo envenenadas — só se descobre rodando o `dry-run` lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)