### PR TITLE
feat(web): página de erro HTML na navegação (JSON preservado na API)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,12 +228,12 @@ O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView c
   #56 era `"automatic"` e o WebView reservava a área segura sozinho. Saiba em qual
   dos dois mundos você está antes de somar `padding`: com `automatic`, inset em CSS
   **duplica** o espaçamento; com `never`, a falta dele deixa conteúdo sob o notch.
-- **Quem carrega o CSS ≠ quem é alcançável.** Das **25** páginas em `frontend/`:
+- **Quem carrega o CSS ≠ quem é alcançável.** Das **26** páginas em `frontend/`:
 
   | quantas | o que carregam | quem |
   |---|---|---|
-  | 6 | `app-mode.css`/`app-mode.js` | `login`, `cadastro`, `home`, `dashboard`, `comandos-app`, `settings` |
-  | 14 | o shim `frontend/safe-area.js` | as estáticas: `index`, `precos`, `termos`, `privacy`, `onboarding`, `suporte`, `agents`, `changelog`, `comandos`, `como-funciona`, `funcionalidades`, `blog-article`, `reset-password`, `whatsapp` |
+  | 6 | `app-mode.css`/`app-mode.js` | `login`, `cadastro`, `home`, `dashboard`, `comandos-app`, `settings` — mais a `changelog`, que carrega **os dois** (`changelog.html:15` shim, `:16-17` app-mode) e está contada na linha de baixo |
+  | 15 | o shim `frontend/safe-area.js` | as estáticas: `index`, `precos`, `termos`, `privacy`, `onboarding`, `suporte`, `agents`, `changelog`, `comandos`, `como-funciona`, `funcionalidades`, `blog-article`, `reset-password`, `whatsapp` — mais a `error`, que **não é rota**: é template servido pelo `error_page_response` (`frontend/routes/shared.py`) em quase toda URL que dá erro. Quase: as **4** exceções são `/webhook` e `/wa/webhook` (403 `text/plain` "forbidden", `adapters/whatsapp/wa_app.py:224,241,255`) e `/fonts/{name}` e `/brand/{path}` (404 de corpo vazio, `static_pages.py:536,559,564,567`) — endpoints de máquina e de subrecurso, que de propósito não gastam 1,4 KB de HTML |
   | 5 | nada, de propósito | `admin-login`, `admin-dashboard`, `_dash_mockup`, `preview_agentes`, e o `ddf99f17-…` |
 
   As duas páginas geradas em Python (bullet seguinte) também carregam o shim.
@@ -273,8 +273,13 @@ O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView c
 - **O cache-buster `?v=N` de CSS/JS é reescrito no serve-time — não bumpe à mão.**
   `stamp_asset_versions` (`frontend/routes/shared.py`) troca o `?v=N` de qualquer
   `*.css`/`*.js` de `frontend/` por um hash do conteúdo do arquivo, em toda saída de
-  HTML (o funil `html_file`, `/suporte`, `/blog/{slug}` e as duas páginas geradas em
-  Python). O número hardcoded no `<head>` (ex.: `app-mode.css?v=29`) é **ignorado** —
+  HTML — os **6** call sites: o funil `html_file`, `/suporte`, `/blog/{slug}`, as duas
+  páginas geradas em Python e a **página de erro** (`error_page_response`, onde o stamp
+  é aplicado no cache do template, não por requisição: trocar um asset sem reiniciar o
+  processo deixa só ESSA página com o hash velho até o restart). A página de erro **não**
+  passa pelo `html_file` — aquele funil injeta o Meta Pixel, e ela fica fora do rastreio
+  de propósito; se você "reusar o html_file" pra ganhar o stamp, reintroduz o pixel
+  calado. O número hardcoded no `<head>` (ex.: `app-mode.css?v=29`) é **ignorado** —
   está lá só como resquício; mexer nele não faz nada. A invalidação passou a ser
   automática (muda o arquivo → muda o hash). Antes cada asset era bumpado à mão em
   ~8 HTMLs por PR e `v=31` vs `v=33` na mesma linha dava merge conflict a cada duas

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1288,9 +1288,23 @@ async def admin_error_logging_middleware(request: Request, call_next):
             },
         )
 
+        # Navegação (Accept: text/html) recebe página; API segue no JSON de hoje.
+        # Import dentro da função de propósito: core/ não importa frontend/ no
+        # topo (shared.py roda load_app_env() no import) e este é caminho frio.
+        # Qualquer falha aqui cai no JSONResponse — o pior caso é o de hoje.
+        try:
+            from frontend.routes.shared import wants_html, error_page_response
+            if wants_html(request):
+                return error_page_response(status_code)
+        except Exception:
+            pass
+
+        # Vary inline (não pelo helper): se o import acima falhou, o helper também
+        # não existe — e este ramo tem que sair de pé de qualquer jeito.
         return JSONResponse(
             status_code=status_code,
             content={"error": user_msg},
+            headers={"Vary": "Accept"},
         )
 
 

--- a/core/observability.py
+++ b/core/observability.py
@@ -24,6 +24,22 @@ class _DashboardHandler(logging.Handler):
     """
     Handler que espelha WARNING e ERROR no dashboard (tabela system_event_logs).
     Só grava se DATABASE_URL estiver configurado.
+
+    ponytail: `emit` chama `log_system_event_sync` direto — um psycopg.connect()
+    + INSERT bloqueante POR REGISTRO, sem pool e sem fila. Teto: como este handler
+    fica no ROOT logger, qualquer `warning()`/`error()` de qualquer módulo paga a
+    conta, e no processo web (uvicorn) ela é paga DENTRO do event loop, travando
+    todas as conexões enquanto dura. Medido em localhost: 11,3 ms na 1ª chamada e
+    2,1–3,7 ms por chamada em série, contra 0,02 ms sem o handler; com banco remoto
+    cada connect ainda paga o RTT (não medido daqui — produção inacessível). Foi
+    barato até aqui porque warning em produção é raro; o que assusta é o caso em
+    que ele deixa de ser — um laço quente logando por requisição. Já obrigou
+    contorno em pelo menos um ponto: `frontend/routes/shared.py` loga a queda da
+    página de erro uma vez por TRANSIÇÃO (flag `_error_degraded`) em vez de por
+    requisição, senão um bot varrendo URL vira um INSERT por 404.
+    Upgrade: `logging.handlers.QueueHandler` + `QueueListener` (stdlib) tira o
+    INSERT do caller; ou reusar o pool async em vez de abrir conexão por registro.
+    Transversal (mexe no logger de todo o processo) — não é o PR da página de erro.
     """
 
     def emit(self, record: logging.LogRecord) -> None:

--- a/frontend/error.html
+++ b/frontend/error.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{CODE}} — {{TITLE}} | PigBank</title>
+<meta name="robots" content="noindex">
+<script src="/safe-area.js?v=1"></script>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#070b14;font-family:-apple-system,BlinkMacSystemFont,"SF Pro Display","Segoe UI",sans-serif;
+display:flex;align-items:center;justify-content:center;min-height:100vh;color:rgba(255,255,255,.85)}
+.box{text-align:center;max-width:400px;padding:48px 32px}
+.code{font-size:3.5rem;font-weight:700;color:rgba(255,255,255,.22);letter-spacing:.04em;margin-bottom:12px}
+h2{font-size:1.4rem;font-weight:600;margin-bottom:10px}
+p{color:rgba(255,255,255,.5);line-height:1.7;margin-bottom:28px}
+a{display:inline-block;padding:11px 28px;background:rgba(124,58,237,.45);
+border:1px solid rgba(124,58,237,.55);border-radius:14px;color:white;
+text-decoration:none;font-size:.9rem;transition:background .2s}
+a:hover{background:rgba(124,58,237,.65)}
+</style></head>
+<body><div class="box">
+<div class="code">{{CODE}}</div>
+<h2>{{TITLE}}</h2>
+<p>{{MESSAGE}}</p>
+<a href="/">← Página inicial</a>
+</div></body></html>

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -37,6 +37,10 @@ from fastapi import BackgroundTasks, FastAPI, WebSocket, WebSocketDisconnect, HT
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse, RedirectResponse, HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.exceptions import RequestValidationError
+from fastapi.exception_handlers import http_exception_handler, request_validation_exception_handler
+from fastapi.utils import is_body_allowed_for_status_code
+from starlette.exceptions import HTTPException as StarletteHTTPException
 import uvicorn
 from pydantic import BaseModel
 from slowapi.util import get_remote_address
@@ -106,6 +110,7 @@ from frontend.routes.shared import (
     dashboard_current_cache as _dashboard_current_cache,
     db_connect,
     decode_jwt as _decode_jwt,
+    error_page_response,
     get_auth_token_from_request as _get_auth_token_from_request,
     invalidate_dashboard_current_cache as _invalidate_dashboard_current_cache,
     jdump,
@@ -117,6 +122,8 @@ from frontend.routes.shared import (
     resolve_analytics_window as _resolve_analytics_window,
     resolve_dashboard_user_id as _resolve_dashboard_user_id,
     stamp_asset_versions as _stamp_asset_versions,
+    vary_accept,
+    wants_html,
 )
 from frontend.routes.static_pages import router as static_pages_router
 
@@ -1788,12 +1795,22 @@ _SECURITY_HEADERS = {
     ),
 }
 
-@app.middleware("http")
-async def security_headers_middleware(request: Request, call_next):
-    response = await call_next(request)
+def _with_security_headers(response: Response) -> Response:
+    """Aplica os _SECURITY_HEADERS numa resposta.
+
+    Usado pelo middleware abaixo e pelos DOIS pontos que respondem fora do
+    alcance dele: o short-circuit do csrf_middleware (registrado depois, logo
+    mais externo) e o handler do ServerErrorMiddleware (fora de todo middleware
+    de usuário). Os dois agora devolvem documento HTML nosso, e HTML sem
+    `frame-ancestors 'none'`/`X-Frame-Options` é enquadrável."""
     for header, value in _SECURITY_HEADERS.items():
         response.headers.setdefault(header, value)
     return response
+
+
+@app.middleware("http")
+async def security_headers_middleware(request: Request, call_next):
+    return _with_security_headers(await call_next(request))
 
 
 def _make_csrf_token() -> str:
@@ -1822,10 +1839,26 @@ async def csrf_middleware(request: Request, call_next):
     if request.method.upper() not in CSRF_SAFE_METHODS and not _csrf_exempt(request.url.path):
         header_token = request.headers.get(CSRF_HEADER_NAME) or ""
         if not token or not header_token or not secrets.compare_digest(token, header_token):
-            return JSONResponse(
-                status_code=403,
-                content={"detail": "Token CSRF inválido ou ausente."},
-                headers={"Cache-Control": "no-store"},
+            # HOJE nenhum caminho conhecido cai aqui por navegação: o CSRF só
+            # olha método não-seguro, e o produto não tem submit de formulário —
+            # os 13 `<form>` de frontend/*.html não têm um `method=`/`action=`
+            # sequer (9 com `onsubmit=`, 4 com addEventListener("submit"), todos
+            # em fetch), o callback do Google é @app.get, e fetch sem Accept
+            # manda */* → ramo JSON. O ramo HTML fica assim mesmo: no dia em que
+            # um POST de navegação existir (um <form> comum, um retorno de
+            # provedor externo), ele não pode depender de alguém ter lembrado
+            # deste bloco pra não despejar JSON cru numa aba do navegador. E o
+            # middleware não passa por exception handler nenhum, então isto só
+            # pode ser decidido aqui.
+            # _with_security_headers porque este return não passa pelo
+            # security_headers_middleware (csrf é o mais externo dos dois).
+            return _with_security_headers(
+                error_page_response(403) if wants_html(request)
+                else vary_accept(JSONResponse(
+                    status_code=403,
+                    content={"detail": "Token CSRF inválido ou ausente."},
+                    headers={"Cache-Control": "no-store"},
+                ))
             )
 
     response = await call_next(request)
@@ -1944,14 +1977,65 @@ app.state.limiter = limiter  # instância compartilhada em frontend/routes/share
 
 
 async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):
-    return JSONResponse(
+    if wants_html(request):
+        return error_page_response(429, headers={"Retry-After": "60"})
+    return vary_accept(JSONResponse(
         status_code=429,
         content={"detail": RATE_LIMIT_DETAIL},
         headers={"Retry-After": "60"},
-    )
+    ))
 
 
 app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
+
+
+# Erro que chega por NAVEGAÇÃO (Accept: text/html — barra de endereço, link,
+# WebView do app, fetch do pb-nav.js) responde página; chamada de API continua
+# no JSON de hoje, delegado aos handlers padrão do FastAPI (mesmo corpo,
+# mesmo Content-Type, mesmo exc.headers).
+async def http_exception_page_handler(request: Request, exc: StarletteHTTPException):
+    if not is_body_allowed_for_status_code(exc.status_code):  # 204/304 não podem ter corpo
+        return Response(status_code=exc.status_code, headers=getattr(exc, "headers", None))
+    if wants_html(request):
+        # exc.headers carrega o Allow do 405 e o WWW-Authenticate do 401 — o
+        # error_page_response filtra o resto (allowlist em shared.py).
+        return error_page_response(exc.status_code, headers=getattr(exc, "headers", None))
+    return vary_accept(await http_exception_handler(request, exc))
+
+
+async def validation_exception_page_handler(request: Request, exc: RequestValidationError):
+    if wants_html(request):
+        return error_page_response(422)
+    return vary_accept(await request_validation_exception_handler(request, exc))
+
+
+async def unhandled_exception_page_handler(request: Request, exc: Exception):
+    """Handler do ServerErrorMiddleware (o mais externo de todos).
+
+    Cobre exceção levantada em middleware FORA do admin_error_logging (CORS,
+    security_headers, csrf) — sem isto o Starlette devolve o
+    `PlainTextResponse("Internal Server Error")` dele. O corpo JSON é o mesmo do
+    middleware do admin, de propósito: não criar um terceiro formato de erro.
+
+    O ServerErrorMiddleware re-levanta a exceção depois de chamar o handler
+    (starlette/middleware/errors.py:186), então o uvicorn continua logando.
+    """
+    # _with_security_headers: aqui é FORA de todo middleware de usuário, então
+    # o security_headers_middleware nunca vê esta resposta.
+    return _with_security_headers(
+        error_page_response(500) if wants_html(request)
+        else vary_accept(JSONResponse(status_code=500, content={"error": "Erro interno do servidor."}))
+    )
+
+
+# StarletteHTTPException (não a do FastAPI): o 404/405 automático do router
+# levanta a do Starlette — registrar só a subclasse deixaria o caso principal fora.
+app.add_exception_handler(StarletteHTTPException, http_exception_page_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_page_handler)
+# Exception (não 500): o Starlette tira esta chave do ExceptionMiddleware e a usa
+# como handler do ServerErrorMiddleware (applications.py:85-95).
+app.add_exception_handler(Exception, unhandled_exception_page_handler)
+
 
 app.add_middleware(
     CORSMiddleware,
@@ -4821,7 +4905,18 @@ async def unsubscribe_one_click(uid: int, token: str):
 @app.get("/unsubscribe")
 async def unsubscribe(uid: int, token: str):
     if not await _apply_unsubscribe(uid, token):
-        return HTMLResponse("<h2>Link inválido ou expirado.</h2>", status_code=400)
+        # Mesmo perfil do 410 do link de exportação: link de e-mail, navegação
+        # pura, sem chance de retry — um `<h2>` solto era a última superfície de
+        # erro do produto sem documento decente. Continua 400 (o POST one-click
+        # do RFC 8058 responde 400 no mesmo caso), mas com texto próprio: o 400
+        # genérico é o dos 422 de validação e não diria o que fazer. O token é um
+        # HMAC de user_id:email sem validade — quebra se o e-mail mudou depois do
+        # envio, ou se o link veio truncado pelo cliente de e-mail.
+        return error_page_response(400, text=(
+            "Link inválido",
+            "Este link de descadastro não vale mais. Você pode cancelar os e-mails "
+            "em Configurações → Notificações, ou mandar “parar emails” pro bot.",
+        ))
 
     return HTMLResponse(_stamp_asset_versions("""
 <!DOCTYPE html>

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import re
 from datetime import date, datetime, timezone
+from html import escape
 from decimal import Decimal
 from typing import Any
 
@@ -124,8 +125,9 @@ def stamp_asset_versions(html_text: str) -> str:
     """Troca o `?v=N` de cada CSS/JS de frontend/ por um hash do conteúdo.
 
     Aplicado em TODA saída de HTML (template, gerado em Python, montado à mão) —
-    ver os call sites em static_pages.py e no monólito. Assets fora de
-    FRONTEND_DIR ficam intactos.
+    ver os call sites: `html_file` logo abaixo, `error_page_response` (no cache do
+    template), static_pages.py e as duas páginas geradas no monólito. Assets fora
+    de FRONTEND_DIR ficam intactos.
     """
     def repl(m: "re.Match[str]") -> str:
         url = m.group(1)             # ex: /app-mode.css
@@ -152,6 +154,202 @@ def html_file(path: pathlib.Path, pixel: bool = True) -> Response:
                         media_type="text/html; charset=utf-8")
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
+    return response
+
+
+# ─── Página de erro HTML (navegação) ─────────────────────────────────────────
+# Texto SEMPRE constante do servidor: exc.detail nunca chega aqui — ele carrega
+# str(exc) de exceção arbitrária (finance_bot_websocket_custom.py:3208), nem
+# sempre é string (dict/lista nos 422) e vaza nome de parâmetro interno
+# (parse_date_param).
+_ERROR_TEXTS = {
+    404: ("Página não encontrada", "Este endereço não existe ou mudou de lugar."),
+    # 405 herda o texto do 404 de propósito: o Allow já diz que o recurso existe,
+    # mas para quem navegou é o mesmo beco sem saída — não vale uma tela própria.
+    405: ("Página não encontrada", "Este endereço não existe ou mudou de lugar."),
+    401: ("Acesso negado", "Você não tem acesso a esta página. Entre na sua conta e tente de novo."),
+    403: ("Acesso negado", "Você não tem acesso a esta página. Entre na sua conta e tente de novo."),
+    # 410 é hoje só o link de download da exportação (finance_bot_websocket_custom.py:3203),
+    # clicado DE DENTRO do e-mail — navegação pura. O default 4xx tirava a única
+    # instrução acionável da tela, por isso ele tem texto próprio.
+    410: ("Link expirado", "Este link já foi usado ou passou da validade. Peça um novo em Configurações → Meus dados."),
+    429: ("Muitas tentativas", "Você fez muitas requisições em pouco tempo. Aguarde um instante."),
+    400: ("Requisição inválida", "Não consegui entender esse pedido."),
+    422: ("Requisição inválida", "Não consegui entender esse pedido."),
+    503: ("Serviço indisponível", "Estamos com instabilidade. Tente novamente em instantes."),
+}
+_ERROR_DEFAULT_4XX = ("Não deu pra abrir", "Algo nesse pedido não está certo.")
+_ERROR_DEFAULT_5XX = ("Algo deu errado do nosso lado", "Já registramos o problema. Tente de novo em instantes.")
+
+_error_template: str | None = None
+# Já logamos a queda pro fallback? Sem isto o warning sai POR REQUISIÇÃO, e no
+# processo web o root logger carrega o _DashboardHandler (core/observability.py:23),
+# que faz psycopg.connect() + INSERT bloqueante dentro do event loop — um connect
+# por registro. Medido aqui, chamando logging.warning() em série com e sem o
+# handler, contra o Postgres em localhost: 11,3 ms na 1ª chamada, 3,7 ms/chamada
+# em 10 e 2,1 ms/chamada em 25, contra 0,02 ms com o handler fora. Cada connect
+# paga o RTT até o banco, então com Postgres remoto (produção) a conta é maior —
+# quanto, não dá pra medir daqui (CLAUDE.md §6: produção inacessível). Loga na
+# transição pro estado degradado e cala enquanto ele durar.
+_error_degraded = False
+
+# Só estes headers do exc.headers são repassados à página. O resto é descartado
+# porque quem monta o exc não sabe que a resposta virou HTML: um Content-Length
+# vindo dali mata a conexão (h11: "Too much data for declared Content-Length") e
+# um Content-Type rotula ~1,4 KB de HTML como application/json. `location` também
+# fica de fora: todo 3xx do repo é RedirectResponse (que não passa por aqui) — não
+# há um `raise HTTPException` 3xx sequer —, então na prática ele só faria um 404
+# sair com Location.
+_ERROR_PASSTHROUGH_HEADERS = frozenset({"allow", "www-authenticate", "retry-after"})
+
+# Último recurso quando nem o template abre (não entrou no deploy, permissão,
+# disco). Autossuficiente: nada de arquivo, nada de import, mesmos placeholders.
+# Sem CSS/JS externo de propósito (só style inline e um <a href="/">), então não
+# passa nem precisa passar pelo `stamp_asset_versions` — não há `?v=` aqui.
+_ERROR_FALLBACK_HTML = (
+    '<!DOCTYPE html><html lang="pt-BR"><head><meta charset="UTF-8">'
+    '<meta name="viewport" content="width=device-width,initial-scale=1">'
+    '<meta name="robots" content="noindex"><title>{{CODE}} — {{TITLE}} | PigBank</title></head>'
+    '<body style="background:#070b14;color:#fff;font-family:sans-serif;text-align:center;padding:64px 24px">'
+    "<h1>{{CODE}}</h1><h2>{{TITLE}}</h2><p>{{MESSAGE}}</p>"
+    '<p><a href="/" style="color:#a78bfa">← Página inicial</a></p></body></html>'
+)
+
+
+def wants_html(request: Request) -> bool:
+    """True quando a requisição é navegação (browser/WebView), não chamada de API.
+
+    Só o Accept: `*/*` NÃO conta — é o que o fetch de API e o TestClient mandam,
+    e é o que mantém o contrato JSON (o front lê `detail` dali).
+
+    ponytail: comparação por substring, sem q-values — `text/html;q=0.1,
+    application/json;q=0.9` cai no ramo HTML. Inclusive `text/html;q=0`, que é a
+    forma padrão de dizer "NÃO me mande isto": é o único caso em que a
+    simplificação faz o oposto do pedido em vez de só ignorar a preferência.
+    Fica assim de propósito — separar `q=0` de `q=0.5` já é parsear Accept, e
+    zero clientes nossos mandam qualquer q (pb-nav.js:226,255 pede text/html;
+    blog-news.js:89 pede application/json; o resto é fetch sem Accept → */*).
+    Accept duplicado também: o Starlette devolve só a primeira ocorrência, então
+    dois headers caem no ramo da primeira — navegador nenhum duplica Accept.
+    Se algum dia importar: a stdlib não tem parser de Accept e o werkzeug (cujo
+    `http.parse_accept_header` resolveria) NÃO está no requirements.txt — só chega
+    transitivamente no venv local, então contar com ele quebraria no CI/produção.
+    São ~10 linhas à mão (split por vírgula, ler o `q=`, ordenar) ou assumir a
+    dependência de propósito."""
+    # Case-insensitive: media type não tem caixa (RFC 7231 §3.1.1.1) — sem o
+    # .lower() um `Accept: TEXT/HTML` caía no ramo JSON.
+    return "text/html" in (request.headers.get("accept") or "").lower()
+
+
+def vary_accept(response: Response) -> Response:
+    """Marca a resposta como dependente do Accept (ramo JSON dos erros).
+
+    O ramo HTML já sai marcado do `error_page_response`. `add_vary_header` soma
+    ao Vary existente em vez de sobrescrever (o CORS depois soma o `Origin`)."""
+    response.headers.add_vary_header("Accept")
+    return response
+
+
+def error_page_response(status_code: int, headers: dict | None = None,
+                        text: tuple[str, str] | None = None) -> Response:
+    """Página de erro HTML preservando o status (nada de soft-404) e no-store.
+
+    `{{CODE}}`/`{{TITLE}}`/`{{MESSAGE}}` do error.html saem do mapa fixo
+    `_ERROR_TEXTS` acima, mas o escape é por CONSTRUÇÃO e não por regra escrita:
+    título e mensagem passam por `html.escape()` e a troca é em UMA passagem (ver
+    abaixo). Constante do servidor não tem nada para escapar, então o custo é zero
+    e a garantia deixa de depender de quem lê este parágrafo.
+
+    `text=(titulo, mensagem)` sobrepõe o mapa para o caso em que o status já está
+    tomado por outra coisa e a tela ficaria sem instrução — hoje só o `/unsubscribe`
+    com token inválido, que é 400 como qualquer 422 de validação mas precisa dizer o
+    que fazer. Continua sendo para constante do servidor (é texto de produto, não
+    eco de entrada), só que agora um deslize ali sai escapado em vez de virar HTML.
+
+    NÃO passa pelo `html_file`: aquele funil injeta o Meta Pixel, e a página de erro
+    fica fora do rastreio de marketing por decisão explícita. O que ela precisa dele
+    — o `stamp_asset_versions` — está aplicado abaixo, no cache do template.
+
+    Sem caminho de falha: é a resposta de último recurso, então uma exceção aqui
+    viraria 500 + `http_unhandled_exception` no log a cada 404 de bot varrendo URL.
+    """
+    global _error_template, _error_degraded
+    default = _ERROR_DEFAULT_5XX if status_code >= 500 else _ERROR_DEFAULT_4XX
+    # Desempacotamento que NÃO pode estourar (a promessa do parágrafo acima): um
+    # `text=` de aridade errada levantava `ValueError: not enough values to
+    # unpack` — medido com `text=("so-um-item",)` — e um call site errado bastava
+    # para todo 404 daquela rota virar 500 + `http_unhandled_exception`. O
+    # isinstance cobre o resto: `len()` de um não-Sized levanta TypeError, e
+    # `escape()` de um não-str também. Fora do contrato → cai no texto do mapa.
+    if not (isinstance(text, tuple) and len(text) == 2
+            and all(isinstance(t, str) for t in text)):
+        text = _ERROR_TEXTS.get(status_code, default)
+    title, message = text
+    template = _error_template
+    if template is None:
+        try:
+            # Contrato do error.html — esta função é o único consumidor dele, e a
+            # nota mora aqui e não lá dentro porque comentário em HTML VIAJA no
+            # corpo de toda resposta de erro (era o caso; saiu). Quem for editar o
+            # arquivo precisa saber de duas coisas: os três placeholders abaixo são
+            # obrigatórios (a validação seguinte rejeita o arquivo sem eles), e nada
+            # de CDN — só CSS inline e o `/safe-area.js` do próprio domínio, porque
+            # esta página roda justamente quando algo já quebrou.
+            # `raw`, não `text`: `text` é o parâmetro de override do título/
+            # mensagem acima — reusar o nome aqui seria shadowing silencioso.
+            raw = (FRONTEND_DIR / "error.html").read_text(encoding="utf-8")
+            # Arquivo que ABRE mas veio pela metade (deploy interrompido, rsync
+            # cortado, disco cheio) é o mesmo problema do arquivo ausente — e sem
+            # esta checagem viraria cache envenenado até o restart. `</html>` é a
+            # última linha (pega truncamento no fim, e o vazio de graça) e os TRÊS
+            # placeholders precisam estar lá: truncamento não é a única corrupção —
+            # lixo no meio, ou um `{{MESSAGE}}</html>` de 50 bytes, passava sem
+            # {{CODE}}/{{TITLE}} e ia ao usuário sem o código do erro na tela.
+            if not all(p in raw for p in ("{{CODE}}", "{{TITLE}}", "{{MESSAGE}}")) \
+                    or not raw.rstrip().endswith("</html>"):
+                raise ValueError(f"error.html incompleto ({len(raw)} bytes)")
+            # Stamp aqui, JUNTO do cache, e não na montagem do corpo: o
+            # `?v=` do <script src="/safe-area.js"> do error.html precisa do
+            # hash como qualquer outra saída de HTML (senão é a única URL de
+            # asset do produto que nunca invalida), mas re-hashear a cada
+            # requisição pagaria um stat() por 404 de bot varrendo URL. O
+            # preço é que trocar o safe-area.js sem reiniciar o processo deixa
+            # ESTA página com o hash velho até o restart — em deploy o
+            # processo reinicia, e o html_file/static_pages (que releem o
+            # arquivo por requisição) continuam pegando na hora.
+            template = _error_template = stamp_asset_versions(raw)
+            _error_degraded = False  # arquivo voltou: pode logar a próxima queda
+        except Exception as exc:
+            # O fallback NÃO é cacheado: se o arquivo voltar (deploy pela metade),
+            # a próxima requisição tenta de novo em vez de degradar até o restart.
+            # Um log por TRANSIÇÃO, não por requisição (ver _error_degraded acima):
+            # como nada é cacheado aqui, logar sempre transformaria um bot varrendo
+            # URL em um INSERT síncrono por 404. Sem exc_info: ~25 linhas de
+            # traceback não dizem mais que o repr (tipo + caminho).
+            if not _error_degraded:
+                _error_degraded = True
+                logging.getLogger(__name__).warning(
+                    "error.html indisponível (%r) — servindo fallback embutido", exc
+                )
+            template = _ERROR_FALLBACK_HTML
+    # Escape + UMA passagem, no lugar dos três `.replace()` encadeados. Os dois
+    # defeitos eram do encadeamento, não do texto: (1) o valor entrava cru, então
+    # qualquer deslize no `text=` renderizava HTML; (2) a ordem CODE→TITLE→MESSAGE
+    # reexpandia placeholder que caísse DENTRO de um valor — um título contendo
+    # `{{MESSAGE}}` era reescrito pelo replace seguinte. O escape sozinho não
+    # resolve o (2): `html.escape` não toca em chaves. A passagem única resolve os
+    # dois. `re` e não `str.format`/`Template`: o template tem CSS cheia de chaves.
+    valores = {"{{CODE}}": str(status_code),
+               "{{TITLE}}": escape(title), "{{MESSAGE}}": escape(message)}
+    body = re.sub(r"\{\{(?:CODE|TITLE|MESSAGE)\}\}", lambda m: valores[m.group()], template)
+    response = Response(content=body, status_code=status_code, media_type="text/html; charset=utf-8")
+    for key, value in (headers or {}).items():
+        if key.lower() in _ERROR_PASSTHROUGH_HEADERS:
+            response.headers[key] = value
+    response.headers["Cache-Control"] = "no-store"
+    # A mesma URL devolve HTML ou JSON conforme o Accept — sem isto um CDN pode
+    # servir a página de erro para uma chamada de API (e vice-versa).
+    response.headers.add_vary_header("Accept")
     return response
 
 

--- a/tests/test_error_pages.py
+++ b/tests/test_error_pages.py
@@ -1,0 +1,871 @@
+"""Erro por NAVEGAÇÃO responde HTML; chamada de API continua no JSON de hoje.
+
+Os asserts de `Accept: text/html` são a medição (falham sem a correção); os de
+`Accept: */*` são guarda de regressão do contrato JSON (passam antes e depois).
+"""
+
+import asyncio
+import html as html_lib
+import json
+import logging
+import pathlib
+import re
+import uuid
+
+import pytest
+from fastapi import HTTPException, Request
+from fastapi.testclient import TestClient
+
+import core.admin_dashboard as admin_dashboard
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.shared as shared
+
+HTML = {"Accept": "text/html,application/xhtml+xml"}
+
+
+def _vary_values(response) -> list[str]:
+    """Vary pode vir repetido ou em lista — normaliza pra comparar."""
+    headers = response.headers  # httpx.Headers -> get_list; starlette -> getlist
+    raw = getattr(headers, "get_list", None) or headers.getlist
+    return sorted(v.strip().lower() for item in raw("vary") for v in item.split(",") if v.strip())
+
+
+def _client() -> TestClient:
+    return TestClient(dashboard.app)
+
+
+def _csrf_headers(client: TestClient) -> dict[str, str]:
+    token = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, token)
+    return {dashboard.CSRF_HEADER_NAME: token}
+
+
+def _reset_rate_limits(*identifiers: str):
+    """Zera os DOIS limitadores: o persistente (auth_rate_limits, no Postgres) e
+    o in-memory do slowapi — este último é global ao processo e usa a chave
+    "testclient", a MESMA de tests/test_auth_cookie.py. Sem o reset no finally,
+    este arquivo queimaria a cota do outro na suíte completa."""
+    dashboard.limiter.reset()
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "delete from auth_rate_limits where identifier = any(%s)",
+                (list(identifiers),),
+            )
+        conn.commit()
+
+
+# Comentários que a página serve hoje: NENHUM. Continua sendo allowlist e não
+# lista de proibidos — um comentário NOVO reprova seja qual for a redação, que é o
+# que a lista de strings ruins de `test_pagina_de_erro_nao_vaza_nota_interna` não
+# consegue fazer. O único item que estava aqui (a nota "Placeholders preenchidos
+# no servidor…") saiu do error.html e virou comentário em
+# `shared.error_page_response`, no ponto que lê e valida o arquivo: nota de dev é
+# para quem abre o código, não para quem recebe a resposta de erro.
+_COMENTARIOS_SERVIDOS = set()
+
+
+def _texto_visivel(html_text: str) -> str:
+    """O que o usuário LÊ: sem <style>/<script>, sem comentário, sem tag."""
+    t = re.sub(r"<(script|style)\b.*?</\1>", " ", html_text, flags=re.S | re.I)
+    t = re.sub(r"<!--.*?-->", " ", t, flags=re.S)
+    t = re.sub(r"<[^>]+>", " ", t)
+    return " ".join(html_lib.unescape(t).split())
+
+
+def _assert_error_page(response, status_code: int, snippet: str, textos=None):
+    assert response.status_code == status_code
+    assert response.headers["content-type"].startswith("text/html")
+    assert response.headers["cache-control"] == "no-store"
+    assert snippet in response.text
+    assert str(status_code) in response.text
+
+    # Invariante no lugar da lista de strings ruins: o texto visível é EXATAMENTE
+    # código + título + mensagem + o rótulo do link, e nada mais. Isso vale por
+    # todos os `assert "<coisa ruim>" not in text` de uma vez — inclusive por
+    # palavra que ninguém pensou em proibir (exc.detail, caminho de fonte, nome de
+    # parâmetro interno, a própria nota de desenvolvimento que já foi parar na
+    # tela). `textos=` só para o override do kwarg `text=` do error_page_response.
+    default = shared._ERROR_DEFAULT_5XX if status_code >= 500 else shared._ERROR_DEFAULT_4XX
+    title, message = textos or shared._ERROR_TEXTS.get(status_code, default)
+    assert _texto_visivel(response.text) == (
+        f"{status_code} — {title} | PigBank {status_code} {title} {message} ← Página inicial"
+    )
+    # E nada de nota nova escondida em comentário (invisível ao assert acima).
+    comentarios = {c.strip() for c in re.findall(r"<!--(.*?)-->", response.text, re.S)}
+    assert comentarios <= _COMENTARIOS_SERVIDOS, comentarios - _COMENTARIOS_SERVIDOS
+
+
+# ─── 404 de rota inexistente ─────────────────────────────────────────────────
+
+def test_rota_inexistente_navegacao_recebe_html():
+    _assert_error_page(_client().get("/rota-que-nao-existe", headers=HTML), 404, "não encontrada")
+
+
+def test_rota_inexistente_api_continua_json():
+    response = _client().get("/rota-que-nao-existe")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Not Found"
+
+
+# ─── 404 levantado por rota (HTTPException com detail) ───────────────────────
+
+def test_guia_inexistente_navegacao_recebe_html_generico(monkeypatch):
+    monkeypatch.setattr("frontend.routes.static_pages.gate_pro_page", lambda request: None)
+    response = _client().get("/blog/guia-que-nao-existe", headers=HTML)
+    _assert_error_page(response, 404, "não encontrada")
+    assert "Guia não encontrado" not in response.text
+
+
+def test_guia_inexistente_api_continua_json(monkeypatch):
+    monkeypatch.setattr("frontend.routes.static_pages.gate_pro_page", lambda request: None)
+    response = _client().get("/blog/guia-que-nao-existe")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Guia não encontrado."
+
+
+# ─── 429 (handler do slowapi) ────────────────────────────────────────────────
+
+def _burn_rate_limit(client: TestClient, email: str, extra_headers: dict):
+    for _ in range(3):
+        response = client.post(
+            "/auth/forgot-password",
+            headers={**_csrf_headers(client), **extra_headers},
+            json={"email": email},
+        )
+        assert response.status_code == 200
+    return client.post(
+        "/auth/forgot-password",
+        headers={**_csrf_headers(client), **extra_headers},
+        json={"email": email},
+    )
+
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_429_preserva_retry_after_nos_dois_ramos(monkeypatch, accept_html):
+    monkeypatch.setattr(db, "create_password_reset_token", lambda email: None)
+    client = _client()
+    email = f"errpage-{uuid.uuid4().hex}@example.com"
+    _reset_rate_limits("ip:testclient", f"email:{email}")
+    try:
+        response = _burn_rate_limit(client, email, HTML if accept_html else {})
+        assert response.status_code == 429
+        assert response.headers["Retry-After"] == "60"
+        if accept_html:
+            _assert_error_page(response, 429, "Muitas tentativas")
+        else:
+            assert response.json()["detail"] == dashboard.RATE_LIMIT_DETAIL
+    finally:
+        _reset_rate_limits("ip:testclient", f"email:{email}")
+
+
+# ─── 500 (middleware de log do admin, fora do ExceptionMiddleware) ───────────
+
+@pytest.fixture
+def boom_route():
+    path = f"/__boom-{uuid.uuid4().hex}"
+
+    @dashboard.app.get(path)
+    async def _boom():
+        raise RuntimeError("estouro proposital")
+
+    yield path
+    dashboard.app.router.routes = [
+        r for r in dashboard.app.router.routes if getattr(r, "path", None) != path
+    ]
+
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_500_html_na_navegacao_json_na_api_e_log_preservado(monkeypatch, boom_route, accept_html):
+    logged = []
+
+    async def _spy(*args, **kwargs):
+        logged.append((args, kwargs))
+
+    monkeypatch.setattr(admin_dashboard, "log_system_event", _spy)
+
+    response = TestClient(dashboard.app, raise_server_exceptions=False).get(
+        boom_route, headers=HTML if accept_html else {}
+    )
+
+    assert response.status_code == 500
+    if accept_html:
+        _assert_error_page(response, 500, "Algo deu errado")
+    else:
+        assert response.json() == {"error": "Erro interno do servidor."}
+    # O Vary deste ramo é inline no admin_error_logging_middleware (o helper
+    # vary_accept vive em frontend/ e este é o caminho onde o import dele pode
+    # ter falhado) — a mesma URL devolve HTML ou JSON conforme o Accept.
+    assert "accept" in _vary_values(response)
+    assert len(logged) == 1
+    assert logged[0][0][1] == "http_unhandled_exception"
+
+
+# ─── 405 (Allow do exc.headers tem que sobreviver ao ramo HTML) ──────────────
+
+def test_405_navegacao_recebe_html_com_allow():
+    client = _client()
+    response = client.post("/robots.txt", headers={**_csrf_headers(client), **HTML})
+    _assert_error_page(response, 405, "não encontrada")
+    assert "GET" in response.headers["allow"]
+
+
+def test_405_api_continua_json():
+    client = _client()
+    response = client.post("/robots.txt", headers=_csrf_headers(client))
+    assert response.status_code == 405
+    assert response.json()["detail"] == "Method Not Allowed"
+
+
+# ─── A. Nota interna não vaza no corpo servido ───────────────────────────────
+
+@pytest.mark.parametrize(
+    "vazamento",
+    ["shared.py", "error_page_response", "app-mode.js", "PAGES", "CONSTANTES DO SERVIDOR"],
+)
+def test_pagina_de_erro_nao_vaza_nota_interna(vazamento):
+    """Comentário de desenvolvimento (caminho de fonte, nome de helper) não pode
+    ir junto no corpo — é disclosure de layout de fonte em toda página de erro.
+
+    O param "CONSTANTES DO SERVIDOR" cobre o segundo defeito da nota antiga: ela
+    citava os placeholders literalmente, o .replace() reescrevia a própria linha,
+    e o cliente lia '404 ... são CONSTANTES DO SERVIDOR'."""
+    assert vazamento not in _client().get("/rota-que-nao-existe", headers=HTML).text
+
+
+# ─── B. Template ausente/ilegível não pode virar 500 ─────────────────────────
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_template_ausente_ainda_responde_o_status_certo(monkeypatch, tmp_path, accept_html):
+    """Sem guarda, o FileNotFoundError sobe até o middleware de log do admin e
+    todo 404 de navegação vira 500 + `http_unhandled_exception` no banco."""
+    monkeypatch.setattr(shared, "FRONTEND_DIR", tmp_path)  # tmp_path não tem error.html
+    monkeypatch.setattr(shared, "_error_template", None)
+
+    response = TestClient(dashboard.app, raise_server_exceptions=False).get(
+        "/rota-que-nao-existe", headers=HTML if accept_html else {}
+    )
+
+    assert response.status_code == 404
+    if accept_html:
+        assert response.headers["content-type"].startswith("text/html")
+        assert "404" in response.text and "não encontrada" in response.text
+    else:
+        assert response.json()["detail"] == "Not Found"
+
+
+def test_template_ausente_nao_envenena_o_cache(monkeypatch, tmp_path):
+    """O fallback não pode ficar cacheado: se o arquivo voltar, a próxima
+    requisição tem que servir a página de verdade, não degradar até o restart."""
+    monkeypatch.setattr(shared, "_error_template", None)
+    monkeypatch.setattr(shared, "FRONTEND_DIR", tmp_path)
+    assert shared.error_page_response(404).status_code == 404
+    assert shared._error_template is None
+
+    monkeypatch.undo()
+    monkeypatch.setattr(shared, "_error_template", None)
+    assert "safe-area.js" in shared.error_page_response(404).body.decode()
+
+
+# ─── C. Allowlist de headers do exc.headers ──────────────────────────────────
+
+@pytest.mark.parametrize(
+    "header,value",
+    [("Allow", "GET"), ("WWW-Authenticate", "Bearer"), ("Retry-After", "60")],
+)
+def test_headers_da_allowlist_passam(header, value):
+    assert shared.error_page_response(400, headers={header: value}).headers[header] == value
+
+
+def test_allowlist_e_case_insensitive():
+    assert shared.error_page_response(405, headers={"allow": "GET, HEAD"}).headers["allow"] == "GET, HEAD"
+
+
+@pytest.mark.parametrize(
+    "header,value",
+    [
+        # Mata a conexão com uvicorn/h11: "Too much data for declared Content-Length".
+        ("Content-Length", "3"),
+        # Rotularia ~1.3 KB de HTML como JSON.
+        ("Content-Type", "application/json"),
+        ("Set-Cookie", "x=1"),
+        ("X-Qualquer-Coisa", "1"),
+        # Todo 3xx do repo é RedirectResponse (não passa por aqui); repassar isto
+        # só fazia um 404 sair com Location.
+        ("Location", "/x"),
+    ],
+)
+def test_header_fora_da_allowlist_e_descartado(header, value):
+    response = shared.error_page_response(400, headers={header: value})
+    assert response.headers.get(header) != value
+    assert response.headers["content-type"] == "text/html; charset=utf-8"
+    assert int(response.headers["content-length"]) == len(response.body)
+
+
+def test_header_fora_da_allowlist_e_descartado_ponta_a_ponta():
+    """O mesmo, mas pela pilha real: HTTPException com headers hostis."""
+    path = f"/__hdrinj-{uuid.uuid4().hex}"
+
+    @dashboard.app.get(path)
+    async def _hdrinj():
+        raise HTTPException(
+            status_code=400,
+            detail="x",
+            headers={"Content-Length": "3", "Content-Type": "application/json", "Allow": "GET"},
+        )
+
+    try:
+        response = _client().get(path, headers=HTML)
+        assert response.status_code == 400
+        assert response.headers["content-type"] == "text/html; charset=utf-8"
+        assert response.headers["allow"] == "GET"  # da allowlist, sobrevive
+        assert int(response.headers["content-length"]) == len(response.content)
+        assert len(response.content) > 3
+    finally:
+        dashboard.app.router.routes = [
+            r for r in dashboard.app.router.routes if getattr(r, "path", None) != path
+        ]
+
+
+# ─── D. Vary: Accept nos dois ramos ──────────────────────────────────────────
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_404_declara_vary_accept_nos_dois_ramos(accept_html):
+    """A mesma URL devolve HTML ou JSON conforme o Accept; sem o Vary um CDN
+    pode servir um pelo outro."""
+    response = _client().get("/rota-que-nao-existe", headers=HTML if accept_html else {})
+    assert "accept" in _vary_values(response)
+
+
+def test_vary_accept_soma_ao_existente_em_vez_de_sobrescrever():
+    response = shared.error_page_response(404, headers={"Allow": "GET"})
+    response.headers.add_vary_header("Origin")  # é o que o CORSMiddleware faz depois
+    assert _vary_values(response) == ["accept", "origin"]
+
+
+# ─── E. Accept é case-insensitive (RFC 7231 §3.1.1.1) ────────────────────────
+
+@pytest.mark.parametrize("accept", ["TEXT/HTML", "Text/Html,application/xhtml+xml", "text/html"])
+def test_accept_em_qualquer_caixa_cai_no_ramo_html(accept):
+    response = _client().get("/rota-que-nao-existe", headers={"Accept": accept})
+    assert response.headers["content-type"].startswith("text/html"), accept
+
+
+def test_accept_sem_text_html_continua_json():
+    response = _client().get("/rota-que-nao-existe", headers={"Accept": "application/json"})
+    assert response.json()["detail"] == "Not Found"
+
+
+# ─── F. 403 do CSRF (middleware, sem exception handler nenhum) ───────────────
+
+def test_csrf_403_navegacao_recebe_html():
+    """Chega por navegação de verdade: aba antiga com cookie expirado, SameSite
+    perdendo o cookie na volta do OAuth."""
+    response = _client().post("/auth/forgot-password", headers=HTML, json={"email": "x@example.com"})
+    _assert_error_page(response, 403, "Acesso negado")
+    assert "CSRF" not in response.text  # nada de vocabulário interno na tela
+
+
+def test_csrf_403_api_continua_json():
+    response = _client().post("/auth/forgot-password", json={"email": "x@example.com"})
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Token CSRF inválido ou ausente."}
+    assert response.headers["cache-control"] == "no-store"
+    assert "accept" in _vary_values(response)
+
+
+# ─── G. Exceção em middleware externo não cai no PlainTextResponse ───────────
+
+def test_handler_de_exception_esta_ligado_ao_server_error_middleware():
+    """`add_exception_handler(Exception, ...)` vira o handler do
+    ServerErrorMiddleware (starlette/applications.py:85-95) — o mais externo de
+    todos. Sem ele, exceção no CORS/security_headers/csrf sai como
+    PlainTextResponse('Internal Server Error')."""
+    stack = dashboard.app.build_middleware_stack()
+    assert type(stack).__name__ == "ServerErrorMiddleware"
+    assert stack.handler is dashboard.unhandled_exception_page_handler
+
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_handler_de_exception_responde_html_ou_json(accept_html):
+    scope = {
+        "type": "http", "method": "GET", "path": "/x", "headers": (
+            [(b"accept", b"text/html")] if accept_html else [(b"accept", b"*/*")]
+        ),
+    }
+    response = asyncio.run(
+        dashboard.unhandled_exception_page_handler(Request(scope), RuntimeError("boom"))
+    )
+    assert response.status_code == 500
+    assert "accept" in _vary_values(response)
+    # Este handler roda FORA de todo middleware de usuário: o
+    # security_headers_middleware nunca vê esta resposta.
+    _assert_security_headers(response)
+    if accept_html:
+        assert response.headers["content-type"] == "text/html; charset=utf-8"
+        assert b"Algo deu errado" in response.body
+    else:
+        # Mesmo formato do middleware do admin — nada de um terceiro corpo de erro.
+        assert json.loads(response.body) == {"error": "Erro interno do servidor."}
+
+
+# ─── H. Template vazio/truncado é tão inútil quanto ausente ──────────────────
+
+@pytest.mark.parametrize(
+    "mutila",
+    [
+        pytest.param(lambda t: "", id="vazio"),
+        pytest.param(lambda t: t[: len(t) // 2], id="truncado_no_meio"),
+        # Perde o </html> mas mantém {{MESSAGE}} — só a checagem do fim pega.
+        pytest.param(lambda t: t[:-12], id="truncado_no_fim"),
+        # Corrupção NO MEIO: prefixo e sufixo intactos, {{CODE}}/{{TITLE}} vão
+        # embora. Só a checagem dos três placeholders pega estes.
+        pytest.param(
+            lambda t: t.replace("{{CODE}}", "").replace("{{TITLE}}", ""), id="sem_code_e_title"
+        ),
+        pytest.param(lambda t: "\x00\x01\x02 {{MESSAGE}} \xff</html>", id="lixo_binario"),
+        pytest.param(lambda t: "{{MESSAGE}}</html>", id="so_o_message"),
+    ],
+)
+def test_template_incompleto_cai_no_fallback_e_nao_envenena_o_cache(monkeypatch, tmp_path, mutila):
+    """Arquivo que ABRE mas veio pela metade (deploy interrompido, disco cheio)
+    não levanta exceção: sem validação de conteúdo ele era aceito, cacheado em
+    _error_template e servido até o restart, mesmo depois do arquivo voltar."""
+    real = (shared.FRONTEND_DIR / "error.html").read_text(encoding="utf-8")
+    (tmp_path / "error.html").write_text(mutila(real), encoding="utf-8")
+    monkeypatch.setattr(shared, "FRONTEND_DIR", tmp_path)
+    monkeypatch.setattr(shared, "_error_template", None)
+
+    response = shared.error_page_response(404)
+    body = response.body.decode()
+    assert response.status_code == 404
+    assert "404" in body and "não encontrada" in body
+    assert body.rstrip().endswith("</html>")
+    assert "safe-area.js" not in body        # é o fallback embutido, não o arquivo cru
+    assert shared._error_template is None    # nada de cache do que não passou
+
+    # Arquivo restaurado: a requisição seguinte serve a página de verdade.
+    (tmp_path / "error.html").write_text(real, encoding="utf-8")
+    assert "safe-area.js" in shared.error_page_response(404).body.decode()
+
+
+# ─── I. 410 do link de exportação (clicado de dentro do e-mail) ──────────────
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_410_do_link_de_exportacao(accept_html):
+    """Navegação pura: o default 4xx tirava a única instrução acionável da tela."""
+    response = _client().get(
+        f"/auth/account/export/download/{uuid.uuid4().hex}",
+        headers=HTML if accept_html else {},
+    )
+    assert response.status_code == 410
+    if accept_html:
+        _assert_error_page(response, 410, "Link expirado")
+        assert "Configurações" in response.text          # diz o que fazer
+        assert "Algo nesse pedido não está certo" not in response.text  # não é o default
+    else:
+        assert "Solicite uma nova exportação" in response.json()["detail"]
+
+
+# ─── J. Status que não pode ter corpo não recebe página ──────────────────────
+
+def test_status_sem_corpo_nao_recebe_pagina():
+    """204/304 com corpo é resposta malformada. `shared.error_page_response(204)`
+    devolve status 204 com ~1,4 KB de HTML — a guarda no handler é o que impede."""
+    path = f"/__nobody-{uuid.uuid4().hex}"
+
+    @dashboard.app.get(path)
+    async def _nobody():
+        raise HTTPException(status_code=204)
+
+    try:
+        response = _client().get(path, headers=HTML)
+        assert response.status_code == 204
+        assert response.content == b""
+        assert "content-type" not in response.headers
+    finally:
+        dashboard.app.router.routes = [
+            r for r in dashboard.app.router.routes if getattr(r, "path", None) != path
+        ]
+
+
+# ─── K. Security headers no HTML servido fora do middleware ──────────────────
+
+def _assert_security_headers(response):
+    assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
+
+
+def test_csrf_403_sai_com_security_headers():
+    """csrf_middleware é registrado DEPOIS do security_headers_middleware, logo é
+    o mais externo dos dois: o short-circuit nunca passa por lá. Uma página HTML
+    nossa sem frame-ancestors é enquadrável."""
+    _assert_security_headers(
+        _client().post("/auth/forgot-password", headers=HTML, json={"email": "x@example.com"})
+    )
+
+
+# ─── L. Estado degradado loga uma vez por transição, não por requisição ──────
+
+def _degraded_logs(caplog):
+    return [r for r in caplog.records if "error.html indisponível" in r.getMessage()]
+
+
+def test_degradado_loga_uma_vez_por_transicao(monkeypatch, tmp_path, caplog):
+    """Este teste NÃO mede tempo: ele conta registros de log — 2 transições ao
+    longo de 35 páginas de erro degradadas, em vez de 35.
+
+    O motivo de contar é o custo por registro: o warning propaga pro root, que no
+    processo web carrega o _DashboardHandler (core/observability.py:23) →
+    psycopg.connect() + INSERT BLOQUEANTE no event loop, um connect por registro.
+    A medição está em core/observability.py e em shared.py:186 (logging.warning()
+    em série, com e sem o handler, contra Postgres em localhost: 11,3 ms na 1ª
+    chamada, 2,1–3,7 ms/chamada em série, contra 0,02 ms sem o handler). O número
+    que já esteve aqui — "539 ms em 10 páginas contra 5,7 ms em repouso" — não se
+    sustenta e foi removido: a remedição deu 36,71 ms em n=10 e 52,41 ms em n=25.
+    Sem o gate, um bot varrendo URL vira um INSERT síncrono por 404."""
+    real = (shared.FRONTEND_DIR / "error.html").read_text(encoding="utf-8")
+    (tmp_path / "error.html").write_text("{{MESSAGE}}</html>", encoding="utf-8")
+    monkeypatch.setattr(shared, "FRONTEND_DIR", tmp_path)
+    monkeypatch.setattr(shared, "_error_template", None)
+    monkeypatch.setattr(shared, "_error_degraded", False)
+
+    with caplog.at_level(logging.WARNING, logger=shared.__name__):
+        for _ in range(25):
+            assert shared.error_page_response(404).status_code == 404
+        assert len(_degraded_logs(caplog)) == 1
+
+        # Arquivo volta: serve a página de verdade e sai do estado degradado.
+        (tmp_path / "error.html").write_text(real, encoding="utf-8")
+        assert "safe-area.js" in shared.error_page_response(404).body.decode()
+        assert len(_degraded_logs(caplog)) == 1
+
+        # Quebra de novo (cache derrubado, como num restart): loga a nova queda.
+        (tmp_path / "error.html").write_text("", encoding="utf-8")
+        monkeypatch.setattr(shared, "_error_template", None)
+        for _ in range(10):
+            shared.error_page_response(404)
+        assert len(_degraded_logs(caplog)) == 2
+
+
+# ─── M. A página de erro entra no cache-buster, e sem o Meta Pixel junto ─────
+
+def test_pagina_de_erro_passa_pelo_stamp_asset_versions(monkeypatch):
+    """O `?v=` do safe-area.js sai com o hash do conteúdo, como TODA saída de HTML
+    (stamp_asset_versions, #119). Antes ia o `?v=1` literal do error.html — a única
+    URL de asset do produto que nunca invalidava, e já cacheada nos navegadores
+    exatamente com esse valor, de quando `?v=1` era o padrão de todo mundo."""
+    monkeypatch.setattr(shared, "_error_template", None)  # o stamp é feito no cache
+    body = shared.error_page_response(404).body.decode()
+
+    mtime_ns = (shared.FRONTEND_DIR / "safe-area.js").stat().st_mtime_ns
+    esperado = shared._asset_hash("safe-area.js", mtime_ns)
+    assert f"/safe-area.js?v={esperado}" in body
+    assert "?v=1" not in body
+
+
+def test_pagina_de_erro_nao_leva_o_meta_pixel(monkeypatch):
+    """Decisão explícita do dono do produto: a página de erro fica FORA do rastreio
+    de marketing. O atalho pra ganhar o stamp seria servi-la pelo `html_file`, que
+    injeta o pixel quando META_PIXEL_ID está setado — este assert é o que impede
+    isso de entrar calado junto com a próxima refatoração."""
+    monkeypatch.setattr(shared, "META_PIXEL_ID", "000000000000000")
+    monkeypatch.setattr(shared, "_error_template", None)
+    assert shared.meta_pixel_snippet()  # o pixel ESTÁ ligado nesta requisição
+
+    body = shared.error_page_response(404).body.decode()
+    assert "fbq" not in body
+    assert "connect.facebook.net" not in body
+    assert "facebook.com/tr" not in body
+
+
+# ─── N. 422 de validação — o handler que estava no diff sem um teste sequer ───
+#
+# `/unsubscribe?uid=&token=` não é caso de laboratório: é o link do rodapé de todo
+# e-mail de engajamento (core/services/email_service.py:323), com `uid: int` e
+# `token: str` OBRIGATÓRIOS na query. Cliente de e-mail que corta a URL entrega
+# exatamente isto, e antes deste PR o usuário via na tela o array cru do FastAPI
+# com `loc`/`msg`/`input` e o nome do parâmetro interno.
+
+_URLS_422 = [
+    pytest.param("/unsubscribe", id="parametros_ausentes"),
+    pytest.param("/unsubscribe?uid=&token=", id="link_truncado"),   # uid='' → int_parsing
+]
+
+
+@pytest.mark.parametrize("url", _URLS_422)
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_422_de_validacao_nos_dois_ramos(url, accept_html):
+    """Apagar `add_exception_handler(RequestValidationError, ...)` mantinha a suíte
+    verde: o handler inteiro não tinha nada que o prendesse."""
+    response = _client().get(url, headers=HTML if accept_html else {})
+    assert response.status_code == 422
+    if accept_html:
+        _assert_error_page(response, 422, "Requisição inválida")
+    else:
+        # Contrato de API preservado: o array do FastAPI, intacto.
+        assert isinstance(response.json()["detail"], list)
+        assert response.json()["detail"][0]["loc"][0] == "query"
+        assert "accept" in _vary_values(response)
+
+
+@pytest.mark.parametrize("url", _URLS_422)
+def test_422_nao_vaza_o_detail_na_pagina(url):
+    """O `detail` do 422 é uma LISTA com nome de campo interno (`uid`), o tipo do
+    erro (`int_parsing`) e o valor recebido (`input`) — nada disso pode chegar à
+    tela. As strings proibidas são DERIVADAS da resposta JSON da mesma URL, não
+    listadas à mão: se o FastAPI mudar o formato, o teste acompanha."""
+    json_body = _client().get(url).json()
+    html_text = _client().get(url, headers=HTML).text
+    visivel = _texto_visivel(html_text)
+
+    proibidas = set()
+    def _coleta(node):
+        if isinstance(node, str):
+            proibidas.add(node)
+        elif isinstance(node, dict):
+            for k, v in node.items():
+                proibidas.add(k)
+                _coleta(v)
+        elif isinstance(node, list):
+            for v in node:
+                _coleta(v)
+    _coleta(json_body)
+
+    assert "uid" in proibidas and "detail" in proibidas   # o teste está olhando algo
+    for termo in proibidas:
+        if termo:
+            assert termo not in visivel, termo
+    # E o texto longo do pydantic não pode estar nem escondido no HTML cru.
+    assert json_body["detail"][0]["msg"] not in html_text
+
+
+# ─── O. 401 ponta a ponta (até aqui só havia teste unitário do header) ────────
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_401_de_rota_protegida_nos_dois_ramos(accept_html):
+    """`GET /auth/me` sem token. O ramo HTML existe porque isto chega por
+    navegação: link de e-mail para área logada, deep link do app, aba velha."""
+    response = _client().get("/auth/me", headers=HTML if accept_html else {})
+    assert response.status_code == 401
+    if accept_html:
+        _assert_error_page(response, 401, "Acesso negado")
+        assert "Token não fornecido" not in response.text  # vocabulário interno
+    else:
+        assert response.json()["detail"] == "Token não fornecido."
+        assert "accept" in _vary_values(response)
+
+
+def test_401_www_authenticate_sobrevive_ao_ramo_html():
+    """A allowlist já tem teste unitário (`test_headers_da_allowlist_passam`), mas
+    ninguém provava que o header sai vivo do outro lado da pilha — do `exc.headers`
+    do `raise` até a resposta. Rota sintética porque HOJE nenhum 401 do produto
+    manda WWW-Authenticate (`git grep -i www-authenticate` só acha o comentário do
+    handler, a allowlist e o teste): quem adicionar um vai depender deste caminho."""
+    path = f"/__401-{uuid.uuid4().hex}"
+
+    @dashboard.app.get(path)
+    async def _naoautorizado():
+        raise HTTPException(
+            status_code=401,
+            detail="Token inválido ou expirado.",
+            headers={"WWW-Authenticate": 'Bearer realm="pigbank", error="invalid_token"'},
+        )
+
+    try:
+        response = _client().get(path, headers=HTML)
+        _assert_error_page(response, 401, "Acesso negado")
+        assert response.headers["www-authenticate"] == 'Bearer realm="pigbank", error="invalid_token"'
+        assert "invalid_token" not in response.text  # no header sim, no corpo não
+    finally:
+        dashboard.app.router.routes = [
+            r for r in dashboard.app.router.routes if getattr(r, "path", None) != path
+        ]
+
+
+# ─── P. 503: o ramo is_timeout do middleware do admin ────────────────────────
+
+@pytest.fixture
+def timeout_route():
+    """Exceção cuja mensagem casa com os `("timeout", "connection", "could not
+    connect")` de admin_dashboard.py — é como uma queda de Postgres chega aqui."""
+    path = f"/__timeout-{uuid.uuid4().hex}"
+
+    @dashboard.app.get(path)
+    async def _timeout():
+        raise RuntimeError("connection timeout expired")
+
+    yield path
+    dashboard.app.router.routes = [
+        r for r in dashboard.app.router.routes if getattr(r, "path", None) != path
+    ]
+
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_503_de_timeout_nos_dois_ramos(monkeypatch, timeout_route, accept_html):
+    """O teste do 500 só exercitava o outro ramo do mesmo `if`: trocar o 503 por
+    500 (ou apagar a detecção) passava despercebido. Aqui o status, o texto de
+    indisponibilidade e o `status_code` que vai pro log ficam presos."""
+    logged = []
+
+    async def _spy(*args, **kwargs):
+        logged.append((args, kwargs))
+
+    monkeypatch.setattr(admin_dashboard, "log_system_event", _spy)
+
+    response = TestClient(dashboard.app, raise_server_exceptions=False).get(
+        timeout_route, headers=HTML if accept_html else {}
+    )
+
+    assert response.status_code == 503
+    if accept_html:
+        _assert_error_page(response, 503, "Serviço indisponível")
+        # Não pode cair no texto genérico de 5xx: quem vê isto tem que saber que
+        # é instabilidade passageira, não erro permanente.
+        assert "Algo deu errado do nosso lado" not in response.text
+    else:
+        assert response.json() == {
+            "error": "Serviço temporariamente indisponível. Tente novamente em instantes."
+        }
+    assert "accept" in _vary_values(response)
+    assert logged[0][1]["details"]["status_code"] == 503
+
+
+# ─── Q. /unsubscribe com token inválido — o irmão do 410 e o kwarg `text=` ────
+
+# Cópia literal de frontend/finance_bot_websocket_custom.py:4908-4912 (as aspas
+# curvas são as do código). Mudou lá, muda aqui — é o ponto do teste.
+_UNSUB_TEXTO = (
+    "Link inválido",
+    "Este link de descadastro não vale mais. Você pode cancelar os e-mails "
+    "em Configurações → Notificações, ou mandar “parar emails” pro bot.",
+)
+
+
+@pytest.mark.parametrize("accept_html", [True, False])
+def test_unsubscribe_token_invalido_recebe_pagina_com_texto_proprio(accept_html):
+    """Era o último `<h2>Link inválido ou expirado.</h2>` pelado do produto, e
+    chega por navegação pura (link do rodapé do e-mail, sem retry possível).
+
+    Os DOIS Accepts respondem HTML aqui, de propósito e diferente do resto do
+    mapa: o GET só existe para o clique humano — o caminho de máquina do RFC 8058
+    é o POST, coberto pelo teste seguinte."""
+    response = _client().get(
+        f"/unsubscribe?uid=999999999&token=lixo-{uuid.uuid4().hex}",
+        headers=HTML if accept_html else {},
+    )
+    _assert_error_page(response, 400, "Link inválido", textos=_UNSUB_TEXTO)
+    # O default do 400 é o texto dos 422 de validação e não diz o que fazer.
+    assert "Não consegui entender esse pedido" not in response.text
+    assert "Configurações" in response.text          # a instrução acionável
+    assert "<h2>Link inválido ou expirado.</h2>" not in response.text  # o corpo antigo
+
+
+def test_unsubscribe_one_click_do_gmail_continua_texto_plano():
+    """RFC 8058: o POST é server-to-server (Gmail/Yahoo), sem interação. Trocar
+    este corpo por HTML manda 1,4 KB de página para um robô que só lê o status —
+    e o `text=` do GET fica a uma linha de distância deste return."""
+    response = _client().post(f"/unsubscribe?uid=999999999&token=lixo-{uuid.uuid4().hex}")
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("text/plain")
+    assert response.text == "invalid"
+
+
+def test_unsubscribe_one_click_ignora_o_accept_do_cliente():
+    """Mesmo com Accept: text/html — servidor de e-mail que manda `Accept: */*` ou
+    qualquer coisa não pode arrastar o one-click pro ramo HTML."""
+    response = _client().post(
+        f"/unsubscribe?uid=999999999&token=lixo-{uuid.uuid4().hex}", headers=HTML
+    )
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("text/plain")
+
+
+def test_kwarg_text_sobrepoe_o_mapa_sem_afetar_o_resto():
+    """O override é por chamada: o `text=` de uma requisição não pode vazar para a
+    página de erro da próxima (o template é cacheado em global de módulo — se o
+    texto fosse cacheado junto, o 400 seguinte sairia com 'Link inválido')."""
+    proprio = shared.error_page_response(400, text=("Título próprio", "Mensagem própria"))
+    seguinte = shared.error_page_response(400)
+
+    assert "Título próprio" in proprio.body.decode()
+    assert "Título próprio" not in seguinte.body.decode()
+    assert "Não consegui entender esse pedido" in seguinte.body.decode()
+    # E o override não mexe no status nem no mapa.
+    assert proprio.status_code == 400
+    assert shared._ERROR_TEXTS[400] == ("Requisição inválida", "Não consegui entender esse pedido.")
+
+
+def test_todo_text_de_chamada_e_constante_literal():
+    """O `text=` já sai escapado e sem reexpansão desde
+    `test_text_sai_escapado_e_sem_reexpansao_de_placeholder` (antes disso, medido:
+    `error_page_response(400, text=("{{MESSAGE}}", "<script>alert(1)</script>"))`
+    renderizava o `<script>` intacto e o título com `{{MESSAGE}}` dentro era
+    reescrito pelo `.replace()` seguinte). Este teste continua valendo uma camada
+    acima: escape protege o RENDER, não impede que dado de usuário vire texto de
+    página de erro (eco de query param já é disclosure mesmo escapado). A regra
+    escrita do docstring vira verificação — todo call site passa tupla de literais
+    de string —
+    f-string, variável, `str(exc)` ou `request.query_params[...]` reprovam aqui,
+    que é onde o dado do usuário entraria."""
+    import ast
+
+    raiz = pathlib.Path(shared.__file__).resolve().parents[2]
+    ignorar = {".venv", ".claude", "node_modules", ".git", "mobile"}
+    call_sites = 0
+
+    for arquivo in raiz.rglob("*.py"):
+        # relative_to(raiz): o próprio caminho da raiz contém ".claude" quando o
+        # repo está num worktree — comparar os parts absolutos ignoraria TUDO.
+        if ignorar & set(arquivo.relative_to(raiz).parts) or arquivo.name.startswith("test_"):
+            continue
+        arvore = ast.parse(arquivo.read_text(encoding="utf-8"), filename=str(arquivo))
+        for node in ast.walk(arvore):
+            if not (isinstance(node, ast.Call)
+                    and getattr(node.func, "id", getattr(node.func, "attr", None))
+                    == "error_page_response"):
+                continue
+            for kw in node.keywords:
+                if kw.arg != "text":
+                    continue
+                call_sites += 1
+                onde = f"{arquivo}:{node.lineno}"
+                assert isinstance(kw.value, ast.Tuple), f"{onde}: text= não é tupla literal"
+                for elt in kw.value.elts:
+                    # ast.Constant(str) cobre a concatenação implícita de literais
+                    # ("a" "b"); JoinedStr (f-string), Name e Call reprovam.
+                    assert isinstance(elt, ast.Constant) and isinstance(elt.value, str), \
+                        f"{onde}: text= carrega {ast.dump(elt)[:60]} — não é constante"
+
+    assert call_sites == 1, f"call sites com text=: {call_sites} (era 1: o /unsubscribe)"
+
+
+# ─── Escape e desempacotamento do `text=` (fechados por construção) ──────────
+
+def test_text_sai_escapado_e_sem_reexpansao_de_placeholder():
+    """O que o AST guard acima cobre por regra, isto cobre por construção: mesmo
+    entrando HTML no `text=`, ele sai escapado; e um valor que CONTÉM um
+    placeholder não é reexpandido pela troca seguinte (era o efeito da ordem
+    CODE→TITLE→MESSAGE em `.replace()` encadeado — hoje é uma passagem só)."""
+    corpo = shared.error_page_response(
+        400, text=("{{MESSAGE}}", "<script>alert(1)</script>")
+    ).body.decode()
+
+    assert "<script>alert(1)</script>" not in corpo
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in corpo
+    # O título `{{MESSAGE}}` fica literal nos dois pontos onde {{TITLE}} aparece
+    # (<title> e <h2>); com a reexpansão ele virava a mensagem nos dois.
+    assert corpo.count("{{MESSAGE}}") == 2
+
+
+def test_text_malformado_nao_levanta_e_cai_no_texto_do_mapa():
+    """`error_page_response` promete não ter caminho de falha — é a resposta de
+    último recurso, e uma exceção aqui vira 500 + `http_unhandled_exception` no
+    log a cada 404 de bot varrendo URL. Medido antes da guarda:
+    `text=("so-um-item",)` → `ValueError: not enough values to unpack`."""
+    for ruim in [("so-um-item",), ("a", "b", "c"), (), "ab", 5, None, ("x", None)]:
+        response = shared.error_page_response(400, text=ruim)
+        assert response.status_code == 400, ruim
+        assert "Não consegui entender esse pedido" in response.body.decode(), ruim


### PR DESCRIPTION
## O que muda

Erro que chega por **navegação** — barra de endereço, link, WebView do app iOS, e o fetch do `pb-nav.js` que manda `Accept: text/html` de propósito — passa a responder uma **página HTML**. Chamada de **API** continua recebendo exatamente o JSON de hoje, delegado aos handlers padrão do FastAPI: é dali que o frontend lê `detail` para montar os alertas do app.

Antes, rota inexistente devolvia `{"detail":"Not Found"}` cru na tela — inclusive dentro do app, que abre qualquer rota do domínio no WKWebView. E `/unsubscribe` com link truncado por cliente de e-mail mostrava o array de validação do pydantic:

```
GET /unsubscribe?uid=&token=   ->  {"detail":[{"type":"missing","loc":["query","uid"],...}]}
```

Cobre 404, 405, 422, 429, o 403 do CSRF e o 500/503 — esse último num middleware que engole a exceção antes de qualquer exception handler, então precisou de tratamento próprio.

## Decisões que valem revisão

**Sinal de navegação é só o `Accept` contendo `text/html`.** `*/*` não conta — é o que o fetch de API e o `TestClient` mandam, e é o que mantém o contrato JSON de pé. `Sec-Fetch-Mode` foi descartado: o `pb-nav` manda `cors`, então cobri-lo exigiria o `Accept` de qualquer forma.

**`exc.detail` nunca é renderizado.** Ele carrega `str(exc)` de exceção arbitrária (`finance_bot_websocket_custom.py:3208`), nem sempre é string (dict no billing, lista nos 422) e vaza nome de parâmetro interno. Todo texto da página é constante do servidor. Custo aceito: `"Guia não encontrado."` vira `"Página não encontrada"` na navegação, e continua específico no JSON.

**Arquivo real `frontend/error.html`, não string em Python.** O §5 do `CLAUDE.md` avisa que HTML gerado em Python some das varreduras globais de frontend — já havia duas vítimas.

**Passa pelo `stamp_asset_versions` do #119, mas não reusa o `html_file`.** O `html_file` faz o stamp **e** injeta o Meta Pixel; a página de erro fica fora do rastreio de propósito. Tem teste prendendo isso, porque a refatoração óbvia ("reusa o `html_file`") reintroduziria o pixel calado — o teste do stamp passa sob essa mutação, só o do pixel pega.

**Status preservado**, sem soft-404. `Vary: Accept` em todos os ramos. `Cache-Control: no-store`. Allowlist dos headers repassados do `exc` — um `Content-Length` vindo dali matava a conexão no h11.

## Varredura da classe, não da instância

11 respostas HTML de erro montadas à mão em 10 sítios. Corrigida **1**: o `GET /unsubscribe` com token inválido, que era um `<h2>` pelado — mesmo perfil do 410 (link de e-mail, navegação pura, sem instrução). As outras 9 ficam de propósito: 404 vazio de fonte/brand (mandar 1,4 KB de HTML no lugar de um `.woff2` ausente é pior), 403 `text/plain` dos webhooks (endpoint de máquina), o `PlainTextResponse` do POST one-click RFC 8058, e o 401 do magic link — esse já é documento completo e tem a única instrução que a página genérica não saberia dar.

## Testes

`1296 passed`, zero falhas. Baseline pré-mudança: 1217 (o #124 trouxe 5 testes próprios). São +74 testes novos, nenhuma regressão.

`tests/test_error_pages.py` cobre cada status nos **dois** Accepts. Todo teste tem prova de mutação — aplicada, rodada, revertida. Duas que valem citar: comentando o registro do handler de 422, **6 testes** ficam vermelhos com o JSON cru visível no corpo (o bug do usuário reproduzido); e a asserção de vazamento é por **invariante** (o texto visível tem que ser exatamente o esperado), não por lista de strings proibidas — injetar `<p>ref: uvicorn worker 3</p>` passa pela lista e reprova no invariante.

## Não verificado aqui

**Renderização no WKWebView.** `env(safe-area-inset-*)` vale 0 no Chromium headless e produção não é acessível deste ambiente (proxy 403). O comportamento sob o notch, em paisagem e no arrasto elástico só se confirma no aparelho depois do build. Ponto concreto: a `error.html` carrega só o shim `safe-area.js`, não o `app-mode.js` — ela **não recebe `pb-root-*` no `<html>`**, e é dali que sai a cor do canvas revelada pelo overscroll (§5).

Também não verificado: o que provedores externos mandam no `Accept` (Stripe/Meta/Pluggy), se um CDN honra o `Vary: Accept`, e o custo do INSERT do `_DashboardHandler` contra o Postgres de produção.

## Fora de escopo (PR separado)

Os alertas dentro do próprio app, que ainda mostram `{"detail":"..."}` literal no modal — o `dashboard.js` joga o corpo cru da resposta no `alertModal`. É frontend, verificável de outro jeito, e por isso vai separado (§4 do `CLAUDE.md`).

## Dívida registrada, não corrigida

`ponytail:` novo em `core/observability.py`: o `_DashboardHandler` faz qualquer `warning()` do processo web virar `psycopg.connect()` + INSERT **bloqueante dentro do event loop**. É a razão de existir o mecanismo de log-once deste PR, e atinge outros emissores (ex. `gate_plan_selection`). Transversal, escopo próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)