### PR TITLE
fix(lancamentos): duas respostas simultaneas gravavam o mesmo item duas vezes

### DIFF
--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -816,7 +816,20 @@ def _devolve_head(user_id: int, head: dict, platform: str) -> None:
                 "item %r não foi devolvido", tentativas, teto, user_id,
                 head.get("desc"))
             return
-        if not atual or atual.get("action_type") != "multi_launch_values":
+        if atual and atual.get("action_type") != "multi_launch_values":
+            # A linha está ocupada por OUTRA pendência — tipicamente a oferta
+            # de "categoria errada?" que outra tarefa acabou de armar ao
+            # terminar a fila. Sem desalojar, o insert condicional perde todas
+            # as tentativas e o item some. Fila com dinheiro do usuário vale
+            # mais que uma oferta de conveniência: desaloja, condicionado ao
+            # que está lá, para não atropelar uma fila real.
+            if db.advance_pending_action(
+                    user_id, atual["action_type"], atual.get("payload") or {},
+                    {"queue": [head], "platform": platform},
+                    new_action_type="multi_launch_values"):
+                return
+            continue
+        if not atual:
             # Condicional, não upsert: duas devoluções simultâneas veriam as
             # duas a fila vazia e a última apagaria a primeira. Quem perder a
             # inserção volta ao topo do laço e prepende na fila que a outra

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -733,14 +733,7 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
             # `PlanLimitExceeded` quando o usuário do Grátis bate o teto do mês
             # (`core/services/plan_service.py`) e quem captura é o
             # `core/handle_incoming.py`, que só responde o texto de upgrade.
-            if novo_payload is None:
-                db.set_pending_action(user_id, "multi_launch_values", payload)
-            else:
-                # Se este CAS falhar, outra thread já é dona da fila — deixar
-                # como está é o certo, gravar por cima ressuscitaria item já
-                # registrado.
-                db.advance_pending_action(
-                    user_id, "multi_launch_values", novo_payload, payload)
+            _devolve_head(user_id, head, platform)
             raise
 
         if resto:
@@ -750,6 +743,35 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
         return resp
 
     return None
+
+
+
+def _devolve_head(user_id: int, head: dict, platform: str) -> None:
+    """Põe `head` de volta na FRENTE da fila que existir agora.
+
+    O item foi reivindicado (tirado da fila) antes de registrar, e o registro
+    estourou — sem devolver, ele some. Restaurar o payload ANTIGO não serve:
+    entre a reivindicação e a falha, outra thread pode ter avançado ou apagado
+    a fila, e gravar o estado velho por cima ressuscitaria um item que ela já
+    registrou. Por isso relemos e prependemos ao que estiver lá.
+
+    CAS em laço porque a fila pode mudar entre a leitura e a escrita. Se as
+    tentativas acabarem, é melhor perder a devolução do que gravar por cima de
+    um item já registrado — o `raise` de quem chamou ainda avisa o usuário.
+    """
+    for _ in range(4):
+        atual = db.get_pending_action(user_id)
+        if not atual or atual.get("action_type") != "multi_launch_values":
+            db.set_pending_action(
+                user_id, "multi_launch_values",
+                {"queue": [head], "platform": platform})
+            return
+        antigo = atual.get("payload") or {}
+        fila = [head] + list(antigo.get("queue") or [])
+        if db.advance_pending_action(
+                user_id, "multi_launch_values", antigo,
+                {"queue": fila, "platform": antigo.get("platform", platform)}):
+            return
 
 
 def _register_parsed(user_id: int, parsed: dict, fallback_note: str, platform: str) -> str:

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -384,6 +384,7 @@ def add_from_entities(
     is_internal: bool | None = None,
     platform: str = "whatsapp",
     suppress_pending: bool = False,
+    conditional_pending: bool = False,
 ) -> str:
     """Registra um lançamento a partir de args já estruturados (sem regex).
 
@@ -399,6 +400,11 @@ def add_from_entities(
     oferta. A tabela tem UMA linha por usuário, então a oferta atropelaria a
     fila de lançamentos múltiplos que o chamador acabou de gravar. Usado só por
     `resolve_multi_launch_value`, quando ainda sobrou item na fila.
+
+    `conditional_pending=True`: cria ofertas de conveniência só se nenhuma
+    pendência apareceu desde o commit do lançamento. Usado no último item da
+    fila de multi-lançamento: outra recuperação pode ter recriado a fila entre
+    a reivindicação e a oferta final.
     """
     if valor <= 0:
         return "Não consegui identificar o valor. Tente: *gastei 50 no mercado*"
@@ -507,7 +513,14 @@ def add_from_entities(
 
     if recurring_offer:
         try:
-            db.set_pending_action(user_id, "confirm_recurring_offer", recurring_offer)
+            if conditional_pending:
+                gravou_pending = db.create_pending_action_if_absent(
+                    user_id, "confirm_recurring_offer", recurring_offer)
+            else:
+                db.set_pending_action(user_id, "confirm_recurring_offer", recurring_offer)
+                gravou_pending = True
+            if not gravou_pending:
+                recurring_offer = None
         except Exception:
             logger.warning(
                 "falha ao salvar pending confirm_recurring_offer (user %s) — oferta perdida",
@@ -518,11 +531,16 @@ def add_from_entities(
     # _send_reply_with_optional_buttons no wa_runtime e limpo em seguida).
     elif platform == "whatsapp" and launch_id and not suppress_pending:
         try:
-            db.set_pending_action(
-                user_id,
-                "recategorize_launch_offer",
-                {"launch_id": int(launch_id), "user_seq": int(user_seq)},
-            )
+            recat_payload = {"launch_id": int(launch_id), "user_seq": int(user_seq)}
+            if conditional_pending:
+                db.create_pending_action_if_absent(
+                    user_id, "recategorize_launch_offer", recat_payload)
+            else:
+                db.set_pending_action(
+                    user_id,
+                    "recategorize_launch_offer",
+                    recat_payload,
+                )
         except Exception:
             logger.warning(
                 "falha ao salvar pending recategorize_launch_offer (user %s, launch %s) — botão de recategorizar não vai aparecer",
@@ -751,11 +769,11 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
                 return None
             continue
 
-        # `suppress_pending` porque `pending_actions` tem uma linha só por
-        # usuário: a oferta de "categoria errada?" apagaria a fila que o CAS
-        # logo acima acabou de gravar. (Antes o atropelo era ao contrário — a
-        # fila era escrita depois e matava a oferta, que ainda saía impressa
-        # no texto sem pendência nenhuma por trás.)
+        # Enquanto ainda há resto, suprime ofertas: `pending_actions` tem uma
+        # linha só por usuário e a oferta apagaria a fila que o CAS acabou de
+        # gravar. No último item, a oferta ainda pode aparecer, mas só com
+        # criação condicional: se uma recuperação recriou a fila durante o
+        # registro, a fila vence.
         try:
             resp = add_from_entities(
                 user_id,
@@ -765,6 +783,7 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
                 nota=head.get("desc"),
                 platform=platform,
                 suppress_pending=bool(resto),
+                conditional_pending=not bool(resto),
             )
         except Exception:
             # O item já saiu da fila (é o que impede a duplicação), mas o

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -788,6 +788,13 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
         if depois and depois.get("action_type") == "multi_launch_values":
             fila_agora = (depois.get("payload") or {}).get("queue") or []
         if fila_agora:
+            # Se a oferta de gasto fixo foi criada e outra tarefa a substituiu
+            # por esta fila restaurada, o texto dela ficou órfão em `resp`:
+            # sairiam DUAS perguntas incompatíveis ("responda sim ou não" e
+            # "quanto foi X?"), e um "sim" não é valor — descartaria o
+            # lançamento restaurado. A pendência que vale é a fila; o convite
+            # sai do texto.
+            resp = _sem_oferta_de_gasto_fixo(resp)
             return f"{resp}\n\n{_ask_value_question(fila_agora[0])}"
         # fila vazia: não re-arma multi_launch_values. O add_from_entities acima já
         # gravou o pending de "categoria errada?" (WhatsApp), que fica valendo.
@@ -795,6 +802,22 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
 
     return None
 
+
+
+
+_OFERTA_GASTO_FIXO_RE = re.compile(
+    r"\n\n💡 Você já lançou .*?Responda \*sim\* ou \*não\*\.", re.DOTALL)
+
+
+def _sem_oferta_de_gasto_fixo(texto: str) -> str:
+    """Tira o convite de gasto fixo de uma resposta já montada.
+
+    Usado quando a pendência da oferta foi substituída por uma fila restaurada:
+    o convite pede "sim ou não" e a fila pede um valor. Deixar os dois no mesmo
+    texto faz o usuário responder "sim", que não é valor — e o item restaurado
+    é descartado.
+    """
+    return _OFERTA_GASTO_FIXO_RE.sub("", texto)
 
 
 def _devolve_head(user_id: int, head: dict, platform: str) -> None:

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -669,8 +669,10 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
     resp_norm = normalize_text(text).strip()
     valor = _extract_valor(text)
 
-    # Duas respostas do mesmo usuário chegam em POSTs separados do Meta e cada
-    # POST vira uma thread (`adapters/whatsapp/wa_app.py:320`). Sem o
+    # Duas respostas do mesmo usuário podem ser processadas em paralelo pelo
+    # Discord (`discord_bot.py:122`, `on_message` async sem lock, em processo
+    # separado do uvicorn). O webhook do WhatsApp sozinho não corre — enfileira
+    # e um worker único consome. Sem o
     # compare-and-swap abaixo as duas leem a mesma fila, gravam o MESMO item
     # duas vezes e o segundo valor some sem uma palavra.
     #

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -676,13 +676,34 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
     # compare-and-swap abaixo as duas leem a mesma fila, gravam o MESMO item
     # duas vezes e o segundo valor some sem uma palavra.
     #
-    # ponytail: 4 tentativas bastam para as 2 threads que o Meta gera por
-    # usuário; cada CAS que vence encurta a fila, então não há laço infinito.
-    for _ in range(4):
+    # Sem teto fixo de tentativas: cada colisão de CAS significa que OUTRA
+    # tarefa avançou a fila, então a fila encolheu e o laço converge. Um teto de
+    # 4 descartava calado o valor do usuário quando 5+ respostas concorriam — o
+    # `on_message` do Discord não limita a duas. O limite real é o tamanho da
+    # fila; o `len(queue) + 2` é só cinto de segurança contra fila que cresce
+    # por um caminho que eu não previ, e nesse caso é melhor devolver None do
+    # que girar para sempre.
+    tentativas = 0
+    teto = None  # definido na 1a volta, a partir da fila inicial
+    while True:
+        tentativas += 1
         payload = pending.get("payload") or {}
         queue: list[dict] = list(payload.get("queue") or [])
         if not queue:
             db.clear_pending_action(user_id)
+            return None
+        if teto is None:
+            # Pelo tamanho INICIAL da fila: a atual já encolheu por causa das
+            # outras tarefas, e medir por ela faz desistir no meio.
+            teto = len(queue) + 5
+        if tentativas > teto:
+            # Só chega aqui se a fila estiver crescendo em vez de encolher, o
+            # que nenhum caminho conhecido faz. Devolver None é melhor que
+            # girar: o roteador ainda trata a mensagem como comando novo.
+            logger.warning(
+                "resolve_multi_launch_value: %d tentativas (teto %d, fila "
+                "agora %d) para o user %s — desistindo",
+                tentativas, teto, len(queue), user_id)
             return None
 
         if resp_norm in _CANCEL_WORDS:

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -713,34 +713,18 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
     # compare-and-swap abaixo as duas leem a mesma fila, gravam o MESMO item
     # duas vezes e o segundo valor some sem uma palavra.
     #
-    # Sem teto fixo de tentativas: cada colisão de CAS significa que OUTRA
-    # tarefa avançou a fila, então a fila encolheu e o laço converge. Um teto de
-    # 4 descartava calado o valor do usuário quando 5+ respostas concorriam — o
-    # `on_message` do Discord não limita a duas. O limite real é o tamanho da
-    # fila; o `len(queue) + 2` é só cinto de segurança contra fila que cresce
-    # por um caminho que eu não previ, e nesse caso é melhor devolver None do
-    # que girar para sempre.
-    tentativas = 0
-    teto = None  # definido na 1a volta, a partir da fila inicial
+    # Sem teto de tentativas, e sem contador. Perder o CAS significa que outra
+    # tarefa mexeu na fila; as concorrentes são finitas, então quando elas
+    # acabarem o nosso CAS vence. QUALQUER teto por tamanho de fila é errado na
+    # premissa: o `_devolve_head` FAZ a fila crescer quando um registro falha,
+    # então ela não só encolhe — foi por isso que as duas versões anteriores
+    # (teto 4, e depois `len(fila) + 5`) descartavam o valor do usuário em
+    # silêncio. A saída é a fila sumir, tratada logo abaixo.
     while True:
-        tentativas += 1
         payload = pending.get("payload") or {}
         queue: list[dict] = list(payload.get("queue") or [])
         if not queue:
             db.clear_pending_action(user_id)
-            return None
-        if teto is None:
-            # Pelo tamanho INICIAL da fila: a atual já encolheu por causa das
-            # outras tarefas, e medir por ela faz desistir no meio.
-            teto = len(queue) + 5
-        if tentativas > teto:
-            # Só chega aqui se a fila estiver crescendo em vez de encolher, o
-            # que nenhum caminho conhecido faz. Devolver None é melhor que
-            # girar: o roteador ainda trata a mensagem como comando novo.
-            logger.warning(
-                "resolve_multi_launch_value: %d tentativas (teto %d, fila "
-                "agora %d) para o user %s — desistindo",
-                tentativas, teto, len(queue), user_id)
             return None
 
         if resp_norm in _CANCEL_WORDS:
@@ -795,8 +779,16 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
             _devolve_head(user_id, head, platform)
             raise
 
-        if resto:
-            return f"{resp}\n\n{_ask_value_question(resto[0])}"
+        # RELÊ antes de perguntar: `resto` é do momento da reivindicação. Se
+        # outra tarefa registrou itens enquanto esta demorava, perguntar pelo
+        # `resto[0]` velho pede um valor de algo JÁ registrado — e a resposta
+        # do usuário chega sem item correspondente na fila.
+        depois = db.get_pending_action(user_id)
+        fila_agora = []
+        if depois and depois.get("action_type") == "multi_launch_values":
+            fila_agora = (depois.get("payload") or {}).get("queue") or []
+        if fila_agora:
+            return f"{resp}\n\n{_ask_value_question(fila_agora[0])}"
         # fila vazia: não re-arma multi_launch_values. O add_from_entities acima já
         # gravou o pending de "categoria errada?" (WhatsApp), que fica valendo.
         return resp

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -455,13 +455,24 @@ def add_from_entities(
         is_internal_movement=is_int,
     )
 
-    learn_from_inference(
-        user_id,
-        nota_clean,
-        categoria_final,
-        target_hint=alvo_clean,
-        reason=reason_final,
-    )
+    # DEPOIS DO COMMIT nada pode subir exceção. O lançamento e o saldo já
+    # existem; quem chamou não tem como distinguir "não gravou" de "gravou e
+    # falhou no acessório", e na fila de multi-lançamento essa confusão faz o
+    # item ser devolvido e o MESMO gasto ser registrado de novo, dobrando o
+    # saldo. Aprender a regra e armar as ofertas são melhor-esforço: se
+    # falharem, o usuário fica sem a comodidade, não sem o dinheiro.
+    try:
+        learn_from_inference(
+            user_id,
+            nota_clean,
+            categoria_final,
+            target_hint=alvo_clean,
+            reason=reason_final,
+        )
+    except Exception:
+        logger.exception(
+            "learn_from_inference falhou depois do commit (user %s, lancamento %s)",
+            user_id, launch_id)
 
     # Reconciliação reversa (Open Finance): se o banco já importou esse gasto, funde
     # com o lançamento que o usuário acabou de fazer — não duplica no "sobrou".
@@ -482,9 +493,17 @@ def add_from_entities(
         # nota)) — nota_clean sozinho é a frase toda ("gastei 44,90 na
         # netflix"), que nunca bate com o alvo limpo ("netflix") gravado no mês
         # passado, e a oferta nunca dispara mesmo quando a despesa repete.
-        recurring_offer = _maybe_recurring_offer(
-            user_id, alvo_clean or nota_clean, valor, categoria_final, criado_em, launch_id,
-        )
+        try:
+            recurring_offer = _maybe_recurring_offer(
+                user_id, alvo_clean or nota_clean, valor, categoria_final,
+                criado_em, launch_id,
+            )
+        except Exception:
+            # Pós-commit: melhor perder a oferta que subir exceção (ver o
+            # comentário do learn_from_inference acima).
+            logger.exception(
+                "_maybe_recurring_offer falhou depois do commit (user %s, lancamento %s)",
+                user_id, launch_id)
 
     if recurring_offer:
         try:
@@ -780,8 +799,23 @@ def _devolve_head(user_id: int, head: dict, platform: str) -> None:
     tentativas acabarem, é melhor perder a devolução do que gravar por cima de
     um item já registrado — o `raise` de quem chamou ainda avisa o usuário.
     """
-    for _ in range(4):
+    # Sem teto fixo, pela mesma razão do laço de reivindicação: cada colisão
+    # significa que outra devolução venceu, então a fila cresceu e o laço
+    # converge. O teto é cinto de segurança, do tamanho inicial.
+    tentativas = 0
+    teto = None
+    while True:
+        tentativas += 1
         atual = db.get_pending_action(user_id)
+        if teto is None:
+            fila_ini = ((atual or {}).get("payload") or {}).get("queue") or []
+            teto = len(fila_ini) + 5
+        if tentativas > teto:
+            logger.warning(
+                "_devolve_head: %d tentativas (teto %d) para o user %s — "
+                "item %r não foi devolvido", tentativas, teto, user_id,
+                head.get("desc"))
+            return
         if not atual or atual.get("action_type") != "multi_launch_values":
             # Condicional, não upsert: duas devoluções simultâneas veriam as
             # duas a fila vazia e a última apagaria a primeira. Quem perder a

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -383,6 +383,7 @@ def add_from_entities(
     criado_em=None,
     is_internal: bool | None = None,
     platform: str = "whatsapp",
+    suppress_pending: bool = False,
 ) -> str:
     """Registra um lançamento a partir de args já estruturados (sem regex).
 
@@ -392,6 +393,12 @@ def add_from_entities(
 
     Toda lógica compartilhada (categorização, learn, DB write, botão WhatsApp,
     alerta de orçamento) vive aqui — fonte única de verdade.
+
+    `suppress_pending=True`: não grava oferta nenhuma em `pending_actions` (nem
+    a de recorrente, nem o botão de recategorizar) e não imprime o texto da
+    oferta. A tabela tem UMA linha por usuário, então a oferta atropelaria a
+    fila de lançamentos múltiplos que o chamador acabou de gravar. Usado só por
+    `resolve_multi_launch_value`, quando ainda sobrou item na fila.
     """
     if valor <= 0:
         return "Não consegui identificar o valor. Tente: *gastei 50 no mercado*"
@@ -469,7 +476,7 @@ def add_from_entities(
     # com o botão de recategorizar; quando há oferta de recorrente ela vence
     # (é mais valiosa) e o botão de recategorizar é suprimido nesse lançamento.
     recurring_offer = None
-    if tipo == "despesa" and not is_int:
+    if tipo == "despesa" and not is_int and not suppress_pending:
         # merchant_key precisa da mesma prioridade alvo>nota que a query em
         # find_recurring_candidate usa pro lançamento anterior (coalesce(alvo,
         # nota)) — nota_clean sozinho é a frase toda ("gastei 44,90 na
@@ -490,7 +497,7 @@ def add_from_entities(
             recurring_offer = None
     # Botão "categoria errada?" no WhatsApp (one-shot, lido por
     # _send_reply_with_optional_buttons no wa_runtime e limpo em seguida).
-    elif platform == "whatsapp" and launch_id:
+    elif platform == "whatsapp" and launch_id and not suppress_pending:
         try:
             db.set_pending_action(
                 user_id,
@@ -651,47 +658,96 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
     - resposta de cancelamento → descarta o que faltava.
     - resposta sem valor (o user mudou de assunto) → abandona a pendência e
       retorna None pra que o roteador processe a mensagem normalmente.
+
+    Duas respostas simultâneas: a fila avança por compare-and-swap
+    (`db.advance_pending_action`) ANTES do registro, então a segunda thread
+    perde o CAS, relê a fila já encurtada e responde o item seguinte em vez de
+    registrar o mesmo de novo. Sem lock — ver o porquê em `db/pending.py`.
     """
     from utils_text import normalize_text
 
-    payload = pending.get("payload", {})
-    queue: list[dict] = list(payload.get("queue") or [])
-    if not queue:
-        db.clear_pending_action(user_id)
-        return None
-
     resp_norm = normalize_text(text).strip()
-    if resp_norm in _CANCEL_WORDS:
-        db.clear_pending_action(user_id)
-        restantes = ", ".join(i.get("desc", "?") for i in queue)
-        return f"❌ Beleza, deixei de lado: {restantes}."
-
     valor = _extract_valor(text)
-    if valor is None or valor <= 0:
-        # Não é um valor — o usuário mudou de assunto. Abandona a pendência e
-        # deixa o roteador tratar a mensagem como um comando novo.
-        db.clear_pending_action(user_id)
-        return None
 
-    head = queue.pop(0)
-    resp = add_from_entities(
-        user_id,
-        tipo=head.get("tipo", "despesa"),
-        valor=float(valor),
-        alvo=head.get("desc"),
-        nota=head.get("desc"),
-        platform=platform,
-    )
+    # Duas respostas do mesmo usuário chegam em POSTs separados do Meta e cada
+    # POST vira uma thread (`adapters/whatsapp/wa_app.py:320`). Sem o
+    # compare-and-swap abaixo as duas leem a mesma fila, gravam o MESMO item
+    # duas vezes e o segundo valor some sem uma palavra.
+    #
+    # ponytail: 4 tentativas bastam para as 2 threads que o Meta gera por
+    # usuário; cada CAS que vence encurta a fila, então não há laço infinito.
+    for _ in range(4):
+        payload = pending.get("payload") or {}
+        queue: list[dict] = list(payload.get("queue") or [])
+        if not queue:
+            db.clear_pending_action(user_id)
+            return None
 
-    if queue:
-        db.set_pending_action(
-            user_id, "multi_launch_values",
-            {"queue": queue, "platform": platform},
-        )
-        return f"{resp}\n\n{_ask_value_question(queue[0])}"
-    # fila vazia: não re-arma multi_launch_values. O add_from_entities acima já
-    # gravou o pending de "categoria errada?" (WhatsApp), que fica valendo.
-    return resp
+        if resp_norm in _CANCEL_WORDS:
+            db.clear_pending_action(user_id)
+            restantes = ", ".join(i.get("desc", "?") for i in queue)
+            return f"❌ Beleza, deixei de lado: {restantes}."
+
+        if valor is None or valor <= 0:
+            # Não é um valor — o usuário mudou de assunto. Abandona a pendência e
+            # deixa o roteador tratar a mensagem como um comando novo.
+            db.clear_pending_action(user_id)
+            return None
+
+        head, resto = queue[0], queue[1:]
+
+        # Tira o head da fila ANTES de registrar: é isso que impede a outra
+        # thread de registrar o MESMO item. Fila vazia = apaga a pendência; o
+        # `add_from_entities` grava logo abaixo a dele ("categoria errada?").
+        novo_payload = {"queue": resto, "platform": platform} if resto else None
+        if not db.advance_pending_action(
+                user_id, "multi_launch_values", payload, novo_payload):
+            # Outra thread avançou a fila entre a leitura e agora. Relê e
+            # reavalia: o item que sobrou é o próximo, não este.
+            pending = db.get_pending_action(user_id)
+            if not pending or pending.get("action_type") != "multi_launch_values":
+                return None
+            continue
+
+        # `suppress_pending` porque `pending_actions` tem uma linha só por
+        # usuário: a oferta de "categoria errada?" apagaria a fila que o CAS
+        # logo acima acabou de gravar. (Antes o atropelo era ao contrário — a
+        # fila era escrita depois e matava a oferta, que ainda saía impressa
+        # no texto sem pendência nenhuma por trás.)
+        try:
+            resp = add_from_entities(
+                user_id,
+                tipo=head.get("tipo", "despesa"),
+                valor=float(valor),
+                alvo=head.get("desc"),
+                nota=head.get("desc"),
+                platform=platform,
+                suppress_pending=bool(resto),
+            )
+        except Exception:
+            # O item já saiu da fila (é o que impede a duplicação), mas o
+            # trabalho não aconteceu — sem devolver, o lançamento some calado.
+            # Não é hipótese: `check_can_create_launch` levanta
+            # `PlanLimitExceeded` quando o usuário do Grátis bate o teto do mês
+            # (`core/services/plan_service.py`) e quem captura é o
+            # `core/handle_incoming.py`, que só responde o texto de upgrade.
+            if novo_payload is None:
+                db.set_pending_action(user_id, "multi_launch_values", payload)
+            else:
+                # Se este CAS falhar, outra thread já é dona da fila — deixar
+                # como está é o certo, gravar por cima ressuscitaria item já
+                # registrado.
+                db.advance_pending_action(
+                    user_id, "multi_launch_values", novo_payload, payload)
+            raise
+
+        if resto:
+            return f"{resp}\n\n{_ask_value_question(resto[0])}"
+        # fila vazia: não re-arma multi_launch_values. O add_from_entities acima já
+        # gravou o pending de "categoria errada?" (WhatsApp), que fica valendo.
+        return resp
+
+    return None
 
 
 def _register_parsed(user_id: int, parsed: dict, fallback_note: str, platform: str) -> str:

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -762,10 +762,15 @@ def _devolve_head(user_id: int, head: dict, platform: str) -> None:
     for _ in range(4):
         atual = db.get_pending_action(user_id)
         if not atual or atual.get("action_type") != "multi_launch_values":
-            db.set_pending_action(
-                user_id, "multi_launch_values",
-                {"queue": [head], "platform": platform})
-            return
+            # Condicional, não upsert: duas devoluções simultâneas veriam as
+            # duas a fila vazia e a última apagaria a primeira. Quem perder a
+            # inserção volta ao topo do laço e prepende na fila que a outra
+            # acabou de criar.
+            if db.create_pending_action_if_absent(
+                    user_id, "multi_launch_values",
+                    {"queue": [head], "platform": platform}):
+                return
+            continue
         antigo = atual.get("payload") or {}
         fila = [head] + list(antigo.get("queue") or [])
         if db.advance_pending_action(

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -795,27 +795,12 @@ def _devolve_head(user_id: int, head: dict, platform: str) -> None:
     a fila, e gravar o estado velho por cima ressuscitaria um item que ela já
     registrou. Por isso relemos e prependemos ao que estiver lá.
 
-    CAS em laço porque a fila pode mudar entre a leitura e a escrita. Se as
-    tentativas acabarem, é melhor perder a devolução do que gravar por cima de
-    um item já registrado — o `raise` de quem chamou ainda avisa o usuário.
+    CAS em laço porque a fila pode mudar entre a leitura e a escrita. A
+    recuperação precisa ir até uma escrita condicional vencer; se ela desistir
+    cedo, o item que já saiu da fila some.
     """
-    # Sem teto fixo, pela mesma razão do laço de reivindicação: cada colisão
-    # significa que outra devolução venceu, então a fila cresceu e o laço
-    # converge. O teto é cinto de segurança, do tamanho inicial.
-    tentativas = 0
-    teto = None
     while True:
-        tentativas += 1
         atual = db.get_pending_action(user_id)
-        if teto is None:
-            fila_ini = ((atual or {}).get("payload") or {}).get("queue") or []
-            teto = len(fila_ini) + 5
-        if tentativas > teto:
-            logger.warning(
-                "_devolve_head: %d tentativas (teto %d) para o user %s — "
-                "item %r não foi devolvido", tentativas, teto, user_id,
-                head.get("desc"))
-            return
         if atual and atual.get("action_type") != "multi_launch_values":
             # A linha está ocupada por OUTRA pendência — tipicamente a oferta
             # de "categoria errada?" que outra tarefa acabou de armar ao

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -128,6 +128,7 @@ from .categories import (
 # ── Ações pendentes ───────────────────────────────────────────────────────────
 from .pending import (
     advance_pending_action,
+    create_pending_action_if_absent,
     set_pending_action,
     get_pending_action,
     clear_pending_action,

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -127,6 +127,7 @@ from .categories import (
 
 # ── Ações pendentes ───────────────────────────────────────────────────────────
 from .pending import (
+    advance_pending_action,
     set_pending_action,
     get_pending_action,
     clear_pending_action,
@@ -448,6 +449,7 @@ __all__ = [
     "list_custom_category_names",
     # pending
     "set_pending_action", "get_pending_action", "clear_pending_action",
+    "advance_pending_action",
     # budgets
     "list_budgets", "get_budget", "upsert_budget", "delete_budget",
     "list_user_categories", "sum_spent_in_category_this_month",

--- a/db/pending.py
+++ b/db/pending.py
@@ -57,6 +57,32 @@ def advance_pending_action(user_id: int, action_type: str,
     return gravou
 
 
+
+def create_pending_action_if_absent(user_id: int, action_type: str, payload: dict,
+                                    minutes: int = 10) -> bool:
+    """Cria a pendência SÓ SE o usuário não tiver nenhuma. Devolve True se criou.
+
+    Irmã do `advance_pending_action` para o caso "não havia linha". O
+    `set_pending_action` faz upsert incondicional: duas devoluções simultâneas
+    (dois itens reivindicados que estouraram, ex. os dois batendo o teto de
+    plano) veem a fila vazia e cada uma grava a SUA — a última apaga a primeira
+    e um item some. Aqui a segunda insere zero linhas, devolve False, e quem
+    chamou relê e prepende na fila que a primeira acabou de criar.
+    """
+    ensure_user(user_id)
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=minutes)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "insert into pending_actions (user_id, action_type, payload, expires_at) "
+                "values (%s, %s, %s, %s) on conflict (user_id) do nothing",
+                (user_id, action_type, Jsonb(payload), expires_at),
+            )
+            criou = cur.rowcount == 1
+        conn.commit()
+    return criou
+
+
 def set_pending_action(user_id: int, action_type: str, payload: dict, minutes: int = 10):
     """Cria/atualiza uma ação pendente de confirmação (persistente no Postgres)."""
     ensure_user(user_id)

--- a/db/pending.py
+++ b/db/pending.py
@@ -15,8 +15,12 @@ def advance_pending_action(user_id: int, action_type: str,
                            minutes: int = 10) -> bool:
     """Avança (ou apaga) a pendência SÓ SE ela ainda for `old_payload`.
 
-    Compare-and-swap. Duas respostas do mesmo usuário chegam em POSTs separados
-    do Meta e cada POST vira uma thread (`adapters/whatsapp/wa_app.py:320`).
+    Compare-and-swap. Duas respostas do mesmo usuário podem ser processadas em
+    paralelo: `adapters/discord/discord_bot.py:122` é um `on_message` async sem
+    lock, e o `launch.py` sobe o Discord num processo separado do uvicorn — um
+    usuário com as duas plataformas ligadas é alcançado pelos dois ao mesmo
+    tempo. (O webhook do WhatsApp, sozinho, NÃO corre: `wa_app.py` enfileira em
+    `_queue` e um `_worker_loop` único consome um payload por vez.)
     Sem isso as duas leem a mesma fila, registram o MESMO item e o segundo valor
     some. Aqui a segunda escrita não pega: o Postgres serializa o UPDATE na
     linha, a condição `payload = <o que eu li>` já não vale, `rowcount` volta 0 e

--- a/db/pending.py
+++ b/db/pending.py
@@ -12,7 +12,8 @@ from .users import ensure_user
 
 def advance_pending_action(user_id: int, action_type: str,
                            old_payload: dict, new_payload: dict | None,
-                           minutes: int = 10) -> bool:
+                           minutes: int = 10,
+                           new_action_type: str | None = None) -> bool:
     """Avança (ou apaga) a pendência SÓ SE ela ainda for `old_payload`.
 
     Compare-and-swap. Duas respostas do mesmo usuário podem ser processadas em
@@ -46,9 +47,11 @@ def advance_pending_action(user_id: int, action_type: str,
             else:
                 cur.execute(
                     "update pending_actions "
-                    "set payload = %s, created_at = now(), expires_at = %s "
+                    "set action_type = %s, payload = %s, created_at = now(), "
+                    "    expires_at = %s "
                     "where user_id = %s and action_type = %s and payload = %s",
-                    (Jsonb(new_payload),
+                    (new_action_type or action_type,
+                     Jsonb(new_payload),
                      datetime.now(timezone.utc) + timedelta(minutes=minutes),
                      user_id, action_type, Jsonb(old_payload)),
                 )

--- a/db/pending.py
+++ b/db/pending.py
@@ -10,6 +10,49 @@ from .connection import get_conn
 from .users import ensure_user
 
 
+def advance_pending_action(user_id: int, action_type: str,
+                           old_payload: dict, new_payload: dict | None,
+                           minutes: int = 10) -> bool:
+    """Avança (ou apaga) a pendência SÓ SE ela ainda for `old_payload`.
+
+    Compare-and-swap. Duas respostas do mesmo usuário chegam em POSTs separados
+    do Meta e cada POST vira uma thread (`adapters/whatsapp/wa_app.py:320`).
+    Sem isso as duas leem a mesma fila, registram o MESMO item e o segundo valor
+    some. Aqui a segunda escrita não pega: o Postgres serializa o UPDATE na
+    linha, a condição `payload = <o que eu li>` já não vale, `rowcount` volta 0 e
+    quem chamou relê a fila e reavalia.
+
+    Sem lock de propósito. Um `pg_advisory_xact_lock` numa conexão dedicada
+    segura uma conexão do pool durante todo o trabalho: com o pool em 8, oito
+    usuários simultâneos consomem o pool só em locks e o bot inteiro para.
+
+    Devolve True se gravou, False se outra thread já tinha avançado. Gravar
+    renova o prazo (`minutes`), como o `set_pending_action` que ela substitui —
+    senão uma fila longa expiraria 10 min depois da PRIMEIRA pergunta, não da
+    última resposta.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            if new_payload is None:
+                cur.execute(
+                    "delete from pending_actions "
+                    "where user_id = %s and action_type = %s and payload = %s",
+                    (user_id, action_type, Jsonb(old_payload)),
+                )
+            else:
+                cur.execute(
+                    "update pending_actions "
+                    "set payload = %s, created_at = now(), expires_at = %s "
+                    "where user_id = %s and action_type = %s and payload = %s",
+                    (Jsonb(new_payload),
+                     datetime.now(timezone.utc) + timedelta(minutes=minutes),
+                     user_id, action_type, Jsonb(old_payload)),
+                )
+            gravou = cur.rowcount == 1
+        conn.commit()
+    return gravou
+
+
 def set_pending_action(user_id: int, action_type: str, payload: dict, minutes: int = 10):
     """Cria/atualiza uma ação pendente de confirmação (persistente no Postgres)."""
     ensure_user(user_id)

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -1,0 +1,183 @@
+"""
+Duas respostas para a MESMA fila `multi_launch_values` não podem gravar o mesmo
+item duas vezes.
+
+O caminho é real: `adapters/whatsapp/wa_app.py:320` roda cada POST do Meta em
+`asyncio.to_thread(process_payload, ...)`, e o Meta entrega duas mensagens
+seguidas em dois POSTs. Antes do compare-and-swap (`db.advance_pending_action`)
+as duas threads liam a mesma fila, as duas gravavam o item da FRENTE e o
+segundo valor sumia sem uma palavra.
+
+O `__main__` no fim deste arquivo é o controle negativo: roda as duas threads
+20 vezes COM e SEM o CAS e imprime o placar. Ele não está na suíte de propósito
+— a metade "sem CAS" é uma corrida, e corrida perdida vira teste vermelho por
+motivo errado. O que a suíte guarda são os dois casos determinísticos abaixo.
+"""
+from __future__ import annotations
+
+import threading
+
+import db
+from core.handlers import launches
+
+
+def _armar_fila(user_id: int) -> dict:
+    """Deixa o usuário com a fila [aluguel, luz] e devolve o pending lido.
+
+    Esse dict é o que as duas threads teriam em mãos: as duas leem a pendência
+    antes de qualquer uma escrever.
+    """
+    launches.add(user_id, "recebi 100 de x e paguei o aluguel e paguei a luz", {})
+    p = db.get_pending_action(user_id)
+    assert [i["desc"] for i in p["payload"]["queue"]] == ["aluguel", "luz"]
+    return p
+
+
+def _registrados(user_id: int) -> set[tuple[str, float]]:
+    """(alvo, valor) das despesas — a receita de armação fica de fora."""
+    return {
+        ((r.get("alvo") or "").strip(), float(r["valor"]))
+        for r in db.list_launches(user_id, limit=20)
+        if r["tipo"] == "despesa"
+    }
+
+
+def test_leitura_velha_nao_grava_o_mesmo_item_duas_vezes(user_id):
+    """A segunda chamada usa o pending JÁ VELHO (o que a outra thread leu).
+
+    Sem CAS ela grava "aluguel" de novo e a luz morre na fila. Com CAS ela
+    perde a escrita, relê a fila encurtada e responde a luz. Determinístico:
+    é o mesmo interleaving da corrida, só que serializado.
+    """
+    velho = _armar_fila(user_id)
+
+    launches.resolve_multi_launch_value(user_id, "800", velho)
+    launches.resolve_multi_launch_value(user_id, "200", velho)
+
+    assert _registrados(user_id) == {("aluguel", 800.0), ("luz", 200.0)}
+    p = db.get_pending_action(user_id)
+    assert p is None or p["action_type"] != "multi_launch_values"
+
+
+def test_duas_threads_simultaneas(user_id):
+    """A corrida de verdade, com as duas threads soltas ao mesmo tempo.
+
+    Qual thread pega qual item depende de quem vence o CAS — por isso a
+    asserção é sobre o CONJUNTO: cada valor num item, nenhum item repetido.
+    """
+    velho = _armar_fila(user_id)
+
+    largada = threading.Barrier(2)
+    erros: list[BaseException] = []
+
+    def responde(valor_txt: str):
+        try:
+            largada.wait(timeout=10)
+            launches.resolve_multi_launch_value(user_id, valor_txt, velho)
+        except BaseException as exc:  # noqa: BLE001 — o teste precisa ver
+            erros.append(exc)
+
+    ts = [threading.Thread(target=responde, args=(v,)) for v in ("800", "200")]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join(timeout=30)
+
+    assert not erros, erros
+    feitos = _registrados(user_id)
+    assert len(feitos) == 2, feitos
+    assert {alvo for alvo, _ in feitos} == {"aluguel", "luz"}, feitos
+    assert {v for _, v in feitos} == {800.0, 200.0}, feitos
+
+
+def test_teto_de_plano_devolve_o_item_pra_fila(user_id, monkeypatch):
+    """O item sai da fila ANTES do registro — se o registro estoura, ele volta.
+
+    `check_can_create_launch` levanta `PlanLimitExceeded` quando o usuário do
+    Grátis bate o teto do mês. Sem devolver, o lançamento sumiria calado: a
+    fila já tinha sido encurtada e ninguém mais perguntaria por ele.
+    """
+    _armar_fila(user_id)
+
+    def estoura(*_a, **_kw):
+        raise RuntimeError("teto do plano")
+
+    monkeypatch.setattr("core.services.plan_service.check_can_create_launch", estoura)
+    try:
+        launches.resolve_multi_launch_value(user_id, "800", db.get_pending_action(user_id))
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("a exceção deveria ter subido")
+
+    p = db.get_pending_action(user_id)
+    assert p["action_type"] == "multi_launch_values"
+    assert [i["desc"] for i in p["payload"]["queue"]] == ["aluguel", "luz"]
+
+
+# ── Controle negativo (fora da suíte) ────────────────────────────────────────
+# `python3 tests/test_multi_launch_concurrency.py` → placar com e sem o CAS.
+if __name__ == "__main__":
+    import os
+    import sys
+    import uuid
+
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from db.connection import get_conn
+
+    RODADAS = 20
+
+    def _sem_cas(user_id, action_type, old_payload, new_payload, minutes=10):
+        """O que a `main` fazia: escreve sem conferir o que estava lá."""
+        if new_payload is None:
+            db.clear_pending_action(user_id)
+        else:
+            db.set_pending_action(user_id, action_type, new_payload)
+        return True
+
+    def _limpa(uid):
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                for t in ("launches", "pending_actions", "user_category_rules"):
+                    cur.execute(f"delete from {t} where user_id = %s", (uid,))
+                cur.execute("delete from users where id = %s", (uid,))
+            conn.commit()
+
+    def placar(com_cas: bool) -> int:
+        original = db.advance_pending_action
+        if not com_cas:
+            db.advance_pending_action = _sem_cas  # launches.db é o mesmo módulo
+        ok = 0
+        try:
+            for _ in range(RODADAS):
+                uid = int(uuid.uuid4().int % 10_000_000_000)
+                db.ensure_user(uid)
+                try:
+                    velho = _armar_fila(uid)
+                    largada = threading.Barrier(2)
+
+                    def responde(v):
+                        try:
+                            largada.wait(timeout=10)
+                            launches.resolve_multi_launch_value(uid, v, velho)
+                        except Exception:
+                            pass
+
+                    ts = [threading.Thread(target=responde, args=(v,))
+                          for v in ("800", "200")]
+                    for t in ts:
+                        t.start()
+                    for t in ts:
+                        t.join(timeout=30)
+                    feitos = _registrados(uid)
+                    if ({a for a, _ in feitos} == {"aluguel", "luz"}
+                            and {v for _, v in feitos} == {800.0, 200.0}):
+                        ok += 1
+                finally:
+                    _limpa(uid)
+        finally:
+            db.advance_pending_action = original
+        return ok
+
+    print(f"SEM  CAS: {placar(False)}/{RODADAS} rodadas corretas")
+    print(f"COM  CAS: {placar(True)}/{RODADAS} rodadas corretas")

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -244,3 +244,42 @@ def test_duas_devolucoes_simultaneas_com_fila_vazia_nao_perdem_item(user_id):
     fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
     nomes = sorted(i["desc"] for i in fila)
     assert nomes == ["aluguel", "luz"], f"item perdido — fila ficou {fila}"
+
+
+def test_cinco_respostas_concorrentes_nenhuma_e_descartada(user_id):
+    """P2 (3ª rodada do Codex): teto fixo de 4 tentativas descartava valor.
+
+    Com 5 respostas concorrendo, uma tarefa podia perder o CAS quatro vezes
+    seguidas (uma para cada vencedora), esgotar o laço e devolver None — o
+    valor que o usuário digitou sumia sem uma palavra. O `on_message` do
+    Discord não limita a duas.
+
+    Cinco itens na fila, cinco respostas soltas ao mesmo tempo: os cinco
+    valores têm que virar cinco lançamentos.
+    """
+    launches.add(user_id, "recebi 1 de x e paguei o aluguel e paguei a luz "
+                          "e paguei a agua e paguei o gas e paguei o wifi", {})
+    velho = db.get_pending_action(user_id)
+    assert len(velho["payload"]["queue"]) == 5, velho["payload"]["queue"]
+
+    largada = threading.Barrier(5)
+    erros: list[BaseException] = []
+
+    def responde(valor_txt: str):
+        try:
+            largada.wait(timeout=15)
+            launches.resolve_multi_launch_value(user_id, valor_txt, velho)
+        except BaseException as exc:  # noqa: BLE001
+            erros.append(exc)
+
+    valores = ("100", "200", "300", "400", "500")
+    ts = [threading.Thread(target=responde, args=(v,)) for v in valores]
+    for th in ts:
+        th.start()
+    for th in ts:
+        th.join(timeout=60)
+
+    assert not erros, erros
+    feitos = _registrados(user_id)
+    assert {v for _, v in feitos} == {100.0, 200.0, 300.0, 400.0, 500.0}, (
+        f"valor descartado em silêncio — gravados: {sorted(v for _, v in feitos)}")

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -470,3 +470,32 @@ def test_controle_com_a_fila_intacta_a_pergunta_continua_saindo(user_id):
     velho = _armar_fila(user_id)
     resp = launches.resolve_multi_launch_value(user_id, "800", velho)
     assert "luz" in (resp or "").lower(), resp
+
+
+def test_oferta_final_nao_apaga_fila_restaurada_por_devolucao(user_id, monkeypatch):
+    """Codex: a oferta de 'categoria errada?' sobrescrevia fila restaurada.
+
+    Cena: duas tarefas pegam os últimos itens. A de trás falha e o
+    `_devolve_head` restaura o item dela; a da frente ainda está dentro do
+    `add_from_entities`, calculou `resto` vazio, e grava a oferta por cima —
+    apagando a fila restaurada e sumindo com o lançamento que falhou.
+
+    Simulo devolvendo um item durante o registro.
+    """
+    velho = _armar_fila(user_id)
+    db.set_pending_action(user_id, "multi_launch_values",
+                          {"queue": [{"desc": "aluguel", "tipo": "despesa"}],
+                           "platform": "whatsapp"})
+    real = launches.add_from_entities
+
+    def registra_e_devolve(*a, **k):
+        r = real(*a, **k)
+        launches._devolve_head(user_id, {"desc": "gas", "tipo": "despesa"}, "whatsapp")
+        return r
+
+    monkeypatch.setattr(launches, "add_from_entities", registra_e_devolve)
+    launches.resolve_multi_launch_value(user_id, "800", velho)
+
+    p = db.get_pending_action(user_id) or {}
+    assert p.get("action_type") == "multi_launch_values", (
+        f"a oferta apagou a fila restaurada — ficou {p.get('action_type')}")

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -434,3 +434,39 @@ def test_controle_devolucao_nao_atropela_uma_fila_de_verdade(user_id):
 
     fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
     assert [i["desc"] for i in fila] == ["aluguel", "luz"], fila
+
+
+def test_pergunta_o_head_atual_nao_o_resto_velho(user_id, monkeypatch):
+    """Codex: `resto` fica velho se outra tarefa registra enquanto esta demora.
+
+    Cena: fila [aluguel, luz]. A tarefa A reivindica 'aluguel'. Enquanto ela
+    registra, a tarefa B termina 'luz' e esvazia a fila. A responde ao usuário
+    com o `resto` que ela calculou lá atrás e pergunta "Quanto foi luz?" — de
+    algo já registrado. A resposta do usuário chega sem item na fila.
+
+    Simulo o atraso esvaziando a fila dentro do registro de A.
+    """
+    velho = _armar_fila(user_id)
+    real = launches.add_from_entities
+
+    def registra_e_esvazia(*a, **k):
+        r = real(*a, **k)
+        db.clear_pending_action(user_id)      # a outra tarefa terminou a fila
+        return r
+
+    monkeypatch.setattr(launches, "add_from_entities", registra_e_esvazia)
+
+    resp = launches.resolve_multi_launch_value(user_id, "800", velho)
+
+    assert "luz" not in (resp or "").lower(), (
+        f"perguntou por item já registrado: {resp!r}")
+
+
+def test_controle_com_a_fila_intacta_a_pergunta_continua_saindo(user_id):
+    """Controle: sem interferência, o próximo item ainda é perguntado.
+
+    Sem isto, o teste acima passaria num código que parou de perguntar.
+    """
+    velho = _armar_fila(user_id)
+    resp = launches.resolve_multi_launch_value(user_id, "800", velho)
+    assert "luz" in (resp or "").lower(), resp

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -313,3 +313,40 @@ def test_falha_depois_do_commit_nao_devolve_item_nem_duplica(user_id, monkeypatc
     fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
     assert [i["desc"] for i in fila] == ["luz"], (
         f"o item já gravado foi devolvido pra fila — duplicaria: {fila}")
+
+
+def test_devolucao_desaloja_oferta_de_conveniencia(user_id):
+    """P2 (4ª rodada do Codex): a linha ocupada por OUTRA pendência.
+
+    Outra tarefa terminou o último item da fila e armou `recategorize_launch_offer`.
+    A devolução do item que estourou não consegue inserir (a linha por usuário
+    está ocupada por um tipo diferente), gira até o teto e o lançamento some.
+
+    Fila com dinheiro vale mais que oferta de conveniência: desaloja.
+    """
+    db.set_pending_action(user_id, "recategorize_launch_offer",
+                          {"user_seq": 1, "launch_id": 999})
+
+    launches._devolve_head(user_id, {"desc": "aluguel", "tipo": "despesa"}, "whatsapp")
+
+    p = db.get_pending_action(user_id) or {}
+    assert p.get("action_type") == "multi_launch_values", (
+        f"item não devolvido — pendência ficou {p.get('action_type')}")
+    fila = (p.get("payload") or {}).get("queue", [])
+    assert [i["desc"] for i in fila] == ["aluguel"], fila
+
+
+def test_controle_devolucao_nao_atropela_uma_fila_de_verdade(user_id):
+    """Controle do teste acima: desalojar não pode comer fila real.
+
+    Se o que está lá JÁ é uma fila de multi-lançamento, o item tem que ser
+    somado a ela, não substituí-la.
+    """
+    db.set_pending_action(user_id, "multi_launch_values",
+                          {"queue": [{"desc": "luz", "tipo": "despesa"}],
+                           "platform": "whatsapp"})
+
+    launches._devolve_head(user_id, {"desc": "aluguel", "tipo": "despesa"}, "whatsapp")
+
+    fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
+    assert [i["desc"] for i in fila] == ["aluguel", "luz"], fila

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -246,6 +246,46 @@ def test_duas_devolucoes_simultaneas_com_fila_vazia_nao_perdem_item(user_id):
     assert nomes == ["aluguel", "luz"], f"item perdido — fila ficou {fila}"
 
 
+def test_devolucao_continua_apos_cinco_colisoes_com_fila_vazia(user_id, monkeypatch):
+    """P2 (5ª rodada do Codex): recuperação não pode ter teto aditivo.
+
+    Quando vários itens já foram reivindicados e todos falham depois que a fila
+    foi apagada, uma devolução pode perder a inserção condicional para as outras
+    várias vezes seguidas. Com `len([]) + 5`, a sexta volta desistia antes de
+    restaurar o item.
+    """
+    head = {"desc": "aluguel", "tipo": "despesa"}
+    tentativas = 0
+    gravado: dict = {}
+
+    monkeypatch.setattr(launches.db, "get_pending_action", lambda _uid: None)
+
+    def cria(_uid, action_type, payload, minutes=10):
+        nonlocal tentativas
+        tentativas += 1
+        if tentativas <= 5:
+            return False
+        gravado["action_type"] = action_type
+        gravado["payload"] = payload
+        return True
+
+    monkeypatch.setattr(launches.db, "create_pending_action_if_absent", cria)
+    monkeypatch.setattr(
+        launches.db,
+        "advance_pending_action",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("não deveria atualizar fila inexistente")),
+    )
+
+    launches._devolve_head(user_id, head, "whatsapp")
+
+    assert tentativas == 6
+    assert gravado == {
+        "action_type": "multi_launch_values",
+        "payload": {"queue": [head], "platform": "whatsapp"},
+    }
+
+
 def test_cinco_respostas_concorrentes_nenhuma_e_descartada(user_id):
     """P2 (3ª rodada do Codex): teto fixo de 4 tentativas descartava valor.
 

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -2,9 +2,9 @@
 Duas respostas para a MESMA fila `multi_launch_values` não podem gravar o mesmo
 item duas vezes.
 
-O caminho é real: `adapters/whatsapp/wa_app.py:320` roda cada POST do Meta em
-`asyncio.to_thread(process_payload, ...)`, e o Meta entrega duas mensagens
-seguidas em dois POSTs. Antes do compare-and-swap (`db.advance_pending_action`)
+O caminho é real pelo Discord: `adapters/discord/discord_bot.py:122` é um
+`on_message` async sem lock, num processo separado do uvicorn. Duas mensagens
+seguidas do mesmo usuário viram duas tarefas concorrentes. Antes do compare-and-swap (`db.advance_pending_action`)
 as duas threads liam a mesma fila, as duas gravavam o item da FRENTE e o
 segundo valor sumia sem uma palavra.
 

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -283,3 +283,33 @@ def test_cinco_respostas_concorrentes_nenhuma_e_descartada(user_id):
     feitos = _registrados(user_id)
     assert {v for _, v in feitos} == {100.0, 200.0, 300.0, 400.0, 500.0}, (
         f"valor descartado em silêncio — gravados: {sorted(v for _, v in feitos)}")
+
+
+def test_falha_depois_do_commit_nao_devolve_item_nem_duplica(user_id, monkeypatch):
+    """P1 (4ª rodada do Codex): exceção APÓS o lançamento já gravado.
+
+    `add_launch_and_update_balance` commita e só depois roda o acessório
+    (aprender a regra, armar ofertas). Se o acessório estoura, quem chamou não
+    distingue "não gravou" de "gravou e falhou no acessório" — e a devolução
+    põe o item de volta, fazendo a próxima resposta registrar o MESMO gasto e
+    dobrar o saldo.
+
+    Depois da correção o acessório não sobe exceção: o lançamento fica, a fila
+    avança, e o saldo muda uma vez só.
+    """
+    velho = _armar_fila(user_id)
+
+    def estoura(*a, **k):
+        raise RuntimeError("upsert da regra caiu")
+
+    monkeypatch.setattr(launches, "learn_from_inference", estoura)
+
+    resp = launches.resolve_multi_launch_value(user_id, "800", velho)
+
+    feitos = [(a, v) for a, v in _registrados(user_id) if a == "aluguel"]
+    assert len(feitos) == 1 and feitos[0][1] == 800.0, feitos
+    assert resp, "o usuário tem que receber a confirmação, não um erro"
+
+    fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
+    assert [i["desc"] for i in fila] == ["luz"], (
+        f"o item já gravado foi devolvido pra fila — duplicaria: {fila}")

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -209,3 +209,38 @@ def test_item_que_estourou_volta_pra_fila_mesmo_com_outra_thread_avancando(user_
     fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
     assert [i["desc"] for i in fila] == ["aluguel"], (
         f"o item que estourou sumiu — fila ficou {fila}")
+
+
+def test_duas_devolucoes_simultaneas_com_fila_vazia_nao_perdem_item(user_id):
+    """P2 (2ª rodada do Codex): dois itens que estouram juntos, fila já vazia.
+
+    Cena: os dois últimos itens são reivindicados por tarefas diferentes e
+    AMBOS os registros estouram (ex.: os dois batem o teto de plano). As duas
+    devoluções veem "não há pendência" e cada uma quer criar a sua. Com upsert
+    incondicional a última apaga a primeira e um item some.
+
+    Precisa de threads de verdade com barreira: em sequência a segunda já
+    encontraria a fila criada e nunca passaria pelo ramo que tem o defeito.
+    """
+    db.clear_pending_action(user_id)
+
+    largada = threading.Barrier(2)
+    erros: list[BaseException] = []
+
+    def devolve(desc: str):
+        try:
+            largada.wait(timeout=10)
+            launches._devolve_head(user_id, {"desc": desc, "tipo": "despesa"}, "whatsapp")
+        except BaseException as exc:  # noqa: BLE001 — o teste precisa ver
+            erros.append(exc)
+
+    ts = [threading.Thread(target=devolve, args=(d,)) for d in ("aluguel", "luz")]
+    for th in ts:
+        th.start()
+    for th in ts:
+        th.join(timeout=30)
+
+    assert not erros, erros
+    fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
+    nomes = sorted(i["desc"] for i in fila)
+    assert nomes == ["aluguel", "luz"], f"item perdido — fila ficou {fila}"

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -355,6 +355,50 @@ def test_falha_depois_do_commit_nao_devolve_item_nem_duplica(user_id, monkeypatc
         f"o item já gravado foi devolvido pra fila — duplicaria: {fila}")
 
 
+def test_oferta_final_condicional_nao_sobrescreve_fila_restaurada(user_id, monkeypatch):
+    """P2 (6ª rodada do Codex): oferta do último item não atropela recuperação.
+
+    A thread do último item calcula `resto=[]` antes de registrar. Enquanto ela
+    está dentro de `add_from_entities`, outra recuperação pode recriar a fila.
+    A oferta de recategorização do último item precisa ser condicional, senão o
+    `set_pending_action` incondicional apaga a fila restaurada.
+    """
+    ultimo = {"desc": "luz", "tipo": "despesa"}
+    devolvido = {"desc": "aluguel", "tipo": "despesa"}
+    db.set_pending_action(
+        user_id, "multi_launch_values",
+        {"queue": [ultimo], "platform": "whatsapp"},
+    )
+    pending = db.get_pending_action(user_id)
+
+    class CategoriaFake:
+        category = "outros"
+        reason = "test"
+
+    monkeypatch.setattr(
+        "core.services.plan_service.check_can_create_launch",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(launches, "infer_category", lambda *_a, **_k: CategoriaFake())
+    monkeypatch.setattr(launches, "learn_from_inference", lambda *_a, **_k: None)
+    monkeypatch.setattr(launches, "_maybe_recurring_offer", lambda *_a, **_k: None)
+    monkeypatch.setattr(launches.db, "reconcile_manual_launch", lambda *_a, **_k: None)
+
+    def registra_enquanto_recupera(*_a, **_k):
+        launches._devolve_head(user_id, devolvido, "whatsapp")
+        return 999, 2, 0
+
+    monkeypatch.setattr(
+        launches.db, "add_launch_and_update_balance", registra_enquanto_recupera)
+
+    launches.resolve_multi_launch_value(user_id, "200", pending)
+
+    p = db.get_pending_action(user_id) or {}
+    assert p.get("action_type") == "multi_launch_values", p
+    fila = (p.get("payload") or {}).get("queue", [])
+    assert [i["desc"] for i in fila] == ["aluguel"], fila
+
+
 def test_devolucao_desaloja_oferta_de_conveniencia(user_id):
     """P2 (4ª rodada do Codex): a linha ocupada por OUTRA pendência.
 

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -499,3 +499,43 @@ def test_oferta_final_nao_apaga_fila_restaurada_por_devolucao(user_id, monkeypat
     p = db.get_pending_action(user_id) or {}
     assert p.get("action_type") == "multi_launch_values", (
         f"a oferta apagou a fila restaurada — ficou {p.get('action_type')}")
+
+
+def test_oferta_de_gasto_fixo_sai_quando_a_fila_e_restaurada(user_id, monkeypatch):
+    """Codex: duas perguntas incompatíveis na mesma resposta.
+
+    A tarefa do último item cria a oferta de gasto fixo ("responda sim ou
+    não"); outra tarefa, falhando, substitui essa pendência por uma fila
+    restaurada. O texto da oferta fica órfão em `resp`, e a resposta sai com
+    duas perguntas. Um "sim" não é valor — descartaria o item restaurado.
+    """
+    velho = _armar_fila(user_id)
+    real = launches.add_from_entities
+
+    def registra_com_oferta_e_devolve(*a, **k):
+        r = real(*a, **k)
+        r += ("\n\n💡 Você já lançou *aluguel* de R$ 800,00 em outro mês. "
+              "Quer marcar como *gasto fixo* (a Piggy lança sozinha todo mês)? "
+              "Responda *sim* ou *não*.")
+        launches._devolve_head(user_id, {"desc": "gas", "tipo": "despesa"}, "whatsapp")
+        return r
+
+    monkeypatch.setattr(launches, "add_from_entities", registra_com_oferta_e_devolve)
+    resp = launches.resolve_multi_launch_value(user_id, "800", velho) or ""
+
+    assert "sim* ou *não" not in resp, (
+        f"duas perguntas incompatíveis na mesma resposta:\n{resp}")
+    assert "Quanto foi" in resp or "Faltou o valor" in resp, resp
+
+
+def test_controle_oferta_de_gasto_fixo_sobrevive_sem_fila(user_id):
+    """Controle: sem fila restaurada, o convite continua saindo.
+
+    Sem isto, o teste acima passaria num código que apagasse a oferta sempre.
+    """
+    texto = ("💸 Despesa registrada: R$ 800,00\n\n💡 Você já lançou *aluguel* de "
+             "R$ 800,00 em outro mês. Quer marcar como *gasto fixo* (a Piggy "
+             "lança sozinha todo mês)? Responda *sim* ou *não*.")
+    assert "sim* ou *não" in texto
+    assert "sim* ou *não" not in launches._sem_oferta_de_gasto_fixo(texto)
+    assert "Despesa registrada" in launches._sem_oferta_de_gasto_fixo(texto)

--- a/tests/test_multi_launch_concurrency.py
+++ b/tests/test_multi_launch_concurrency.py
@@ -15,6 +15,7 @@ motivo errado. O que a suíte guarda são os dois casos determinísticos abaixo.
 """
 from __future__ import annotations
 
+import pytest
 import threading
 
 import db
@@ -181,3 +182,30 @@ if __name__ == "__main__":
 
     print(f"SEM  CAS: {placar(False)}/{RODADAS} rodadas corretas")
     print(f"COM  CAS: {placar(True)}/{RODADAS} rodadas corretas")
+
+
+def test_item_que_estourou_volta_pra_fila_mesmo_com_outra_thread_avancando(user_id, monkeypatch):
+    """P2 do Codex, pelo caminho real: `resolve_multi_launch_value` com exceção.
+
+    Cena: fila [aluguel, luz]. A thread A reivindica 'aluguel'; ANTES de ela
+    registrar, a thread B avança a fila (registra 'luz'). Aí o registro de A
+    estoura (teto de plano). O payload que A tinha em mãos não existe mais.
+
+    Código antigo: tentava restaurar o estado velho, o CAS falhava, e 'aluguel'
+    sumia. Código novo: relê e prepende na fila que existir.
+    """
+    pending = _armar_fila(user_id)
+
+    def estoura_e_avanca_por_baixo(*a, **k):
+        # simula a thread B tendo avançado a fila enquanto A trabalhava
+        db.clear_pending_action(user_id)
+        raise RuntimeError("teto de plano")
+
+    monkeypatch.setattr(launches, "add_from_entities", estoura_e_avanca_por_baixo)
+
+    with pytest.raises(RuntimeError):
+        launches.resolve_multi_launch_value(user_id, "800", pending)
+
+    fila = (db.get_pending_action(user_id) or {}).get("payload", {}).get("queue", [])
+    assert [i["desc"] for i in fila] == ["aluguel"], (
+        f"o item que estourou sumiu — fila ficou {fila}")


### PR DESCRIPTION
## O bug

A fila de multi-lançamento (`multi_launch_values`) era lida, trabalhada e regravada sem proteção nenhuma. Quando duas respostas do mesmo usuário são processadas em paralelo, as duas liam a mesma fila, registravam o **mesmo** item e o segundo valor sumia.

```
fila = [30, 45];  duas respostas ao mesmo tempo
antes  → grava [30, 30], os R$45 somem, e a fila fica pendurada
depois → grava [30, 45]
```

## Onde a corrida é alcançável — corrigido em 5f7bac6

A primeira versão deste PR afirmava que cada POST do Meta vira uma thread, citando `adapters/whatsapp/wa_app.py:320`. **Isso estava errado** e a afirmação foi corrigida no código, nos testes e aqui: aquela linha é o `wa_simulate`. O webhook de verdade (`:293`) apenas enfileira em `_queue`, e um `_worker_loop` **único** consome um payload por vez; o `launch.py` sobe um uvicorn sem `--workers`. **Pelo WhatsApp, sozinho, a corrida não acontece.**

Onde acontece, conferido no código:
- `adapters/discord/discord_bot.py:122` é um `on_message` **async sem lock nenhum** — duas mensagens seguidas do mesmo usuário viram duas tarefas concorrentes;
- o Discord roda em **processo separado** do uvicorn (`launch.py`), então um usuário com as duas plataformas ligadas é alcançado pelos dois ao mesmo tempo.

## A correção

`db.advance_pending_action` grava só se a fila ainda for a que foi lida (compare-and-swap, conferindo `rowcount`). O `resolve_multi_launch_value` reivindica o item **antes** de trabalhar, e **devolve** a reivindicação se o registro estourar — senão o teto de plano do Grátis, batido no meio da fila, apagava o item silenciosamente.

**Sem lock, de propósito.** A primeira tentativa usava `pg_advisory_xact_lock` numa conexão dedicada e derrubava o bot: com o pool em 8, oito usuários simultâneos davam **0 sucessos e 8 erros**, e um nono usuário sem relação nenhuma não conseguia nem consultar o saldo. O precedente correto do repo é `db/agents.py:101`, que usa a **mesma** conexão para o lock e para o trabalho.

## Como foi medido

| verificação | resultado |
|---|---|
| controle negativo (20 rodadas, 2 threads) | **0/20** corretas sem a correção · **20/20** com |
| suíte | **1227 passed**, 0 falhas (1217 da `main` + 10 novos) |
| varredura do separador de frases (363.972 frases) | **118.738** — idêntico à `main` |
| bateria de categorização (123 casos) | 98 verdes — idêntico à `main` |

As duas últimas são travas de escopo: se qualquer uma mudasse, teria vindo junto código que não é desta correção.

## O que NÃO está incluído

Este PR foi **separado** de um trabalho maior sobre mensagens com vários lançamentos. Ficou de fora, para PR próprio com desenho antes do código: a divisão de `gastei 30 no uber e no ifood`, a fila de perguntas ("Quanto foi gasto em X?") e os guardas dela. Esse trabalho foi preservado, não está perdido.

Nenhum comportamento de categorização muda aqui.

## Não verificado

Concorrência real entre os dois processos em produção — a corrida foi reproduzida com duas threads no mesmo processo, contra Postgres local. E a expiração de 10 minutos da pendência, que segue matando a fila sem aviso (buraco pré-existente, não tocado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Histórico das observações do Codex

| # | o que era | estado |
|---|---|---|
| ordem das respostas não preservada | dois valores trocam de item | fora do escopo → issue #130 |
| item que falhou some após outra tarefa avançar | `92d4fa7` | corrigido |
| recriar a fila devolvida não era atômico | `5cac796` | corrigido |
| teto fixo de 4 no laço de reivindicação | `aa767cd` | corrigido |
| falha pós-commit devolvia item já gravado (dobrava saldo) | `df769ad` | corrigido |
| teto de 4 esquecido no `_devolve_head` | `df769ad` | corrigido |
| devolução perdia para oferta de conveniência | `a40bb0a` | corrigido |
| cinto do `_devolve_head` ainda é teto fixo | — | **conhecido, acima** |

---

## Limitação conhecida, registrada e não corrigida

**Item reivindicado some se o processo morrer.** O item sai da fila num commit e o lançamento é gravado noutro. Morte do processo entre os dois (deploy, OOM, kill) não gera exceção, então a devolução não roda e o item desaparece. Não é remendável no laço — pede claim+registro na mesma transação, ou estado durável de *in-flight*. Está na issue #130, junto com a ordenação por usuário, que é da mesma natureza.

**Alcance:** um item some em silêncio, para um usuário com fila ativa. Sem duplicação e sem saldo errado.