### PR TITLE
fix(app): pinta o canvas das páginas de erro, não só o body

### DIFF
--- a/frontend/error.html
+++ b/frontend/error.html
@@ -6,6 +6,7 @@
 <script src="/safe-area.js?v=1"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
+html{background:#050506}
 body{background:#050506;font-family:-apple-system,BlinkMacSystemFont,"SF Pro Display","Segoe UI",sans-serif;
 display:flex;align-items:center;justify-content:center;min-height:100vh;color:rgba(255,255,255,.85)}
 .box{text-align:center;max-width:400px;padding:48px 32px}

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4785,6 +4785,7 @@ async def dashboard_short_link(
 <script src="/safe-area.js?v=1"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
+html{background:#050506}
 body{background:#050506;font-family:-apple-system,BlinkMacSystemFont,"SF Pro Display","Segoe UI",sans-serif;
 display:flex;align-items:center;justify-content:center;min-height:100vh;color:rgba(255,255,255,.85)}
 .box{text-align:center;max-width:400px;padding:48px 32px}

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -207,7 +207,7 @@ _ERROR_PASSTHROUGH_HEADERS = frozenset({"allow", "www-authenticate", "retry-afte
 # Sem CSS/JS externo de propósito (só style inline e um <a href="/">), então não
 # passa nem precisa passar pelo `stamp_asset_versions` — não há `?v=` aqui.
 _ERROR_FALLBACK_HTML = (
-    '<!DOCTYPE html><html lang="pt-BR"><head><meta charset="UTF-8">'
+    '<!DOCTYPE html><html lang="pt-BR" style="background:#050506"><head><meta charset="UTF-8">'
     '<meta name="viewport" content="width=device-width,initial-scale=1">'
     '<meta name="robots" content="noindex"><title>{{CODE}} — {{TITLE}} | PigBank</title></head>'
     '<body style="background:#050506;color:#fff;font-family:sans-serif;text-align:center;padding:64px 24px">'


### PR DESCRIPTION
## O problema

O arrasto elástico no WKWebView revela o **canvas**, e o canvas vem do `<html>` — o §5 do `CLAUDE.md` documenta isso e avisa que pintar só o `<body>` deixa a faixa do overscroll na cor errada.

As três páginas standalone de erro pintavam só o `<body>`. Elas não carregam o `app-mode.js`, então não recebem `pb-root-*` no `<html>` e não herdam a regra que cuida disso nas telas do app.

A cor que apareceria está no `mobile/capacitor.config.json`:

```json
"ios": { "contentInset": "never", "backgroundColor": "#111111" }
```

`#111111` contra o `#050506` da página — a faixa sairia visivelmente mais clara.

## A correção

Uma linha por página:

| arquivo | como |
|---|---|
| `frontend/error.html` | `html{background:#050506}` no `<style>` |
| `finance_bot_websocket_custom.py` (gêmea do `/d/{code}`) | idem |
| `shared.py`, `_ERROR_FALLBACK_HTML` | `style` inline no `<html>` — não tem bloco `<style>` |

## Por que preventivo

O `/d/{code}` é carregado direto no WebView pelo `AppDelegate`, e a página de erro aparece em qualquer URL do domínio que dê erro — e qualquer rota do domínio abre no app. Descobrir isso no aparelho custaria um ciclo de build; o §5 e o `capacitor.config.json` juntos já diziam o que aconteceria.

## Testes

`1296 passed`, zero falhas. Sem teste novo: `env(safe-area-inset-*)` vale 0 no Chromium headless e o elástico do WKWebView não é reproduzível aqui (§6) — um teste local seria estruturalmente cego ao que a mudança corrige.

## Não verificado

**Nada disto foi visto rodando.** A confirmação é o próximo build: abrir uma rota inexistente no app e puxar a tela. É o que este PR existe para tornar verde na primeira tentativa em vez da segunda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)