### PR TITLE
modo app: site sempre no layout web, app entra so por user agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,15 +257,15 @@ O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView c
 
   | elemento | classe | onde | para quê |
   |---|---|---|---|
-  | `<body>` | `pb-page-*` | `app-mode.js:85` | escopar o CSS por página |
-  | `<html>` | `pb-root-*` | `app-mode.js:88` | pintar o **canvas** |
+  | `<body>` | `pb-page-*` | `app-mode.js:151` | escopar o CSS por página |
+  | `<html>` | `pb-root-*` | `app-mode.js:82` (`<head>`, 1º paint) e `:154` | pintar o **canvas** |
 
-  (mais `pb-app` em `:30` e `pb-no-tabs` em `:84`, quando a rota não tem tab bar.)
+  (mais `pb-app` em `:46` e `pb-no-tabs` em `:150`, quando a rota não tem tab bar.)
 
   O fundo que o elástico revela é o do canvas, e o canvas vem do `<html>` — por isso
-  a cor por tela está em `html.pb-app.pb-root-*` (`app-mode.css:33-36`), não no
+  a cor por tela está em `html.pb-app.pb-root-*` (`app-mode.css:54-71`), não no
   `<body>`. Pintar só o `<body>` deixa a faixa do overscroll na cor errada. O modo
-  claro do dashboard depende da mesma regra (`app-mode.css:42`).
+  claro do dashboard depende da mesma regra (`app-mode.css:77`).
 - **`position: fixed` não herda o padding do `body`.** Todo fixo ancorado numa borda
   precisa reservar a área segura por conta própria.
 - **Paisagem está habilitada no iPhone** (`mobile/ios/App/App/Info.plist`), então os

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -2,8 +2,8 @@
  * app-mode.css — Reskin "modo app" do PigBank.
  *
  * TODO o arquivo é escopado sob html.pb-app (setado por app-mode.js quando o
- * user agent contém PigBankApp, ou pbapp=1 pra preview no navegador). Sem a
- * classe, nada aqui tem efeito — o site segue idêntico.
+ * user agent contém PigBankApp, ou o ícone está instalado). Sem a classe,
+ * nada aqui tem efeito — o site segue idêntico.
  *
  * Princípios:
  *  - Navegação primária mora na tab bar inferior (zona do polegar).

--- a/frontend/app-mode.js
+++ b/frontend/app-mode.js
@@ -1,29 +1,45 @@
 /**
  * app-mode.js — Ativa o "modo app" do PigBank e monta a tab bar inferior.
  *
- * Ativação (qualquer um):
- *   - user agent contém "PigBankApp" (WebView do app iOS/Capacitor)
- *   - PWA instalada (display-mode: standalone / navigator.standalone no iOS)
- *   - ?pbapp=1 na URL (persiste em localStorage — preview no navegador)
- *   - localStorage.pbApp === "1"
- *   Desativação no preview: ?pbapp=0
+ * Ativação — dois gatilhos, os dois derivados do AMBIENTE:
+ *   - user agent contém "PigBankApp" (o app iOS/Capacitor manda PigBankApp/1.0)
+ *   - ícone instalado / PWA (display-mode: standalone, ou navigator.standalone
+ *     no iOS)
+ *
+ * Não existe atalho de navegador. O preview ?pbapp=1 foi REMOVIDO: nada que
+ * o usuário toque — link, query, storage — liga o modo app. O preview antigo
+ * gravava localStorage.pbApp pra sempre e sem UI de saída, e travou o Safari
+ * de um usuário de verdade; qualquer link velho (histórico, autocomplete,
+ * bookmark, WhatsApp) reabria a armadilha. Quem já tinha ficado preso se
+ * destrava sozinho no primeiro load desta versão — porque o gate abaixo parou
+ * de LER a chave, não porque alguém a apague. Único resíduo: o removeItem, que
+ * é higiene.
+ *
+ * QA que precisa ver o layout de app: abra no app de verdade, ou falsifique o
+ * user agent no devtools (Safari: Desenvolvedor → User Agent; Chrome: Network
+ * conditions) — spoof vale só naquela sessão do inspetor e não grava nada no
+ * aparelho.
  *
  * Deve ser incluído no <head> (sem defer) pra classe pb-app existir antes do
  * primeiro paint — evita o "pulo" de layout do chrome de site sumindo.
  */
 (() => {
-  const qs = new URLSearchParams(location.search);
-  if (qs.get("pbapp") === "0") { try { localStorage.removeItem("pbApp"); } catch (_) {} }
-  if (qs.get("pbapp") === "1") { try { localStorage.setItem("pbApp", "1"); } catch (_) {} }
+  // Higiene, não destravamento. Quem visitou ?pbapp=1 antes desta versão já
+  // volta ao site no primeiro load, e o mérito é do GATE: ele não lê mais
+  // storage nenhum pra decidir. Esta linha só apaga uma chave legada que
+  // ninguém consulta.
+  // O try/catch, esse sim, é obrigatório: é a ÚNICA linha do arquivo que toca
+  // storage, e com storage bloqueado (Safari privado, cookies off) o acesso
+  // ESTOURA. Sem o catch a exceção mataria o script antes do classList.add e o
+  // app nativo abriria com layout de site (nav, footer, sem tab bar).
+  try { localStorage.removeItem("pbApp"); } catch (_) {}
 
-  let stored = null;
-  try { stored = localStorage.getItem("pbApp"); } catch (_) {}
   // PWA instalada roda o mesmo "modo app" do app iOS — atualizações do site
   // chegam nas duas cascas sem passo extra.
   const standalone =
     (window.matchMedia && window.matchMedia("(display-mode: standalone)").matches) ||
     window.navigator.standalone === true;
-  const inApp = /PigBankApp/.test(navigator.userAgent) || stored === "1" || standalone;
+  const inApp = /PigBankApp/.test(navigator.userAgent) || standalone;
   if (!inApp) return;
 
   const root = document.documentElement;
@@ -44,7 +60,7 @@
     "/changelog":    "changelog",
     "/settings":     "settings",
   };
-  // Variantes do preview local (mock serve arquivos .html e o dash na raiz)
+  // Variantes do servidor local de dev (mock serve .html e o dash na raiz)
   if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
     Object.assign(PAGES, {
       "/home.html": "home", "/dashboard.html": "app",
@@ -523,7 +539,12 @@
 
   // Chegou pelo + de outra página: abre o modal de lançamento assim que o
   // dashboard.js terminar de definir a função (poll curto).
+  // A query fica declarada AQUI, no único lugar que a consome: ela não
+  // participa do gate do modo app (isso é só UA/standalone) e, solta no topo do
+  // arquivo, parecia resíduo do preview ?pbapp=1 removido — candidata a virar
+  // ReferenceError na próxima limpeza.
   function maybeOpenLaunch() {
+    const qs = new URLSearchParams(location.search);
     if (page !== "app" || qs.get("lancar") !== "1") return;
     let tries = 0;
     const t = setInterval(() => {
@@ -589,8 +610,8 @@
 
   // Push notification (só app iOS nativo + usuário logado). Pede pro nativo
   // registrar no APNs; o device token volta em window.PBPush.onToken, que faz
-  // o POST autenticado (reusa os cookies de sessão do WebView). PWA/preview não
-  // têm a ponte pbPush → no-op (push em PWA é fase futura, canal diferente).
+  // o POST autenticado (reusa os cookies de sessão do WebView). PWA e navegador
+  // NÃO têm a ponte pbPush → no-op (push em PWA é fase futura, canal diferente).
   function pbCookie(name) {
     const m = document.cookie.split("; ").find(r => r.startsWith(name + "="));
     return m ? decodeURIComponent(m.split("=").slice(1).join("=")) : "";
@@ -606,7 +627,7 @@
       const bridge = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.pbPush;
       if (!bridge) {
         if (++tries < 20) setTimeout(attempt, 500);  // ~10s
-        return;                 // PWA/preview/navegador: nunca aparece → no-op
+        return;                 // PWA/navegador: a ponte nunca aparece → no-op
       }
       window.PBPush = window.PBPush || {};
       window.PBPush.onToken = function (token, environment) {
@@ -650,7 +671,7 @@
 
   function initPullToRefresh() {
     if (!page) return;                        // só nas telas logadas do app
-    if (!("ontouchstart" in window)) return;  // preview no desktop não tem gesto
+    if (!("ontouchstart" in window)) return;  // desktop (PWA/devtools) não tem gesto
 
     const el = document.createElement("div");
     el.className = "pb-ptr";

--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -7,9 +7,16 @@
  * DENTRO de um documento só (fetch + swap em startViewTransition): sem
  * navegação de documento, o vão não existe.
  *
- * Ativação (POC): modo app (html.pb-app) + flag pbspa. Liga com ?pbspa=1
- * (persiste em localStorage, igual ao pbapp), desliga com ?pbspa=0.
- * Teste no iPhone: Safari → https://pigbankai.com/home?pbapp=1&pbspa=1
+ * Ativação (POC): modo app (html.pb-app) + flag pbspa, desligada por padrão.
+ * DENTRO do app, ?pbspa=1 liga e ?pbspa=0 desliga; a flag vive em
+ * sessionStorage — morre com a sessão da aba/app e não fica gravada no
+ * aparelho. FORA do modo app a query não faz nada: nem liga, nem grava. Era
+ * esse o buraco — um link ?pbspa=1 aberto no navegador armava a flag pra
+ * sempre, sem UI de saída, e o motor acordava sozinho quando o app abrisse,
+ * sem ninguém ter pedido. A chave pbSpa antiga do localStorage é apagada em
+ * todo load (higiene) e ninguém mais a lê.
+ * Teste no iPhone: no APP instalado, /home?pbspa=1 — não há como entrar em
+ * modo app pelo Safari (o preview ?pbapp=1 foi removido do app-mode.js).
  *
  * Contrato por página (só as ROUTES abaixo):
  *   - scripts inline embrulhados em (PBPages.<key> ||= {inits:[]}).inits.push(fn)
@@ -34,13 +41,50 @@
   "use strict";
 
   const qs = new URLSearchParams(location.search);
-  if (qs.get("pbspa") === "0") { try { localStorage.removeItem("pbSpa"); } catch (_) {} }
-  if (qs.get("pbspa") === "1") { try { localStorage.setItem("pbSpa", "1"); } catch (_) {} }
-  let flag = null;
-  try { flag = localStorage.getItem("pbSpa"); } catch (_) {}
 
-  // pb-app já está no <html> (app-mode.js roda antes, síncrono no head)
-  const enabled = document.documentElement.classList.contains("pb-app") &&
+  // Modo app já decidido antes daqui. Atenção: html.pb-app tem DOIS setters,
+  // e os dois rodam síncronos no <head>, sem defer:
+  //   - auth-refresh.js:84-86 (só UA PigBankApp; também liga PB_IN_APP)
+  //   - app-mode.js:46 (decisão em :42 — UA PigBankApp OU PWA standalone)
+  // Nas duas únicas páginas que carregam este arquivo os dois já executaram:
+  // home.html:455 (auth-refresh) e :458 (app-mode), antes do :459 daqui;
+  // comandos-app.html:84 (app-mode, sem auth-refresh) antes do :85. Ou seja,
+  // a classe pb-app já está no <html> quando esta linha executa — por isso o
+  // gate abaixo pode usar a classe, e não repetir o sinal de ambiente
+  // (UA/standalone) do app-mode. Se mexer em qualquer um dos dois setters,
+  // lembre que este gate depende dos dois.
+  const inApp = document.documentElement.classList.contains("pb-app");
+
+  // Higiene da chave legada. A versão anterior gravava pbSpa no localStorage a
+  // partir de ?pbspa=1, inclusive fora do modo app e sem UI de saída — quem
+  // clicou num link de QA carrega a flag no aparelho até hoje. Este removeItem
+  // limpa sozinho no primeiro load; o destravamento em si vem do gate, que
+  // parou de LER o localStorage.
+  // O try/catch é obrigatório: esta linha toca storage e, com storage
+  // bloqueado (Safari privado, cookies off), o acesso ESTOURA. Sem o catch a
+  // exceção mataria o resto do arquivo — inclusive o window.PBNav que o dock
+  // do app-mode chama em toda troca de aba.
+  try { localStorage.removeItem("pbSpa"); } catch (_) {}
+
+  // O atalho de QA só existe DENTRO do modo app, e só pela sessão:
+  // sessionStorage morre com a aba/app, então ?pbspa=1 serve pra testar sem
+  // virar trava permanente, e ?pbspa=0 continua a saída explícita. Fora do
+  // modo app nada é lido nem gravado. Mesmo try/catch, mesmo motivo (são
+  // acessos a storage); se estourar, flag fica null e o motor não liga.
+  let flag = null;
+  try {
+    if (inApp) {
+      if (qs.get("pbspa") === "0") sessionStorage.removeItem("pbSpa");
+      if (qs.get("pbspa") === "1") sessionStorage.setItem("pbSpa", "1");
+      flag = sessionStorage.getItem("pbSpa");
+    }
+  } catch (_) {}
+
+  // inApp entra aqui de novo de propósito, mesmo já sendo condição pra flag
+  // existir: nenhum teste separa as duas barreiras (sem o guard de cima a flag
+  // nem chega a ser lida fora do app), mas afrouxar UMA delas sozinha não pode
+  // bastar pra religar o motor num navegador comum.
+  const enabled = inApp &&
     flag === "1" &&
     typeof document.startViewTransition === "function" &&
     typeof DOMParser === "function";

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -360,7 +360,7 @@ async def serve_modals_js():
 @router.get("/app-mode.js")
 async def serve_app_mode_js():
     """Modo app (WebView iOS): seta html.pb-app e monta a tab bar inferior.
-    Inerte no site (só ativa com UA PigBankApp ou ?pbapp=1)."""
+    Inerte no site (só ativa com UA PigBankApp ou ícone instalado)."""
     return FileResponse(
         FRONTEND_DIR / "app-mode.js",
         media_type="application/javascript",

--- a/frontend/safe-area.js
+++ b/frontend/safe-area.js
@@ -13,20 +13,25 @@
  * ou montar tab bar — só o respiro das bordas. A landing, por exemplo,
  * precisa continuar mostrando a nav dela (é o caminho de volta pro app).
  *
- * Inerte fora do app: sem o user agent do app (nem PWA instalada, nem
- * ?pbapp=1), não faz nada.
+ * Inerte fora do app: sem o user agent do app e sem ícone instalado, não faz
+ * nada. Navegador comum não tem como entrar — o preview ?pbapp=1 foi removido.
  */
 (() => {
-  let stored = null;
-  try { stored = localStorage.getItem("pbApp"); } catch (_) {}
   const standalone =
     (window.matchMedia && window.matchMedia("(display-mode: standalone)").matches) ||
     window.navigator.standalone === true;
-  const inApp =
-    /PigBankApp/.test(navigator.userAgent) ||
-    stored === "1" ||
-    new URLSearchParams(location.search).get("pbapp") === "1" ||
-    standalone;
+
+  // Mesma condição do app-mode.js, repetida na unha: a página que carrega os
+  // dois (changelog.html) põe ESTE script antes, então não dá pra ler a classe
+  // pb-app dele — e /precos & landing carregam só este. Se mudar aqui, mude lá.
+  //
+  // Não há assimetria entre os dois arquivos: nenhum dos dois GRAVA nada, e
+  // nenhum LÊ storage ou query pra decidir. A condição é puramente derivada do
+  // ambiente (UA do app nativo ou ícone instalado), então os dois chegam sempre
+  // à mesma resposta sem precisar combinar estado. A única escrita que sobrou
+  // no par mora no app-mode.js e é uma limpeza: removeItem da chave legada
+  // localStorage.pbApp, do preview ?pbapp=1 que foi removido.
+  const inApp = /PigBankApp/.test(navigator.userAgent) || standalone;
   if (!inApp) return;
 
   document.documentElement.classList.add("pb-safe");

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -9,10 +9,19 @@ aberturas, e o `login.html` pula direto pra `/home` quando a sessão está viva.
 - **Modo remoto** (`server.url` no `capacitor.config.json`): o WebView carrega o
   site de produção. Deploy do site = update do app, sem passar pela App Store
   (só mudanças nativas exigem novo build).
-- **User agent** ganha o sufixo `PigBankApp/1.0`. O frontend usa isso
-  (`window.PB_IN_APP` em `auth-refresh.js`) pra esconder CTAs de upgrade e
-  trocar o redirect de paywall por tela neutra — exigência da diretriz 3.1.1
-  da App Store (sem link de compra externa dentro do app).
+- **User agent** ganha o sufixo `PigBankApp/1.0` (`capacitor.config.json:18`).
+  **Este sufixo sustenta o LAYOUT INTEIRO do app**, não só as regras da App
+  Store: depois que o preview `?pbapp=1` foi removido, ele e o ícone instalado
+  (`display-mode: standalone`) são os ÚNICOS gatilhos de `html.pb-app`
+  (`frontend/app-mode.js`) e de `html.pb-safe` (`frontend/safe-area.js`) — sem
+  ele o app abre com layout de site: nav, footer, sem tab bar, desenhando sob o
+  notch. Quem for mexer aqui: os dois arquivos e o servidor
+  (`frontend/routes/shared.py:548`) casam por SUBSTRING `PigBankApp`, então
+  trocar o número da versão é seguro; trocar o NOME quebra tudo.
+  Além do layout, o mesmo UA vira `window.PB_IN_APP` (`auth-refresh.js`), que
+  esconde CTAs de upgrade e troca o redirect de paywall por tela neutra —
+  exigência da diretriz 3.1.1 da App Store (sem link de compra externa dentro
+  do app).
 - **Regra de push** (Anexo 1 do contrato Apple): notificação NÃO pode conter
   valor, saldo ou dado financeiro — texto genérico, detalhe só dentro do app.
 - Plugins instalados: `@capacitor/app`, `@capacitor/push-notifications`

--- a/tests/frontend/app_mode_gate.test.mjs
+++ b/tests/frontend/app_mode_gate.test.mjs
@@ -1,0 +1,204 @@
+/**
+ * Porteiro do modo app: QUEM ganha html.pb-app (app-mode.js) e html.pb-safe
+ * (safe-area.js).
+ *
+ * UM invariante: modo app é do APP (UA PigBankApp) e do ÍCONE INSTALADO
+ * (standalone), e de mais nada. Nenhum storage e nenhuma query participam da
+ * decisão — o preview ?pbapp=1 foi REMOVIDO. Ele gravava localStorage.pbApp
+ * pra sempre, sem UI de saída, e travou o Safari de um usuário de verdade;
+ * qualquer link velho (histórico, autocomplete, bookmark, WhatsApp) reabria a
+ * armadilha. Quem ficou preso se destrava no primeiro load porque o GATE parou
+ * de ler a chave — o removeItem que sobrou é higiene, não a saída. E os dois
+ * scripts têm que concordar: pb-safe sem pb-app deixa o site com respiro de
+ * notch sem motivo.
+ *
+ * Sem browser: o gate dos dois arquivos é JS puro (storage, navigator,
+ * matchMedia, location.search) e só toca no DOM na PRIMEIRA linha depois de
+ * decidir — `classList.add`. O stub abaixo registra a classe e estoura um
+ * sentinela ali, o que também poda as ~980 linhas de montagem da tab bar.
+ * Por isso este teste não precisa do playwright do outro .test.mjs.
+ *
+ * Rodar:  npm run test:frontend
+ *         (ou, um arquivo só: node --test tests/frontend/app_mode_gate.test.mjs
+ *          — `node --test tests/frontend/` NÃO funciona no Node 24 do Windows:
+ *          ele trata o diretório como módulo e sai com MODULE_NOT_FOUND.)
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
+const APP_MODE = join(FRONTEND, "app-mode.js");
+const SAFE_AREA = join(FRONTEND, "safe-area.js");
+const FILES = [[APP_MODE, "pb-app"], [SAFE_AREA, "pb-safe"]];
+
+const SAFARI = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1";
+const APP_UA = SAFARI + " PigBankApp/1.0";
+/** Versões que o app ainda vai ter: o sufixo mora em capacitor.config.json. */
+const APP_UA_NEXT = [SAFARI + " PigBankApp/2.7", SAFARI + " PigBankApp/10.0.3"];
+
+/** Storage do modo privado/cookies bloqueados: qualquer acesso estoura. */
+const THROWS = new Proxy({}, {
+  get() { throw new Error("SecurityError: storage bloqueado"); },
+});
+
+const mapStorage = (m) => ({
+  getItem: (k) => (m.has(k) ? m.get(k) : null),
+  setItem: (k, v) => m.set(k, String(v)),
+  removeItem: (k) => m.delete(k),
+});
+
+class Stop extends Error {}
+
+/**
+ * Roda `file` num contexto falso e devolve se `cls` foi aplicada.
+ * `store`/`session` podem ser reaproveitados entre chamadas pra simular dois
+ * loads seguidos no mesmo aparelho/aba.
+ */
+function run(file, cls, ctx = {}) {
+  const {
+    ua = SAFARI, stored = null, search = "", displayMode = false, iosStandalone = false,
+    store = new Map(), session = new Map(),
+    localStorage: lsOverride, sessionStorage: ssOverride,
+  } = ctx;
+  if (stored !== null) store.set("pbApp", stored);
+  const added = [];
+
+  const navigator = { userAgent: ua };
+  if (iosStandalone) navigator.standalone = true;
+  const sandbox = {
+    navigator,
+    localStorage: lsOverride || mapStorage(store),
+    sessionStorage: ssOverride || mapStorage(session),
+    location: { search, pathname: "/app", replace: () => {} },
+    matchMedia: (q) => ({ matches: displayMode && q.includes("standalone") }),
+    document: {
+      documentElement: { classList: { add: (c) => { added.push(c); throw new Stop(); } } },
+    },
+    URLSearchParams,
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  try {
+    vm.runInContext(readFileSync(file, "utf8"), sandbox, { filename: file });
+  } catch (e) {
+    if (!(e instanceof Stop)) throw e;
+  }
+  return {
+    applied: added.includes(cls),
+    pbApp: store.has("pbApp") ? store.get("pbApp") : null,
+    store,
+    session,
+  };
+}
+
+const appMode = (ctx) => run(APP_MODE, "pb-app", ctx);
+const safeArea = (ctx) => run(SAFE_AREA, "pb-safe", ctx);
+
+test("navegador travado pelo ?pbapp=1 antigo volta pro site e se auto-limpa", () => {
+  const r = appMode({ stored: "1" });
+  assert.equal(r.applied, false);
+  assert.equal(r.pbApp, null, "a chave legada tem que sumir do localStorage");
+});
+
+test("navegador limpo continua no site", () => {
+  assert.equal(appMode({}).applied, false);
+});
+
+test("app iOS entra, mesmo sem storage nenhum e sem query — e sem gravar nada", () => {
+  // A segunda metade é o contrário do bug original: re-armar localStorage.pbApp
+  // no caminho do app recria a forma exata dele (chave gravada pra sempre, sem
+  // UI de saída). Hoje seria inócuo, porque ninguém mais LÊ a chave — e é por
+  // ser inócuo que passaria despercebido até alguém religar a leitura.
+  for (const [file, cls] of FILES) {
+    const r = run(file, cls, { ua: APP_UA });
+    assert.equal(r.applied, true, cls);
+    assert.equal(r.store.size, 0, `${cls}: o caminho do app não pode gravar no localStorage`);
+    assert.equal(r.session.size, 0, `${cls}: nem no sessionStorage`);
+  }
+});
+
+test("o gatilho é a SUBSTRING PigBankApp: bump de versão não desliga o app", () => {
+  // O sufixo do UA (mobile/capacitor.config.json:18) vai mudar, e depois da
+  // remoção do preview ele é o ÚNICO gatilho do app nativo: uma regex cravada
+  // em "PigBankApp/1.0" derrubaria o layout do app inteiro num bump de versão,
+  // em todas as páginas. O servidor já tem esse contrato coberto
+  // (shared.py:548 usa `"PigBankApp" in ua`; test_gate_plan_selection.py:82
+  // testa com PigBankApp/1.2) — o cliente precisa do mesmo.
+  for (const [file, cls] of FILES) {
+    for (const ua of APP_UA_NEXT) {
+      assert.equal(run(file, cls, { ua }).applied, true, `${cls}: ${ua}`);
+    }
+  }
+});
+
+test("ícone instalado entra pelos dois sinais de standalone", () => {
+  assert.equal(appMode({ displayMode: true }).applied, true);
+  assert.equal(appMode({ iosStandalone: true }).applied, true);
+});
+
+test("storage que estoura em qualquer acesso não derruba o app nativo", () => {
+  // Sem o try/catch em volta do localStorage.removeItem, a exceção mata o
+  // script antes do classList.add e o app abre com layout de site (nav,
+  // footer, sem tab bar). Este é o caso que prova o try/catch — e que trava
+  // qualquer volta de leitura de storage sem proteção.
+  for (const [file, cls] of FILES) {
+    assert.equal(run(file, cls, { ua: APP_UA, localStorage: THROWS }).applied, true,
+      `${cls}: localStorage bloqueado`);
+    assert.equal(run(file, cls, { ua: APP_UA, sessionStorage: THROWS }).applied, true,
+      `${cls}: sessionStorage bloqueado`);
+    assert.equal(run(file, cls, { ua: APP_UA, localStorage: THROWS, sessionStorage: THROWS }).applied,
+      true, `${cls}: os dois bloqueados`);
+  }
+});
+
+test("?pbapp=1 no navegador comum NÃO liga o modo app — nem no load seguinte", () => {
+  // O preview foi removido de propósito: um link velho (histórico,
+  // autocomplete, bookmark, WhatsApp) não pode mais prender uma aba de Safari
+  // em modo app. Nem naquele load, nem no próximo — porque nada é gravado.
+  for (const [file, cls] of FILES) {
+    const store = new Map(), session = new Map();
+    assert.equal(run(file, cls, { search: "?pbapp=1", store, session }).applied, false,
+      `${cls}: load com ?pbapp=1`);
+    assert.equal(store.size, 0, `${cls}: não pode gravar no localStorage`);
+    assert.equal(session.size, 0, `${cls}: não pode gravar no sessionStorage`);
+    assert.equal(run(file, cls, { search: "", store, session }).applied, false,
+      `${cls}: load seguinte, sem query`);
+
+    // Aba que ficou armada pela versão ANTERIOR (sessionStorage.pbApp) também
+    // não vale mais: o iOS restaura sessionStorage quando a aba volta.
+    assert.equal(run(file, cls, { search: "", session: new Map([["pbApp", "1"]]) }).applied, false,
+      `${cls}: sessão armada pela versão antiga`);
+  }
+});
+
+test("safe-area decide igual ao app-mode em todo contexto", () => {
+  // As queries pbapp e as chaves pbApp aqui são SOBRAS DE MUNDO, não features:
+  // link velho no histórico/WhatsApp, aparelho travado pela versão antiga. O
+  // ?pbapp=1 não liga nada e o ?pbapp=0 não desliga nada (não há mais o que
+  // desligar) — entram na lista só pra provar que os DOIS arquivos ignoram
+  // cada uma delas do mesmo jeito, hoje e depois de qualquer refactor.
+  const CTXS = [
+    {}, { stored: "1" }, { ua: APP_UA }, { displayMode: true }, { iosStandalone: true },
+    { search: "?pbapp=1" }, { search: "?pbapp=0" },
+    { session: new Map([["pbApp", "1"]]) },
+    { stored: "1", search: "?pbapp=1", session: new Map([["pbApp", "1"]]) },
+    { ua: APP_UA, localStorage: THROWS, sessionStorage: THROWS },
+  ];
+  for (const [i, ctx] of CTXS.entries()) {
+    // Storage fresco por chamada é higiene, não necessidade: o app-mode escreve
+    // storage (removeItem da chave legada, app-mode.js:35) mas o safe-area não
+    // LÊ storage nenhum, então não há o que um vazar pro outro. A cópia só
+    // mantém as duas chamadas independentes se algum dia voltarem a ler.
+    const a = appMode({ ...ctx, store: new Map(ctx.store), session: new Map(ctx.session) });
+    const b = safeArea({ ...ctx, store: new Map(ctx.store), session: new Map(ctx.session) });
+    // Só campos escalares na mensagem: JSON.stringify(ctx) estoura no Proxy de
+    // storage da lista.
+    const label = `${Object.keys(ctx).join()} search=${JSON.stringify(ctx.search ?? "")}`
+      + ` ua=${/PigBankApp/.test(ctx.ua ?? "") ? "PigBankApp" : "Safari"}`;
+    assert.equal(b.applied, a.applied, `contexto #${i}: ${label}`);
+  }
+});

--- a/tests/frontend/pb_nav_gate.test.mjs
+++ b/tests/frontend/pb_nav_gate.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * Porteiro do motor SPA experimental (pb-nav.js): QUEM liga o pbspa.
+ *
+ * UM invariante: o atalho ?pbspa=1 só vale DENTRO do modo app (html.pb-app) e
+ * só pela sessão (sessionStorage). Fora do modo app a query não liga nada e —
+ * o que importa — não GRAVA nada: era assim que o link de QA
+ * /home?pbspa=1 aberto no navegador deixava a flag armada no aparelho pra
+ * sempre, sem UI de saída, e o motor experimental acordava sozinho no próximo
+ * abrir do app. A chave pbSpa legada do localStorage não liga mais nada e é
+ * apagada em todo load.
+ *
+ * Arquivo separado do app_mode_gate porque o formato é outro: o app-mode
+ * decide com um classList.add (sentinela), o pb-nav decide num const `enabled`
+ * exposto em window.PBNav. Aqui o IIFE roda inteiro — no load ele só lê
+ * storage/navigator e registra handlers; nada de DOM até um boot()/tap.
+ *
+ * Rodar:  npm run test:frontend
+ *         (ou, um arquivo só: node --test tests/frontend/pb_nav_gate.test.mjs
+ *          — `node --test tests/frontend/` NÃO funciona no Node 24 do Windows:
+ *          ele trata o diretório como módulo e sai com MODULE_NOT_FOUND.)
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+const PB_NAV = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend", "pb-nav.js");
+
+/** Storage do modo privado/cookies bloqueados: qualquer acesso estoura. */
+const THROWS = new Proxy({}, {
+  get() { throw new Error("SecurityError: storage bloqueado"); },
+});
+
+const mapStorage = (m) => ({
+  getItem: (k) => (m.has(k) ? m.get(k) : null),
+  setItem: (k, v) => m.set(k, String(v)),
+  removeItem: (k) => m.delete(k),
+});
+
+/**
+ * Roda pb-nav.js num contexto falso. `store`/`session` podem ser reaproveitados
+ * entre chamadas pra simular dois loads seguidos no mesmo aparelho/aba (é assim
+ * que o sessionStorage se comporta de verdade: sobrevive ao load, morre com a
+ * aba).
+ */
+function run(ctx = {}) {
+  const {
+    inApp = false, search = "", store = new Map(), session = new Map(),
+    localStorage: lsOverride, sessionStorage: ssOverride,
+  } = ctx;
+  // Toda leitura de localStorage fica registrada: o gate decide sem consultar
+  // o aparelho, e isso é o que impede a chave legada de voltar a valer.
+  const localReads = [];
+  const spied = mapStorage(store);
+  const localGet = spied.getItem;
+  spied.getItem = (k) => { localReads.push(k); return localGet(k); };
+  const sandbox = {
+    location: {
+      search, hostname: "pigbankai.com", pathname: "/home", hash: "",
+      origin: "https://pigbankai.com", href: "https://pigbankai.com/home",
+    },
+    localStorage: lsOverride || spied,
+    sessionStorage: ssOverride || mapStorage(session),
+    document: {
+      documentElement: { classList: { contains: (c) => c === "pb-app" && inApp } },
+      startViewTransition() {},
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      scripts: [],
+    },
+    DOMParser: function DOMParser() {},
+    addEventListener() {},
+    URLSearchParams, URL, console, performance,
+    fetch: () => Promise.reject(new Error("sem rede no teste")),
+  };
+  sandbox.window = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(readFileSync(PB_NAV, "utf8"), sandbox, { filename: PB_NAV });
+  return {
+    enabled: sandbox.PBNav.enabled,
+    store, session, localReads,
+    local: store.has("pbSpa") ? store.get("pbSpa") : null,
+    sess: session.has("pbSpa") ? session.get("pbSpa") : null,
+  };
+}
+
+test("?pbspa=1 no navegador comum não liga nem grava — nem no load seguinte", () => {
+  // O caminho cruzado que este gate fecha: clicar o link de QA no navegador
+  // não mostra nada (o motor exige pb-app), mas a versão antiga já tinha
+  // gravado a flag; depois, abrindo pelo ícone/app, o modo app aparecia, a
+  // flag era lida e o motor experimental ligava sem ninguém ter pedido.
+  const store = new Map(), session = new Map();
+  const first = run({ inApp: false, search: "?pbspa=1", store, session });
+  assert.equal(first.enabled, false, "load com ?pbspa=1 fora do app");
+  assert.equal(store.size, 0, "não pode gravar no localStorage");
+  assert.equal(session.size, 0, "não pode gravar no sessionStorage");
+
+  assert.equal(run({ inApp: false, search: "", store, session }).enabled, false,
+    "load seguinte, sem query");
+  // E o pulo do gato: entrar no modo app depois NÃO pode achar flag nenhuma.
+  assert.equal(run({ inApp: true, search: "", store, session }).enabled, false,
+    "abrir o app depois do link no navegador");
+});
+
+test("?pbspa=1 dentro do app liga, grava só na sessão e vale no load seguinte", () => {
+  const store = new Map(), session = new Map();
+  const r = run({ inApp: true, search: "?pbspa=1", store, session });
+  assert.equal(r.enabled, true);
+  assert.equal(r.sess, "1", "a flag mora no sessionStorage");
+  assert.equal(store.size, 0, "e nunca no localStorage — é isso que a tornaria permanente");
+  // Sem isso o atalho seria inútil: trocar de aba dentro do app perde a query.
+  assert.equal(run({ inApp: true, search: "", store, session }).enabled, true,
+    "próximo load da mesma sessão continua ligado");
+});
+
+test("?pbspa=0 dentro do app desliga e limpa a sessão", () => {
+  const session = new Map([["pbSpa", "1"]]);
+  const r = run({ inApp: true, search: "?pbspa=0", session });
+  assert.equal(r.enabled, false);
+  assert.equal(r.sess, null, "a saída explícita tem que apagar a flag");
+});
+
+test("localStorage.pbSpa legado não liga em lugar nenhum e é apagado", () => {
+  for (const inApp of [false, true]) {
+    const store = new Map([["pbSpa", "1"]]);
+    const r = run({ inApp, store });
+    assert.equal(r.enabled, false, `inApp=${inApp}: chave legada não pode ligar`);
+    assert.equal(r.local, null, `inApp=${inApp}: chave legada tem que sumir`);
+    // O destravamento vem do gate, não do removeItem: ele não LÊ o
+    // localStorage. Sem esta asserção, religar a leitura da chave legada
+    // (ainda que hoje inócua, porque o removeItem roda antes) passaria batido.
+    assert.deepEqual(r.localReads, [], `inApp=${inApp}: o gate não pode ler o localStorage`);
+  }
+});
+
+test("storage que estoura em qualquer acesso não derruba o pb-nav", () => {
+  // Sem try/catch a exceção mata o arquivo inteiro antes do window.PBNav — e o
+  // dock do app-mode chama PBNav.go em todo tap de aba.
+  // Com só o localStorage bloqueado o atalho segue funcionando (a flag mora na
+  // sessão); com a sessão bloqueada não há onde guardar e o motor fica
+  // desligado — fail-safe. Nos três casos o arquivo tem que chegar ao fim.
+  for (const [label, over, want] of [
+    ["localStorage bloqueado", { localStorage: THROWS }, true],
+    ["sessionStorage bloqueado", { sessionStorage: THROWS }, false],
+    ["os dois bloqueados", { localStorage: THROWS, sessionStorage: THROWS }, false],
+  ]) {
+    const r = run({ inApp: true, search: "?pbspa=1", ...over });
+    assert.equal(typeof r.enabled, "boolean", `${label}: PBNav tem que existir`);
+    assert.equal(r.enabled, want, `${label}: enabled`);
+  }
+  // E fora do app, com storage estourando, também não pode ligar nem morrer.
+  assert.equal(run({ search: "?pbspa=1", localStorage: THROWS, sessionStorage: THROWS }).enabled,
+    false, "navegador comum com storage bloqueado");
+});
+
+test("sem flag nenhuma o motor fica desligado, dentro e fora do app", () => {
+  assert.equal(run({ inApp: true }).enabled, false);
+  assert.equal(run({ inApp: false }).enabled, false);
+});


### PR DESCRIPTION
## O problema

O dashboard renderizava em **dois layouts diferentes no mesmo aparelho**, com 6 minutos de diferença: aba privada mostrava o layout web (coluna única, barra `Atualizar / Importar OFX / Exportar`, pill de usuário, `+ Lançar`), aba normal mostrava o layout de app (grade 2x2, bottom nav, FAB).

Causa: a classe `pb-app` no `<html>` podia ser ligada por uma flag no `localStorage`, gravada a partir de `?pbapp=1` — o atalho de QA documentado no próprio `pb-nav.js`. A flag era **permanente** e não tinha UI de saída, só `?pbapp=0` — que é silenciosamente descartado quando um gate de página redireciona, porque os 302 de `shared.py` usam `request.url.path`, sem query. Um Safari que visitou o link de teste uma vez ficava travado em modo app indefinidamente.

## A mudança

O preview foi **removido** em vez de mitigado (expiração por prazo foi a primeira proposta e descartada — mitiga a instância, não a classe). O gate agora é só:

```js
const inApp = /PigBankApp/.test(navigator.userAgent) || standalone;
```

Nenhum storage e nenhuma query participam da decisão, então **não existe mais como travar um navegador em modo app**.

**O app nativo não é afetado.** Ele entra pelo sufixo de user agent que injeta em si mesmo (`mobile/capacitor.config.json`), que sempre foi o único sinal válido lá dentro — `localStorage.pbApp` e `standalone` nunca são verdadeiros no WKWebView do Capacitor, então os termos removidos nunca valeram no app. `git log -S` confirma que o `appendUserAgent` existe desde o commit que criou o projeto iOS: não há build publicado sem ele.

Sobrou `localStorage.removeItem("pbApp")` como higiene da chave legada. Quem destrava é o gate ter parado de ler storage — a limpeza só remove uma chave que ninguém mais lê. O `try/catch` é obrigatório: essa é a única linha dos dois arquivos que toca storage, e `localStorage` estoura em aba privada do iOS.

`pb-nav.js` recebe o mesmo tratamento — `?pbspa=1` gravava `pbSpa` no `localStorage` para sempre, a partir de uma URL, antes de checar `pb-app`. Agora só grava dentro do modo app, em `sessionStorage`, e a chave legada é apagada. O motor SPA e o roteamento estão intocados.

## Testes

`tests/frontend/app_mode_gate.test.mjs` (8) e `tests/frontend/pb_nav_gate.test.mjs` (6), rodando os arquivos reais em `node:vm`. Cobrem: navegador legado destravando e se auto-limpando; app entrando sem storage nenhum; `standalone` pelos dois sinais; storage que estoura em qualquer acesso não derrubando o app; `?pbapp=1` sendo inerte no navegador (nem naquele load, nem no seguinte); o contrato de **substring** do user agent (um bump de versão não pode desligar o app — o servidor já era version-agnostic e testado, o cliente não era); e a equivalência entre `app-mode.js` e `safe-area.js`.

Validação adversarial antes do merge: 7296 combinações de query, chave legada, ordem dos dois scripts e loads sucessivos → 0 vazamentos. 17 mutantes → os 2 que sobreviveram (regex de UA cravada na versão; caminho do app escrevendo em storage) viraram os testes novos e agora ficam vermelhos.

## Não verificado

- Nada rodou em iPhone real, WKWebView ou PWA instalada — os testes são sandbox `node:vm` com `navigator` falso e não observam layout.
- Nada rodou em produção. O `stamp_asset_versions` (que garante que o JS novo chegue apesar do cache) foi verificado por leitura de código e pela regex isolada, não por request real.
- O motor SPA em si não foi exercitado, só o gate dele.
- `npm run test:frontend` termina vermelho neste checkout por `playwright` ausente — falha **pré-existente**, não deste diff.

## Pré-existentes encontrados de passagem (fora do escopo, não corrigidos)

- `frontend/dashboard.html:30` carrega `app-mode.js` com `defer`, contrariando o cabeçalho do próprio arquivo. Sem efeito no site depois deste fix (a classe nunca é adicionada), mas continua valendo dentro do app.
- Num PWA standalone **sem** o UA `PigBankApp`, `app-mode.js` liga `pb-app` mas `auth-refresh.js` não liga `window.PB_IN_APP` — os CTAs de `/precos` aparecem. Tem cheiro de trava da App Store.
- `?lancar=1` não tem cobertura de teste (exigiria um stub que sobreviva ao `classList.add` e monte ~980 linhas de tab bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
