### PR TITLE
feat(landing): como funciona vira trilho de 3 cards que abrem no cursor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,116 @@
 
 ---
 
+## 0. Regras permanentes — leia antes de escrever qualquer linha
+
+**Estas regras valem para toda alteração de código deste repositório**, sem exceção:
+implementação, correção, refatoração, arquivo novo. Não são um checklist de abertura
+— elas valem durante o trabalho inteiro, e de novo a cada nova tarefa da mesma sessão.
+
+**Antes de começar, leia o `CLAUDE.md` relevante.** Este arquivo para processo;
+`docs/CLAUDE.md` para domínio (tabelas, endpoints, integrações). Se existir um
+`CLAUDE.md` mais específico dentro da área que você vai mexer, ele também vale — e o
+mais específico ganha quando os dois falarem do mesmo assunto.
+
+### 0.1 Procure antes de criar
+
+Antes de escrever **qualquer** função, classe, helper, utilitário, componente,
+módulo, endpoint, serviço, arquivo ou abstração: **procure se já existe**. Este
+repositório tem 300+ arquivos Python e 15 anos-pessoa de código acumulado em
+`dashboard.js` — a chance de o que você precisa já existir é alta, e a de você
+não achar sem procurar é ainda maior.
+
+```bash
+grep -rn "nome_provavel\|conceito" --include="*.py" --exclude-dir=.venv --exclude-dir=.claude .
+git grep -n "conceito" -- frontend/
+```
+
+Nunca crie função nova porque criar é mais rápido que procurar. Ordem de preferência,
+nesta ordem:
+
+1. **reutilizar** uma função existente;
+2. **estender** uma existente, quando fizer sentido para os dois chamadores;
+3. **extrair** o comportamento comum, quando houver reutilização real (não especulada);
+4. só então **criar** algo novo.
+
+Não copie-e-cole lógica para outro lugar. Duas funções com nomes diferentes fazendo
+essencialmente a mesma coisa são um bug esperando o dia em que só uma for corrigida —
+já aconteceu aqui (`handlers/credit.py` × `core/handlers/credit.py`, ver
+`docs/refactor_plan.md`).
+
+### 0.2 Escreva o mínimo que resolve
+
+A solução preferida é a mais simples que resolve **corretamente** o problema. Evite:
+abstração prematura, wrapper desnecessário, helper de uso único, código defensivo
+exagerado, sistema genérico para problema específico, camada nova de arquitetura,
+comentário explicando o óbvio, duplicação, boilerplate, e funcionalidade que ninguém
+pediu.
+
+Não "melhore" área não relacionada. Não transforme mudança pequena em refatoração
+grande. Isso **não** vale para o que nunca se simplifica: validação em fronteira de
+confiança, tratamento de erro que evita perda de dado, segurança, acessibilidade, e
+o que foi explicitamente pedido.
+
+### 0.3 Mudanças cirúrgicas
+
+Para bug e feature pequena: mudança pequena e localizada. Não altere arquivo que não
+precisa mudar, não renomeie sem necessidade, não reformate arquivo inteiro para trocar
+três linhas, não misture refatoração não relacionada com feature. **O diff deve ser o
+menor possível sem comprometer a solução** — e o revisor mede o PR pelo que ele tem de
+ler, não pelo que você achou bonito de arrumar no caminho.
+
+### 0.4 Entenda o fluxo antes de mexer
+
+Nunca altere funcionalidade importante olhando só o trecho isolado. Antes de tocar em
+**autenticação, MFA, pagamentos, Open Finance, WebSocket, navegação, estado global,
+service worker ou cache**, levante o fluxo inteiro: quem chama, quem escuta, quais
+callbacks, quais eventos, quais imports, quais endpoints relacionados, quais efeitos
+colaterais. É o mesmo inventário do §2, e a §5 lista onde ele já foi pago caro.
+
+### 0.5 Organização de arquivos é prioridade
+
+Arquivo grande demais não é tradição a ser respeitada. Se um arquivo acumula
+responsabilidades diferentes, divida por assunto:
+
+```text
+dashboard/                 em vez de     dashboard.js
+  boletos.js                             // 10.587 linhas, 414 funções
+  cartoes.js
+  investimentos.js
+```
+
+Ao criar arquivo novo: uma responsabilidade clara, nome que a reflita, diretório
+apropriado. Nada de `utils.js`/`helpers.js`/`common.js`/`misc.js` gigantes onde coisa
+não relacionada é despejada. Ao mexer num arquivo já enorme, pergunte se o novo código
+não cabe melhor num módulo separado.
+
+O oposto também é erro: não estilhace em dezenas de arquivos minúsculos sem ganho.
+O alvo é **coesão alta, acoplamento baixo, estrutura fácil de navegar**.
+
+### 0.6 Respeite a arquitetura atual
+
+Não introduza framework, biblioteca ou padrão arquitetural novo porque seria a forma
+mais moderna. Antes de adicionar dependência, veja se o projeto ou a própria
+plataforma já resolvem (o navegador tem módulos ES, `<dialog>`, `Intl`, View
+Transitions; o Postgres tem constraint). Alteração local segue o padrão existente,
+salvo decisão explícita de migração.
+
+### 0.7 Uma fonte de verdade
+
+Antes de adicionar constante, configuração, status, string, regra de negócio, lista ou
+mapeamento: veja se já existe a fonte oficial daquilo. Não mantenha duas versões da
+mesma regra em lugares diferentes. Quando a duplicação for inevitável (ex.: HTML
+estático que não consegue importar Python), **um teste tem que comparar as duas** —
+é o que já se faz com o subset de ícones (`tests/test_phosphor_subset.py`).
+
+### 0.8 Otimize para quem vem depois
+
+Entre duas soluções equivalentes, prefira a que tem menos código, menos estado, menos
+dependências, reutiliza o que existe, deixa claro de quem é cada responsabilidade e
+vai ser mais fácil de mudar. Não otimize só para a implementação de hoje funcionar.
+
+---
+
 ## 1. Antes de escrever a primeira linha
 
 **Entenda a queixa antes de diagnosticar.** Relato de usuário quase nunca é
@@ -73,12 +183,19 @@ export JWT_SECRET="…"                    # 32+ bytes
 export PII_ENCRYPTION_KEY="…" PII_HASH_PEPPER="…"
 export PII_AUDIT_DISABLED=1 RUN_BACKGROUND_TASKS=0
 
-PYTHONPATH=. python3 -m pytest -q                 # tudo
-PYTHONPATH=. python3 -m pytest tests/test_x.py -q # durante o desenvolvimento
+PY=/Users/<user>/Desktop/bot/bot_wa/.venv/bin/python   # na máquina local; ver §6a
+PYTHONPATH=. $PY -m pytest -q                 # tudo
+PYTHONPATH=. $PY -m pytest tests/test_x.py -q # durante o desenvolvimento
 ```
 
-Use `python3 -m pytest`, não `pytest` solto — o binário no PATH pode ser de outro
-interpretador, sem as dependências instaladas.
+Use `<interpretador> -m pytest`, nunca `pytest` solto — o binário no PATH costuma ser
+de outro interpretador, sem as dependências. **Na máquina local o `python3` do PATH
+(Homebrew) não tem nem `fastapi` nem `pytest`**: use o do `.venv` da raiz, que tem
+tudo (§6a). No sandbox da web o interpretador é o `python3` mesmo, e aí valem as
+exclusões do §6b.
+
+**Frontend:** `npm run test:frontend` (`node --test tests/frontend/*.test.mjs`, com
+Playwright). O `package.json` da raiz existe só para isso — não há build de JS.
 
 O CI (`.github/workflows/tests.yml`) sobe seu próprio Postgres 16 e roda `pytest`
 (bloqueante) e `audit` de CVEs (não-bloqueante) em todo push e PR. Não use o CI como
@@ -285,6 +402,86 @@ O app iOS (Capacitor, `mobile/`) carrega `https://pigbankai.com` num WKWebView c
   ~8 HTMLs por PR e `v=31` vs `v=33` na mesma linha dava merge conflict a cada duas
   PRs paralelas. Asset servido de fora de `frontend/` fica intacto.
 
+### Frontend: como a navegação funciona hoje
+
+Não há build, não há bundler, não há framework: o `package.json` da raiz existe **só**
+para o harness de testes de frontend (`node --test tests/frontend/*.test.mjs`, com
+Playwright). O HTML é escrito à mão e servido pelo FastAPI; templating de servidor
+existe em dois lugares só, por `str.replace("{{X}}")` (`/blog/{slug}` e o `{{FAQ}}` do
+`/suporte`, ambos em `frontend/routes/static_pages.py`).
+
+Três mundos convivem, e confundi-los produz bug:
+
+| | como navega | quem |
+|---|---|---|
+| **Páginas públicas** | MPA clássico, request por clique | `index`, `precos`, `funcionalidades`, `termos`, `privacy`, `suporte`, `blog/*`, `whatsapp`, … |
+| **Área logada** | MPA clássico **também**, com muito JS por página | `dashboard`, `settings`, `home`, `onboarding` |
+| **POC de SPA** | `fetch` + troca de DOM, **desligado por padrão** | só `/home` e `/comandos-app`, só no app |
+
+**O POC de SPA é o `frontend/pb-nav.js`, e ele NÃO está ligado em produção.** Ler o
+cabeçalho do arquivo antes de tocar em navegação. O que ele é, exatamente:
+
+- Ativa só quando as **três** condições valem: modo app (`html.pb-app`) **e** a flag
+  `pbspa` em `sessionStorage` (ligada por `?pbspa=1` dentro do app, desligada por
+  padrão, morre com a sessão) **e** a rota estar em `ROUTES` — que hoje tem **duas**
+  entradas: `/home` e `/comandos-app` (`pb-nav.js:93`).
+- Quando ativo: `fetch` da próxima página, swap dos nós dentro de
+  `document.startViewTransition`, `history.pushState`, cache por página (nós, estilos,
+  título, scroll) e re-execução dos inits. Existe para matar a piscada preta do
+  WKWebView entre documentos, não para virar SPA.
+- **Contrato por página convertida**: script inline embrulhado em
+  `(PBPages.<key> ||= {inits:[]}).inits.push(fn)`, e o último script marcado
+  `data-pb-boot` chamando `PBNav.boot("<key>")`. Quebrar esse contrato quebra a página
+  no app e não quebra nada no navegador — o pior tipo de bug daqui.
+- **Fallback sempre-navega**: qualquer erro (fetch, timeout de 5s, redirect de auth,
+  rota não convertida) cai em `location.href`. O pior caso é o comportamento de hoje.
+
+Ao escrever qualquer coisa nova, o default é **MPA**. Não descreva nem trate a área
+logada como SPA, e não presuma que uma migração para framework aconteceu: ela não
+aconteceu, nem está decidida.
+
+### `dashboard.js`: 10.587 linhas num arquivo só
+
+É o maior passivo de organização do repositório e o exemplo vivo da §0.5: **414
+funções e 159 `const/let` no escopo global**, 35 seções demarcadas por comentário,
+491 KB. Nasceu de um `<script>` inline extraído do `dashboard.html` ("refactor Fase 1:
+CSP script-src").
+
+Três fatos que decidem qualquer mexida ali:
+
+- **`dashboard.html` tem 139 handlers inline** (`onclick="abrirX()"`) chamando **86
+  nomes** distintos. Eles funcionam porque o arquivo é script clássico e tudo no topo
+  é global. `settings.html` tem 61 handlers inline e `home.html` tem 11.
+- **Trocar por `<script type="module">` sem mais nada quebra os 139** — módulo tem
+  escopo próprio, os nomes somem do `window`, o botão para de funcionar **sem erro
+  visível**. Enquanto os handlers inline existirem, qualquer divisão precisa devolver
+  os 86 nomes ao `window` e ter teste que compare a lista com o HTML.
+- **Esses handlers inline são também o que segura o `'unsafe-inline'`** no
+  `script-src` da CSP. A Fase 1 já tirou o `<script>` inline; matar os handlers é o
+  que falta para fechar o `script-src`.
+
+Ao adicionar funcionalidade nova de dashboard, **prefira arquivo novo** a mais uma
+seção nesse arquivo — e ele precisa de rota própria em `static_pages.py` (ver abaixo).
+
+### Assets: não há `StaticFiles` mount
+
+Cada CSS/JS servido tem **uma rota `@router.get` escrita à mão** em
+`frontend/routes/static_pages.py`. Arquivo novo em `frontend/` **não é servido
+sozinho** — sem a rota, ele dá 404 e o sintoma aparece só no navegador.
+
+Cuidado ao mexer em cache aqui: o `stamp_asset_versions` reescreve `?v=` **no HTML**.
+Um `import "./x.js"` dentro de um JS **nunca é carimbado** — módulo ES importado por
+outro módulo não pode receber `immutable` enquanto não tiver hash no nome.
+
+### Service worker e PWA
+
+`frontend/service-worker.js` (`CACHE_NAME` versionado à mão, hoje `pigbank-v7`):
+HTML e auth nunca são cacheados, assets são network-first com fallback de cache,
+API e WebSocket passam direto. O `manifest.json` tem `start_url: "/login"` — e a
+`index.html` tem um guard no topo que manda a PWA instalada para `/login`, com saída
+por `?site=1`. Mexeu na estratégia de cache? Bumpe o `CACHE_NAME`, senão o aparelho
+que já instalou continua com o SW velho.
+
 ### Componentes fragmentados
 
 Três overlays (`.overlay`, `.pig-modal-overlay`, `.mfa-overlay`) e quatro modais
@@ -295,25 +492,67 @@ fixo de toda mudança de layout.
 
 ### Backend
 
-- **`db/` é um pacote**, não o `db.py` único que o `docs/CLAUDE.md` descreve — aquele
-  arquivo está desatualizado nesse ponto. As rotas também estão divididas em
-  `frontend/routes/`.
+- **`db/` é um pacote** com ~30 módulos por domínio, não um `db.py` único. O DDL de
+  todas as tabelas vive em `db/schema.py::init_db()` — é a fonte de verdade do schema
+  (§0.7), e o `docs/CLAUDE.md` aponta para lá em vez de repetir a lista.
+- **O monólito ainda existe e ainda cresce.**
+  `frontend/finance_bot_websocket_custom.py` tem ~14,5 mil linhas e concentra auth,
+  MFA, billing, WebSocket, dashboard e o `ConnectionManager`. Parte das rotas já saiu
+  para `frontend/routes/` (`static_pages`, `settings`, `pockets`, `cards`,
+  `analytics`, `open_finance`, `push`, `agents`, `affiliates`, `shared`), registradas
+  por `include_router`. **Rota nova vai para um router de `frontend/routes/`** — não
+  para o monólito. O plano completo está em `docs/refactor_plan.md`.
 - **Isolamento por usuário é regra dura**: toda query com `WHERE user_id = %s`.
   Nunca vazar dado entre usuários.
+- **`launch.py` sobe dois processos**: o uvicorn (que atende o `$PORT` do Railway) e o
+  `bot.py` do Discord. Um `web` no Procfile, dois processos filhos.
+- **Tarefas de fundo sobem no startup do app** quando `RUN_BACKGROUND_TASKS != "0"`
+  (agendadores de investimento, Open Finance, engajamento, cobrança recorrente…).
+  Em teste e no `dashboard_dev.py` isso é desligado — se você ligar sem querer num
+  ambiente com banco real, elas escrevem.
 
 ---
 
-## 6. Limites deste ambiente (não são bugs, não tente contornar)
+## 6. Limites do ambiente (não são bugs, não tente contornar)
 
-- **A produção não é acessível.** O proxy bloqueia `pigbankai.com` (403). Não dá para
-  conferir o comportamento real do site daqui.
+**Antes de tudo: descubra em QUAL ambiente você está.** São dois, com limites
+diferentes, e confundi-los já produziu documentação errada neste próprio arquivo.
+
+```bash
+ls -d /Users/<user>/Desktop/bot/bot_wa/.venv   # existe → máquina local
+python3 -c "import fastapi" 2>&1 | tail -1     # ModuleNotFoundError → não é o venv
+```
+
+### 6a. Máquina local (macOS)
+
+- **Existe um `.venv` na raiz do repositório com TODOS os pacotes**, inclusive
+  `ofxparse`, `reportlab` e `pypdf`. Nada do §6b abaixo se aplica aqui: não há
+  `--ignore`, não há os 9 erros de coleta, e os 7 testes de `test_statement_import.py`
+  não têm por que falhar por dependência.
+- **O `python3` do PATH (Homebrew) NÃO tem os pacotes** — nem `fastapi`, nem
+  `psycopg`, nem `pytest`. Rodar `python3 -m pytest` dá `ModuleNotFoundError` e isso
+  **não é falha de teste**. Use o interpretador do venv, com caminho absoluto:
+
+  ```bash
+  PYTHONPATH=. /Users/<user>/Desktop/bot/bot_wa/.venv/bin/python -m pytest -q
+  ```
+
+  Vale também a partir de um worktree de `.claude/worktrees/` — o venv da raiz serve
+  os dois.
+- **As variáveis de ambiente continuam obrigatórias** (§3). Sem elas o import de
+  `frontend/finance_bot_websocket_custom.py` chama `sys.exit(1)` na linha 277
+  (`DATABASE_URL`) e o pytest morre com `INTERNALERROR` — de novo, não é falha de
+  teste.
+- **A produção é acessível** por HTTP a partir daqui (medido: `GET https://pigbankai.com/`
+  → 200, assets idem). `HEAD` responde 405 com `Allow: GET`, e isso é o roteamento
+  sendo estrito, não uma falha. Antes de afirmar que algo está no ar, busque.
+
+### 6b. Sandbox do Claude Code na web
+
+- **A produção não é acessível**: o proxy bloqueia `pigbankai.com` (403).
 - **CDNs são bloqueados.** Chart.js e afins falham; `applyTheme` do dashboard, por
   exemplo, lança no meio por causa disso. Saiba disso ao interpretar um teste.
-- **`env(safe-area-inset-*)` vale sempre 0** no Chromium headless. Regras de área
-  segura são inertes aqui; só dá para verificar a aritmética substituindo valores fixos.
-- **Comportamento nativo do WKWebView não é reproduzível.** `contentInset`, elástico,
-  teclado: só no aparelho, depois do build.
-- **Faltam pacotes de `requirements.txt` aqui** — pelo menos `ofxparse`, `reportlab` e
+- **Faltam pacotes de `requirements.txt`** — pelo menos `ofxparse`, `reportlab` e
   `pypdf` (o `pip install` falha pelo proxy). A ausência do `ofxparse` não
   faz "alguns testes falharem": são **9 erros de coleta**, e o pytest **interrompe a
   suíte inteira** antes de rodar qualquer teste. Sem tratar isso você não tem sinal
@@ -402,7 +641,17 @@ fixo de toda mudança de layout.
   sinal, não baseline.
 
   No CI os três pacotes estão presentes (`requirements.txt:56–57,66`), então lá tudo
-  isso roda normalmente — a exclusão é só local.
+  isso roda normalmente — a exclusão é só do sandbox.
+
+### 6c. Vale nos dois ambientes
+
+- **`env(safe-area-inset-*)` vale sempre 0** no Chromium headless. Regras de área
+  segura são inertes ali; só dá para verificar a aritmética substituindo valores fixos.
+- **Comportamento nativo do WKWebView não é reproduzível.** `contentInset`, elástico,
+  teclado: só no aparelho, depois do build.
+- **Exportar PDF depende de `reportlab`** (`_render_pdf`,
+  `frontend/finance_bot_websocket_custom.py`). Onde o pacote falta, esse fluxo não é
+  exercitável — diga isso no relato em vez de chamar de testado.
 
 Nunca desligue verificação de TLS nem tire o `HTTPS_PROXY` para contornar bloqueio.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,212 +1,312 @@
-# Bot Financeiro — Contexto do Projeto
+# PigBank — contexto de domínio
 
-> Leia este arquivo no início de cada sessão antes de fazer qualquer coisa.
+> **Antes de escrever qualquer código, leia o `CLAUDE.md` da raiz.** Ele traz as
+> **regras permanentes de desenvolvimento** (§0: procurar antes de criar, escrever o
+> mínimo, mudança cirúrgica, uma fonte de verdade, organização de arquivos), o
+> processo de teste e PR, e as armadilhas que já custaram caro. Este arquivo aqui é
+> **só o domínio**: o que o produto é, onde cada coisa mora e o que existe hoje.
+>
+> As duas regras que mais se aplicam a este arquivo: **não repita aqui o que o código
+> já declara** (aponte para o arquivo-fonte) e **não invente o que não está no
+> repositório**.
 
 ---
 
 ## O que é o projeto
 
-Bot financeiro pessoal que virou produto SaaS. Permite registrar despesas e receitas
-em linguagem natural pelo **WhatsApp** e **Discord**. Tem dashboard web ao vivo,
-categorização automática com IA (GPT-4o-mini como fallback), cartões de crédito,
-caixinhas, investimentos com CDI e importação OFX.
+Assistente financeiro pessoal usado por **WhatsApp** (canal principal), **Discord** e
+por um **dashboard web**. Registra despesa e receita em linguagem natural, categoriza
+com IA, e cobre cartão de crédito, parcelamentos, caixinhas, metas, orçamentos,
+boletos, recorrentes, investimentos com CDI, importação de extrato (OFX/CSV/PDF) e
+Open Finance.
 
-**Stack:** Python 3.13, FastAPI, PostgreSQL, psycopg3, discord.py, Railway (deploy).
+**Stack:** Python 3.13 · FastAPI · PostgreSQL (psycopg 3) · discord.py · Railway
+(deploy) · Cloudflare (borda). Frontend em HTML/CSS/JS escritos à mão, **sem build e
+sem framework**. App iOS em Capacitor carregando o próprio site.
 
 ---
 
-## Estrutura de arquivos
+## Mapa do repositório
 
 ```
-bot.py                          — bot do Discord (processo 2)
-launch.py                       — ponto de entrada Railway (sobe bot + dashboard em paralelo)
-db.py                           — TODA a lógica de banco (queries, init_db, auth, etc.)
-ai_router.py                    — fallback de IA (GPT-4o-mini)
-parsers.py                      — parse de linguagem natural ("gastei 50 mercado")
+launch.py                 — entrypoint do Railway: sobe uvicorn ($PORT) + bot.py em paralelo
+bot.py                    — bot do Discord (processo 2)
+ai_router.py              — chamada à OpenAI (modelo em OPENAI_MODEL, default gpt-4o-mini)
+parsers.py                — parse de linguagem natural ("gastei 50 mercado")
+statement_import.py       — importação de extrato (OFX/CSV/PDF)
+
 core/
-  handle_incoming.py            — roteador principal de mensagens (Discord e WhatsApp)
-  types.py                      — IncomingMessage, OutgoingMessage
-  help_text.py                  — textos de ajuda
-  services/
-    quick_entry.py              — registra despesa/receita rapidamente
-    email_service.py            — envio de emails (SMTP, Gmail pessoal com App Password)
-    category_service.py         — serviço de categorias
-    ofx_service.py              — importação de extratos OFX
-    cc_services.py              — cartão de crédito
-  reports/
-    reports_daily.py            — relatório diário automático
+  handle_incoming.py      — roteador principal de mensagens (Discord e WhatsApp)
+  intent_classifier.py    — classificação de intenção
+  intent_router.py        — despacho por intenção
+  handlers/               — handlers por domínio do fluxo de mensagem
+  services/               — 35 módulos + 2 pacotes: e-mail, Pluggy, planos, push,
+                            agentes, agendadores, OFX, PIX, categorias, cartão…
+  reports/                — relatório diário (reports_daily.py)
+  crypto.py, audit.py     — PII cifrada e trilha de auditoria
+
+db/                       — PACOTE com ~30 módulos, um por domínio
+  schema.py               — DDL de TODAS as tabelas (init_db) — fonte de verdade
+  connection.py           — pool psycopg3
+
 frontend/
-  finance_bot_websocket_custom.py  — FastAPI app (dashboard + TODOS os endpoints REST)
-  index.html                    — landing page + cadastro + login
-  dashboard.html                — dashboard financeiro ao vivo
-  reset-password.html           — página de redefinição de senha
+  finance_bot_websocket_custom.py — app FastAPI (~14,5k linhas): auth, MFA, billing,
+                                    WebSocket, dashboard. AINDA é o monólito.
+  routes/                 — routers já extraídos: static_pages, settings, pockets,
+                            cards, analytics, open_finance, push, agents, affiliates,
+                            shared (html_file, stamp_asset_versions, página de erro)
+  *.html (26 páginas)     — servidas por static_pages.py; ver o §5 do CLAUDE.md da raiz
+  *.css / *.js            — cada arquivo tem uma rota própria; não há StaticFiles mount
+
 adapters/
-  whatsapp/wa_app.py            — webhook WhatsApp (FastAPI)
-tests/                          — pytest
+  whatsapp/               — webhook + cliente da API oficial (Cloud API)
+  discord/                — bot e cogs
+
+mobile/                   — app iOS (Capacitor) que carrega https://pigbankai.com/login
+scripts/                  — utilitários operacionais e de build de assets
+tests/                    — pytest (backend) e tests/frontend/*.mjs (node --test)
+docs/refactor_plan.md     — plano de quebra do monólito FastAPI
 ```
 
 ---
 
-## Banco de dados — tabelas principais
+## Backend
 
-| Tabela | Função |
-|--------|--------|
-| `users` | usuário canônico (id interno) |
-| `accounts` | saldo da conta corrente |
-| `launches` | todos os lançamentos (despesas, receitas, movimentos internos) |
-| `auth_accounts` | email + password_hash + plano Stripe |
-| `user_identities` | mapeamento platform (discord/whatsapp/email) → user_id |
-| `link_codes` | código temporário para vincular plataformas |
-| `email_verification_codes` | código de 6 dígitos enviado no cadastro |
-| `password_reset_tokens` | token de recuperação de senha (30 min) |
-| `dashboard_sessions` | token JWT de acesso ao dashboard |
-| `pockets` | caixinhas (poupança por objetivo) |
-| `investments` | investimentos com CDI |
-| `credit_cards` / `credit_bills` / `credit_transactions` | cartão de crédito |
-| `user_category_rules` | regras de categorização automática |
-| `pending_actions` | ações pendentes de confirmação (ex: apagar lançamento) |
+### App e rotas
+
+O `app` FastAPI vive em `frontend/finance_bot_websocket_custom.py`. Parte das rotas já
+saiu para routers em `frontend/routes/`, registrados com `include_router`:
+`static_pages`, `settings`, `pockets`, `cards`, `analytics`, `affiliates`, `agents`,
+`open_finance`, `push`.
+
+**Rota nova vai para um router de `frontend/routes/`**, não para o monólito. Ao
+procurar uma rota existente, procure nos dois lugares:
+
+```bash
+grep -rn '@\(app\|router\)\.\(get\|post\|put\|patch\|delete\)("/caminho' --include="*.py" frontend/ adapters/
+```
+
+São ~198 rotas. Os grupos maiores: `/auth` (27), `/open-finance` (11), `/settings`
+(10), `/billing` (8), `/agents` (7), `/cards`, `/categories`, `/pockets`,
+`/recurring-bills` (6 cada), `/analytics` (6), `/investments`, `/installments`,
+`/recurring-incomes`, `/recurring-expenses` (5 cada), `/budgets` (4).
+
+### Autenticação
+
+Sessão por **JWT em cookie `HttpOnly`** + **refresh token** (tabela
+`auth_refresh_tokens`), com **CSRF por cookie `csrf_token`** (`SameSite=strict`) e
+rate limiting via `slowapi` nos endpoints sensíveis.
+
+No cliente, `frontend/auth-refresh.js` faz *monkey-patch* de `window.fetch`: em 401
+que não seja o próprio `/auth/refresh`, dispara o refresh, deduplica chamadas
+paralelas e repete a request original. Se o refresh falhar, o 401 passa para o
+chamador decidir. **Esse interceptor é global nas páginas autenticadas** — considere-o
+antes de tratar 401 na mão em qualquer tela.
+
+Caminhos de entrada, todos em `/auth/*`: `register` → `verify-email` (código de 6
+dígitos) → `login`; `forgot-password`/`reset-password`; **Google OAuth**
+(`google/start`, `google/callback`, `google/complete-signup`, `google/pending/{token}`);
+`dashboard-link`/`dashboard-token` (link mágico); `link-code` (vincula WhatsApp e
+Discord à conta); `logout`; `refresh`; `account` (exclusão) e `account/export`.
+
+### MFA
+
+TOTP (`pyotp`) com códigos de backup: `/auth/mfa/setup`, `enable`, `disable`,
+`verify-login`, `status`, `regenerate-backup-codes`, `onboarding-seen`. Tabelas
+`user_mfa`, `user_mfa_backup_codes`, `mfa_login_challenges`; segredo cifrado com
+`MFA_ENCRYPTION_KEY`.
+
+**Os códigos de backup aparecem uma única vez.** Qualquer tela ou refresh que passe
+por cima deles perde os códigos do usuário — já quase aconteceu (registro no §4 do
+`CLAUDE.md` da raiz).
+
+### WebSocket
+
+`ConnectionManager` + endpoint `@app.websocket("/ws/{user_id}")` no monólito. É o que
+mantém o dashboard ao vivo quando o bot registra algo pelo WhatsApp. Mudou o formato
+de mensagem? Os dois lados mudam junto — o consumidor está no `dashboard.js`.
+
+### Pagamentos
+
+Stripe: `/billing/create-checkout`, `webhook`, `portal`, `subscription`,
+`change-plan`, `cancel-change`, `select-free`, `plans-config`.
+
+A **escada de planos é `free < essencial < plus < pro`**, atrás do flag
+`PLANS_V2_ENABLED` (lido dinamicamente, sem redeploy; `0`/`false` é freio de
+emergência e colapsa no binário legado). **A fonte de verdade é
+`core/services/plan_service.py`** — não duplique a tabela de tiers, limites ou nomes
+em outro lugar (§0.7 da raiz). Limites por plano em `core/services/plan_limits.py`.
+
+### Open Finance
+
+Via **Pluggy**. Endpoints em `frontend/routes/open_finance.py`
+(`/open-finance/{user_id}` e `connect-token`, `connectors`, `sync`, `refresh`,
+`pluggy-item`, `caixinhas`, `caixinhas/bind`, `mock-connect`) mais o webhook
+`/open-finance/pluggy/webhook`. Serviços em `core/services/pluggy*.py` e
+`open_finance*.py`; tabelas `open_finance_connections/accounts/transactions/investments`.
+
+Boa parte do comportamento é regida por flags `OF_*` (beta por e-mail/user_id, limite
+de bancos no free, refresh proativo). Antes de mexer, leia as flags — o
+comportamento em produção pode não ser o do seu ambiente.
+
+### IA
+
+`ai_router.py` chama a OpenAI (`OPENAI_MODEL`, default `gpt-4o-mini`) como fallback da
+categorização determinística. Há rate limiting próprio (`core/ai_rate_limiter.py`),
+limite mensal de chat (`AI_CHAT_MONTHLY_LIMIT`), chat "Piggy" no dashboard
+(`core/services/ai_chat/`) e agentes proativos (`core/services/piggy_agents.py`,
+atrás de `AGENTS_ENABLED` + listas de beta).
+
+Categorização tem uma armadilha própria: **categoria e regra de categoria são tabelas
+diferentes** (`user_categories` × `user_category_rules`) e a regra ganha da categoria
+na inferência.
+
+### E-mail
+
+**Resend** (`RESEND_API_KEY`), em `core/services/email_service.py` — **não é mais
+SMTP/Gmail**. Além dos transacionais (verificação, boas-vindas, reset), há e-mails de
+ciclo de vida (reengajamento, nudge de upgrade, downsell de trial, relatório de
+agente, mudança de plano), com link de descadastro (`make_unsub_url` + `unsub_headers`).
+
+Falha de e-mail é silenciosa por contrato: loga e não quebra o fluxo principal.
+
+### Push (app iOS)
+
+APNs direto, sem serviço intermediário: `core/services/push_service.py` +
+`frontend/routes/push.py`, tabela `push_tokens` (token único por aparelho, com
+`environment` separando sandbox de produção — o mesmo token não vale nos dois).
+Configuração em `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_AUTH_KEY`, `APNS_TOPIC`.
+
+### Admin e afiliados
+
+Área administrativa própria (`/admin`, `/admin/login`, `/admin/api/*`) com sessão
+separada (`ADMIN_DASHBOARD_*`), visão de usuários, overview, auditoria de acesso a PII
+e gestão do programa de afiliados (comissões, payouts, PIX). As páginas
+`admin-login.html` e `admin-dashboard.html` **não carregam app-mode nem o shim de área
+segura**, de propósito.
+
+### Tarefas de fundo
+
+Sobem no startup do app quando `RUN_BACKGROUND_TASKS != "0"`: rendimento de
+investimento, refresh e expiração de Open Finance, cobrança de recorrentes,
+agendadores de engajamento e de IA proativa, retenção de eventos de login. Em teste e
+no `dashboard_dev.py` ficam desligadas.
 
 ---
 
-## Endpoints REST (finance_bot_websocket_custom.py)
+## Frontend
 
-### Auth
-| Método | Rota | Função |
-|--------|------|--------|
-| POST | `/auth/register` | Inicia cadastro → envia código de verificação por email |
-| POST | `/auth/verify-email` | Confirma código de 6 dígitos → cria conta |
-| POST | `/auth/login` | Login email+senha → retorna JWT |
-| GET | `/auth/validate` | Valida token JWT |
-| GET | `/auth/me` | Dados do usuário autenticado |
-| POST | `/auth/link-code` | Gera novo link_code para vincular plataforma |
-| POST | `/auth/forgot-password` | Envia email de recuperação de senha |
-| POST | `/auth/reset-password` | Redefine senha com token do email |
+O detalhamento das armadilhas está no **§5 do `CLAUDE.md` da raiz** (é lá que ele
+mora; não duplicar aqui). O essencial de domínio:
 
-### Dashboard
-| Método | Rota | Função |
-|--------|------|--------|
-| GET | `/d/{code}` | Acessa dashboard via token seguro |
-| GET | `/data/{user_id}` | Dados financeiros do mês |
-| GET | `/history/{user_id}` | Histórico de meses |
-| GET | `/export/{user_id}` | Download CSV |
-| WS | `/ws/{user_id}` | WebSocket para updates ao vivo |
-
-### Billing (Stripe — parcialmente implementado)
-| Método | Rota | Função |
-|--------|------|--------|
-| POST | `/billing/create-checkout` | Cria sessão Stripe Checkout |
-| POST | `/billing/webhook` | Webhook Stripe (atualiza plano) |
-| POST | `/billing/portal` | Portal de gerenciamento Stripe |
+- **Sem build, sem bundler, sem framework.** O `package.json` da raiz serve só ao
+  harness de testes de frontend.
+- **Páginas públicas e área logada são as duas MPA.** Existe um POC de navegação
+  client-side (`pb-nav.js`) **desligado por padrão**, restrito ao modo app e a duas
+  rotas. Não trate a área logada como SPA e não presuma migração para framework.
+- **`dashboard.js` tem 10.587 linhas e 414 funções globais**, e `dashboard.html` tem
+  139 handlers `onclick=` que dependem disso. Funcionalidade nova de dashboard deve
+  nascer em arquivo próprio (§0.5 da raiz), com rota própria em `static_pages.py`.
+- **Segurança de borda** (medida em produção): CSP com allowlist explícita
+  (`cdnjs`, `jsdelivr`, `cdn.pluggy.ai`, `connect.facebook.net`,
+  `static.cloudflareinsights.com`), HSTS, `X-Frame-Options: DENY`,
+  `Permissions-Policy` zerando câmera/microfone/geolocalização,
+  `Referrer-Policy: strict-origin-when-cross-origin`, `X-Content-Type-Options: nosniff`.
+  O `'unsafe-inline'` do `script-src` só sai quando os handlers inline saírem.
+- **PWA**: `manifest.json` (`start_url: /login`) + `service-worker.js` (HTML e auth
+  nunca cacheados; assets network-first; API e WS passam direto).
+- **App iOS**: `mobile/` (Capacitor) aponta para `https://pigbankai.com/login` com
+  `allowNavigation` do domínio inteiro — **qualquer rota do site abre dentro do app**.
 
 ---
 
-## Fluxo de cadastro (atual)
+## Banco de dados
 
-```
-1. Usuário preenche email + senha na landing page
-2. POST /auth/register → gera código 6 dígitos, envia email, retorna {status: "verification_sent"}
-3. Frontend mostra campo para digitar o código
-4. POST /auth/verify-email → valida código, cria conta, envia email de boas-vindas
-5. Frontend mostra tela de sucesso com link_code para vincular o bot
-6. Usuário envia "vincular XXXXXX" no Discord ou WhatsApp
+**A fonte de verdade do schema é `db/schema.py::init_db()`** — DDL de ~62 tabelas.
+Não mantenha uma segunda lista de tabelas ou colunas em documentação (§0.7 da raiz);
+para saber o que existe:
+
+```bash
+grep -ohiE "create table if not exists ([a-z_]+)" db/*.py | awk '{print $NF}' | sort -u
 ```
 
-## Fluxo de recuperação de senha
+Os agrupamentos, para orientar a busca: **core** (`users`, `accounts`, `launches`) ·
+**auth** (`auth_accounts`, `auth_identities`, `auth_sessions`, `auth_refresh_tokens`,
+`auth_login_events`, `auth_rate_limits`, `user_identities`, `link_codes`,
+`password_reset_tokens`, `email_verification_codes`, `pending_google_signups`) ·
+**MFA** (`user_mfa`, `user_mfa_backup_codes`, `mfa_login_challenges`) ·
+**crédito** (`credit_cards`, `credit_bills`, `credit_transactions`) ·
+**planejamento** (`category_budgets`, `pockets`, `pocket_lots`, `financial_spaces`,
+`recurring_*`, `bill_instances`) · **investimentos** (`investments`,
+`investment_lots`, `market_rates`) · **Open Finance** (`open_finance_*`) ·
+**IA** (`ai_messages`, `ai_pending_actions`, `ai_fallback_log`, `ai_proactive_cache`,
+`agents`, `agent_events`) · **afiliados** (`affiliates`, `affiliate_*`) ·
+**privacidade/auditoria** (`audit_events`, `pii_access_log`, `data_export_tokens`).
 
-```
-1. Usuário clica "Esqueci minha senha" no login
-2. Modal pede o email → POST /auth/forgot-password
-3. Email enviado com link: DASHBOARD_URL/reset-password?token=xxx (expira 30 min)
-4. Página reset-password.html lê token da URL
-5. POST /auth/reset-password → senha atualizada
-```
+**Isolamento por usuário é regra dura**: toda query com `WHERE user_id = %s`.
 
 ---
 
-## Email (email_service.py)
+## Integrações externas
 
-Usa SMTP padrão (smtplib built-in). Configurado com Gmail pessoal + App Password.
+| Serviço | Para quê | Onde |
+|---|---|---|
+| WhatsApp **Cloud API oficial** (`graph.facebook.com`) | canal principal | `adapters/whatsapp/` |
+| Discord | canal secundário | `adapters/discord/`, `bot.py` |
+| OpenAI | categorização, chat, agentes | `ai_router.py`, `core/services/ai_chat/` |
+| Stripe | assinaturas | billing no monólito |
+| Pluggy | Open Finance | `core/services/pluggy*.py` |
+| Resend | e-mail transacional e de ciclo de vida | `core/services/email_service.py` |
+| APNs | push do app iOS | `core/services/push_service.py` |
+| Meta Pixel / CAPI | marketing (só páginas públicas) | `inject_meta_pixel`, `core/services/meta_capi.py` |
 
-**Variáveis de ambiente:**
-```
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=lucaskuramoti06@gmail.com
-SMTP_PASSWORD=<app password de 16 chars>
-EMAIL_FROM_NAME=Bot Financeiro
-```
-
-**Funções disponíveis:**
-- `send_verification_email(to, code)` — código de 6 dígitos no cadastro
-- `send_welcome_email(to, link_code, dashboard_url)` — boas-vindas após verificação
-- `send_password_reset_email(to, reset_url)` — link de recuperação de senha
-- `send_email(to, subject, html_body, text_body)` — genérico
-
-Falha silenciosa: se SMTP não estiver configurado, loga WARNING mas não quebra o fluxo.
+O webhook do WhatsApp **verifica assinatura** (`X-Hub-Signature-256` com
+`WA_APP_SECRET`) e se recusa a subir em `APP_ENV=prod` sem o segredo.
 
 ---
 
-## Variáveis de ambiente (todas)
+## Variáveis de ambiente
 
-```
-DATABASE_URL           — PostgreSQL (Railway)
-DISCORD_BOT_TOKEN      — token do bot Discord
-OPENAI_API_KEY         — GPT-4o-mini (fallback de categorização)
-WA_VERIFY_TOKEN        — webhook WhatsApp
-WA_TOKEN               — token WhatsApp não-oficial
-WA_PHONE_NUMBER_ID     — número WhatsApp
-DASHBOARD_URL          — URL pública do Railway (ex: https://xxx.up.railway.app)
-DASHBOARD_USER_ID      — user_id do dono (para uso interno)
-JWT_SECRET             — secret para assinar JWTs (trocar em produção!)
-SMTP_HOST/PORT/USER/PASSWORD/EMAIL_FROM_NAME — email transacional
-STRIPE_SECRET_KEY      — Stripe (parcialmente implementado)
-STRIPE_WEBHOOK_SECRET  — Stripe webhook
-STRIPE_PRICE_ID_PRO    — ID do preço Pro no Stripe
+São ~130, lidas com `os.getenv` espalhado pelo código (só `APP_ENV` passa por
+`config/env.py`). Para a lista real:
+
+```bash
+grep -rhoE 'os\.(getenv|environ(\.get)?)\(\s*"([A-Z][A-Z0-9_]{2,})"' --include="*.py" . \
+  | grep -oE '"[A-Z][A-Z0-9_]{2,}"' | tr -d '"' | sort -u
 ```
 
----
+Obrigatórias para o app subir: `DATABASE_URL` e `JWT_SECRET` — sem elas o import faz
+`sys.exit(1)`. Para rodar a suíte, ver o §3 do `CLAUDE.md` da raiz.
 
-## Decisões já tomadas (não sugerir alternativas)
-
-- **Sem Google Sheets** — removido, não usar mais
-- **Gmail pessoal com App Password** — escolha atual para SMTP (sem CNPJ para Business)
-- **WhatsApp não-oficial** — risco conhecido, migração para API oficial planejada para depois
-- **Railway** — plataforma de deploy escolhida
-- **psycopg3** (não psycopg2) — biblioteca Postgres em uso
-- **Sem Redis ainda** — fila de tarefas e cache são Fase 2 do roadmap
-- **Rate limiting com slowapi** — já implementado nos endpoints de auth
-
----
-
-## O que está pendente (roadmap)
-
-### Crítico para lançar
-- [ ] Stripe completo (produtos criados + webhook funcionando + middleware de plano)
-- [ ] Teste de ponta a ponta do fluxo de cadastro em produção
-
-### Fase 2 (pós-lançamento)
-- [ ] Redis para cache do dashboard e fila de IA
-- [ ] Worker separado para tarefas pesadas (OFX, relatórios, CDI)
-- [ ] Resumo semanal automático (todo domingo)
-- [ ] Notificações: alerta de gasto alto, fatura chegando
-- [ ] Dashboard mobile-first (redesign responsivo)
-- [ ] Métricas de uso (PostHog ou Mixpanel)
-- [ ] Row-Level Security no Postgres
-
-### Fase 3 (escala)
-- [ ] App mobile (React Native)
-- [ ] Open Finance (integração com bancos)
-- [ ] Plano Família
-- [ ] API pública
-- [ ] Migração WhatsApp para API oficial da Meta
+Grupos: `DATABASE_URL`/`DB_POOL_*` · `JWT_SECRET`/`DASHBOARD_*` ·
+`PII_ENCRYPTION_KEY`/`PII_HASH_PEPPER`/`PII_AUDIT_DISABLED` · `MFA_ENCRYPTION_KEY` ·
+`WA_*` · `DISCORD_BOT_TOKEN` · `OPENAI_*`/`AI_*`/`AGENTS_*` · `STRIPE_*`/`PLANS_V2_ENABLED` ·
+`PLUGGY_*`/`OF_*` · `RESEND_API_KEY`/`EMAIL_FROM*` · `APNS_*` · `ADMIN_DASHBOARD_*` ·
+`META_PIXEL_ID` · `RUN_BACKGROUND_TASKS`/`SKIP_INIT_DB`/`ENABLE_DEV_ENDPOINTS`.
 
 ---
 
 ## Convenções de código
 
-- Queries sempre com `WHERE user_id = %s` — nunca vazar dados entre usuários
-- Falhas de email sempre silenciosas (log WARNING, não quebra fluxo principal)
-- Endpoints de auth com rate limiting via `@limiter.limit()`
-- Modelos Pydantic para todos os bodies de POST
-- `ensure_user()` antes de qualquer operação de banco para usuários novos
-- Imports dentro das funções nos endpoints FastAPI (evita circular imports)
+- Query sempre com `WHERE user_id = %s`. Nunca vazar dado entre usuários.
+- Falha de e-mail é silenciosa (log, não quebra o fluxo principal).
+- Endpoints sensíveis com rate limit (`@limiter.limit()`).
+- Modelo Pydantic para todo body de POST.
+- `ensure_user()` antes de operação de banco para usuário novo.
+- Import dentro da função nos endpoints, quando necessário para evitar import circular.
+- PII cifrada (`core/crypto.py`) e acesso registrado (`pii_access_log`, `core/audit.py`).
+- Nunca passe segredo em `details` de auditoria (senha, TOTP, código de backup).
+
+---
+
+## Decisões tomadas (não sugerir alternativa sem pedido explícito)
+
+- **Railway** para deploy, **Cloudflare** na borda.
+- **psycopg 3**, não psycopg2.
+- **WhatsApp Cloud API oficial** — a migração planejada já aconteceu.
+- **Resend** para e-mail — SMTP/Gmail foi abandonado.
+- **Sem Google Sheets.**
+- **Sem Redis** até hoje: não há fila nem cache externo no repositório.
+- **Frontend sem build** — HTML/CSS/JS à mão, servidos pelo FastAPI. Não há React,
+  Vite, bundler nem processo de build de JS neste repositório, e a discussão de
+  migração **não** tem decisão tomada.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -213,41 +213,134 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       <div class="section-head" data-reveal>
         <div class="eyebrow">Como funciona</div>
         <h2>Simples, rápido e<br>no seu <span class="grad">WhatsApp</span></h2>
-        <p>Em poucos minutos você já está no controle do seu dinheiro, sem planilha, sem app pra baixar.</p>
       </div>
 
-      <div class="how-grid">
-        <div class="steps" data-reveal>
-          <div class="step">
-            <div class="step-num">1</div>
-            <div><h3>Crie sua conta</h3><p>Grátis e em segundos, entrando com o Google. Sem cadastro chato.</p></div>
-          </div>
-          <div class="step">
-            <div class="step-num">2</div>
-            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece. Nada pra instalar.</p></div>
-          </div>
-          <div class="step">
-            <div class="step-num">3</div>
-            <div><h3>Registre falando</h3><p>"Gastei R$ 50 no mercado" e pronto: a IA entende, categoriza e salva na hora.</p></div>
-          </div>
-          <div class="step">
-            <div class="step-num">4</div>
-            <div><h3>Acompanhe tudo</h3><p>Saldo, gastos, caixinhas e metas no dashboard, atualizados em tempo real.</p></div>
-          </div>
-        </div>
+      <div class="hiw-rail">
 
-        <div class="phone" data-reveal>
-          <div class="phone-notch"></div>
-          <div class="chat-head">
-            <img src="/brand/icon.png?v=1" alt="" /> <strong>PigBank</strong>
-            <span class="online"><i></i> online</span>
+        <article class="hiw-card is-open" tabindex="0" aria-current="step">
+          <div class="hiw-head"><span class="hiw-num">01</span><h3>Conexão</h3></div>
+          <div class="hiw-stage">
+            <div class="hiw-state hiw-demo">
+              <div class="hiw-panel">
+                <div class="hiw-panel-top"><span><span class="hiw-dot"></span>WhatsApp</span><span>Piggy</span></div>
+                <div class="hiw-qr">
+                  <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.04 2C6.58 2 2.13 6.45 2.13 11.91c0 1.75.46 3.46 1.32 4.96L2 22l5.25-1.38a9.9 9.9 0 0 0 4.79 1.22h.01c5.46 0 9.9-4.45 9.9-9.91 0-2.65-1.03-5.14-2.9-7.01A9.82 9.82 0 0 0 12.04 2Zm0 18.15h-.01a8.2 8.2 0 0 1-4.19-1.15l-.3-.18-3.12.82.83-3.04-.2-.31a8.2 8.2 0 0 1-1.26-4.38c0-4.54 3.7-8.23 8.25-8.23 2.2 0 4.27.86 5.83 2.42a8.18 8.18 0 0 1 2.41 5.82c0 4.54-3.7 8.23-8.24 8.23Z"/></svg>
+                  <div><b>+55 11 91234-5678</b><span>salve o número e mande um “oi”</span></div>
+                </div>
+                <div class="hiw-chat">
+                  <div class="hiw-msg out hiw-d1">oi<time>09:12</time></div>
+                  <div class="hiw-msg in hiw-d2">Oi! Sou o Piggy 🐷 Me conta seus gastos como você contaria pra um amigo — texto, áudio ou foto do comprovante.<time>09:12</time></div>
+                  <div class="hiw-msg out hiw-d3">gastei 32 no almoço<time>09:12</time></div>
+                </div>
+              </div>
+            </div>
+            <div class="hiw-state hiw-done">
+              <div class="hiw-tick"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12.5 9.5 18 20 6.5"/></svg></div>
+              <b>WhatsApp conectado</b><span>abrindo o próximo passo…</span>
+            </div>
+            <div class="hiw-state hiw-idle">
+              <div class="hiw-ring"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"/></svg></div>
+              <span>passo 1 de 3</span>
+            </div>
           </div>
-          <div class="bubble user">Gastei 32 no uber</div>
-          <div class="bubble bot">Anotado!<br>Categoria: <b>Transporte</b><br>Saldo atual: <b>R$ 1.218,00</b></div>
-          <div class="bubble user">quanto sobrou esse mês?</div>
-          <div class="bubble bot">Você tem <b>R$ 1.218,00</b><br>Já guardou <b>R$ 300</b> na caixinha "Viagem". Bora?</div>
-        </div>
+          <div class="hiw-foot">
+            <h4>Sem app, sem cadastro chato</h4>
+          </div>
+        </article>
+
+        <article class="hiw-card is-idle" tabindex="0">
+          <div class="hiw-head"><span class="hiw-num">02</span><h3>Resposta</h3></div>
+          <div class="hiw-stage">
+            <div class="hiw-state hiw-demo">
+              <div class="hiw-panel">
+                <div class="hiw-panel-top"><span><span class="hiw-dot"></span>Piggy responde</span><span>0,8 s</span></div>
+                <div class="hiw-chat">
+                  <div class="hiw-msg out hiw-d1">gastei 32 no almoço<time>09:12</time></div>
+                  <div class="hiw-msg in hiw-d2">Anotado! 🐷<time>09:12</time></div>
+                </div>
+                <div class="hiw-receipt">
+                  <div class="hiw-row"><span class="hiw-k">Almoço</span><span class="hiw-v">R$ 32,00</span></div>
+                  <div class="hiw-row"><span class="hiw-k">Categoria</span><span class="hiw-tag">Alimentação</span></div>
+                  <div class="hiw-row"><span class="hiw-k">Restam hoje</span><span class="hiw-v" style="color:var(--neon)">R$ 18,00</span></div>
+                </div>
+                <div class="hiw-chat" style="margin-top:12px">
+                  <div class="hiw-msg in hiw-d4">Esse é o 4º almoço fora essa semana — R$ 121 no total. Quer que eu te avise quando passar de R$ 150?<time>09:12</time></div>
+                </div>
+              </div>
+            </div>
+            <div class="hiw-state hiw-done">
+              <div class="hiw-tick"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12.5 9.5 18 20 6.5"/></svg></div>
+              <b>Gasto registrado</b><span>abrindo o próximo passo…</span>
+            </div>
+            <div class="hiw-state hiw-idle">
+              <div class="hiw-ring"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"/></svg></div>
+              <span>passo 2 de 3</span>
+            </div>
+          </div>
+          <div class="hiw-foot">
+            <h4>Categorizado antes de você guardar o celular</h4>
+          </div>
+        </article>
+
+        <article class="hiw-card is-idle" tabindex="0">
+          <div class="hiw-head"><span class="hiw-num">03</span><h3>Painel</h3></div>
+          <div class="hiw-stage">
+            <div class="hiw-state hiw-demo">
+              <div class="hiw-charts">
+                <div class="hiw-kpis">
+                  <div class="hiw-kpi"><span>Gasto do mês</span><b class="neg">R$ 2.148</b></div>
+                  <div class="hiw-kpi"><span>Sobra prevista</span><b class="pos">R$ 612</b></div>
+                </div>
+                <div class="hiw-panel">
+                  <div class="hiw-panel-top"><span>Para onde foi</span><span>Agosto</span></div>
+                  <div class="hiw-donut">
+                    <svg viewBox="0 0 100 100" aria-hidden="true">
+                      <circle cx="50" cy="50" r="42" stroke="#FF2D8E" stroke-dasharray="109 155"></circle>
+                      <circle cx="50" cy="50" r="42" stroke="#2E7FE0" stroke-dasharray="64 200" stroke-dashoffset="-111"></circle>
+                      <circle cx="50" cy="50" r="42" stroke="#C6F11A" stroke-dasharray="40 224" stroke-dashoffset="-177"></circle>
+                      <circle cx="50" cy="50" r="42" stroke="#5a5a62" stroke-dasharray="43 221" stroke-dashoffset="-219"></circle>
+                    </svg>
+                    <ul class="hiw-legend">
+                      <li><i style="background:#FF2D8E"></i>Alimentação <b>42%</b></li>
+                      <li><i style="background:#2E7FE0"></i>Transporte <b>25%</b></li>
+                      <li><i style="background:#C6F11A"></i>Lazer <b>16%</b></li>
+                      <li><i style="background:#5a5a62"></i>Outros <b>17%</b></li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="hiw-panel hiw-spark">
+                  <div class="hiw-panel-top"><span>Gasto por mês</span><span>−18% vs. março</span></div>
+                  <svg viewBox="0 0 280 70" preserveAspectRatio="none" aria-hidden="true">
+                    <line class="hiw-grid" x1="0" y1="18" x2="280" y2="18"></line>
+                    <line class="hiw-grid" x1="0" y1="44" x2="280" y2="44"></line>
+                    <path class="hiw-line" d="M4,58 L50,52 L96,54 L142,40 L188,42 L234,24 L276,14"></path>
+                    <circle class="hiw-cap" cx="276" cy="14" r="4"></circle>
+                  </svg>
+                  <div class="hiw-months"><span>MAR</span><span>ABR</span><span>MAI</span><span>JUN</span><span>JUL</span><span>AGO</span></div>
+                </div>
+              </div>
+            </div>
+            <div class="hiw-state hiw-done">
+              <div class="hiw-tick"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12.5 9.5 18 20 6.5"/></svg></div>
+              <b>Painel atualizado</b><span>em tempo real</span>
+            </div>
+            <div class="hiw-state hiw-idle">
+              <div class="hiw-ring"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"/></svg></div>
+              <span>passo 3 de 3</span>
+            </div>
+          </div>
+          <div class="hiw-foot">
+            <h4>O mês inteiro, sem você abrir nada</h4>
+          </div>
+        </article>
+
       </div>
+
+      <div class="hiw-cta" data-reveal>
+        <p>A conta leva alguns segundos e é grátis pra testar.</p>
+        <a class="btn btn-primary" href="/cadastro">Criar minha conta <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
+      </div>
+
     </section>
 
     <!-- ─── IA / Tecnologia ───────────────────────────────────────── -->
@@ -528,7 +621,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
   (function () {
     var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduce) return;
-    var cards = document.querySelectorAll(".rd .card, .rd .plan-solo, .rd .phone, .rd .step");
+    var cards = document.querySelectorAll(".rd .card, .rd .plan-solo");
     cards.forEach(function (c) {
       c.addEventListener("pointermove", function (e) {
         var r = c.getBoundingClientRect();
@@ -536,6 +629,90 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         c.style.setProperty("--my", (e.clientY - r.top) + "px");
       });
     });
+  })();
+  </script>
+  <!-- Como funciona: um card aberto por vez; hover/foco/clique assume o controle -->
+  <script>
+  (function () {
+    var rail = document.querySelector(".hiw-rail");
+    var cards = rail ? rail.querySelectorAll(".hiw-card") : [];
+    if (!cards.length) return;
+
+    var active = 0, timer = null, comecou = false, tocado = false, dentro = false;
+
+    function paint() {
+      for (var i = 0; i < cards.length; i++) {
+        var aberto = i === active;
+        cards[i].classList.toggle("is-open", aberto);
+        cards[i].classList.toggle("is-done", i < active);
+        cards[i].classList.toggle("is-idle", i > active);
+        if (aberto) cards[i].setAttribute("aria-current", "step");
+        else cards[i].removeAttribute("aria-current");
+      }
+    }
+
+    // Autoplay só onde dá para parar antes: em touch não há hover, o conteúdo
+    // trocaria sozinho sob o dedo. Reduced-motion também fica parado no card 1.
+    var mm = window.matchMedia;
+    var autoplay = !!mm && !mm("(prefers-reduced-motion: reduce)").matches
+                        && mm("(hover: hover) and (pointer: fine)").matches;
+
+    /** O ciclo roda só depois de o trilho aparecer, com ninguém tendo decidido
+        por clique/foco e sem o mouse em cima. Todo evento reavalia isto. */
+    function sincronizar() {
+      var rodar = comecou && autoplay && !tocado && !dentro;
+      if (rodar && !timer) timer = setInterval(function () { active = (active + 1) % cards.length; paint(); }, 6000);
+      if (!rodar && timer) { clearInterval(timer); timer = null; }
+    }
+
+    /** mousemove só PAUSA o ciclo; clique e foco são deliberados e param de vez. */
+    function open(i) {
+      return function (e) {
+        rail.classList.remove("is-esperando");   // quem interagiu já viu o trilho
+        if (e.type === "mousemove") dentro = true; else tocado = true;
+        if (i !== active) { active = i; paint(); }   // mousemove chega dezenas de vezes por segundo
+        sincronizar();
+      };
+    }
+
+    for (var i = 0; i < cards.length; i++) {
+      var go = open(i);
+      // mousemove, não mouseenter: rolar a página com o cursor PARADO trazia um
+      // card para debaixo dele e matava o autoplay sem ninguém ter interagido.
+      // O preço: com o cursor imóvel e o trilho subindo por baixo dele o Chrome
+      // só emite mouseenter, então o ciclo segue trocando os cards até o
+      // primeiro pixel de movimento — "mouse em cima pausa" só vale depois disso.
+      cards[i].addEventListener("mousemove", go);
+      cards[i].addEventListener("focus", go);
+      cards[i].addEventListener("click", go);
+    }
+    // um handler no trilho, não três nos cards: sair de um card para o vizinho
+    // não é sair do trilho. Atravessar a caminho do CTA vira pausa, não morte.
+    // Não há blur/focusout equivalente DE PROPÓSITO: tabular até um card é ato
+    // deliberado (marca tocado) e não se desfaz ao sair; mover o mouse não é.
+    rail.addEventListener("mouseleave", function () { dentro = false; sincronizar(); });
+
+    /** Solta as animações da demo e libera o ciclo — uma vez só, ao aparecer. */
+    function comecar() {
+      rail.classList.remove("is-esperando");
+      comecou = true;
+      sincronizar();
+    }
+
+    paint();
+    // O trilho começa quando entra na tela, não no load: senão o chat do card 1
+    // termina de animar bem antes da dobra. Sem observer, começa na hora.
+    if ("IntersectionObserver" in window) {
+      rail.classList.add("is-esperando");
+      var io = new IntersectionObserver(function (entries, obs) {
+        if (!entries[0].isIntersecting) return;
+        obs.unobserve(rail);
+        comecar();
+      }, { threshold: 0.12, rootMargin: "0px 0px -8% 0px" });
+      io.observe(rail);
+    } else {
+      comecar();
+    }
   })();
   </script>
   <script src="/nav-auth.js?v=7" defer></script>

--- a/frontend/site-redesign.css
+++ b/frontend/site-redesign.css
@@ -67,9 +67,7 @@
 
 /* ─── 5. Cards com profundidade + borda-holofote sob o cursor ──────────── */
 .rd .card,
-.rd .plan-solo,
-.rd .phone,
-.rd .step {
+.rd .plan-solo {
   position: relative;
   transition: transform .22s ease, border-color .22s ease, box-shadow .22s ease;
 }
@@ -117,14 +115,10 @@
 }
 .rd .value-chip:hover { border-color: rgba(198,241,26,.4); transform: translateY(-2px); }
 
-/* ─── 7. Steps: numeração com anel e trilho conectando ────────────────── */
-.rd .step { padding: 4px 0; }
-.rd .step-num { box-shadow: 0 8px 22px rgba(255,45,142,.35), inset 0 1px 0 rgba(255,255,255,.25); }
-
-/* ─── 8. Chat / summary / phone: elevação com sombra tingida ───────────── */
+/* ─── 8. Chat / summary: elevação com sombra tingida ───────────────────── */
+/* (não há seção 7: era a dos .rd .step, removida junto com o markup) */
 .rd .chat-card,
-.rd .summary-card,
-.rd .phone {
+.rd .summary-card {
   box-shadow: 0 30px 70px rgba(0,0,0,.55), 0 0 0 1px rgba(255,45,142,.06),
               0 12px 40px rgba(255,45,142,.08);
 }
@@ -162,4 +156,168 @@
 @media (max-width: 560px) {
   .rd .hero-title { font-size: clamp(2.2rem, 9vw, 3rem); }
   .rd .plan-solo-amount { font-size: 3rem; }
+}
+
+/* ─── 13. Como funciona: trilho de 3 cards que abre no hover ───────────── */
+/* Um card aberto por vez: os anteriores ficam com check (is-done), os
+   seguintes com anel tracejado (is-idle). Estados vêm do IIFE da index. */
+.rd .hiw-rail {
+  --hiw-ease: cubic-bezier(.45,0,0,1);   /* NÃO usar --ease: brand.css tem outra curva */
+  --hiw-wa: #25D366;
+  display: flex; flex-direction: column; gap: 14px; margin-top: 44px;
+}
+/* altura em rem, não px: com fonte-raiz grande (ajuste de acessibilidade do
+   navegador, que não é zoom) a caixa precisa crescer junto com o texto. */
+@media (min-width: 900px) { .rd .hiw-rail { flex-direction: row; height: 41.25rem; } }
+
+.rd .hiw-card {
+  position: relative; display: flex; flex-direction: column; justify-content: space-between;
+  min-width: 0; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-lg);
+  background: var(--card); padding: 28px 26px 30px; flex: 1 1 0;
+  /* ponytail: redimensionar cruzando 899→900px pisca os 3 cards em 54px por
+     ~150ms (abaixo é flex:none/basis auto, acima é basis 0 com transition de
+     flex-grow saindo do zero). Basis não-zero muda a razão aberto/fechado e
+     derruba a asserção "aberto ≥ 2× fechado"; sair disso pede transicionar
+     outra propriedade que não flex-grow. Só quem redimensiona/gira vê. */
+  transition: flex-grow .6s var(--hiw-ease), background-color .6s var(--hiw-ease),
+              border-color .6s var(--hiw-ease), box-shadow .6s var(--hiw-ease);
+  cursor: pointer;
+}
+.rd .hiw-card:focus-visible { outline: 2px solid var(--pink); outline-offset: 3px; }
+@media (min-width: 900px) { .rd .hiw-card.is-open { flex-grow: 2.7; } }
+@media (max-width: 899px) {
+  .rd .hiw-rail { gap: 12px; }
+  /* flex-basis:0 do desktop faria o card ignorar o conteúdo e travar na
+     min-height: aberto, a demo transbordava por cima do rodapé. */
+  .rd .hiw-card { flex: none; min-height: 7.375rem; transition: none; }
+  .rd .hiw-card.is-open { min-height: 35rem; }
+}
+.rd .hiw-card.is-open { background: var(--card-2); border-color: var(--line-2); box-shadow: var(--shadow); }
+.rd .hiw-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 14px; }
+.rd .hiw-num { font-size: 1.9rem; font-weight: 800; color: var(--ink-3); letter-spacing: -.04em; font-variant-numeric: tabular-nums; }
+.rd .hiw-card.is-open .hiw-num { color: var(--pink); }
+.rd .hiw-card.is-done .hiw-num { color: var(--neon); }
+.rd .hiw-head h3 { font-size: 1.55rem; font-weight: 700; letter-spacing: -.03em; }
+
+.rd .hiw-foot { margin-top: auto; padding-top: 22px; }
+.rd .hiw-foot h4 { font-size: 1.12rem; font-weight: 700; letter-spacing: -.02em; text-wrap: balance; }
+
+/* miolo: os três estados empilhados na mesma célula */
+.rd .hiw-stage { flex: 1 1 auto; display: grid; place-items: center; margin: 22px 0 0; min-height: 0; }
+.rd .hiw-state { grid-area: 1/1; width: 100%; opacity: 0; visibility: hidden; transition: opacity .35s ease; }
+.rd .hiw-card.is-open .hiw-demo { opacity: 1; visibility: visible; transition-delay: .18s; }
+.rd .hiw-card.is-done .hiw-done { opacity: 1; visibility: visible; transition-delay: .1s; }
+.rd .hiw-card.is-idle .hiw-idle { opacity: 1; visibility: visible; }
+/* O JS põe .is-esperando enquanto o trilho não apareceu na tela: sem isso o chat
+   do card 1 termina de animar ~1290px antes da dobra. Sem JS a classe não existe
+   e as animações rodam no parse, como antes. */
+.rd .hiw-rail.is-esperando .hiw-card.is-open * { animation: none; }
+/* done/idle saem do fluxo e ancoram pelo CÍRCULO no meio do CARD (altura igual
+   nos três): 37px = metade dos 74px do .hiw-tick/.hiw-ring. Centrar o BLOCO
+   desalinharia — o done tem duas linhas de texto e o idle uma. */
+.rd .hiw-done, .rd .hiw-idle {
+  position: absolute; top: calc(50% - 37px);
+  left: 26px; right: 26px; width: auto;   /* = padding lateral do .hiw-card */
+}
+@media (max-width: 899px) {
+  .rd .hiw-card:not(.is-open) .hiw-stage { display: none; }
+  .rd .hiw-card:not(.is-open) { justify-content: center; }
+  .rd .hiw-card:not(.is-open) .hiw-foot { display: none; }
+}
+
+/* estado concluído */
+.rd .hiw-done { text-align: center; }
+.rd .hiw-tick {
+  width: 74px; height: 74px; margin: 0 auto 18px; border-radius: 50%; background: var(--neon);
+  display: grid; place-items: center;
+  box-shadow: 0 0 0 12px rgba(198,241,26,.10), 0 0 46px rgba(198,241,26,.30);
+}
+.rd .hiw-tick svg { width: 34px; height: 34px; fill: none; stroke: var(--neon-ink); stroke-width: 3.4; stroke-linecap: round; stroke-linejoin: round; }
+.rd .hiw-done b { display: block; font-size: 1rem; font-weight: 700; }
+.rd .hiw-done span { display: block; margin-top: 6px; color: var(--ink-3); font-size: .85rem; }
+
+/* estado ocioso */
+.rd .hiw-idle { text-align: center; color: var(--ink-3); }
+.rd .hiw-ring { width: 74px; height: 74px; margin: 0 auto 18px; border-radius: 50%; border: 1px dashed var(--line-2); display: grid; place-items: center; }
+.rd .hiw-ring svg { width: 28px; height: 28px; fill: none; stroke: currentColor; stroke-width: 1.5; }
+.rd .hiw-idle span { font-size: .85rem; }
+
+/* painéis de demo */
+.rd .hiw-panel { background: var(--bg); border: 1px solid var(--line); border-radius: 18px; padding: 16px; }
+.rd .hiw-panel-top {
+  display: flex; align-items: center; justify-content: space-between; color: var(--ink-3);
+  font-size: .74rem; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; margin-bottom: 14px;
+}
+.rd .hiw-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--hiw-wa); display: inline-block; margin-right: 7px; vertical-align: 1px; }
+
+/* chat */
+.rd .hiw-chat { display: flex; flex-direction: column; gap: 10px; }
+.rd .hiw-msg { max-width: 82%; padding: 10px 13px; border-radius: 14px; font-size: .92rem; line-height: 1.42; opacity: 0; }
+.rd .hiw-card.is-open .hiw-msg { animation: hiw-pop .45s var(--hiw-ease) forwards; }
+.rd .hiw-msg.out { align-self: flex-end; background: #134D3C; border-bottom-right-radius: 5px; }
+.rd .hiw-msg.in { align-self: flex-start; background: #1E1E22; border-bottom-left-radius: 5px; }
+.rd .hiw-msg time { display: block; margin-top: 4px; font-size: .66rem; color: rgba(255,255,255,.35); text-align: right; }
+@keyframes hiw-pop { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+.rd .hiw-d1 { animation-delay: .35s; } .rd .hiw-d2 { animation-delay: .95s; }
+.rd .hiw-d3 { animation-delay: 1.55s; } .rd .hiw-d4 { animation-delay: 2.15s; }
+
+.rd .hiw-qr {
+  display: flex; align-items: center; gap: 14px; margin-bottom: 14px; padding: 12px; border-radius: 14px;
+  background: color-mix(in srgb, var(--hiw-wa) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hiw-wa) 22%, transparent);
+}
+.rd .hiw-qr svg { width: 38px; height: 38px; flex: none; fill: var(--hiw-wa); }
+.rd .hiw-qr b { display: block; font-size: .92rem; }
+.rd .hiw-qr span { color: var(--ink-2); font-size: .8rem; }
+
+/* recibo do Piggy */
+.rd .hiw-receipt { margin-top: 12px; border-radius: 14px; border: 1px solid rgba(255,45,142,.28); background: var(--pink-soft); padding: 13px 14px; opacity: 0; }
+.rd .hiw-card.is-open .hiw-receipt { animation: hiw-pop .5s var(--hiw-ease) .8s forwards; }
+.rd .hiw-row { display: flex; justify-content: space-between; align-items: center; font-size: .86rem; }
+.rd .hiw-row + .hiw-row { margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,.08); }
+.rd .hiw-k { color: var(--ink-2); }
+.rd .hiw-v { font-weight: 700; font-variant-numeric: tabular-nums; }
+.rd .hiw-tag { font-size: .7rem; font-weight: 700; padding: 3px 9px; border-radius: 999px; background: rgba(255,45,142,.22); color: #FFA9D0; }
+
+/* gráficos */
+.rd .hiw-charts { display: grid; gap: 12px; }
+.rd .hiw-kpis { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.rd .hiw-kpi { background: var(--bg); border: 1px solid var(--line); border-radius: 16px; padding: 13px 15px; }
+.rd .hiw-kpi span { display: block; color: var(--ink-3); font-size: .72rem; font-weight: 600; letter-spacing: .07em; text-transform: uppercase; }
+.rd .hiw-kpi b { display: block; margin-top: 5px; font-size: 1.32rem; font-weight: 800; letter-spacing: -.02em; font-variant-numeric: tabular-nums; }
+.rd .hiw-kpi b.neg { color: var(--neg); } .rd .hiw-kpi b.pos { color: var(--neon); }
+.rd .hiw-donut { display: flex; align-items: center; gap: 18px; }
+.rd .hiw-donut svg { width: 118px; height: 118px; flex: none; transform: rotate(-90deg); }
+/* nada de stroke-dashoffset aqui: os offsets vêm dos atributos do SVG (que a
+   CSS venceria), e é o que põe cada fatia depois da anterior. */
+.rd .hiw-donut circle { fill: none; stroke-width: 11; }
+.rd .hiw-card.is-open .hiw-donut circle { animation: hiw-draw .9s var(--hiw-ease) .25s backwards; }
+@keyframes hiw-draw { from { stroke-dasharray: 0 264; } }
+.rd .hiw-legend { list-style: none; display: grid; gap: 9px; font-size: .86rem; flex: 1; }
+.rd .hiw-legend li { display: flex; align-items: center; gap: 9px; color: var(--ink-2); }
+.rd .hiw-legend i { width: 9px; height: 9px; border-radius: 3px; flex: none; }
+.rd .hiw-legend b { margin-left: auto; color: var(--ink); font-variant-numeric: tabular-nums; }
+.rd .hiw-spark { position: relative; }
+.rd .hiw-spark svg { width: 100%; height: 78px; display: block; overflow: visible; }
+.rd .hiw-line {
+  fill: none; stroke: var(--pink); stroke-width: 2.5; stroke-linecap: round; stroke-linejoin: round;
+  stroke-dasharray: 340; stroke-dashoffset: 340;
+}
+.rd .hiw-card.is-open .hiw-line { animation: hiw-trace 1.1s var(--hiw-ease) .35s forwards; }
+@keyframes hiw-trace { to { stroke-dashoffset: 0; } }
+.rd .hiw-grid { stroke: rgba(255,255,255,.06); stroke-width: 1; }
+.rd .hiw-cap { fill: var(--pink); }
+.rd .hiw-months { display: flex; justify-content: space-between; color: var(--ink-3); font-size: .68rem; margin-top: 6px; letter-spacing: .04em; }
+
+/* CTA logo abaixo do trilho */
+.rd .hiw-cta { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 16px; margin-top: 32px; }
+.rd .hiw-cta p { color: var(--ink-2); }
+
+/* Escopado no trilho de propósito: um `*` global mataria as transições da
+   página inteira (nav, botões, FAQ, reveal). */
+@media (prefers-reduced-motion: reduce) {
+  .rd .hiw-rail, .rd .hiw-rail * {
+    animation-duration: .001ms !important; animation-delay: 0s !important; transition-duration: .001ms !important;
+  }
+  .rd .hiw-msg, .rd .hiw-receipt { opacity: 1; }
 }

--- a/tests/frontend/hiw_rail.test.mjs
+++ b/tests/frontend/hiw_rail.test.mjs
@@ -1,0 +1,235 @@
+/**
+ * Trilho "Como funciona" da index: um card aberto por vez.
+ *
+ * Onze asserções, cada uma discriminando uma forma de quebrar:
+ *  1. hover no card 3 → 3 aberto, 1 e 2 com check (is-done), nenhum is-idle;
+ *  2. card aberto ≥ 2× a largura de um fechado (falha se o CSS não carregar —
+ *     é a prova de que a medição mede algo);
+ *  3. hover PAUSA o ciclo: 7s (> os 6000ms) com o mouse sobre o card 1 e ele
+ *     continua aberto;
+ *  4. bolinhas alinhadas entre cards E entre estados: done/idle ancoram o
+ *     CÍRCULO no meio do card (altura igual), não o bloco dentro do stage (que
+ *     encolhe quando o h4 do foot quebra, e cujo texto tem 1 ou 2 linhas);
+ *  5. o autoplay RODA sem interação nenhuma — o par da asserção 3, que sozinha
+ *     passa igual com o setInterval deletado;
+ *  6. mobile 390×844: a demo do card aberto não cobre nem corta o h4 do rodapé;
+ *  7. nada começa antes de o trilho aparecer na tela (ciclo e animações da demo);
+ *  8. o ciclo RETOMA quando o mouse sai do trilho (a pausa em si é a 3);
+ *  9. Espaço com um card focado continua rolando a página;
+ * 10. clique antes de o observer disparar mantém o ciclo parado depois dele;
+ * 11. o donut do card 3 usa os offsets do SVG — sem eles as 4 fatias saem todas
+ *     das 12h, empilhadas, e a de 16% desaparece por baixo da última.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+const PORT = Number(process.env.PB_HIW_TEST_PORT || 8901);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function startServer() {
+  const proc = spawn("python3", ["-m", "http.server", String(PORT), "--bind", "127.0.0.1", "--directory", FRONTEND],
+    { stdio: "ignore" });
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    if (proc.exitCode !== null) throw new Error(`http.server morreu (porta ${PORT} ocupada?)`);
+    try { if ((await fetch(`${ORIGIN}/index.html`)).ok) return proc; } catch { /* ainda subindo */ }
+  }
+  proc.kill();
+  throw new Error(`http.server não subiu em ${ORIGIN}`);
+}
+
+let server, browser;
+before(async () => { server = await startServer(); browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/** Desktop: o trilho só vira linha (flex-grow) a partir de 900px. */
+async function openIndex(opts = { viewport: { width: 1280, height: 900 } }) {
+  const page = await browser.newPage(opts);
+  await page.goto(`${ORIGIN}/index.html`);
+  await page.waitForSelector(".hiw-card");
+  return page;
+}
+
+/** Espera o scroll suave (html { scroll-behavior: smooth } na site.css) parar.
+    Sem isto, uma medição de rolagem mede a inércia da rolagem anterior. */
+const scrollParado = async (page) => {
+  let a = -1, b = await page.evaluate(() => scrollY);
+  for (let i = 0; i < 30 && a !== b; i++) { await sleep(100); a = b; b = await page.evaluate(() => scrollY); }
+  return b;
+};
+
+/** Rola até o trilho: ele só começa a rodar quando entra na tela. */
+const verTrilho = async (page) => {
+  await page.evaluate(() => document.querySelector(".hiw-rail").scrollIntoView({ block: "center" }));
+  await scrollParado(page);
+};
+
+const states = (page) => page.$$eval(".hiw-card", (els) =>
+  els.map((e) => ["is-open", "is-done", "is-idle"].filter((c) => e.classList.contains(c)).join("|")));
+
+test("hover no 3º card: ele abre, os anteriores viram concluídos", async () => {
+  const page = await openIndex();
+  await page.hover(".hiw-card:nth-child(3)");
+  assert.deepEqual(await states(page), ["is-done", "is-done", "is-open"]);
+  assert.deepEqual(await page.$$eval(".hiw-card", (els) => els.map((e) => e.getAttribute("aria-current"))),
+    [null, null, "step"]);
+  await page.close();
+});
+
+test("card aberto é pelo menos 2× mais largo que um fechado", async () => {
+  const page = await openIndex();
+  await page.hover(".hiw-card:nth-child(1)");
+  await sleep(800);   // transição de flex-grow é .6s
+  const [aberto, fechado] = await page.$$eval(".hiw-card", (els) =>
+    [els[0].getBoundingClientRect().width, els[1].getBoundingClientRect().width]);
+  assert.ok(aberto >= 2 * fechado, `aberto=${Math.round(aberto)}px fechado=${Math.round(fechado)}px`);
+  await page.close();
+});
+
+test("hover pausa o ciclo (6000ms): 7s parado e o card 1 segue aberto", async () => {
+  const page = await openIndex();
+  await page.hover(".hiw-card:nth-child(1)");
+  await sleep(7000);
+  assert.deepEqual(await states(page), ["is-open", "is-idle", "is-idle"]);
+  await page.close();
+});
+
+test("bolinhas do mesmo estado ficam na mesma altura entre os cards", async () => {
+  const page = await openIndex();
+  /** centro y do seletor dentro de cada card marcado com `classe` */
+  const centros = (classe, sel) => page.$$eval(`.hiw-card.${classe} ${sel}`, (els) =>
+    els.map((e) => { const b = e.getBoundingClientRect(); return b.top + b.height / 2; }));
+
+  await page.click(".hiw-card:nth-child(3)");   // 1 e 2 viram is-done
+  await sleep(800);                             // flex-grow leva .6s
+  const [t1, t2] = await centros("is-done", ".hiw-tick");
+  assert.ok(Math.abs(t1 - t2) <= 1, `check: c1=${t1.toFixed(1)} c2=${t2.toFixed(1)}`);
+
+  await page.click(".hiw-card:nth-child(1)");   // 2 e 3 viram is-idle
+  await sleep(800);
+  const [r2, r3] = await centros("is-idle", ".hiw-ring");
+  assert.ok(Math.abs(r2 - r3) <= 1, `anel: c2=${r2.toFixed(1)} c3=${r3.toFixed(1)}`);
+
+  // o caso que o usuário vê: check (c1) e anel (c3) lado a lado, estados diferentes
+  await page.click(".hiw-card:nth-child(2)");
+  await sleep(800);
+  const [[k1], [a3]] = [await centros("is-done", ".hiw-tick"), await centros("is-idle", ".hiw-ring")];
+  assert.ok(Math.abs(k1 - a3) <= 1, `check c1=${k1.toFixed(1)} vs anel c3=${a3.toFixed(1)}`);
+  await page.close();
+});
+
+test("sem interação nenhuma o autoplay abre o card 2 (ciclo de 6000ms)", async () => {
+  const page = await openIndex();
+  // sem isto o teste passaria a testar o nada: o autoplay só liga em hover fino
+  assert.ok(await page.evaluate(() => matchMedia("(hover: hover) and (pointer: fine)").matches),
+    "contexto sem hover fino — o autoplay nem ligaria");
+  await verTrilho(page);
+  await sleep(7000);   // mouse parado em 0,0, fora do trilho
+  assert.deepEqual(await states(page), ["is-done", "is-open", "is-idle"]);
+  await page.close();
+});
+
+test("mobile 390×844: a demo do card aberto não cobre nem corta o h4 do rodapé", async () => {
+  // touch emulado: é o alvo real e, de quebra, desliga o autoplay (hover: none)
+  const page = await openIndex({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+  for (const n of [1, 2, 3]) {
+    await page.click(`.hiw-card:nth-child(${n})`);
+    const m = await page.$eval(`.hiw-card:nth-child(${n})`, (c) => {
+      const r = (s) => c.querySelector(s).getBoundingClientRect();
+      return { demo: r(".hiw-demo").bottom, h4t: r(".hiw-foot h4").top, h4b: r(".hiw-foot h4").bottom,
+               base: c.getBoundingClientRect().bottom, aberto: c.classList.contains("is-open") };
+    });
+    assert.ok(m.aberto, `card ${n} não abriu no toque`);
+    assert.ok(m.h4t - m.demo > 0, `card ${n}: a demo invade o h4 em ${(m.demo - m.h4t).toFixed(0)}px`);
+    assert.ok(m.base - m.h4b > 0, `card ${n}: overflow:hidden corta ${(m.h4b - m.base).toFixed(0)}px do h4`);
+  }
+  await page.close();
+});
+
+test("nada começa antes de o trilho aparecer na tela", async () => {
+  const page = await openIndex();          // carrega no topo; o trilho fica ~4000px abaixo
+  await sleep(7000);                       // mais que um ciclo de 6000ms
+  assert.deepEqual(await states(page), ["is-open", "is-idle", "is-idle"], "o ciclo andou fora da tela");
+  const gastas = await page.$eval(".hiw-card:nth-child(1)", (c) => c.getAnimations({ subtree: true }).length);
+  assert.equal(gastas, 0, `a demo gastou ${gastas} animações antes de aparecer`);
+
+  await verTrilho(page);
+  assert.equal(await page.$eval(".hiw-card:nth-child(1)", (c) => c.getAnimations({ subtree: true }).length), 3,
+    "as 3 animações do chat do card 1 não começaram na entrada");
+  await sleep(7000);
+  assert.deepEqual(await states(page), ["is-done", "is-open", "is-idle"], "o ciclo não andou depois de aparecer");
+  await page.close();
+});
+
+test("o ciclo retoma quando o mouse sai do trilho", async () => {
+  const page = await openIndex({ viewport: { width: 1440, height: 900 } });
+  // faixa em que o trilho já está visível mas o observer ainda não disparou
+  const topo = await page.$eval(".hiw-rail", (r) => r.getBoundingClientRect().top + scrollY);
+  await page.evaluate((y) => scrollTo(0, y), topo - 800);
+  await sleep(400);
+  // movimento de verdade: hover() teleporta e não produz o caminho do usuário
+  for (const x of [700, 712, 724]) await page.mouse.move(x, 850);
+  await verTrilho(page);          // o leitor continua rolando
+  await page.mouse.move(20, 700); // e tira o mouse do trilho
+  await sleep(7000);
+  assert.deepEqual(await states(page), ["is-done", "is-open", "is-idle"]);
+  await page.close();
+});
+
+test("Espaço com um card focado continua rolando a página", async () => {
+  const page = await openIndex();
+  await verTrilho(page);
+  await page.focus(".hiw-card:nth-child(1)");
+  const antes = await scrollParado(page);
+  await page.keyboard.press(" ");
+  await sleep(200);
+  const depois = await scrollParado(page);
+  assert.ok(depois > antes, `o Espaço não rolou a página: ${antes} -> ${depois}`);
+  await page.close();
+});
+
+test("clique antes de o observer disparar mantém o ciclo parado", async () => {
+  const page = await openIndex();
+  const topo = await page.$eval(".hiw-rail", (r) => r.getBoundingClientRect().top + scrollY);
+  await page.evaluate((y) => scrollTo(0, y), topo - 841);   // ~9% do trilho na tela
+  await scrollParado(page);
+  assert.ok(await page.$eval(".hiw-rail", (r) => r.classList.contains("is-esperando")),
+    "o observer já disparou — o teste não está mais medindo o caso");
+
+  // card 3, não o 2: "is-done,is-open,is-idle" é o mesmo estado de um passo do
+  // ciclo, então o teste passava até com o listener de clique deletado.
+  const x = await page.$eval(".hiw-card:nth-child(3)", (c) => {
+    const b = c.getBoundingClientRect(); return Math.round(b.left + b.width / 2);
+  });
+  await page.mouse.click(x, 870);   // por coordenada: o click() do locator rolaria a página antes
+  await page.mouse.move(20, 200);   // e o mouse sai: o que tem de segurar é o clique, não o hover
+
+  assert.deepEqual(await states(page), ["is-done", "is-done", "is-open"], "o clique não abriu o card 3");
+
+  await verTrilho(page);
+  await sleep(7000);   // um passo do ciclo levaria ao card 1 (volta do módulo)
+  assert.deepEqual(await states(page), ["is-done", "is-done", "is-open"]);
+  await page.close();
+});
+
+test("o donut do card 3 usa os offsets do SVG, não o zero da CSS", async () => {
+  const page = await openIndex();
+  await page.click(".hiw-card:nth-child(3)");
+  const [attr, computado] = await page.$$eval(".hiw-card:nth-child(3) .hiw-donut circle", (cs) => [
+    cs.map((c) => Number(c.getAttribute("stroke-dashoffset") || 0)),
+    cs.map((c) => parseFloat(getComputedStyle(c).strokeDashoffset)),
+  ]);
+  assert.ok(attr.filter((v) => v !== 0).length === 3, `os offsets sumiram do HTML: ${attr}`);
+  assert.deepEqual(computado, attr, "a CSS está sobrescrevendo o stroke-dashoffset do SVG");
+  await page.close();
+});


### PR DESCRIPTION
A seção "Como funciona" da landing tinha 4 passos em texto ao lado de um mockup de celular estático. Vira um trilho de 3 cards: o card sob o cursor abre (cresce em `flex-grow`), os que já passaram ficam com check neon, os que faltam com anel tracejado. Cada card mostra a demo do próprio passo — a conversa começando no WhatsApp, a resposta do Piggy com categoria e saldo, e os gráficos do painel.

Referência: a mecânica dos cards do doxaviral.com, medida no site deles (`600ms cubic-bezier(.45,0,0,1)`, trilho de altura fixa, `overflow:hidden`).

## Contrato de interação

Escrito como máquina de estados, não como remendo de transição (CLAUDE.md §4): o ciclo roda **sse** `comecou && autoplay && !tocado && !dentro`.

- mouse dentro do trilho **pausa** — a partir do primeiro pixel de movimento, porque cursor imóvel não emite `mousemove`;
- sair do trilho **retoma**; clique ou foco **param de vez**;
- começa quando a seção entra na tela, senão o chat do card 1 terminava de animar 1290px antes da dobra;
- sem autoplay em touch nem em `prefers-reduced-motion`: sem hover não dá para pausar antes, e o conteúdo trocaria sozinho sob o dedo.

Enumeração de **125 sequências de 3 eventos** sobre `{observer, mousemove, mouseleave, click, focus}` contra um modelo de referência: nenhuma divergência. A mutação de controle ("mousemove mata em vez de pausar") acusa 3 divergências na mesma enumeração.

## Medido

| | |
|---|---|
| card aberto × fechado, 1440×900 | 607px × 259px (2,34×) |
| check e anel, todos os cards e estados | mesmo `y=330` (metade do card de 660px) |
| folga demo→rodapé, 390×844 / 360×740 / 320×568 | +22px nos 3 cards |
| donut do card 3 × donut do hero (arco visível, 720 amostras) | 97% × 96% |
| fonte-raiz 16/20/24px × 2 viewports | 0 overflow, folga positiva nos 18 casos |

## Escopo

- CSS na seção 13 do `site-redesign.css`, que só a index carrega, tudo prefixado `hiw-` e escopado em `.rd`; tokens do `:root` do `site.css`, só duas variáveis locais novas (`--hiw-ease`, `--hiw-wa`).
- `site.css` **intocado** — `como-funciona.html` e `whatsapp.html` compartilham `.step`/`.phone`/`.bubble`.
- Nenhum asset novo, logo nenhuma rota nova em `static_pages.py`. Nenhum `?v=` bumpado à mão.
- Alturas em `rem`: com `font-size: 24px` na raiz, o px fixo fazia o rodapé imprimir por cima do chat e estourar o card em 20px.

## Testes

`tests/frontend/hiw_rail.test.mjs`, 11 asserções, **cada uma com a mutação feita** — todas ficam vermelhas quando o bug que guardam volta. `npm run test:frontend`: **31 passam, 0 falham**. Nada de Python mudou, `pytest` não foi rodado.

## Não verificado

Silêncio aqui não é "verificado":

- **só Chromium** — o WebKit do Playwright não está instalado na máquina, Firefox não foi rodado;
- **nada em aparelho real** — WKWebView, elástico, teclado (CLAUDE.md §6c);
- **`prefers-reduced-motion` e o caminho sem JS** foram medidos à mão, corretos, mas não têm asserção. Sem JS os cards 2 e 3 ficam fechados para sempre e some 2/3 do conteúdo da seção — antes eram 4 passos em texto plano;
- **redimensionar cruzando 900px** pisca os cards por ~150ms (`flex-grow` transicionando a partir de 0 com basis 0). Teto conhecido, marcado com comentário `ponytail:` no CSS; a saída barata derruba a razão 2× entre aberto e fechado.

O commit `6b7e387` (`docs:`) vem junto neste branch a pedido — é a separação de processo × domínio nos dois `CLAUDE.md`, sem relação com a feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)