### PR TITLE
Filtro de dano nas quatro portas da pergunta de valor

### DIFF
--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -9,7 +9,6 @@ import threading
 import time
 import traceback
 from dataclasses import dataclass
-from math import isfinite
 from typing import Any
 
 from adapters.whatsapp.wa_client import (
@@ -38,6 +37,7 @@ from adapters.whatsapp.wa_commands_menu import (
     send_commands_section,
 )
 from core.handle_incoming import handle_incoming
+from core.intent_router import abandona_pergunta_de_valor
 from core.handlers import report as h_report
 from core.observability import log_system_event_sync
 from core.types import IncomingMessage
@@ -905,6 +905,24 @@ def process_message(message: InboundMessage) -> None:
                     _send_reply(reply_to, _apply_recategorize(uid, int(launch_id), message.text))
                     return
 
+            # Passo 1 da pergunta de valor, na porta 4 (a numeração das quatro
+            # está em `core/intent_router.py::abandona_pergunta_de_valor`): o
+            # usuário respondeu com outro comando ("saldo", "apagar 42"), e a
+            # decisão é do intent, não da forma — "apagar 42" tem um número e
+            # pagaria a conta com R$ 42,00.
+            if (pending_recat
+                    and pending_recat.get("action_type") == "bill_pay_amount"
+                    and abandona_pergunta_de_valor(message.text or "")):
+                try:
+                    # CAS, não clear: `pending_actions` é uma linha por usuário
+                    # e outra tarefa pode ter posto uma pergunta nova aqui entre
+                    # o `get_pending_action` acima e agora — que já apareceu na
+                    # tela. Só abandonamos a pergunta se ela ainda for a nossa.
+                    consume_pending_action(uid, pending_recat)
+                except Exception as exc:
+                    logger.warning("WA drop bill_pay_amount pending failed: %s", exc)
+                pending_recat = None  # segue pro roteamento normal
+
             # Conta a pagar de valor variável: o usuário tocou "✅ Já paguei" e
             # agora está mandando o valor real que veio no boleto.
             if pending_recat and pending_recat.get("action_type") == "bill_pay_amount":
@@ -921,29 +939,31 @@ def process_message(message: InboundMessage) -> None:
                         pass
                     _send_reply(reply_to, f"Ok, deixei a conta de *{name}* pendente. Quando pagar é só avisar. 🐷")
                     return
-                from core.handlers.bills import (agrupamento_de_milhar_ok,
-                                                 limpa_pontuacao_final)
-                from utils_text import parse_money, fmt_brl
+                from utils_text import (fmt_brl, limpa_pontuacao_final,
+                                        parse_money, valor_perigoso)
+                # Porta 4. A ACEITAÇÃO é o `parse_money` sobre o texto limpo —
+                # a mesma da `main`, que aqui nunca exigiu forma: "paguei 132",
+                # "132 da luz" e "veio 132,50 esse mes" pagam. O filtro de DANO
+                # é o compartilhado: `parse_money("-10")` devolve 10.0, então
+                # sem ele responder "-10" pagava R$ 10,00.
                 try:
-                    # Mesma limpeza do `resolve_bill_amount`: sem ela "132,50."
-                    # vira 13250.0 no `parse_money` e paga R$ 13.250,00. Esta é
-                    # a outra porta da MESMA pergunta, então tem o mesmo furo.
-                    # Idem o milhar malformado: "1.23.456" pagaria R$ 123.456.
+                    # O texto LIMPO vai para os dois: com o cru, o
+                    # `agrupamento_de_milhar_ok` via o grupo vazio depois do
+                    # ponto de "132." e recusava o que a `main` pagava.
                     limpo = limpa_pontuacao_final(txt)
-                    amount = parse_money(limpo) if agrupamento_de_milhar_ok(limpo) else None
+                    amount = parse_money(limpo)
+                    perigo = valor_perigoso(limpo, amount)
                 except Exception:
-                    amount = None
-                # Arredonda para centavos e recusa não finito ANTES de pagar:
-                # "0,001" passava no `> 0` e o `mark_bill_paid` respondia com o
-                # erro genérico, perdendo a pendência. Aqui a pergunta fica de
-                # pé e o usuário responde de novo. Mesma regra do
-                # `resolve_bill_amount` (core/handlers/bills.py).
-                if amount is not None and isfinite(amount):
-                    amount = round(amount, 2)
-                if amount is None or not isfinite(amount) or amount <= 0:
-                    # não entendeu o valor → re-pergunta, mantém o pending
-                    _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de *{name}*. Ex: *132,50* (ou *cancelar*)")
+                    amount, perigo = None, "nao_entendi"
+                if perigo or amount is None:
+                    # recusa → re-pergunta, mantém o pending de pé (descartá-lo
+                    # jogaria o usuário no fallback genérico).
+                    if perigo == "nao_positivo":
+                        _send_reply(reply_to, f"O valor da conta de *{name}* precisa ser maior que zero. Quanto veio? Ex: *132,50* (ou *cancelar*)")
+                    else:
+                        _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de *{name}*. Ex: *132,50* (ou *cancelar*)")
                     return
+                amount = round(amount, 2)
                 # REIVINDICA antes de pagar, e condicionado ao que foi lido:
                 # duas respostas concorrentes chegariam as duas ao
                 # `mark_bill_paid` e debitariam o saldo duas vezes. Quem perde

--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -881,6 +881,8 @@ def process_message(message: InboundMessage) -> None:
                     )
                 return
 
+        ignora_pendencias = False  # ver o CAS da porta 4, mais abaixo
+
         # ---------------------------------------------------------------
         # Interceptação: usuário escolheu "Outra (digitar)" e agora digitou
         # a categoria que quer aplicar ao lançamento.
@@ -918,7 +920,16 @@ def process_message(message: InboundMessage) -> None:
                     # e outra tarefa pode ter posto uma pergunta nova aqui entre
                     # o `get_pending_action` acima e agora — que já apareceu na
                     # tela. Só abandonamos a pergunta se ela ainda for a nossa.
-                    consume_pending_action(uid, pending_recat)
+                    #
+                    # CAS perdido vale para o TURNO: a linha é da pergunta nova,
+                    # e o `handle_incoming` abaixo relê `pending_actions` do
+                    # zero. Sem o `ignora_pendencias`, o comando velho
+                    # ("saldo") entraria na porta 1 ou na porta 3 DELA — a
+                    # porta 3 apaga a fila inteira do multi-lançamento. O
+                    # `bill_pay_amount` nosso, quando o CAS falha por erro de
+                    # banco (except abaixo), não é lido pelo `route()`.
+                    if not consume_pending_action(uid, pending_recat):
+                        ignora_pendencias = True
                 except Exception as exc:
                     logger.warning("WA drop bill_pay_amount pending failed: %s", exc)
                 pending_recat = None  # segue pro roteamento normal
@@ -1076,7 +1087,7 @@ def process_message(message: InboundMessage) -> None:
             attachments=attachments,
         )
 
-        outs = handle_incoming(incoming) or []
+        outs = handle_incoming(incoming, ignora_pendencias=ignora_pendencias) or []
         if not outs:
             logger.info("WA no outgoing messages for from=%s", message.wa_id)
             _send_reply(reply_to, "Nao entendi. Digite ajuda para ver os comandos.")

--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -958,9 +958,9 @@ def process_message(message: InboundMessage) -> None:
                 # é o compartilhado: `parse_money("-10")` devolve 10.0, então
                 # sem ele responder "-10" pagava R$ 10,00.
                 try:
-                    # O texto LIMPO vai para os dois: com o cru, o
-                    # `agrupamento_de_milhar_ok` via o grupo vazio depois do
-                    # ponto de "132." e recusava o que a `main` pagava.
+                    # O texto LIMPO por causa do `parse_money`: sem a
+                    # limpeza "1.500." vira `None` e "132,50. foi isso" paga
+                    # R$ 13.250,00. O `valor_perigoso` limpa por dentro.
                     limpo = limpa_pontuacao_final(txt)
                     amount = parse_money(limpo)
                     perigo = valor_perigoso(limpo, amount)

--- a/core/handle_incoming.py
+++ b/core/handle_incoming.py
@@ -511,7 +511,12 @@ def _paywall_gate(msg: IncomingMessage, platform: str) -> list[OutgoingMessage] 
     ))]
 
 
-def handle_incoming(msg: IncomingMessage) -> list[OutgoingMessage]:
+def handle_incoming(msg: IncomingMessage, *,
+                    ignora_pendencias: bool = False) -> list[OutgoingMessage]:
+    # `ignora_pendencias`: repassado cru ao `route()`. Um chamador só — a
+    # porta 4 (`adapters/whatsapp/wa_runtime.py`), quando o CAS de abandono
+    # dela perde para uma pergunta NOVA que outra tarefa acabou de pôr na
+    # linha. Ver a docstring do `route()`.
     platform = msg.platform
 
     try:
@@ -707,7 +712,8 @@ def handle_incoming(msg: IncomingMessage) -> list[OutgoingMessage]:
         # ------------------------------------------------------------------
         # 6. Roteia → executa → obtém resposta bruta
         # ------------------------------------------------------------------
-        raw_response = route(intent_result, msg_normalized)
+        raw_response = route(intent_result, msg_normalized,
+                             ignora_pendencias=ignora_pendencias)
 
         # ------------------------------------------------------------------
         # 6b. Post-route fallback: o bot tradicional reconheceu intent mas

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -14,9 +14,9 @@ core/handlers/recurring.py (payment_mode='manual'). Ver [[db/bills.py]].
 from __future__ import annotations
 
 import re
-from math import isfinite
 
-from utils_text import fmt_brl, normalize_text, parse_money
+from utils_text import (_TRACOS, fmt_brl, limpa_pontuacao_final,
+                        normalize_text, parse_money, valor_perigoso)
 
 _PAY_RE = re.compile(r"^(ja\s+)?(paguei|quitei)\b")
 _STOP_TOKENS = {
@@ -184,8 +184,11 @@ def try_pay_from_text(user_id: int, text: str) -> str | None:
 _ENCHIMENTO = (r"(?:foi|era|eh|e|de|da|do|deu|veio|custou|saiu|ficou|acho|que"
                r"|uns|umas|um|uma|tipo|mais|ou|menos|deve|ter|dado|ai)")
 _UNIDADE = r"(?:reais?|real|rs|pila|conto|contos|mango|mangos)"
-# O sinal é capturado de propósito: `parse_money("-10")` devolve 10.0, então
-# sem o grupo (1) um "-10" viraria pagamento de R$ 10.
+# O grupo (1) do sinal ficou aqui só como documentação da forma: quem recusa
+# negativo agora é o `valor_perigoso`, que trata as SEIS grafias de traço — o
+# ASCII `-` mais as cinco do `_TRACOS` (U+2212 menos matemático, U+2013 en
+# dash, U+2014 em dash, U+2010 hífen, U+2011 hífen não-quebrável) — e o
+# "menos 10" falado. O `endswith("-")` de antes deixava passar as outras cinco.
 # NADA de `\s` dentro do número: com ele, "132 50" colava em 13250 e pagava
 # R$ 13.250,00 sem confirmação.
 _VALOR_RE = re.compile(
@@ -197,79 +200,44 @@ _VALOR_RE = re.compile(
 _NUMERO_AMBIGUO_RE = re.compile(r"[\d.,\s]+")
 
 
-def limpa_pontuacao_final(raw: str) -> str:
-    """Tira o ponto/exclamação do FIM antes de entregar ao `parse_money`.
-
-    Mesma armadilha do `\\s` comentada acima, por outra porta: "132,50." tem
-    vírgula E ponto, o `parse_money` decide o decimal pelo ÚLTIMO separador,
-    toma a vírgula por milhar e devolve 13250.0 — R$ 13.250,00 no lugar de
-    R$ 132,50 ("0,50." vira 50, "9,99." vira 999). O `_VALOR_RE` aceita `[.!]?`
-    no fim de propósito (quem escreve "132,50." está respondendo, não mudando de
-    assunto), então quem tem de limpar é quem chama.
-
-    Não corrigido no `parse_money`: o bug é dele e é anterior a este PR, mas ele
-    é chamado por dezenas de fluxos e mexer nele aqui é troca de bug conhecido
-    por bug novo. Issue separada.
-    """
-    return (raw or "").rstrip(" .!")
-
-
-def agrupamento_de_milhar_ok(raw: str) -> bool:
-    """False quando o ponto de milhar está malformado ("1.23.456").
-
-    O `parse_money` decide o significado do ponto pelo TAMANHO do último grupo:
-    se tem 3 dígitos, apaga TODOS os pontos. Então "1.23.456" (erro de
-    digitação) vira 123456.0 e "1.2.345" vira 12345.0 — a conta seria paga com
-    valor inflado, em silêncio, logo depois de o bot pedir "manda só o número".
-
-    Regra: com dois ou mais pontos, todo grupo depois do primeiro precisa ter
-    exatamente 3 dígitos (1.234.567 ✓, 1.23.456 ✗); com um ponto só, valem 3
-    (milhar: 1.200) ou 1-2 (decimal: 132.50) — a mesma heurística que o
-    `parse_money` já usa. Vírgula presente corta o decimal, e a mesma regra vale
-    para o que sobra antes dela.
-
-    O CRITÉRIO não é "o usuário digitou certo?", é "o erro dele vira dinheiro
-    errado?". Por isso um ponto solto mal agrupado passa quando há vírgula:
-
-        1.23,45   → 123,45      1.2,34  → 12,34      12.34,56 → 1.234,56
-
-    Nos três, apagar o ponto fora do lugar devolve exatamente o valor que a
-    pessoa parecia querer — o bot acerta a intenção, e recusar seria pedir para
-    redigitar algo já entendido. Já com DOIS pontos a leitura muda de ordem de
-    grandeza (1.23.456 → 123.456,00 quando o provável era 1.234,56), e aí sim
-    recusa. Foi apontado como incoerência na revisão do #133 e mantido de
-    propósito; se um dia isso mudar, mude por medição de dano, não por simetria.
-
-    Não corrigido no `parse_money` pelo mesmo motivo do `limpa_pontuacao_final`:
-    dezenas de fluxos chamam aquilo. Issue separada.
-    """
-    m = re.search(r"\d[\d.,\s]*", raw or "")
-    if not m:
-        return True
-    num = m.group(0).strip().replace(" ", "")
-    if "," in num:
-        num = num[:num.rfind(",")]
-    grupos = num.split(".")
-    if len(grupos) == 1:
-        return True
-    if len(grupos) == 2:
-        return len(grupos[1]) in (1, 2, 3)
-    return all(len(g) == 3 for g in grupos[1:])
-
-
 def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     """Conclui uma conta variável quando a resposta é somente um valor.
 
     Texto que não seja estritamente monetário abandona a pergunta e volta ao
     roteamento normal, em vez de extrair por engano um número de outro comando.
+    A aceitação é o `_VALOR_RE` — a mensagem INTEIRA tem que ser o valor. É a
+    porta mais estrita das quatro, de propósito: aqui o `parse_money` roda sobre
+    a frase toda, e afrouxar para "tem um número dentro" fez, medido,
+    "codigo 8888 valor 132" pagar R$ 8.888,00, "no dia 20 foram 450" pagar
+    R$ 20,00 e "dia 12/05 132" pagar R$ 12,00.
+
+    Esta porta NÃO consulta o `abandona_pergunta_de_valor` (o passo 1 das
+    portas 2, 3 e 4; a numeração está em `core/intent_router.py`). Medido sobre
+    o alfabeto inteiro do `_VALOR_RE` — 44.289 strings (7 números × 9 unidades
+    × 703 prefixos do `_ENCHIMENTO`), todas casando o `fullmatch`: ZERO
+    classificam num intent de `ABANDONA` com `allow_ai=False`. O portão de
+    forma já é mais estrito que o passo 1, então ele não teria entrada
+    alcançável aqui. A enumeração está em
+    `tests/test_bill_amount_pending.py::test_porta_1_nao_precisa_do_passo_1_alfabeto_inteiro_do_valor_re`.
+
+    ORDEM: o abandono por forma vem ANTES do dano. O contrário prendia o
+    usuário: `quanto gastei em 12 05`, `resumo do mes 08 2026` e `apagar 0`
+    (nenhum dos três casa o `_VALOR_RE`) morriam no "Não entendi o valor da
+    *Luz*" / "precisa ser maior que zero" com a pendência de pé, e a repetição
+    idêntica dava a mesma recusa.
+
+    Os traços são normalizados ANTES da forma, não só dentro do
+    `valor_perigoso`: `−10` (U+2212, o que o teclado do iOS produz) não casa o
+    `_VALOR_RE`, e sem esta linha ele abandonaria a pergunta em silêncio em vez
+    de recusar com ela viva.
     """
-    raw = (text or "").strip()
+    raw = (text or "").strip().translate(_TRACOS)
     nome = (pending.get("payload") or {}).get("bill_name") or "conta"
-    casou = _VALOR_RE.fullmatch(raw)
-    if not casou:
+    nao_entendi = (f"Não entendi o valor da *{nome}*. Manda só o número, "
+                   f"por exemplo: *132,50*")
+    if not _VALOR_RE.fullmatch(raw):
         if _NUMERO_AMBIGUO_RE.fullmatch(raw):
-            return (f"Não entendi o valor da *{nome}*. Manda só o número, "
-                    f"por exemplo: *132,50*")
+            return nao_entendi
         # CONDICIONAL, não clear: entre a leitura desta pendência e agora,
         # outra tarefa pode ter posto uma confirmação nova no lugar — que já
         # apareceu na tela do usuário. Apagar por cima a deixaria órfã. Só
@@ -279,25 +247,24 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
         consume_pending_action(user_id, pending)
         return None
 
+    # A forma é de valor. Agora o DANO, sobre o texto JÁ limpo — passar o cru
+    # fazia `agrupamento_de_milhar_ok("132.")` ver o grupo vazio depois do
+    # ponto e recusar "132." e "1.500.", que a `main` pagava.
     limpo = limpa_pontuacao_final(raw)
-    amount = parse_money(limpo) if agrupamento_de_milhar_ok(limpo) else None
-    # Arredonda para centavos ANTES de validar: "0,001" passava no `> 0`,
-    # gravava paid_amount=0.001 e respondia "R$ 0,00 lançado" — mensagem e dado
-    # divergentes. Agora vira 0.0 e cai na validação abaixo.
-    if amount is not None:
-        amount = round(amount, 2)
+    perigo = valor_perigoso(limpo, parse_money(limpo))
+    if perigo == "nao_positivo":
+        return f"O valor da *{nome}* precisa ser maior que zero. Quanto veio este mês?"
+    if perigo == "nao_entendi":
+        return nao_entendi
+
+    amount = parse_money(limpo)
     if amount is None:
         # Casou o formato mas o `parse_money` não extraiu nada ("1.2.3.4",
         # "1,,,2"): dizer "precisa ser maior que zero" para um texto que não é
         # negativo confunde. Mesma mensagem do número ambíguo.
-        return (f"Não entendi o valor da *{nome}*. Manda só o número, "
-                f"por exemplo: *132,50*")
-    # `isfinite` junto com o `<= 0`: `parse_money("1"*400)` devolve `inf`, que
-    # passa no `> 0` e só seria recusado lá no `mark_bill_paid` — depois de a
-    # pendência já ter sido reivindicada, virando "erro interno" para o usuário.
-    # Aqui a pergunta continua de pé e ele responde de novo.
-    if casou.group(1) or not isfinite(amount) or amount <= 0:
-        return f"O valor da *{nome}* precisa ser maior que zero. Quanto veio este mês?"
+        return nao_entendi
+    # Centavos: o `valor_perigoso` já recusou o que arredonda para zero.
+    amount = round(amount, 2)
 
     from db import consume_pending_action, restore_pending_on_error
     from db.bills import mark_bill_paid
@@ -328,4 +295,4 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     )
 
 
-__all__ = ["limpa_pontuacao_final", "resolve_bill_amount", "try_pay_from_text"]
+__all__ = ["resolve_bill_amount", "try_pay_from_text"]

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -247,9 +247,9 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
         consume_pending_action(user_id, pending)
         return None
 
-    # A forma é de valor. Agora o DANO, sobre o texto JÁ limpo — passar o cru
-    # fazia `agrupamento_de_milhar_ok("132.")` ver o grupo vazio depois do
-    # ponto e recusar "132." e "1.500.", que a `main` pagava.
+    # A forma é de valor. Agora o DANO, sobre o texto JÁ limpo — o
+    # `parse_money` precisa da limpeza ("1.500." vira `None` sem ela). O
+    # `valor_perigoso` faz a dele por dentro e não depende desta linha.
     limpo = limpa_pontuacao_final(raw)
     perigo = valor_perigoso(limpo, parse_money(limpo))
     if perigo == "nao_positivo":

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import re
 
-from utils_text import (_TRACOS, fmt_brl, limpa_pontuacao_final,
+from utils_text import (_ENCHIMENTO, _TRACOS, fmt_brl, limpa_pontuacao_final,
                         normalize_text, parse_money, valor_perigoso)
 
 _PAY_RE = re.compile(r"^(ja\s+)?(paguei|quitei)\b")
@@ -177,18 +177,18 @@ def try_pay_from_text(user_id: int, text: str) -> str | None:
 
 
 
-# Enchimento falado antes do número: "foi 132", "acho que 132", "uns 132",
-# "veio 132 reais", "deu 132,50". É `fullmatch`, então TODA palavra antes do
-# número tem que estar nesta lista — "gastei 132 no mercado" não casa e a
-# pergunta é abandonada para o roteamento normal, que é o certo.
-_ENCHIMENTO = (r"(?:foi|era|eh|e|de|da|do|deu|veio|custou|saiu|ficou|acho|que"
-               r"|uns|umas|um|uma|tipo|mais|ou|menos|deve|ter|dado|ai)")
+# `_ENCHIMENTO` vem do `utils_text`: enchimento falado antes do número ("foi
+# 132", "acho que 132", "uns 132", "veio 132 reais"). É `fullmatch`, então TODA
+# palavra antes do número tem que estar naquela lista — "gastei 132 no mercado"
+# não casa e a pergunta é abandonada para o roteamento normal, que é o certo.
+# A MESMA lista decide, no `_sinal_negativo`, se o que vem antes de um traço é
+# conteúdo; por isso ela mora lá e não aqui.
 _UNIDADE = r"(?:reais?|real|rs|pila|conto|contos|mango|mangos)"
-# O grupo (1) do sinal ficou aqui só como documentação da forma: quem recusa
-# negativo agora é o `valor_perigoso`, que trata as SEIS grafias de traço — o
-# ASCII `-` mais as cinco do `_TRACOS` (U+2212 menos matemático, U+2013 en
-# dash, U+2014 em dash, U+2010 hífen, U+2011 hífen não-quebrável) — e o
-# "menos 10" falado. O `endswith("-")` de antes deixava passar as outras cinco.
+# O grupo (1) do sinal ficou aqui só como documentação da FORMA: quem recusa
+# negativo agora é a tabela-verdade do `utils_text._sinal_negativo`, que decide
+# por POSIÇÃO do traço, trata as dez grafias do `_TRACOS` e o "menos" falado.
+# Sozinho, este grupo recusava "-10" e deixava passar "luz - 132"; a tabela
+# separa sinal de separador de prosa.
 # NADA de `\s` dentro do número: com ele, "132 50" colava em 13250 e pagava
 # R$ 13.250,00 sem confirmação.
 _VALOR_RE = re.compile(
@@ -229,7 +229,9 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     Os traços são normalizados ANTES da forma, não só dentro do
     `valor_perigoso`: `−10` (U+2212, o que o teclado do iOS produz) não casa o
     `_VALOR_RE`, e sem esta linha ele abandonaria a pergunta em silêncio em vez
-    de recusar com ela viva.
+    de recusar com ela viva. O "menos" falado não precisa da mesma normalização
+    aqui: ele está no `_ENCHIMENTO`, então "menos 10" já casa a forma e chega ao
+    `valor_perigoso`, que o recusa.
     """
     raw = (text or "").strip().translate(_TRACOS)
     nome = (pending.get("payload") or {}).get("bill_name") or "conta"

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -718,9 +718,9 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
     # A ACEITAÇÃO continua sendo o `_extract_valor` — o mesmo desta função antes
     # do PR, então "10 mil", "cinquenta" e "paguei 132 no mercado" seguem
     # entrando. O `valor_perigoso` só olha o que já foi aceito.
-    # O texto LIMPO vai para os dois: com o cru, `agrupamento_de_milhar_ok`
-    # via o grupo vazio depois do ponto de "132." e recusava o que a `main`
-    # registrava.
+    # O texto LIMPO por causa do `_extract_valor`: sem a limpeza
+    # "132,50. foi isso" registra R$ 13.250,00 e "1.234,56, foi isso" não
+    # registra nada. O `valor_perigoso` limpa por dentro, não depende daqui.
     limpo = limpa_pontuacao_final(text or "")
     valor = _extract_valor(limpo)
     perigo = valor_perigoso(limpo, valor)

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -685,7 +685,8 @@ def register_if_recurring(user_id: int, tipo: str, desc: str, platform: str) -> 
 _CANCEL_WORDS = {"nao", "n", "cancelar", "cancela", "deixa", "esquece", "esquecer", "para", "pare"}
 
 
-def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform: str = "whatsapp") -> str | None:
+def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform: str = "whatsapp",
+                               outro_comando: bool = False) -> str | None:
     """
     Resolve a pergunta de valor pendente de um lançamento múltiplo. O bot havia
     perguntado "quanto foi *aluguel*?"; esta resposta traz o valor.
@@ -695,16 +696,46 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
     - resposta de cancelamento → descarta o que faltava.
     - resposta sem valor (o user mudou de assunto) → abandona a pendência e
       retorna None pra que o roteador processe a mensagem normalmente.
+    - `outro_comando` (passo 1, resolvido no `route()` por
+      `abandona_pergunta_de_valor`) → mesmo abandono, mas para texto que TEM
+      valor e ainda assim é comando ("apagar 42" registrava R$ 42,00 no
+      aluguel).
 
     Duas respostas simultâneas: a fila avança por compare-and-swap
     (`db.advance_pending_action`) ANTES do registro, então a segunda thread
     perde o CAS, relê a fila já encurtada e responde o item seguinte em vez de
     registrar o mesmo de novo. Sem lock — ver o porquê em `db/pending.py`.
     """
-    from utils_text import normalize_text
+    from utils_text import limpa_pontuacao_final, normalize_text, valor_perigoso
 
     resp_norm = normalize_text(text).strip()
-    valor = _extract_valor(text)
+    # Porta 3 da pergunta de valor (a numeração das quatro está em
+    # `core/intent_router.py::abandona_pergunta_de_valor`), e até aqui a única
+    # sem filtro nenhum: o `_extract_valor` sozinho gravava R$ 10,00 para "-10",
+    # R$ 13.250,00 para "132 50" e para "132,50.", R$ 123.456,00 para
+    # "1.23.456", `0.001` para "0,001" e `inf` (→ "erro interno") para 400 uns.
+    #
+    # A ACEITAÇÃO continua sendo o `_extract_valor` — o mesmo desta função antes
+    # do PR, então "10 mil", "cinquenta" e "paguei 132 no mercado" seguem
+    # entrando. O `valor_perigoso` só olha o que já foi aceito.
+    # O texto LIMPO vai para os dois: com o cru, `agrupamento_de_milhar_ok`
+    # via o grupo vazio depois do ponto de "132." e recusava o que a `main`
+    # registrava.
+    limpo = limpa_pontuacao_final(text or "")
+    valor = _extract_valor(limpo)
+    perigo = valor_perigoso(limpo, valor)
+
+    if outro_comando:
+        # Passo 1: o intent diz que isto nunca seria a resposta ("apagar 42",
+        # "quanto gastei em 132"). Vem ANTES do valor de propósito — os dois
+        # têm número, e o `_extract_valor` diria 42.
+        #
+        # CAS, não `clear_pending_action`: `pending_actions` é uma linha por
+        # usuário e outra tarefa pode ter posto uma pergunta nova aqui entre a
+        # leitura de `pending` e agora — que já apareceu na tela. Mesmo padrão
+        # das portas 1 e 4.
+        db.consume_pending_action(user_id, pending)
+        return None
 
     # Duas respostas do mesmo usuário podem ser processadas em paralelo pelo
     # Discord (`discord_bot.py:122`, `on_message` async sem lock, em processo
@@ -733,6 +764,16 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
             db.consume_pending_action(user_id, pending)
             restantes = ", ".join(i.get("desc", "?") for i in queue)
             return f"❌ Beleza, deixei de lado: {restantes}."
+
+        if perigo:
+            # Fala do valor, mas o valor não serve. Recusa MANTENDO a pergunta
+            # viva e a fila intacta (nada de CAS aqui — não avançamos nada):
+            # apagar a pendência jogaria o usuário no fallback genérico e o
+            # resto da fila sumiria com ela.
+            recusa = ("O valor precisa ser maior que zero."
+                      if perigo == "nao_positivo"
+                      else "Não entendi o valor. Manda só o número, por exemplo: *132,50*")
+            return f"{recusa}\n\n{_ask_value_question(queue[0])}"
 
         if valor is None or valor <= 0:
             # Não é um valor — o usuário mudou de assunto. Abandona a pendência e

--- a/core/intent_classifier.py
+++ b/core/intent_classifier.py
@@ -962,12 +962,25 @@ def classify_with_context(
 # Função principal
 # ---------------------------------------------------------------------------
 
-def classify(text: str, user_id: int | None = None) -> IntentResult:
+def classify(text: str, user_id: int | None = None, *, allow_ai: bool = True) -> IntentResult:
     """
     Classifica a intenção do texto em 3 tiers.
     Retorna IntentResult com intent, confidence, entities, etc.
 
     user_id: quando fornecido, aplica rate limiting no Tier 3 (chamada à IA).
+    allow_ai=False: só os tiers 1 e 2 (determinísticos). No lugar do tier 3 sai
+        o mesmo `out_of_scope 0.0` com que ele já degrada hoje quando não há
+        `OPENAI_API_KEY` e quando o usuário não é Pro. Tem um único chamador em
+        produção — o `abandona_pergunta_de_valor`
+        (`core/intent_router.py`), o passo 1 das portas 2, 3 e 4 da pergunta de
+        valor, que precisa saber se a resposta é OUTRO comando: com o tier 3 no
+        meio, uma alucinação do LLM viraria abandono da pergunta e a fila do
+        usuário seria apagada.
+
+        Com o default `True` os DOIS `if not allow_ai` abaixo são inalcançáveis,
+        então nenhum chamador existente muda de comportamento. (O
+        `_is_boleto_ai_query` continua vindo antes dos dois: "132 no boleto"
+        sai `out_of_scope 0.4` mesmo com `allow_ai=False`.)
     """
     norm = _normalize(text)
 
@@ -982,6 +995,8 @@ def classify(text: str, user_id: int | None = None) -> IntentResult:
     # de Tier 1/2 e o domain-hint, que senão mandariam pra launches.add ou
     # out_of_scope (→ IA conversacional criava orçamento por engano).
     if _has_recurrence_marker(norm) or _has_bill_marker(norm):
+        if not allow_ai:
+            return IntentResult(intent="out_of_scope", confidence=0.0)
         return _classify_with_ai(text, user_id=user_id)
 
     # Tier 1
@@ -998,4 +1013,6 @@ def classify(text: str, user_id: int | None = None) -> IntentResult:
         return IntentResult(intent="out_of_scope", confidence=0.4)
 
     # Tier 3
+    if not allow_ai:
+        return IntentResult(intent="out_of_scope", confidence=0.0)
     return _classify_with_ai(text, user_id=user_id)

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import re
 
 import db
-from core.intent_classifier import IntentResult
+from core.intent_classifier import IntentResult, classify
 from core.types import IncomingMessage
-from utils_text import normalize_text
+from utils_text import limpa_pontuacao_final, normalize_text, valor_perigoso
 
 # handlers
 from core.handlers import (
@@ -107,6 +107,90 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
     return first in {"gasto", "gastos", "despesa", "despesas", "lancamento", "lancamentos", "historico", "extrato"}
 
 
+# ---------------------------------------------------------------------------
+# Passo 1 da pergunta de valor. As QUATRO portas são numeradas aqui, e só
+# aqui — qualquer comentário sobre "a porta N" no repositório se refere a esta
+# lista (o passo 1 em si vale para as portas 2, 3 e 4; ver a nota no fim):
+#
+#   porta 1  conta variável, por texto  core/handlers/bills.py::resolve_bill_amount
+#   porta 2  QUALQUER `clarification`  este arquivo, `_clarification_abandonada`
+#            no `route()` — não só a de `launches.add`: a de `recurring.add`, a
+#            de `funds.add_ask` e as genéricas da IA passam pela mesma escotilha.
+#            O filtro não é o intent da pergunta, é o `_ja_tem_o_valor`.
+#   porta 3  fila do multi-lançamento  core/handlers/launches.py::resolve_multi_launch_value
+#   porta 4  botão "✅ Já paguei"      adapters/whatsapp/wa_runtime.py (roda ANTES
+#                                      do handle_incoming, por isso importa daqui)
+#
+# A porta 1 é a única que NÃO consulta o `abandona_pergunta_de_valor`: o portão
+# de forma dela (`_VALOR_RE.fullmatch`) já é mais estrito. Ver
+# `core/handlers/bills.py::resolve_bill_amount`.
+#
+# MUNDO FECHADO, de propósito. A versão anterior era o contrário — abandonava a
+# pergunta para qualquer intent fora de uma lista de permitidos — e isso apagou
+# a fila inteira de um multi-lançamento quando o usuário respondeu "132 no
+# cartao" (`credit.handle` 0.95). Numa blacklist sobre um oráculo ilimitado,
+# todo intent novo e toda alucinação do LLM nascem destruindo pendência; numa
+# whitelist, nascem inertes. O default seguro é NÃO abandonar: a pergunta
+# continua de pé, e o dado do usuário nunca some por engano.
+#
+# Os seis abaixo foram medidos um a um com `classify(..., allow_ai=False)`:
+#   balance.check        "saldo"                 1.0
+#   launches.list        "extrato", "meus gastos"  1.0
+#   launches.delete      "apagar 42"             0.95
+#   launches.spend_query "quanto gastei em 132", "quanto gastei em maio"  0.95
+#   pockets.list         "caixinhas"             1.0
+#   report.monthly       "resumo do mes"         1.0
+#
+# `credit.handle` ficou de FORA por medição, não por esquecimento: "fatura" é
+# 1.0 e "132 no cartao" é 0.95 — mesmo intent, e o segundo é uma resposta
+# legítima ("foram 132, no cartão"). O único corte por confiança que os separa
+# (== 1.0) também derrubaria "fatura do cartao" (0.95), então não é corte
+# limpo.
+#
+# O PREÇO de deixá-lo fora, MEDIDO nas quatro portas com "fatura",
+# "fatura do cartao", "meus cartoes" e "cartao nubank" — não é "o usuário
+# repete o comando", e é diferente em cada porta:
+#
+#   porta 1  custo ZERO: o `_VALOR_RE` não casa, a pergunta é abandonada e o
+#            comando de cartão roda normalmente.
+#   porta 3  custo ZERO: o `_extract_valor` não acha valor, mesmo efeito.
+#   porta 2  LAÇO INDEFINIDO **medido com a IA desligada**: a pergunta volta
+#            ("Quanto foi no *luz*?") e a pendência é RE-ARMADA a cada turno
+#            (medido: `expires_at` cresce em cada resposta), então ela nunca
+#            expira e o comando de cartão nunca roda enquanto o usuário
+#            insistir nele. Em produção o `classify_with_context` roda ANTES do
+#            re-armar (no `_resolve_clarification`) e pode despachar o comando,
+#            encurtando ou eliminando o laço — saída de LLM, não mensurável
+#            aqui.
+#   porta 4  laço, mas com saída: a pergunta volta ("Não peguei o valor") e a
+#            pendência NÃO é reescrita (`expires_at` não muda), então o laço
+#            morre nos 10 min contados da pergunta original.
+#
+# Ainda assim o cartão fica fora: o laço da porta 2 custa turnos, e apagar a
+# fila de quem respondeu "132 no cartao" custa o lançamento do usuário.
+ABANDONA = {
+    "balance.check", "launches.list", "launches.delete",
+    "launches.spend_query", "pockets.list", "report.monthly",
+}
+
+
+def abandona_pergunta_de_valor(text: str) -> bool:
+    """True quando a resposta a uma pergunta de valor é OUTRO comando.
+
+    `allow_ai=False`: só os tiers 1 e 2, que são determinísticos e não fazem
+    rede. Duas razões, as duas medidas:
+
+    - a porta 4 roda ANTES do `handle_incoming`, e "132" (a resposta mais comum
+      daquela pergunta) cai no tier 3 — consultar com IA custaria uma chamada
+      de LLM por conta paga;
+    - com o tier 3 no meio, o oráculo volta a ser ilimitado. Sem ele, "132",
+      "cinquenta" e "132 todo mes" caem em `out_of_scope 0.0` e "132 no boleto"
+      em `out_of_scope 0.4` (tier 2) — nenhum deles está no `ABANDONA`, então
+      nunca abandonam nada, que é exatamente o comportamento da `main`.
+    """
+    return classify((text or "").strip(), allow_ai=False).intent in ABANDONA
+
+
 def route(result: IntentResult, msg: IncomingMessage) -> str:
     """
     Ponto de entrada único do roteador.
@@ -141,7 +225,19 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
     # -----------------------------------------------------------------------
     clarif = h_pending.get_pending_clarification(user_id)
     if clarif:
-        return _resolve_clarification(clarif, text, user_id, platform, external_id)
+        if _clarification_abandonada(clarif, text):
+            # Porta 2. Mesma escotilha de escape do `investment_pick` e do
+            # `funding_source_choice` logo abaixo: outro comando claro abandona
+            # a pergunta em vez de ser engolido por ela ("Quanto foi no *luz*?"
+            # + "saldo" virava "Quanto foi no *luz saldo*?").
+            #
+            # CONDICIONAL, não `clear_pending_action`: entre o
+            # `get_pending_clarification` acima e agora, outra tarefa pode ter
+            # posto uma pergunta NOVA na linha (é uma linha por usuário) — que
+            # já apareceu na tela. Apagar por cima a deixaria órfã.
+            db.consume_pending_action(user_id, clarif)
+        else:
+            return _resolve_clarification(clarif, text, user_id, platform, external_id)
 
     pending = db.get_pending_action(user_id)
 
@@ -149,6 +245,10 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
     # antes do roteamento por intent: um número sozinho costuma ser classificado
     # como out_of_scope e não carregaria qual conta o bot acabou de perguntar.
     if pending and pending.get("action_type") == "bill_amount_expected":
+        # Sem o passo 1 aqui de propósito: o portão de forma da porta 1
+        # (`_VALOR_RE.fullmatch`) já é mais estrito que o
+        # `abandona_pergunta_de_valor` — medido, nenhuma das 44.289 strings que
+        # ele casa cai no `ABANDONA`. Ver `resolve_bill_amount`.
         resp = h_bills.resolve_bill_amount(user_id, text, pending)
         if resp is not None:
             return resp
@@ -158,7 +258,9 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
     # aluguel" sem número → "quanto foi o aluguel?"). A resposta com valor
     # registra o item; sem valor, abandona e segue o roteamento normal.
     if pending and pending.get("action_type") == "multi_launch_values":
-        resp = h_launches.resolve_multi_launch_value(user_id, text, pending, platform)
+        resp = h_launches.resolve_multi_launch_value(
+            user_id, text, pending, platform,
+            outro_comando=abandona_pergunta_de_valor(text))
         if resp is not None:
             return resp
         pending = None  # abandonado → mensagem roteia como comando novo
@@ -536,6 +638,76 @@ def _execute(intent: str, user_id: int, text: str, entities: dict, platform: str
     return OUT_OF_SCOPE_MSG
 
 
+def _ja_tem_o_valor(entities: dict | None) -> bool:
+    """A `clarification` pendente já traz o valor, então ela pede a DESCRIÇÃO.
+
+    Fonte única dos dois lugares que precisam da distinção (a escotilha de
+    abandono e o ramo `launches.add` do `_resolve_clarification`) — se elas
+    divergirem, uma pergunta de descrição vira pergunta de valor e o dinheiro já
+    digitado some.
+
+    São 5 produtores de `clarification`, e 4 deles foram lidos um a um:
+
+      grava `entities["valor"]`  →  pede DESCRIÇÃO/destino, nunca abandona
+        `core/handlers/launches.py:981`  "Em que você gastou R$ 50?"
+        `_ask_add_destination` (este arquivo)  "Onde você quer adicionar…?"
+      NÃO grava  →  pede VALOR, pode abandonar
+        `core/handlers/launches.py:1001`  "Quanto foi no *luz*?"
+        `core/handlers/recurring.py:97`   "Qual o valor desse recorrente?"
+
+    O 5º é o esclarecimento genérico da IA (`result.needs_clarification`, no
+    `route()`): as `entities` vêm do LLM e NÃO são mensuráveis aqui. Ele cai no
+    ramo fail-safe do `try` abaixo quando o campo vier torto, e no `> 0` quando
+    vier limpo.
+
+    (`launches.py:959` NÃO é produtor de `clarification` — é o
+    `multi_launch_values`, a porta 3.)
+
+    Não olha o `orig_text`: uma versão anterior somava
+    `_extract_valor(orig_text)` e classificava "gasto fixo aluguel todo dia 10"
+    como "já tem o valor" por causa do *dia* 10 — a mesma pergunta se comportava
+    de dois jeitos conforme o texto original ter ou não um dígito, e nenhum
+    teste prendia a cláusula.
+    """
+    try:
+        return float((entities or {}).get("valor") or 0) > 0
+    except (AttributeError, TypeError, ValueError):
+        return True
+
+
+def _clarification_abandonada(clarif: dict, text: str) -> bool:
+    """True quando a resposta é OUTRO comando claro, não a resposta à pergunta.
+
+    Porta 2 do passo 1 (`abandona_pergunta_de_valor`). Quem decide é o INTENT,
+    não a forma do texto: "gastei 132" e "apagar 42" têm os dois um número.
+
+    Vale para TODA `clarification`, não só a de `launches.add`: roda no
+    `route()`, antes de o `_resolve_clarification` olhar o `intent` do payload,
+    então a de `recurring.add`, a de `funds.add_ask` e as genéricas da IA
+    passam por aqui também. O único filtro por payload é o `_ja_tem_o_valor`.
+
+    Antes disso, uma condição que nada tem a ver com o classificador: **a
+    pergunta ainda não pode ter o valor.** Toda `clarification` que pede a
+    DESCRIÇÃO já gravou `entities["valor"]`; as que pedem o VALOR não têm nada
+    lá. Abandonar uma pergunta de descrição descartaria em silêncio o dinheiro
+    que o usuário JÁ digitou ("gastei 50" + "extrato" perderia os R$ 50), então
+    ela nunca abandona.
+
+    O que NÃO é comando claro segue para o `_resolve_clarification`, que aceita
+    o valor, recusa o valor perigoso ou re-pergunta — a pergunta continua viva
+    em todos os três casos.
+    """
+    payload = clarif.get("payload")
+    if not isinstance(payload, dict):
+        # Nenhum produtor grava payload não-dict hoje; sem esta linha um dado
+        # torto viraria AttributeError → "erro interno" em loop, com a
+        # pendência nunca sendo limpa.
+        return False
+    if _ja_tem_o_valor(payload.get("entities")):
+        return False
+    return abandona_pergunta_de_valor(text)
+
+
 def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platform: str, external_id: str) -> str:
     """
     O bot tinha feito uma pergunta e está esperando a resposta do usuário.
@@ -637,23 +809,61 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
         from parsers import _extract_valor
         tipo = (original_entities.get("tipo") or "despesa").lower()
         verbo = "recebi" if tipo == "receita" else "gastei"
-        if _extract_valor(user_response) is not None:
+        resposta = limpa_pontuacao_final(user_response.strip())
+        if _ja_tem_o_valor(original_entities):
+            # já tínhamos o valor → a resposta é a descrição/alvo que faltava.
+            # Testado ANTES de parsear a resposta como valor: "gastei 50" +
+            # "mercado 20" tem um número na resposta e virava R$ 2.050,00.
+            #
+            # O " - " não é enfeite. O `parse_money` cola dois grupos de
+            # dígitos separados por espaço, então o combinado "gastei 50 0"
+            # (resposta "0" a uma pergunta de DESCRIÇÃO) virava R$ 500,00 e
+            # "gastei 50 20 no mercado" virava R$ 5.020,00. Medido: com o
+            # traço, os dois voltam a R$ 50,00 — o traço não está em
+            # `[\d.,\s]` e o recorte para no primeiro número.
+            combined = f"{orig_text} - {resposta}".strip()
+        else:
+            valor = _extract_valor(resposta)
+            perigo = valor_perigoso(resposta, valor)
+            if perigo:
+                # Porta 2. Recusa MANTÉM a pergunta viva: re-arma o mesmo
+                # payload (o `orig_text` não cresce) e repete a pergunta
+                # guardada. Descartar a pendência jogaria o usuário no fallback
+                # genérico e o valor já digitado sumiria.
+                #
+                # CONDICIONAL, como os quatro CAS das outras portas. O
+                # `consume_pending_action` no topo desta função já apagou a
+                # linha, então o primitivo certo é o "insere só se não houver" e
+                # NÃO o `advance_pending_action` (o CAS não acharia old_payload
+                # nenhum e não gravaria nada — a pergunta morreria no caso
+                # normal). `set_pending_action` é upsert incondicional: entre o
+                # consumo e aqui, outra tarefa pode ter posto uma pergunta NOVA
+                # na linha (é uma por usuário) — que já apareceu na tela — e o
+                # upsert a atropelava. Medido com a corrida injetada.
+                db.create_pending_action_if_absent(
+                    user_id, "clarification", payload)
+                recusa = ("O valor precisa ser maior que zero."
+                          if perigo == "nao_positivo"
+                          else "Não entendi o valor. Manda só o número, por exemplo: *132,50*")
+                return f"{recusa}\n\n{payload.get('question') or 'Qual foi o valor? Tente: *150*'}"
+            if valor is None:
+                # ainda sem valor reconhecível — refaz a pergunta e mantém o
+                # pending pra não perder a descrição original.
+                db.set_pending_action(user_id, "clarification", payload)
+                return payload.get("question") or "Qual foi o valor? Tente: *150*"
             # resposta trouxe o VALOR que faltava → descrição vem do texto
             # original (sem o verbo, pra não duplicar "gastei 150 gastei ...").
+            #
+            # O texto do USUÁRIO, não `fmt_brl(valor)`: medido, "paguei a luz" +
+            # "132 no mercado" grava categoria *mercado* com o texto cru e
+            # *moradia* com o valor re-renderizado — a palavra que a pessoa
+            # digitou é o que categoriza. Só a pontuação final sai
+            # (`limpa_pontuacao_final`), senão "132,50." vira R$ 13.250,00.
             desc = re.sub(
                 r"^\s*(gastei|gasto|paguei|pagar|comprei|debitei|mandei|enviei|pixei|recebi|receita|ganhei)\b",
                 "", orig_text, flags=re.IGNORECASE,
             ).strip()
-            combined = f"{verbo} {user_response.strip()} {desc}".strip()
-        elif original_entities.get("valor") or _extract_valor(orig_text) is not None:
-            # já tínhamos o valor (no texto/entidades) → a resposta é a
-            # descrição/alvo que faltava. O orig_text já carrega tipo + valor.
-            combined = f"{orig_text} {user_response.strip()}".strip()
-        else:
-            # ainda sem valor reconhecível — refaz a pergunta e mantém o pending
-            # pra não perder a descrição original.
-            db.set_pending_action(user_id, "clarification", payload)
-            return payload.get("question") or "Qual foi o valor? Tente: *150*"
+            combined = f"{verbo} {resposta} {desc}".strip()
         return _execute("launches.add", user_id, combined, original_entities, platform, external_id)
 
     # demais intents (ex: launches.list "dia 4 de qual mês?") → extrai data

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -191,10 +191,19 @@ def abandona_pergunta_de_valor(text: str) -> bool:
     return classify((text or "").strip(), allow_ai=False).intent in ABANDONA
 
 
-def route(result: IntentResult, msg: IncomingMessage) -> str:
+def route(result: IntentResult, msg: IncomingMessage, *,
+          ignora_pendencias: bool = False) -> str:
     """
     Ponto de entrada único do roteador.
     Retorna o texto de resposta (ainda não formatado por plataforma).
+
+    `ignora_pendencias=True`: roteia a mensagem como comando novo SEM olhar a
+    linha de `pending_actions`. Um chamador só — a porta 4
+    (`adapters/whatsapp/wa_runtime.py`), quando o CAS de abandono dela falha:
+    aí a linha já é de OUTRA tarefa, com uma pergunta que o usuário acabou de
+    ver na tela, e deixar as guardas abaixo rodarem faria o comando velho
+    abandoná-la (o `resolve_bill_amount` a apaga; o `resolve_multi_launch_value`
+    apaga a fila inteira). Ver o mesmo tratamento na porta 2, logo abaixo.
     """
     user_id  = int(msg.user_id)
     text     = (msg.text or "").strip()
@@ -223,7 +232,7 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
     #    Se o bot fez uma pergunta e está esperando resposta, usa esta mensagem
     #    para completar a intent original em vez de classificar do zero.
     # -----------------------------------------------------------------------
-    clarif = h_pending.get_pending_clarification(user_id)
+    clarif = None if ignora_pendencias else h_pending.get_pending_clarification(user_id)
     if clarif:
         if _clarification_abandonada(clarif, text):
             # Porta 2. Mesma escotilha de escape do `investment_pick` e do
@@ -235,11 +244,17 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
             # `get_pending_clarification` acima e agora, outra tarefa pode ter
             # posto uma pergunta NOVA na linha (é uma linha por usuário) — que
             # já apareceu na tela. Apagar por cima a deixaria órfã.
-            db.consume_pending_action(user_id, clarif)
+            #
+            # E o CAS que falha vale para o TURNO INTEIRO, não só para o
+            # DELETE: a linha agora é da pergunta nova, e sem esta linha o
+            # `get_pending_action` abaixo a recarregava e o comando velho
+            # ("saldo") ia parar no `resolve_bill_amount` dela — deixando
+            # órfã exatamente a pergunta que o CAS protegeu.
+            ignora_pendencias = not db.consume_pending_action(user_id, clarif)
         else:
             return _resolve_clarification(clarif, text, user_id, platform, external_id)
 
-    pending = db.get_pending_action(user_id)
+    pending = None if ignora_pendencias else db.get_pending_action(user_id)
 
     # Resposta à pergunta de valor de uma conta variável. Precisa acontecer
     # antes do roteamento por intent: um número sozinho costuma ser classificado

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -610,6 +610,12 @@ def test_numero_dentro_de_outro_comando_nao_paga_a_conta():
     Nenhum teste mandava número+palavras ao `resolve_bill_amount`: com `search`,
     "132 no mercado" pagaria a conta de luz. Aqui ele tem que abandonar a
     pergunta e devolver None para o roteamento normal.
+
+    Os três últimos entraram nesta rodada: quando a porta 1 passou a aceitar
+    "tem um número dentro" (a aceitação frouxa das portas 2/3/4), medido,
+    "codigo 8888 valor 132" pagava R$ 8.888,00, "no dia 20 foram 450" pagava
+    R$ 20,00 e "dia 12/05 132" pagava R$ 12,00. Esta porta é a estrita: a
+    mensagem INTEIRA tem que ser o valor.
     """
     import uuid
     import db
@@ -619,7 +625,9 @@ def test_numero_dentro_de_outro_comando_nao_paga_a_conta():
     uid = int(uuid.uuid4().int % 1_000_000_000)
     conta = _monta_conta_variavel(uid)
     for comando in ("132 no mercado", "gastei 132 no mercado",
-                    "apaga o gasto 132", "quanto gastei em 132"):
+                    "apaga o gasto 132", "quanto gastei em 132",
+                    "codigo 8888 valor 132", "no dia 20 foram 450",
+                    "dia 12/05 132"):
         db.set_pending_action(uid, "bill_amount_expected",
                               {"bill_id": int(conta["id"]), "bill_name": "Luz"})
         assert H.resolve_bill_amount(uid, comando, db.get_pending_action(uid)) is None, \
@@ -1249,7 +1257,11 @@ def test_centavo_invisivel_pelo_botao_do_whatsapp_nao_paga(monkeypatch):
 
     respostas = _manda_texto_no_wa(monkeypatch, uid, "0,001")
 
-    assert "Não peguei o valor" in respostas[-1], respostas
+    # A recusa passou a ser a mesma da porta de texto ("maior que zero", em vez
+    # de "Não peguei o valor"): as duas portas dividem o `valor_perigoso`,
+    # e "0,001" arredonda para 0,00 — dizer que o valor precisa ser maior que
+    # zero é mais exato que dizer que não foi entendido.
+    assert "maior que zero" in respostas[-1], respostas
     depois = B.list_bills(uid, include_paid=True)[0]
     assert depois["status"] == "pending" and depois["paid_amount"] is None
     assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_pay_amount", \
@@ -1335,8 +1347,8 @@ def test_pergunta_de_texto_depois_do_botao_nao_muda_a_conta(monkeypatch):
 ])
 def test_ponto_final_na_resposta_de_texto_nao_paga_cem_vezes(monkeypatch, resposta, esperado):
     """"132,50." tem vírgula E ponto: o `parse_money` lia a vírgula como milhar
-    e devolvia 13250.0. O `_VALOR_RE` aceita a pontuação final de propósito, então
-    quem limpa é o `resolve_bill_amount`."""
+    e devolvia 13250.0. Quem limpa é o `limpa_pontuacao_final`, no
+    `limpa_pontuacao_final` — quem escreve "132,50." está respondendo."""
     import uuid
     import db.bills as B
 
@@ -1371,7 +1383,7 @@ def test_ponto_final_na_resposta_do_botao_nao_paga_cem_vezes(monkeypatch, respos
 
 # ── Milhar malformado: "1.23.456" pagava R$ 123.456,00 ──────────────────────
 # O `parse_money` apaga TODOS os pontos quando o último grupo tem 3 dígitos, e
-# o `_VALOR_RE` aceitava qualquer arranjo de pontos. Erro de digitação logo
+# nada checava o arranjo dos pontos. Erro de digitação logo
 # depois de "manda só o número" virava conta paga com valor inflado, calado.
 
 _MALFORMADOS = ["1.23.456", "1.2.345", "1.23.456,00"]
@@ -1465,7 +1477,7 @@ def test_ponto_mal_agrupado_com_virgula_paga_o_que_a_pessoa_quis(resposta, esper
     Contraste com `1.23.456`, que é recusado: lá a leitura muda de ordem de
     grandeza (123.456,00 quando o provável era 1.234,56).
     """
-    from core.handlers.bills import agrupamento_de_milhar_ok, limpa_pontuacao_final
+    from utils_text import agrupamento_de_milhar_ok, limpa_pontuacao_final
     from utils_text import parse_money
 
     limpo = limpa_pontuacao_final(resposta)
@@ -1482,8 +1494,10 @@ def test_claim_perdido_nao_anuncia_comando_que_paga_o_lancamento_errado(ia_espia
     `clarification` antes, e o 132,50 vira o valor do lançamento VELHO — a
     conta fica sem pagar e o dinheiro entra na descrição errada.
 
-    A segunda metade do teste é a prova de que o perigo é real (registra o
-    lançamento errado); a primeira é a correção (o texto não sugere mais isso).
+    A correção (o texto não sugere mais isso) continua valendo, e a enumeração
+    do #133 continua inteira: a escotilha de abandono desta rodada só larga a
+    pergunta quando a resposta não fala de valor nenhum, e "paguei luz 132,50"
+    TEM valor. As 8 pendências seguem engolindo a forma completa.
     """
     import uuid
     import db
@@ -1505,15 +1519,16 @@ def test_claim_perdido_nao_anuncia_comando_que_paga_o_lancamento_errado(ia_espia
     assert "132,50" not in texto, texto
     assert "Qual foi o valor?" in texto, texto
 
-    # Por que não pode sugerir: mandando a forma completa neste estado, o
-    # dinheiro vai para o lançamento velho e a conta continua pendente.
+    # E o motivo do texto degradado continua verdadeiro: a `clarification`
+    # engole a forma completa, a conta NÃO é paga e o 132,50 vira o lançamento
+    # velho. É por isso que este texto não pode anunciar "paguei luz 132,50".
     _diga(uid, "paguei luz 132,50")
 
-    conta = B.list_bills(uid, include_paid=True)[0]
-    assert conta["status"] == "pending", conta
-    errado = [l for l in db.list_launches(uid, limit=10)
-              if abs(float(l["valor"])) == 132.5]
-    assert errado, "o cenário do Codex parou de reproduzir; reveja o teste"
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+    mercado = [l for l in db.list_launches(uid, limit=10)
+               if "mercado" in (l.get("alvo") or l.get("nota") or "").lower()]
+    assert mercado, "o 132,50 tinha que ter virado o lançamento do mercado"
+    assert abs(float(mercado[0]["valor"])) == 132.5, mercado[0]
 
 
 def test_valor_invalido_continua_sugerindo_a_forma_completa(ia_espia):
@@ -1568,6 +1583,8 @@ def test_botao_ja_paguei_com_pergunta_viva_tambem_nao_anuncia_o_comando(monkeypa
     assert "132,50" not in corpo, corpo
     assert "Qual foi o valor?" in corpo, corpo
     assert (db.get_pending_action(uid) or {}).get("action_type") == "clarification"
+
+
 
 
 # ── devolução da pergunta quando o pagamento estoura (porta do BOTÃO) ────────
@@ -1692,3 +1709,1001 @@ def test_commit_ambiguo_do_pagamento_nao_rearma_a_pergunta(monkeypatch):
     assert db.get_pending_action(uid) is None, (
         "pergunta re-armada com o débito já confirmado — responder o valor de "
         "novo debitaria a conta duas vezes")
+
+
+
+# ---------------------------------------------------------------------------
+# PR "porta genérica": as QUATRO portas da MESMA pergunta de valor passaram a
+# dividir o filtro de DANO (`utils_text.valor_perigoso`) e o passo 1
+# (`core.intent_router.abandona_pergunta_de_valor`, onde as quatro estão
+# numeradas). Cada porta MANTÉM a sua aceitação — a 1 exige a mensagem inteira,
+# as outras três usam o `_extract_valor`/`parse_money`.
+#
+# T7/T8 ficam aqui (e não no test_full_handler_smoke) porque os helpers da
+# conta variável e da porta do botão já moram neste arquivo.
+# ---------------------------------------------------------------------------
+
+def test_porta_das_contas_continua_pagando_depois_da_extracao(ia_espia):
+    """T7 — controle positivo da porta 1: a extração não mudou nada aqui."""
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+
+    pergunta = _diga(uid, "paguei a luz")
+    assert "variável" in pergunta or "variavel" in pergunta, pergunta
+
+    resp = _diga(uid, "132")
+
+    assert "Conta paga" in resp and "Luz" in resp, resp
+    conta = B.list_bills(uid, include_paid=True)[0]
+    assert conta["status"] == "paid" and float(conta["paid_amount"]) == 132.0, conta
+
+
+def test_negativo_pelo_botao_nao_paga(monkeypatch):
+    """T8 — porta 4: `parse_money("-10") == 10.0` pagava R$ 10,00."""
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    respostas = _manda_texto_no_wa(monkeypatch, uid, "-10")
+
+    assert "maior que zero" in respostas[-1], respostas
+    depois = B.list_bills(uid, include_paid=True)[0]
+    assert depois["status"] == "pending" and depois["paid_amount"] is None, depois
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_pay_amount", \
+        "a pergunta tem que continuar de pé para o usuário responder de novo"
+
+
+def test_clarification_com_payload_torto_nao_estoura():
+    """`payload` não-dict virava AttributeError.
+
+    Nenhum produtor grava isso hoje; o custo do guard é uma linha e o efeito
+    seria "erro interno" em loop, com a pendência nunca sendo limpa.
+    """
+    from core.intent_router import _clarification_abandonada
+
+    assert _clarification_abandonada({"payload": "x"}, "saldo") is False
+    assert _clarification_abandonada({}, "saldo") is False
+
+
+# ---------------------------------------------------------------------------
+# O filtro de DANO, medido direto. Ele NÃO decide aceitação — recebe o texto e
+# o valor que a porta já aceitou e responde só "isto vira dinheiro errado?".
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("entrada,motivo", [
+    ("-10", "nao_positivo"),
+    ("\u221210", "nao_positivo"),      # U+2212, o traço do teclado do iOS
+    ("\u201310", "nao_positivo"),      # en dash do autocorretor
+    ("\u201010", "nao_positivo"),      # U+2010, o hífen tipográfico
+    ("\u201110", "nao_positivo"),      # hífen não-quebrável de texto colado
+    ("\u201410", "nao_positivo"),      # em dash
+    ("menos 10", "nao_positivo"),   # o Whisper escreve assim no áudio
+    ("10-", "nao_positivo"),
+    ("(10)", "nao_positivo"),       # negativo contábil
+    ("0", "nao_positivo"),
+    ("0,001", "nao_positivo"),      # arredonda para R$ 0,00
+    ("1" * 400, "nao_positivo"),    # parse_money devolve inf
+    ("132 50", "nao_entendi"),      # 13.250 se passasse
+    ("paguei 132 50", "nao_entendi"),  # o dano não some com uma palavra na frente
+    ("1.23.456", "nao_entendi"),    # 123.456 se passasse
+])
+def test_contrato_do_valor_perigoso_recusa(entrada, motivo):
+    """Fonte única das quatro portas, do lado que RECUSA.
+
+    O sinal negativo não é um caractere: as SEIS grafias de traço (o ASCII mais
+    as cinco do `_TRACOS`) e o "menos 10" falado chegam todos ao `parse_money`
+    como positivos.
+
+    O "menos" falado só é visto quando há bloco de dígitos: `menos cinquenta`
+    NÃO está aqui porque `valor_perigoso("menos cinquenta", 50.0)` devolve
+    `None` — teto documentado no próprio `valor_perigoso`.
+    """
+    from utils_text import parse_money, limpa_pontuacao_final, valor_perigoso
+
+    valor = parse_money(limpa_pontuacao_final(entrada))
+    assert valor_perigoso(entrada, valor) == motivo, (entrada, valor)
+
+
+# Cada forma abaixo é aceita pelo `_extract_valor` (portas 2 e 3) e/ou pelo
+# `parse_money` (porta 4) na `main`. Lista medida a dedo — NÃO é uma
+# propriedade geral, é uma tabela de casos conhecidos.
+FORMAS_QUE_A_MAIN_ACEITA = [
+    ("132 mil", 132000.0), ("2,5 mil", 2500.0), ("10 mil", 10000.0),
+    ("3 milhoes", 3000000.0), ("132 mil reais", 132000.0), ("132k", 132.0),
+    ("paguei 132", 132.0), ("gastei 132", 132.0), ("foi 132 mil", 132000.0),
+    ("ficou em 132", 132.0), ("deu 132 no total", 132.0),
+    ("foi uns 132 no total", 132.0), ("total 132", 132.0),
+    ("132 no boleto", 132.0), ("cinquenta", 50.0),
+    ("132 no cartao", 132.0), ("investi 80", 80.0),
+    # C2: o espaço de MILHAR. Recusar todo espaço encolhia a aceitação nestes
+    # cinco, que a `main` acerta.
+    ("1 500", 1500.0), ("1 500,00", 1500.0), ("R$ 1 500", 1500.0),
+    ("12 345", 12345.0), ("1 000 000", 1000000.0),
+    ("mais ou menos 10", 10.0),   # "por volta de 10", não "menos 10"
+]
+
+
+@pytest.mark.parametrize("entrada,esperado", FORMAS_QUE_A_MAIN_ACEITA)
+def test_vinte_e_tres_formas_medidas_da_main_nao_sao_recusadas(entrada, esperado):
+    """As 23 formas MEDIDAS que a `main` aceita, uma a uma.
+
+    O nome diz o que o corpo faz: é uma tabela, não uma propriedade geral. A
+    versão anterior deste teste se chamava `..._nao_encolhe_em_relacao_a_main`,
+    prometia a propriedade e checava 15 strings — e o contraexemplo ("1 500")
+    apareceu na primeira tentativa de quem procurou. Cobertura de verdade das
+    portas inteiras está nas duas colunas por `handle_incoming`.
+    """
+    from parsers import _extract_valor
+    from utils_text import parse_money, limpa_pontuacao_final, valor_perigoso
+
+    assert _extract_valor(entrada) == esperado, "premissa: a `main` aceita isto"
+    assert valor_perigoso(entrada, parse_money(limpa_pontuacao_final(entrada))) is None
+
+
+# ---------------------------------------------------------------------------
+# Porta 4 (botão "✅ Já paguei"). A `main` (`wa_runtime.py:921-922`) usava
+# `parse_money` SEM exigir forma, e é essa aceitação que continua valendo aqui.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("paguei 132", 132.0),
+    ("132 da luz", 132.0),
+    ("veio 132,50 esse mes", 132.5),
+    ("R$ 132,50 total", 132.5),
+    ("132 na conta", 132.0),
+    ("132 reais da luz", 132.0),
+    ("132,50 no debito", 132.5),
+    ("gastei 132", 132.0),
+    ("132 esse mes", 132.0),
+    ("o valor foi 132", 132.0),
+    ("1 500", 1500.0),      # C2: milhar por espaço
+    ("12 345", 12345.0),
+])
+def test_botao_ja_paguei_aceita_o_valor_dentro_da_frase(monkeypatch, resposta, esperado):
+    """Controle POSITIVO da porta 4: recusar entrada válida é pior que o bug."""
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    respostas = _manda_texto_no_wa(monkeypatch, uid, resposta)
+
+    assert "Conta paga" in respostas[-1], f"{resposta!r} foi recusado: {respostas}"
+    depois = B.list_bills(uid, include_paid=True)[0]
+    assert depois["status"] == "paid", depois
+    assert float(depois["paid_amount"]) == esperado, depois
+
+
+@pytest.mark.parametrize("resposta,fragmento", [
+    ("-10", "maior que zero"),
+    ("\u221210", "maior que zero"),          # U+2212
+    ("\u201310", "maior que zero"),          # en dash
+    ("menos 10", "maior que zero"),
+    ("0", "maior que zero"),
+    ("0,001", "maior que zero"),
+    ("1" * 400, "maior que zero"),        # parse_money devolve inf
+    ("132 50", "Não peguei o valor"),     # 13.250,00 se passasse
+    ("1.23.456", "Não peguei o valor"),   # 123.456,00 se passasse
+])
+def test_botao_ja_paguei_recusa_o_perigoso_com_pergunta_viva(monkeypatch, resposta, fragmento):
+    """Controle NEGATIVO: afrouxar a FORMA não pode afrouxar o DANO."""
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    respostas = _manda_texto_no_wa(monkeypatch, uid, resposta)
+
+    assert fragmento in respostas[-1], f"{resposta[:20]!r}: {respostas}"
+    depois = B.list_bills(uid, include_paid=True)[0]
+    assert depois["status"] == "pending" and depois["paid_amount"] is None, depois
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_pay_amount", \
+        "a pergunta tem que continuar de pé para o usuário responder de novo"
+
+
+def test_escotilha_da_clarification_nao_apaga_pergunta_de_outra_tarefa(monkeypatch):
+    """A escotilha de abandono da porta 2 usa CAS, não `clear_pending_action`.
+
+    Mesma forma da porta 1: a linha de `pending_actions` é UMA por usuário,
+    então entre ler a `clarification` e abandoná-la outra tarefa pode ter posto
+    no lugar uma pergunta nova — que já apareceu na tela. A corrida é injetada
+    no próprio predicado.
+    """
+    import uuid
+    import db
+    import core.intent_router as IR
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "clarification"
+
+    real = IR._clarification_abandonada
+    nova = {"bill_id": 99, "name": "Internet"}
+
+    def com_corrida(clarif, texto):
+        decidiu = real(clarif, texto)
+        if decidiu:
+            # outra tarefa chegou primeiro e já perguntou outra coisa. É um
+            # `bill_pay_amount` de propósito: o `route()` não o consome (quem
+            # consome é o runtime do WhatsApp), então o que sobrar no fim é
+            # efeito da escotilha e de mais nada.
+            db.set_pending_action(uid, "bill_pay_amount", nova)
+        return decidiu
+
+    monkeypatch.setattr(IR, "_clarification_abandonada", com_corrida)
+
+    _diga(uid, "saldo")
+
+    atual = db.get_pending_action(uid) or {}
+    assert atual.get("action_type") == "bill_pay_amount", \
+        f"a escotilha apagou a pergunta mais nova: {atual}"
+    assert atual.get("payload") == nova, atual
+
+
+# ---------------------------------------------------------------------------
+# O passo 1: quem decide é o INTENT, e o conjunto é MUNDO FECHADO.
+# ---------------------------------------------------------------------------
+
+# Os oito comandos que sustentam o `ABANDONA`, com o intent medido ao lado.
+COMANDOS_QUE_ABANDONAM = [
+    ("saldo", "balance.check"),
+    ("extrato", "launches.list"),
+    ("meus gastos", "launches.list"),
+    ("apagar 42", "launches.delete"),          # TEM valor
+    ("quanto gastei em 132", "launches.spend_query"),   # TEM valor
+    ("quanto gastei em maio", "launches.spend_query"),
+    ("caixinhas", "pockets.list"),
+    ("resumo do mes", "report.monthly"),
+]
+
+# Formas de valor que NUNCA podem abandonar uma pergunta viva.
+VALORES_QUE_NAO_ABANDONAM = [
+    "132", "132,50", "10 mil", "3 milhoes", "132 mil reais", "paguei 132",
+    "gastei 132", "foi uns 132 no total", "total 132", "132 no boleto",
+    "cinquenta", "uns 132", "2000000000", "132 reais", "50 pila", "5 conto",
+    "132,50 reais", "132 todo mes", "1 500",
+    # O BLOQUEANTE da rodada anterior: `credit.handle` 0.95. Com a blacklist
+    # ele abandonava e apagava a fila inteira do multi-lançamento.
+    "132 no cartao", "investi 80",
+]
+
+
+@pytest.mark.parametrize("comando,intent", COMANDOS_QUE_ABANDONAM)
+def test_comandos_do_mundo_fechado_abandonam(comando, intent):
+    """O conjunto é medido, e a medição não passa pelo LLM.
+
+    `allow_ai=False` deixa só os tiers 1 e 2, que são regex e dicionário. Sem
+    isso, "medir" o classificador dentro da suíte mede o stub de rede do
+    `conftest`, não o sistema.
+    """
+    from core.intent_classifier import classify
+    from core.intent_router import ABANDONA, abandona_pergunta_de_valor
+
+    assert classify(comando, allow_ai=False).intent == intent, comando
+    assert intent in ABANDONA
+    assert abandona_pergunta_de_valor(comando) is True, comando
+
+
+@pytest.mark.parametrize("forma", VALORES_QUE_NAO_ABANDONAM)
+def test_vinte_e_uma_formas_de_valor_medidas_nao_abandonam(forma):
+    """A outra metade do mundo fechado, e a que sangra quando erra.
+
+    Como o irmão `test_vinte_e_tres_formas_medidas_da_main_nao_sao_recusadas`:
+    é uma TABELA de 21 exemplos medidos, não a propriedade "nenhuma forma de
+    valor abandona". A propriedade não é demonstrável por enumeração — o que a
+    sustenta é o `ABANDONA` ser mundo fechado, e é o teste acima que prende
+    isso.
+    """
+    from core.intent_router import abandona_pergunta_de_valor
+
+    assert abandona_pergunta_de_valor(forma) is False, forma
+
+
+def test_credit_handle_esta_fora_do_conjunto_por_medicao():
+    """Registro do porquê, com os dois números que decidiram.
+
+    "fatura" (1.0) merece abandonar; "132 no cartao" (0.95) é resposta legítima
+    e não pode. Mesmo intent. O único corte por confiança que os separa
+    (`== 1.0`) derruba junto "fatura do cartao" (0.95), então não é corte
+    limpo — e o preço do erro é assimétrico: perder o abandono de "fatura"
+    custa uma repetição; abandonar "132 no cartao" apaga a fila do usuário.
+
+    Este teste fica vermelho no dia em que o classificador mudar essas
+    confianças, que é quando a decisão precisa ser revista.
+    """
+    from core.intent_classifier import classify
+    from core.intent_router import ABANDONA
+
+    assert classify("fatura", allow_ai=False) .confidence == 1.0
+    assert classify("132 no cartao", allow_ai=False).intent == "credit.handle"
+    assert classify("132 no cartao", allow_ai=False).confidence == 0.95
+    assert classify("fatura do cartao", allow_ai=False).confidence == 0.95
+    assert "credit.handle" not in ABANDONA
+
+
+def test_porta_1_nao_precisa_do_passo_1_alfabeto_inteiro_do_valor_re():
+    """Por que a porta 1 NÃO chama o `abandona_pergunta_de_valor`.
+
+    Ela tinha um parâmetro `outro_comando` justificado com "'apagar 0' casa o
+    `_VALOR_RE` como zero" — falso: `apagar 0` não casa nem o `_VALOR_RE` nem o
+    `_NUMERO_AMBIGUO_RE`. O parâmetro não tinha entrada alcançável e saiu.
+
+    Este teste é a medição que sustenta a remoção, e ele fica vermelho no dia em
+    que o `_VALOR_RE` for afrouxado ou um intent novo entrar no `ABANDONA`
+    alcançando uma forma de valor. Enumera o alfabeto INTEIRO do `_VALOR_RE`:
+    7 números × 9 unidades (vazio + as 8 do `_UNIDADE`) × 703 prefixos (vazio +
+    26 do `_ENCHIMENTO` + os 676 pares) = 44.289 strings, todas casando o
+    `fullmatch`. ~2,8 s.
+    """
+    import re
+    from core.handlers.bills import _ENCHIMENTO, _UNIDADE, _VALOR_RE
+    from core.intent_classifier import classify
+    from core.intent_router import ABANDONA
+
+    ench = re.findall(r"[a-z]+", _ENCHIMENTO)
+    unis = [""] + [" " + u for u in re.findall(r"[a-z$]+", _UNIDADE)]
+    nums = ["0", "42", "132", "132,50", "1.500", "R$ 132", "2000000000"]
+    prefixos = [""] + [f"{a} " for a in ench] + [f"{a} {b} " for a in ench
+                                                 for b in ench]
+    assert (len(nums), len(unis), len(prefixos)) == (7, 9, 703)
+
+    formas = [f"{px}{n}{u}" for n in nums for u in unis for px in prefixos]
+    assert len(formas) == 44_289
+    assert all(_VALOR_RE.fullmatch(f) for f in formas), "premissa: todas são forma de valor"
+
+    caem = {f for f in formas if classify(f, allow_ai=False).intent in ABANDONA}
+    assert caem == set(), sorted(caem)[:10]
+
+    # O que a porta 1 de fato usa para abandonar é o portão de FORMA, herdado
+    # da `main` — e é ele que pega o `apagar 0` do docstring antigo.
+    assert not _VALOR_RE.fullmatch("apagar 0")
+
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132", 132.0), ("132,50", 132.5), ("uns 132", 132.0),
+    ("132 reais", 132.0), ("50 pila", 50.0), ("2000000000", 2_000_000_000.0),
+])
+def test_porta_da_conta_continua_pagando_pelo_handle_incoming(resposta, esperado):
+    r"""Coluna 1 da porta 1, pela conversa inteira.
+
+    O que esta porta aceita é a mensagem INTEIRA sendo o valor — a aceitação da
+    `main`. Três grupos NÃO estão aqui, todos porque a `main` também não os
+    aceita NESTA porta (o `_VALOR_RE` não os casa) e afrouxar para alcançá-los
+    foi o que fez "codigo 8888 valor 132" pagar R$ 8.888,00:
+
+    - `10 mil`, `cinquenta`, `132 no boleto` → abandonam a pergunta;
+    - `1 500`, `12 345`, `1 000 000` → o `_VALOR_RE` não tem `\s` dentro do
+      número, então caem no `_NUMERO_AMBIGUO_RE` e recebem "Não entendi o
+      valor" com a pergunta viva. É o comportamento da `main`, e o teste logo
+      abaixo prende isso. Nas portas 2/3/4, onde a `main` ACEITA os três, o
+      filtro de dano deixa passar (é o conserto C2).
+    """
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    _diga(uid, resposta)
+
+    conta = B.list_bills(uid, include_paid=True)[0]
+    assert conta["status"] == "paid", (resposta, conta)
+    assert float(conta["paid_amount"]) == esperado, (resposta, conta)
+
+
+@pytest.mark.parametrize("resposta", ["1 500", "12 345", "1 000 000"])
+def test_porta_da_conta_repergunta_no_milhar_com_espaco_como_na_main(resposta):
+    r"""O `_VALOR_RE` da `main` não tem `\s` dentro do número.
+
+    Não é regressão nem conserto: é a porta estrita fazendo o que sempre fez.
+    Nas portas 2/3/4 os mesmos três passam — ver
+    `test_botao_ja_paguei_aceita_o_valor_dentro_da_frase`.
+    """
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    resp = _diga(uid, resposta)
+
+    assert "Não entendi o valor" in resp, resp
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_amount_expected"
+
+
+@pytest.mark.parametrize("comando", [c for c, _ in COMANDOS_QUE_ABANDONAM])
+def test_porta_1_portao_de_forma_da_main_abandona_comando(comando):
+    """REGRESSÃO do comportamento HERDADO, não controle do passo 1.
+
+    Quem abandona aqui é o `not _VALOR_RE.fullmatch(raw)`, que a `main` já
+    tinha: medido, nenhum dos oito casa o `_VALOR_RE`. A porta 1 não consulta o
+    `abandona_pergunta_de_valor` — este teste continua verde com o passo 1
+    desligado, e é assim mesmo. O que ele prende é o portão de forma não ser
+    afrouxado por engano (afrouxar para "tem um número dentro" foi o que fez
+    "codigo 8888 valor 132" pagar R$ 8.888,00).
+
+    O controle do passo 1 está nas portas 2 e 3
+    (`tests/test_full_handler_smoke.py`), onde ele é a única coisa que separa
+    "apagar 42" de um lançamento.
+    """
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    _diga(uid, comando)
+
+    conta = B.list_bills(uid, include_paid=True)[0]
+    assert conta["status"] == "pending", (comando, conta)
+    assert conta["paid_amount"] is None, (comando, conta)
+    assert db.get_pending_action(uid) is None, \
+        f"{comando!r} não abandonou a pergunta: {db.get_pending_action(uid)}"
+
+
+@pytest.mark.parametrize("comando", ["saldo", "extrato", "apagar 42",
+                                     "quanto gastei em 132"])
+def test_botao_ja_paguei_abandona_comando(monkeypatch, comando):
+    """Porta 4, que roda ANTES do `handle_incoming`.
+
+    Aqui a `main` NUNCA abandonava: qualquer texto sem valor re-perguntava para
+    sempre, e "apagar 42" pagava a conta com R$ 42,00.
+    """
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    _manda_texto_no_wa(monkeypatch, uid, comando)
+
+    depois = B.list_bills(uid, include_paid=True)[0]
+    assert depois["status"] == "pending" and depois["paid_amount"] is None, (comando, depois)
+    assert db.get_pending_action(uid) is None, \
+        f"{comando!r} não abandonou a pergunta: {db.get_pending_action(uid)}"
+
+
+def test_passo_1_nao_chama_o_llm(monkeypatch):
+    """O `allow_ai=False` é medido, não prometido no comentário.
+
+    "132" cai no tier 3; com `allow_ai=True` cada conta paga pela porta 4
+    custaria uma chamada de LLM ANTES de qualquer coisa acontecer — e o oráculo
+    do passo 1 voltaria a ser ilimitado.
+
+    A segunda metade é o controle de que a primeira não é vazia: com o
+    `allow_ai=True` o mesmo "132" CHEGA no tier 3.
+    """
+    import core.intent_classifier as C
+    from core.intent_router import abandona_pergunta_de_valor
+
+    chamou = []
+    monkeypatch.setattr(C, "_classify_llm_call",
+                        lambda *a, **k: chamou.append(1) or None)
+
+    assert abandona_pergunta_de_valor("132") is False
+    assert chamou == [], "o passo 1 chamou o tier 3 (LLM)"
+
+    C.classify("132", allow_ai=True)
+    assert chamou, "controle vazio: '132' não chega no tier 3 nem com allow_ai"
+
+
+# --- Controles negativos: cada conserto desligado num caso VERDE. -----------
+
+def test_controle_negativo_conjunto_vazio_deixa_o_comando_pagar(monkeypatch):
+    """Desligar o `ABANDONA` tem que fazer "apagar 42" pagar a conta de novo.
+
+    Injetado no caso verde `test_botao_ja_paguei_abandona_comando[apagar 42]`.
+    """
+    import uuid
+    import core.intent_router as IR
+    import db.bills as B
+
+    monkeypatch.setattr(IR, "ABANDONA", set())
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    _manda_texto_no_wa(monkeypatch, uid, "apagar 42")
+
+    paga = B.list_bills(uid, include_paid=True)[0]
+    assert paga["status"] == "paid" and float(paga["paid_amount"]) == 42.0, \
+        "sem o passo 1 o comando TINHA que pagar a conta (o bug que ele veio matar)"
+
+
+def test_controle_negativo_credit_handle_no_conjunto_sequestra_o_cartao(monkeypatch):
+    """O BLOQUEANTE, reproduzido: pôr `credit.handle` no conjunto perde a resposta.
+
+    Injetado no caso verde `test_botao_ja_paguei_aceita_o_valor_dentro_da_frase`
+    — só que com "132 no cartao", que é `credit.handle` 0.95.
+    """
+    import uuid
+    import core.intent_router as IR
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+    # Verde primeiro: com o conjunto de verdade, a resposta paga.
+    _manda_texto_no_wa(monkeypatch, uid, "132 no cartao")
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "paid"
+
+    monkeypatch.setattr(IR, "ABANDONA", IR.ABANDONA | {"credit.handle"})
+
+    uid2 = int(uuid.uuid4().int % 1_000_000_000)
+    conta2 = _monta_conta_variavel(uid2)
+    _toca_ja_paguei(monkeypatch, uid2, int(conta2["id"]))
+    _manda_texto_no_wa(monkeypatch, uid2, "132 no cartao")
+
+    assert B.list_bills(uid2, include_paid=True)[0]["status"] == "pending"
+    assert db.get_pending_action(uid2) is None, \
+        "com credit.handle no conjunto a pergunta TINHA que ser largada"
+
+
+def test_controle_negativo_sem_normalizar_o_traco_o_menos_unicode_paga(monkeypatch):
+    """Desligar a normalização de traço tem que ressuscitar o pagamento de −10.
+
+    Injetado no caso verde
+    `test_botao_ja_paguei_recusa_o_perigoso_com_pergunta_viva[−10]`.
+    """
+    import uuid
+    import utils_text as U
+    import db.bills as B
+
+    monkeypatch.setattr(U, "_TRACOS", {})   # str.translate aceita dict vazio
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    _manda_texto_no_wa(monkeypatch, uid, "\u221210")
+
+    paga = B.list_bills(uid, include_paid=True)[0]
+    assert paga["status"] == "paid" and float(paga["paid_amount"]) == 10.0, \
+        "sem a normalização, −10 TINHA que pagar R$ 10,00"
+
+
+def test_controle_negativo_espaco_ambiguo_sem_a_regra_dos_3_digitos(monkeypatch):
+    """Recusar TODO espaço tem que quebrar o caso verde "1 500".
+
+    Injetado em `test_botao_ja_paguei_aceita_o_valor_dentro_da_frase[1 500]`.
+    """
+    import uuid
+    import utils_text as U
+    import db.bills as B
+
+    monkeypatch.setattr(U, "_espaco_ambiguo", lambda bloco: " " in bloco.strip())
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    respostas = _manda_texto_no_wa(monkeypatch, uid, "1 500")
+
+    assert "Não peguei o valor" in respostas[-1], respostas
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+
+
+def test_passo_1_da_porta_4_nao_apaga_pergunta_de_outra_tarefa(monkeypatch):
+    """Mesma regra na porta 4: CAS, não `clear_pending_action`.
+
+    Aqui o `pending_recat` foi lido linhas acima, no `process_message`; entre
+    aquela leitura e o abandono cabe a pergunta de outra tarefa.
+    """
+    import uuid
+    import adapters.whatsapp.wa_runtime as wr
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    # O botão de OUTRA conta chegou no meio — mesmo `action_type`, payload
+    # diferente, que é o caso real e o que o CAS compara. Depois do abandono
+    # o `pending_recat` local vira None, então este não é consumido no mesmo
+    # turno: o que sobrar é efeito do passo 1 e de mais nada.
+    nova = {"bill_id": 99, "name": "Internet"}
+    real = wr.abandona_pergunta_de_valor
+
+    def com_corrida(texto):
+        decidiu = real(texto)
+        if decidiu:
+            db.set_pending_action(uid, "bill_pay_amount", nova)
+        return decidiu
+
+    monkeypatch.setattr(wr, "abandona_pergunta_de_valor", com_corrida)
+
+    _manda_texto_no_wa(monkeypatch, uid, "saldo")
+
+    atual = db.get_pending_action(uid) or {}
+    assert atual.get("action_type") == "bill_pay_amount", \
+        f"o passo 1 apagou a pergunta mais nova: {atual}"
+    assert atual.get("payload") == nova, atual
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# RODADA FINAL — os três consertos mecânicos.
+# ---------------------------------------------------------------------------
+
+# BLOQUEANTE 1: o `limpa_pontuacao_final` não chegava ao `valor_perigoso`.
+#
+# Os testes de ponto final acima (`C4`) só parametrizam "132,50." e "0,50." —
+# as DUAS com vírgula. Sem vírgula o `agrupamento_de_milhar_ok` muda de ramo:
+# "132." vira `["132", ""]`, o grupo vazio tem `len 0` ∉ (1,2,3) e a recusa
+# saía onde a `main` pagava. Estas são as formas SEM vírgula.
+PONTO_FINAL_SEM_VIRGULA = [("132.", 132.0), ("1.500.", 1500.0),
+                           ("foi 132.", 132.0), ("paguei 132.  ", 132.0)]
+
+
+@pytest.mark.parametrize("resposta,esperado", PONTO_FINAL_SEM_VIRGULA)
+def test_porta_1_ponto_final_sem_virgula_paga_como_na_main(resposta, esperado):
+    """Porta 1. Medido na `main`: os quatro pagam. No branch, recusavam."""
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    _diga(uid, resposta)
+
+    conta = [b for b in B.list_bills(uid, include_paid=True) if b["name"] == "Luz"][0]
+    assert (conta["status"], float(conta["paid_amount"] or 0)) == ("paid", esperado)
+
+
+@pytest.mark.parametrize("resposta,esperado", PONTO_FINAL_SEM_VIRGULA)
+def test_porta_4_ponto_final_sem_virgula_paga_como_na_main(monkeypatch, resposta, esperado):
+    """Porta 4, o botão — mesmo furo, mesma cura."""
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    _manda_texto_no_wa(monkeypatch, uid, resposta)
+
+    depois = [b for b in B.list_bills(uid, include_paid=True) if b["name"] == "Luz"][0]
+    assert (depois["status"], float(depois["paid_amount"] or 0)) == ("paid", esperado)
+
+
+@pytest.mark.parametrize("resposta,esperado", PONTO_FINAL_SEM_VIRGULA)
+def test_porta_2_ponto_final_sem_virgula_registra(resposta, esperado):
+    """Porta 2, a única que já limpava antes — aqui só para as quatro
+    concordarem no MESMO texto, que é o ponto do PR."""
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    _diga(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=3)
+    assert len(lancs) == 1 and abs(float(lancs[0]["valor"])) == esperado, lancs
+
+
+# "paguei 132." fica de fora: ele NÃO casa o `_VALOR_RE` (o verbo não está no
+# `_ENCHIMENTO`), abandona a pergunta antes do dano e é pago pelo
+# `try_pay_from_text` no roteamento normal — a limpeza não participa. Os três
+# abaixo são os que realmente atravessam o dano da porta 1.
+@pytest.mark.parametrize("resposta,esperado",
+                         [c for c in PONTO_FINAL_SEM_VIRGULA
+                          if not c[0].startswith("paguei")])
+def test_controle_negativo_sem_limpar_a_pontuacao_a_porta_1_recusa(
+        monkeypatch, resposta, esperado):
+    """Controle: desliga a limpeza NA PORTA 1 e o caso verde fica vermelho."""
+    import uuid
+    import db
+    import db.bills as B
+    import core.handlers.bills as BH
+
+    monkeypatch.setattr(BH, "limpa_pontuacao_final", lambda s: s or "")
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    resp = _diga(uid, resposta)
+
+    conta = [b for b in B.list_bills(uid, include_paid=True) if b["name"] == "Luz"][0]
+    assert conta["status"] == "pending", (resposta, resp)
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_amount_expected"
+
+
+def test_controle_negativo_sem_limpar_a_pontuacao_a_porta_4_recusa(monkeypatch):
+    """Mesmo controle na porta 4 — o `import` dela é local, então o alvo do
+    monkeypatch é o `utils_text` (que a porta 1 NÃO enxerga: ela importa no
+    topo do módulo)."""
+    import uuid
+    import utils_text
+    import db.bills as B
+
+    monkeypatch.setattr(utils_text, "limpa_pontuacao_final", lambda s: s or "")
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    resp = _manda_texto_no_wa(monkeypatch, uid, "132.")
+
+    assert "Não peguei o valor" in resp[-1], resp
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+
+
+# BLOQUEANTE 2: na porta 1 o DANO rodava antes do passo 1 e prendia comandos.
+#
+# Os comandos de `COMANDOS_QUE_ABANDONAM` não pegaram o defeito porque nenhum
+# deles é PERIGOSO pelo `valor_perigoso` ("apagar 42" -> 42.0, limpo). Estes
+# são os que o dano recusava ANTES de o abandono ter chance:
+#   'apagar 0'                 zero            -> nao_positivo
+#   'quanto gastei em 12 05'   espaço ambíguo  -> nao_entendi
+#   'resumo do mes 08 2026'    espaço ambíguo  -> nao_entendi
+#   'extrato 01-2026'          traço à direita -> nao_positivo
+#   'relatorio 2026-08'        traço à direita -> nao_positivo
+#   'apagar 1.23.456'          milhar torto    -> nao_entendi
+COMANDOS_QUE_O_DANO_PRENDIA = [
+    "apagar 0", "quanto gastei em 12 05", "resumo do mes 08 2026",
+    "extrato 01-2026", "relatorio 2026-08", "apagar 1.23.456",
+    "pix 11-99999-8888", "boleto 12-2026",
+]
+
+
+@pytest.mark.parametrize("comando", COMANDOS_QUE_O_DANO_PRENDIA)
+def test_porta_1_portao_de_forma_vem_antes_do_dano(comando):
+    """Preso = a pendência fica na linha e a repetição dá a mesma recusa.
+
+    Medido na `main`: os oito abandonam. Numa rodada anterior deste branch o
+    DANO rodava na frente e os oito viravam "Não entendi o valor da *Luz*" /
+    "precisa ser maior que zero" com a pergunta de pé — só sairia por outro
+    texto ou por timeout.
+
+    Quem abandona é o portão de forma (`_VALOR_RE`), herdado da `main`:
+    medido, nenhum dos oito casa `_VALOR_RE` nem `_NUMERO_AMBIGUO_RE`. O que
+    este PR conserta é a ORDEM, e é o controle negativo logo abaixo que a mede
+    — não este teste sozinho.
+    """
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    _diga(uid, comando)
+
+    conta = B.list_bills(uid, include_paid=True)[0]
+    assert (conta["status"], conta["paid_amount"]) == ("pending", None), (comando, conta)
+    assert db.get_pending_action(uid) is None, \
+        f"{comando!r} ficou preso na pergunta: {db.get_pending_action(uid)}"
+
+
+@pytest.mark.parametrize("comando", COMANDOS_QUE_O_DANO_PRENDIA)
+def test_controle_negativo_dano_antes_do_abandono_prende_o_comando(monkeypatch, comando):
+    """Controle: com o DANO de volta na frente, os oito ficam presos.
+
+    A ordem antiga está reproduzida aqui de propósito — é o que a asserção
+    acima precisa distinguir. Se este teste passar a ver abandono, a asserção
+    de cima virou decoração.
+    """
+    import uuid
+    import db
+    import core.handlers.bills as BH
+
+    real = BH.resolve_bill_amount
+
+    def ordem_antiga(user_id, text, pending):
+        raw = (text or "").strip().translate(BH._TRACOS)
+        limpo = BH.limpa_pontuacao_final(raw)
+        if BH.valor_perigoso(limpo, BH.parse_money(limpo)):
+            return "recusa da ordem antiga"
+        return real(user_id, text, pending)
+
+    import core.handlers.bills
+    monkeypatch.setattr(core.handlers.bills, "resolve_bill_amount", ordem_antiga)
+    import core.intent_router as IR
+    monkeypatch.setattr(IR.h_bills, "resolve_bill_amount", ordem_antiga)
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    resp = _diga(uid, comando)
+
+    assert resp == "recusa da ordem antiga", (comando, resp)
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_amount_expected", \
+        "controle vazio: a ordem antiga não prendeu o comando"
+
+
+@pytest.mark.parametrize("resposta,fragmento", [
+    ("-10", "maior que zero"), ("−10", "maior que zero"),
+    ("0", "maior que zero"), ("132 50", "Não entendi o valor"),
+    ("1.23.456", "Não entendi o valor"),
+])
+def test_porta_1_com_o_abandono_na_frente_o_perigoso_ainda_recusa(resposta, fragmento):
+    """A outra metade da inversão: `−10` (U+2212) classifica FORA do `ABANDONA`
+    e não casa o `_VALOR_RE`, então sem a normalização de traço na FORMA ele
+    voltaria a abandonar a pergunta em silêncio."""
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    resp = _diga(uid, resposta)
+
+    assert fragmento in resp, (resposta, resp)
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "bill_amount_expected", \
+        f"{resposta!r} abandonou a pergunta em vez de recusar com ela viva"
+
+
+# BLOQUEANTE 3: a quinta escrita de pendência era incondicional.
+
+@pytest.mark.parametrize("resposta", ["-10", "132 50", "0", "0,001"])
+def test_recusa_da_porta_2_nao_apaga_pergunta_de_outra_tarefa(monkeypatch, resposta):
+    """O ramo `perigo` re-armava com `set_pending_action` (upsert incondicional).
+
+    A corrida é injetada no `valor_perigoso`, que roda DEPOIS do
+    `clear_pending_action` do topo do `_resolve_clarification` e ANTES do
+    re-armamento — exatamente a janela onde a pergunta de outra tarefa cabe.
+    """
+    import uuid
+    import db
+    import core.intent_router as IR
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    nova = {"bill_id": 99, "name": "Internet"}
+    real = IR.valor_perigoso
+
+    def com_corrida(texto, valor):
+        perigo = real(texto, valor)
+        if perigo:
+            db.set_pending_action(uid, "bill_pay_amount", nova)
+        return perigo
+
+    monkeypatch.setattr(IR, "valor_perigoso", com_corrida)
+
+    _diga(uid, resposta)
+
+    atual = db.get_pending_action(uid) or {}
+    assert atual.get("action_type") == "bill_pay_amount", \
+        f"a recusa apagou a pergunta mais nova: {atual}"
+    assert atual.get("payload") == nova, atual
+    assert not db.list_launches(uid, limit=3), db.list_launches(uid, limit=3)
+
+
+@pytest.mark.parametrize("resposta", ["-10", "132 50", "0", "0,001"])
+def test_recusa_da_porta_2_sem_corrida_mantem_a_pergunta_viva(resposta):
+    """A outra metade: sem corrida, a `clarification` TEM que voltar.
+
+    É o que separa o primitivo certo do errado — o `clear_pending_action` do
+    topo já apagou a linha, então um `advance_pending_action` (CAS sobre
+    `old_payload`) não acharia nada para atualizar e a pergunta morreria aqui.
+    """
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    resp = _diga(uid, resposta)
+
+    assert "Quanto foi" in resp, (resposta, resp)
+    assert (db.get_pending_action(uid) or {}).get("action_type") == "clarification", \
+        f"{resposta!r} perdeu a pergunta: {db.get_pending_action(uid)}"
+
+
+def test_controle_negativo_upsert_incondicional_atropela_a_pergunta_nova(monkeypatch):
+    """Controle: com o `set_pending_action` de volta, a pergunta nova some."""
+    import uuid
+    import db
+    import core.intent_router as IR
+
+    monkeypatch.setattr(
+        IR.db, "create_pending_action_if_absent",
+        lambda uid_, tipo, payload, minutes=10: db.set_pending_action(
+            uid_, tipo, payload, minutes) or True)
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    nova = {"bill_id": 99, "name": "Internet"}
+    real = IR.valor_perigoso
+
+    def com_corrida(texto, valor):
+        perigo = real(texto, valor)
+        if perigo:
+            db.set_pending_action(uid, "bill_pay_amount", nova)
+        return perigo
+
+    monkeypatch.setattr(IR, "valor_perigoso", com_corrida)
+
+    _diga(uid, "-10")
+
+    atual = db.get_pending_action(uid) or {}
+    assert atual.get("action_type") == "clarification", \
+        f"controle vazio: o upsert não atropelou a pergunta nova ({atual})"
+
+
+def test_as_quatro_portas_nao_ganharam_escrita_incondicional():
+    """A varredura da "sexta escrita", presa em teste em vez de em prosa.
+
+    `set_pending_action` é upsert incondicional (`db/pending.py:198`) e atropela
+    a pergunta que outra tarefa acabou de pôr na linha única. Nenhuma das quatro
+    portas pode usá-lo.
+
+    O `_resolve_clarification` tem DUAS ocorrências herdadas, e este PR não as
+    introduziu. A checagem olha o CONTEXTO de cada uma, não o total: contar
+    `== 2` deixaria passar "apagou uma herdada e pôs uma nova". As duas:
+
+    - `funds.add_ask` sem destino reconhecido — idêntica à `main:568`;
+    - "ainda sem valor reconhecível" — MESMA chamada e mesmo papel da
+      `main:649`, mas NÃO byte a byte: a indentação e o alcance mudaram (na
+      `main` só se chegava lá quando
+      `not (entities["valor"] or _extract_valor(orig_text))`; este branch tirou
+      o braço do `orig_text`, ver `_ja_tem_o_valor`).
+    """
+    import inspect
+    import adapters.whatsapp.wa_runtime as wr
+    import core.handlers.bills as BH
+    import core.handlers.launches as LH
+    import core.intent_router as IR
+
+    def conta(fn):
+        return inspect.getsource(fn).count("set_pending_action(")
+
+    assert conta(BH.resolve_bill_amount) == 0            # porta 1
+    assert conta(LH.resolve_multi_launch_value) == 0     # porta 3
+    # 1 = o PRODUTOR da `clarification` (`needs_clarification`), da `main`.
+    # A escotilha de abandono que este PR pôs no `route` usa CAS.
+    assert conta(IR.route) == 1
+    # Identidade, não contagem: cada `set_pending_action` do
+    # `_resolve_clarification` tem que ser uma das DUAS herdadas, reconhecida
+    # pela linha que a precede. Uma terceira (ou uma troca) quebra aqui.
+    src = inspect.getsource(IR._resolve_clarification).splitlines()
+    herdadas = ("# destino não reconhecido → re-arma a pergunta pra não perder o valor",
+                "# pending pra não perder a descrição original.")
+    achadas = [src[i - 1].strip() for i, ln in enumerate(src)
+               if "set_pending_action(" in ln]
+    assert achadas == list(herdadas), achadas
+    # Porta 4: o bloco `bill_pay_amount` vive dentro do `process_message`, que
+    # tem outros `set_pending_action` legítimos (o `recategorize_launch_text`).
+    # Recorta só o trecho da pergunta de valor.
+    src = inspect.getsource(wr.process_message)
+    trecho = src[src.index("Passo 1 da pergunta de valor"):src.index("mark_bill_paid")]
+    assert "set_pending_action(" not in trecho, trecho

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -1790,6 +1790,13 @@ def test_clarification_com_payload_torto_nao_estoura():
     ("0", "nao_positivo"),
     ("0,001", "nao_positivo"),      # arredonda para R$ 0,00
     ("1" * 400, "nao_positivo"),    # parse_money devolve inf
+    ("‒10", "nao_positivo"),      # figure dash, fora da lista de cinco
+    ("―10", "nao_positivo"),      # horizontal bar, idem
+    ("foi - 10", "nao_positivo"),   # enchimento + sinal separado (rodada 6)
+    ("paguei - 10", "nao_positivo"),
+    ("menos10", "nao_positivo"),
+    (",50", "nao_entendi"),         # 7ª forma: 50,00 no lugar de 0,50
+    (".50", "nao_entendi"),
     ("132 50", "nao_entendi"),      # 13.250 se passasse
     ("paguei 132 50", "nao_entendi"),  # o dano não some com uma palavra na frente
     ("1.23.456", "nao_entendi"),    # 123.456 se passasse
@@ -1797,9 +1804,10 @@ def test_clarification_com_payload_torto_nao_estoura():
 def test_contrato_do_valor_perigoso_recusa(entrada, motivo):
     """Fonte única das quatro portas, do lado que RECUSA.
 
-    O sinal negativo não é um caractere: as SEIS grafias de traço (o ASCII mais
-    as cinco do `_TRACOS`) e o "menos 10" falado chegam todos ao `parse_money`
-    como positivos.
+    O sinal negativo não é um caractere: as onze grafias de traço (o ASCII mais
+    as dez do `_TRACOS`) e o "menos 10" falado chegam todos ao `parse_money`
+    como positivos. A tabela-verdade completa — POSIÇÃO do traço × o que o
+    cerca — está em `tests/test_valor_sinal.py`; aqui ficam os reprodutores.
 
     O "menos" falado só é visto quando há bloco de dígitos: `menos cinquenta`
     NÃO está aqui porque `valor_perigoso("menos cinquenta", 50.0)` devolve
@@ -1888,6 +1896,9 @@ def test_botao_ja_paguei_aceita_o_valor_dentro_da_frase(monkeypatch, resposta, e
     ("\u221210", "maior que zero"),          # U+2212
     ("\u201310", "maior que zero"),          # en dash
     ("menos 10", "maior que zero"),
+    ("foi - 10", "maior que zero"),       # rodada 6: enchimento + sinal solto
+    ("paguei - 10", "maior que zero"),
+    (",50", "Não peguei o valor"),        # 7ª forma: 50,00 no lugar de 0,50
     ("0", "maior que zero"),
     ("0,001", "maior que zero"),
     ("1" * 400, "maior que zero"),        # parse_money devolve inf
@@ -2560,6 +2571,11 @@ def test_controle_negativo_dano_antes_do_abandono_prende_o_comando(monkeypatch, 
 
 @pytest.mark.parametrize("resposta,fragmento", [
     ("-10", "maior que zero"), ("−10", "maior que zero"),
+    # Rodada 6: enchimento/verbo + sinal SEPARADO por espaço. Os quatro casam
+    # o `_VALOR_RE` (o enchimento está lá) e passavam como R$ 10,00 positivo.
+    ("foi - 10", "maior que zero"), ("deu − 10", "maior que zero"),
+    ("uns - 10", "maior que zero"), ("menos 10", "maior que zero"),
+    (",50", "Não entendi o valor"),   # 7ª forma: 50,00 no lugar de 0,50
     ("0", "maior que zero"), ("132 50", "Não entendi o valor"),
     ("1.23.456", "Não entendi o valor"),
 ])

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -2707,3 +2707,358 @@ def test_as_quatro_portas_nao_ganharam_escrita_incondicional():
     src = inspect.getsource(wr.process_message)
     trecho = src[src.index("Passo 1 da pergunta de valor"):src.index("mark_bill_paid")]
     assert "set_pending_action(" not in trecho, trecho
+
+
+# ---------------------------------------------------------------------------
+# RODADA DO CODEX — P2 #2: espaço DEPOIS do separador decimal.
+#
+# A regra dos 3 dígitos do `_espaco_ambiguo` lia o "50" de "132, 50" como grupo
+# de milhar malformado e recusava — mas o espaço vem depois da VÍRGULA, e o
+# `parse_money` devolve 132.5. As 15 combinações abaixo foram medidas em DUAS
+# COLUNAS (`main` cf54ffb × branch), nas quatro portas, 60 células:
+#
+#   antes do conserto  21 células recusavam o que a `main` aceitava
+#                      (7 formas × portas 2, 3 e 4)
+#   depois             a ÚNICA célula diferente da `main` é o alvo do PR,
+#                      "132 50" → R$ 13.250,00, recusado nas portas 2, 3 e 4.
+#
+# Os testes de espaço que já existiam só tinham espaço ENTRE grupos ("1 500",
+# "12 345"), nunca depois do separador — por isso as 21 células atravessaram
+# quatro ataques.
+# ---------------------------------------------------------------------------
+
+# (texto, valores que a `main` registra na porta 2). A porta 2 recombina a
+# resposta com o texto original ("gastei <resposta> a luz"), e em cinco delas o
+# separador dentro da frase faz o splitter de multi-lançamento criar DOIS
+# lançamentos — é o que a `main` faz, e o branch tem que fazer igual.
+ESPACO_PORTA_2 = [
+    ("132, 50",   [50.0, 132.0]),
+    ("132 , 50",  [50.0, 132.0]),
+    ("132 ,50",   [132.5]),
+    ("132. 50",   [132.5]),
+    ("132 . 50",  [132.5]),
+    ("1.234, 56", [56.0, 1234.0]),
+    ("1 234,56",  [1234.56]),
+    ("1.234 ,56", [1234.56]),
+    ("132, 5",    [5.0, 132.0]),
+    ("132, 500",  [132.0, 500.0]),
+    ("132,50 ",   [132.5]),
+    ("1 500",     [1500.0]),
+    ("12 345",    [12345.0]),
+    ("1 500, 50", [50.0, 1500.0]),
+]
+
+# Portas 3 e 4 recebem a resposta sozinha: um valor só, o mesmo nas duas.
+ESPACO_PORTA_3_E_4 = [
+    ("132, 50", 132.5), ("132 , 50", 132.5), ("132 ,50", 132.5),
+    ("132. 50", 132.5), ("132 . 50", 132.5), ("1.234, 56", 1234.56),
+    ("1 234,56", 1234.56), ("1.234 ,56", 1234.56), ("132, 5", 132.5),
+    ("132, 500", 132.5), ("132,50 ", 132.5), ("1 500", 1500.0),
+    ("12 345", 12345.0), ("1 500, 50", 1500.5),
+]
+
+TODAS_AS_COMBINACOES = [t for t, _ in ESPACO_PORTA_2] + ["132 50"]
+
+
+def _pergunta_e_responde(porta: int, monkeypatch, texto: str):
+    """Arma a pergunta de valor da `porta` e responde `texto`.
+
+    Devolve `(valores registrados, resposta)` — nas portas 1 e 4 o valor pago
+    da conta (lista vazia = não pagou), nas portas 2 e 3 os lançamentos.
+    """
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    if porta == 1:
+        _monta_conta_variavel(uid)
+        assert "só o valor" in _diga(uid, "paguei a luz")
+        resp = _diga(uid, texto)
+    elif porta == 2:
+        assert "Quanto foi" in _diga(uid, "paguei a luz")
+        resp = _diga(uid, texto)
+    elif porta == 3:
+        assert "Faltou o valor de *aluguel*" in _diga(
+            uid, "gastei 30 no mercado e paguei o aluguel")
+        resp = _diga(uid, texto)
+    else:
+        conta = _monta_conta_variavel(uid)
+        _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+        resp = (_manda_texto_no_wa(monkeypatch, uid, texto) or [""])[-1]
+
+    if porta in (1, 4):
+        conta = [b for b in B.list_bills(uid, include_paid=True)
+                 if b["name"] == "Luz"][0]
+        vals = ([float(conta["paid_amount"])]
+                if conta["status"] == "paid" else [])
+    else:
+        vals = sorted(abs(float(l["valor"]))
+                      for l in db.list_launches(uid, limit=6))
+        if porta == 3:
+            vals.remove(30.0)   # o item que já vinha com valor na frase
+    return vals, resp
+
+
+@pytest.mark.parametrize("texto,esperado", ESPACO_PORTA_2)
+def test_espaco_depois_do_separador_registra_na_porta_2(monkeypatch, texto, esperado):
+    vals, resp = _pergunta_e_responde(2, monkeypatch, texto)
+    assert vals == esperado, (texto, resp)
+
+
+@pytest.mark.parametrize("texto,esperado", ESPACO_PORTA_3_E_4)
+def test_espaco_depois_do_separador_registra_na_porta_3(monkeypatch, texto, esperado):
+    vals, resp = _pergunta_e_responde(3, monkeypatch, texto)
+    assert vals == [esperado], (texto, resp)
+
+
+@pytest.mark.parametrize("texto,esperado", ESPACO_PORTA_3_E_4)
+def test_espaco_depois_do_separador_paga_na_porta_4(monkeypatch, texto, esperado):
+    vals, resp = _pergunta_e_responde(4, monkeypatch, texto)
+    assert vals == [esperado], (texto, resp)
+
+
+@pytest.mark.parametrize("texto", TODAS_AS_COMBINACOES)
+def test_porta_1_decide_pela_forma_e_nao_muda_com_o_conserto(monkeypatch, texto):
+    """A porta 1 é inerte ao conserto — medido, não presumido.
+
+    O `_VALOR_RE.fullmatch` não aceita `\\s` dentro do número, então as 15
+    combinações caem no `_NUMERO_AMBIGUO_RE` ANTES de o `valor_perigoso` ser
+    consultado. A única que paga é a que não tem espaço nenhum no meio
+    ("132,50 ", espaço só no fim). Idêntico à `main` nas 15.
+    """
+    vals, resp = _pergunta_e_responde(1, monkeypatch, texto)
+    if texto == "132,50 ":
+        assert vals == [132.5], resp
+    else:
+        assert vals == [] and "Não entendi o valor da *Luz*" in resp, (texto, resp)
+
+
+@pytest.mark.parametrize("porta", [2, 3, 4])
+def test_alvo_132_50_continua_recusado(monkeypatch, porta):
+    """O que o PR foi consertar não pode ter voltado: "132 50" → R$ 13.250,00.
+
+    Na `main` as três portas registram 13250.0 (medido). Aqui, nenhuma.
+    """
+    vals, resp = _pergunta_e_responde(porta, monkeypatch, "132 50")
+    assert vals == [], (porta, resp)
+    assert "ntendi o valor" in resp or "Não peguei o valor" in resp, resp
+
+
+def _espaco_ambiguo_antes_do_conserto(bloco: str) -> bool:
+    """A versão do commit 1cc0955: sem a exceção do separador decimal."""
+    import re
+    partes = bloco.split()
+    return any(len(re.match(r"\d*", p).group(0)) != 3
+               for p in partes[1:] if p[:1].isdigit())
+
+
+@pytest.mark.parametrize("porta", [2, 3, 4])
+def test_controle_negativo_sem_a_excecao_do_decimal_a_porta_recusa(monkeypatch, porta):
+    """Controle negativo, injetado em caso VERDE e uma vez POR PORTA.
+
+    Desliga só a exceção nova e o caso que a `main` aceita fica vermelho nas
+    três portas. Sem este controle, a regressão passava despercebida — foi
+    exatamente o que aconteceu por quatro ataques.
+    """
+    import utils_text
+    monkeypatch.setattr(utils_text, "_espaco_ambiguo",
+                        _espaco_ambiguo_antes_do_conserto)
+
+    vals, resp = _pergunta_e_responde(porta, monkeypatch, "132, 50")
+
+    assert vals == [], (porta, resp)
+
+
+def test_controle_negativo_a_porta_1_nao_muda_com_a_versao_antiga(monkeypatch):
+    """A outra metade do controle: na porta 1 desligar a exceção não muda NADA.
+
+    É a prova de que o portão de forma vem antes — e a razão de não existir
+    controle negativo da porta 1 para este conserto.
+    """
+    import utils_text
+    monkeypatch.setattr(utils_text, "_espaco_ambiguo",
+                        _espaco_ambiguo_antes_do_conserto)
+
+    vals, resp = _pergunta_e_responde(1, monkeypatch, "132, 50")
+
+    assert vals == [] and "Não entendi o valor da *Luz*" in resp, resp
+
+
+# ---------------------------------------------------------------------------
+# RODADA DO CODEX — P2 #1: o CAS que falha vale para o TURNO, não só para o
+# DELETE.
+#
+# Os testes de corrida que já existiam punham como substituta um
+# `bill_pay_amount` — que o `route()` NÃO consome —, então provavam só que a
+# linha não era apagada. A substituta destes é um `multi_launch_values` com
+# fila: se o comando velho ainda alcançar as guardas de pendência, a fila
+# inteira do usuário é apagada pela porta 3, e isso aparece.
+# ---------------------------------------------------------------------------
+
+# `desc` diferente do item que a porta 3 tem em mão de propósito: o CAS compara
+# o PAYLOAD, e uma fila igual à lida faria o compare-and-swap VENCER — a corrida
+# não seria injetada e o teste mediria o caminho normal. Medido: com
+# `desc="aluguel"` (o mesmo item), o teste da porta 3 passa a apagar a fila.
+FILA_DE_OUTRA_TAREFA = {"queue": [{"desc": "internet", "tipo": "despesa"}],
+                        "platform": "whatsapp"}
+
+
+def _corrida_no_cas(monkeypatch, alvo, uid, ignora_resultado=False):
+    """Injeta a pergunta de OUTRA tarefa entre a leitura e o CAS de abandono.
+
+    `ignora_resultado=True` reproduz o código de antes do conserto: o CAS roda
+    (e falha), mas quem chamou trata como se tivesse funcionado.
+
+    Os DOIS bindings do `advance_pending_action`: as quatro portas passam pelo
+    `db.consume_pending_action`, que resolve o nome nos globais de `db.pending`
+    — só o `db` não pega nada. O `db` fica junto porque o CAS da fila
+    (`core/handlers/launches.py`) chama por lá; ele nunca tem `new is None`,
+    então a injeção não dispara nele.
+    """
+    import db
+    import db.pending
+
+    real = db.pending.advance_pending_action
+
+    def com_corrida(u, tipo, old, new, *a, **k):
+        if tipo == alvo and new is None:
+            db.set_pending_action(uid, "multi_launch_values", FILA_DE_OUTRA_TAREFA)
+        ok = real(u, tipo, old, new, *a, **k)
+        return True if ignora_resultado else ok
+
+    monkeypatch.setattr(db.pending, "advance_pending_action", com_corrida)
+    monkeypatch.setattr(db, "advance_pending_action", com_corrida)
+
+
+def _fila_intacta(uid):
+    import db
+    atual = db.get_pending_action(uid) or {}
+    assert atual.get("action_type") == "multi_launch_values", \
+        f"o comando velho encostou na pergunta nova: {atual}"
+    assert atual.get("payload") == FILA_DE_OUTRA_TAREFA, atual
+
+
+def test_cas_perdido_na_porta_2_nao_toca_a_pergunta_nova(monkeypatch):
+    """Porta 2: o CAS falha → o turno roteia "saldo" SEM as guardas de pendência.
+
+    Sem o conserto, o `get_pending_action` seguinte recarregava a substituta e a
+    porta 3 apagava a fila que outra tarefa acabou de mostrar ao usuário.
+    """
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    _corrida_no_cas(monkeypatch, "clarification", uid)
+    resp = _diga(uid, "saldo")
+
+    _fila_intacta(uid)
+    assert "Conta Corrente" in resp, f"o comando velho não foi respondido: {resp!r}"
+
+
+def test_controle_negativo_porta_2_ignorando_o_cas_a_fila_some(monkeypatch):
+    """Controle negativo da porta 2, injetado no caso VERDE acima."""
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    _corrida_no_cas(monkeypatch, "clarification", uid, ignora_resultado=True)
+    _diga(uid, "saldo")
+
+    assert db.get_pending_action(uid) is None, \
+        "sem o conserto a fila da outra tarefa TEM que sumir — o controle não mede nada"
+
+
+def test_cas_perdido_na_porta_4_nao_toca_a_pergunta_nova(monkeypatch):
+    """Porta 4: o CAS falha e o `handle_incoming` relê `pending_actions`.
+
+    Sem o `ignora_pendencias`, "saldo" entrava na porta 3 da fila nova e a
+    apagava — a porta 4 roda ANTES do `handle_incoming`, então o `pending_recat`
+    local não protege nada.
+    """
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    _corrida_no_cas(monkeypatch, "bill_pay_amount", uid)
+    respostas = _manda_texto_no_wa(monkeypatch, uid, "saldo")
+
+    _fila_intacta(uid)
+    assert "Conta Corrente" in (respostas[-1] if respostas else ""), respostas
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+
+
+def test_controle_negativo_porta_4_ignorando_o_cas_a_fila_some(monkeypatch):
+    """Controle negativo da porta 4, injetado no caso VERDE acima."""
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    _corrida_no_cas(monkeypatch, "bill_pay_amount", uid,
+                    ignora_resultado=True)
+    _manda_texto_no_wa(monkeypatch, uid, "saldo")
+
+    assert db.get_pending_action(uid) is None, \
+        "sem o conserto a fila da outra tarefa TEM que sumir — o controle não mede nada"
+
+
+def test_cas_perdido_na_porta_1_ja_nao_tocava_a_pergunta_nova(monkeypatch):
+    """Porta 1: o irmão que NÃO precisava de conserto — medido, não presumido.
+
+    O `resolve_bill_amount` devolve `None` quando o CAS falha, e o `route()`
+    zera o `pending` local nessa linha, então as guardas seguintes já ficavam
+    de fora. O controle negativo desta porta é o CAS em si: trocá-lo por um
+    `clear_pending_action` apaga a fila (é o `test_abandono_...` acima).
+    """
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    _monta_conta_variavel(uid)
+    assert "só o valor" in _diga(uid, "paguei a luz")
+
+    _corrida_no_cas(monkeypatch, "bill_amount_expected", uid)
+    resp = _diga(uid, "saldo")
+
+    _fila_intacta(uid)
+    assert "Conta Corrente" in resp, resp
+
+
+def test_cas_perdido_na_porta_3_ja_nao_tocava_a_pergunta_nova(monkeypatch):
+    """Porta 3: mesmo irmão, mesma medição.
+
+    O ramo `outro_comando` devolve `None` e o `route()` zera o `pending` local.
+    A substituta aqui é uma fila DIFERENTE (payload diferente), que é o que o
+    CAS compara.
+
+    O comando é "saldo", não "apagar 42": medido, o `launches.delete` arma a
+    SUA própria confirmação com `set_pending_action` e sobrescreve a linha
+    sozinho — escrita incondicional herdada (~48 no repositório, ver
+    `db/pending.py`), fora das quatro portas e fora deste PR.
+    """
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Faltou o valor de *aluguel*" in _diga(
+        uid, "gastei 30 no mercado e paguei o aluguel")
+
+    _corrida_no_cas(monkeypatch, "multi_launch_values", uid)
+    resp = _diga(uid, "saldo")
+
+    _fila_intacta(uid)
+    assert "Conta Corrente" in resp, resp

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -2418,13 +2418,22 @@ def test_porta_2_ponto_final_sem_virgula_registra(resposta, esperado):
                           if not c[0].startswith("paguei")])
 def test_controle_negativo_sem_limpar_a_pontuacao_a_porta_1_recusa(
         monkeypatch, resposta, esperado):
-    """Controle: desliga a limpeza NA PORTA 1 e o caso verde fica vermelho."""
+    """Controle: desliga a limpeza NA PORTA 1 e o caso verde fica vermelho.
+
+    Dois alvos porque a limpeza é usada em dois pontos do mesmo turno: o
+    `import` do topo de `core/handlers/bills.py` (o valor que vai ao
+    `parse_money` — sem ele "1.500." vira `None`) e a chamada que o
+    `valor_perigoso` faz por dentro, no `utils_text` (a FORMA — sem ela "132."
+    vira milhar malformado). Desligar só um deixa o outro cobrindo o furo.
+    """
     import uuid
     import db
     import db.bills as B
+    import utils_text
     import core.handlers.bills as BH
 
     monkeypatch.setattr(BH, "limpa_pontuacao_final", lambda s: s or "")
+    monkeypatch.setattr(utils_text, "limpa_pontuacao_final", lambda s: s or "")
 
     uid = int(uuid.uuid4().int % 1_000_000_000)
     _monta_conta_variavel(uid)
@@ -2465,17 +2474,24 @@ def test_controle_negativo_sem_limpar_a_pontuacao_a_porta_4_recusa(monkeypatch):
 #   'apagar 0'                 zero            -> nao_positivo
 #   'quanto gastei em 12 05'   espaço ambíguo  -> nao_entendi
 #   'resumo do mes 08 2026'    espaço ambíguo  -> nao_entendi
-#   'extrato 01-2026'          traço à direita -> nao_positivo
-#   'relatorio 2026-08'        traço à direita -> nao_positivo
 #   'apagar 1.23.456'          milhar torto    -> nao_entendi
 COMANDOS_QUE_O_DANO_PRENDIA = [
     "apagar 0", "quanto gastei em 12 05", "resumo do mes 08 2026",
-    "extrato 01-2026", "relatorio 2026-08", "apagar 1.23.456",
-    "pix 11-99999-8888", "boleto 12-2026",
+    "apagar 1.23.456",
+]
+# Estes quatro TAMBÉM eram presos, pelo traço à direita do primeiro bloco
+# ('01-2026' -> `depois.startswith("-")` -> nao_positivo). A rodada 5 tirou-os
+# do perigoso: traço só é sinal quando TERMINA a expressão, e numa data ou num
+# telefone ele separa dois números. Continuam aqui porque o portão de forma
+# ainda tem de abandoná-los — mas já não servem de controle do DANO, que não os
+# vê mais.
+COMANDOS_COM_TRACO_ENTRE_NUMEROS = [
+    "extrato 01-2026", "relatorio 2026-08", "pix 11-99999-8888", "boleto 12-2026",
 ]
 
 
-@pytest.mark.parametrize("comando", COMANDOS_QUE_O_DANO_PRENDIA)
+@pytest.mark.parametrize("comando", COMANDOS_QUE_O_DANO_PRENDIA
+                         + COMANDOS_COM_TRACO_ENTRE_NUMEROS)
 def test_porta_1_portao_de_forma_vem_antes_do_dano(comando):
     """Preso = a pendência fica na linha e a repetição dá a mesma recusa.
 

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -552,6 +552,9 @@ _PERIGOSOS_COM_PREFIXO = [
     for e, s in [("-10", "maior que zero"), ("132 50", "Não entendi o valor"),
                  ("132 50 reais", "Não entendi o valor"),
                  ("1.23.456", "Não entendi o valor"),
+                 # Rodada 6: sinal separado por espaço depois de enchimento.
+                 ("- 10", "maior que zero"), ("foi - 10", "maior que zero"),
+                 (",50", "Não entendi o valor"),   # 7ª forma
                  ("0,001", "maior que zero"), ("1" * 400, "maior que zero")]
     for p in ("", "paguei ")
 ]
@@ -1059,6 +1062,9 @@ def test_controle_negativo_pontuacao_so_no_fim_da_mensagem(
 _PROSA_PERIGOSA = [
     ("132 -", "maior que zero"),      # traço que TERMINA a expressão = sinal
     ("paguei 132 -", "maior que zero"),
+    ("uns - 10", "maior que zero"),   # enchimento + sinal separado (rodada 6)
+    ("paguei - 10", "maior que zero"),
+    ("R$ ,50", "Não entendi o valor"),  # 7ª forma: 50,00 no lugar de 0,50
     ("(10)", "maior que zero"),       # negativo contábil
     ("132 50 no mercado", "Não entendi o valor"),
     ("paguei 1.23.456 da luz", "Não entendi o valor"),

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -173,3 +173,708 @@ def test_full_product_smoke(pro_uid, spy_ai, capsys):
     # A IA não deveria ser necessária pra nenhum comando determinístico acima.
     # Se for chamada, é sinal de que a classificação regrediu (não é crash, mas
     # anotar). Não falha o teste por isso — só reporta.
+
+
+# ---------------------------------------------------------------------------
+# Porta genérica da pergunta de valor (`clarification` de launches.add).
+#
+# "Paguei a luz" sem conta cadastrada cai aqui: `try_pay_from_text` desiste e
+# `core/handlers/launches.py` grava a pendência `clarification` com a pergunta
+# "🐷 Quanto foi no *luz*?". Antes deste PR essa porta não tinha validação
+# nenhuma — "-10" registrava R$ 10,00, "0" matava a pendência e "saldo" virava
+# "Quanto foi no *luz saldo*?".
+#
+# A conversa inteira, não a função: cada caso arma a pergunta pelo `_send`.
+# ---------------------------------------------------------------------------
+
+def _pergunta_de_valor(uid: int, texto: str = "paguei a luz") -> str:
+    resp = _send(uid, texto)
+    assert "Quanto foi" in resp, resp
+    return resp
+
+
+def _pendencia(uid: int):
+    import db
+    return db.get_pending_action(uid)
+
+
+def test_clarification_comando_confiante_abandona_a_pergunta(pro_uid, spy_ai):
+    """T1 — "saldo" é comando, não valor: larga a pergunta e responde o saldo."""
+    uid = pro_uid
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, "saldo")
+
+    assert "Quanto foi" not in resp, resp
+    assert "Conta Corrente" in resp, resp
+    assert _pendencia(uid) is None, _pendencia(uid)
+
+
+def test_clarification_valor_negativo_recusado_pergunta_viva(pro_uid, spy_ai):
+    """T2 — "-10" registrava R$ 10,00 (`parse_money("-10") == 10.0`)."""
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, "-10")
+
+    assert "maior que zero" in resp, resp
+    assert "Quanto foi no *luz*?" in resp, resp
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "clarification", pend
+    assert pend["payload"]["orig_text"] == "paguei a luz", pend
+    assert not db.list_launches(uid, limit=5), "não pode ter registrado nada"
+
+
+def test_clarification_zero_recusado_pergunta_viva(pro_uid, spy_ai):
+    """T3 — "0" respondia "Não consegui identificar o valor" e MATAVA a pendência."""
+    uid = pro_uid
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, "0")
+
+    assert "maior que zero" in resp, resp
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "clarification", pend
+
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132,50.", 132.5),    # antes: 13.250,00 (parse_money lê a vírgula como milhar)
+    ("1.23,45", 123.45),   # ponto solto + vírgula: passa, é o que a pessoa quis dizer
+])
+def test_clarification_pontuacao_nao_infla_o_valor(pro_uid, spy_ai, resposta, esperado):
+    """T4 (metade que PASSA) — o critério é o dano, não a boa digitação."""
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, "deveria ter registrado"
+    assert abs(float(lancs[0]["valor"])) == esperado, lancs[0]
+
+
+@pytest.mark.parametrize("resposta", [
+    "132 50",     # antes: 13.250,00
+    "1.23.456",   # antes: 123.456,00 quando o provável era 1.234,56
+])
+def test_clarification_valor_ambiguo_recusado_pergunta_viva(pro_uid, spy_ai, resposta):
+    """T4 (metade que RECUSA) — ambíguo re-pergunta em vez de inflar."""
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, resposta)
+
+    assert "Não entendi o valor" in resp, resp
+    assert "Quanto foi no *luz*?" in resp, resp
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "clarification", pend
+    assert not db.list_launches(uid, limit=5), "não pode ter registrado nada"
+
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132", 132.0),
+    ("uns 132", 132.0),           # enchimento falado
+    ("cinquenta", 50.0),          # por extenso: o Whisper escreve assim
+    ("2000000000", 2_000_000_000.0),  # sem teto inventado
+    # As formas COM UNIDADE — o buraco da rodada 1. Faltavam aqui, e por isso a
+    # escotilha por confiança (uma blacklist sobre o classificador inteiro)
+    # passou verde sequestrando todas elas. Com o `ABANDONA` fechado, nenhuma
+    # delas pode abandonar nada: só os seis intents de comando abandonam.
+    ("132 reais", 132.0),
+    ("50 pila", 50.0),
+    ("5 conto", 5.0),
+    ("132,50 reais", 132.5),
+    ("1 real", 1.0),
+    ("132 reais.", 132.0),
+])
+def test_clarification_positivo_o_aperto_nao_recusa_tudo(pro_uid, spy_ai, resposta, esperado):
+    """T5 — controle positivo do grupo: pega teto inventado e recusa-tudo.
+
+    Assere DESCRIÇÃO e CATEGORIA, não só o valor: com a escotilha invertida,
+    "50 pila" ainda registrava R$ 50,00 — mas com descrição "50 pila" e
+    categoria "outros", porque a resposta virava um lançamento novo e a "luz"
+    da pergunta era jogada fora. O valor sozinho não denunciava nada.
+    """
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, f"{resposta!r} deveria ter registrado"
+    assert abs(float(lancs[0]["valor"])) == esperado, lancs[0]
+    texto = f"{lancs[0].get('alvo') or ''} {lancs[0].get('nota') or ''}".lower()
+    assert "luz" in texto, f"{resposta!r} perdeu a descrição da pergunta: {lancs[0]}"
+    assert lancs[0].get("categoria") == "moradia", lancs[0]
+
+
+@pytest.mark.parametrize("resposta", ["mercado", "mercado 20"])
+def test_clarification_descricao_completa_sem_somar_valor(pro_uid, spy_ai, resposta):
+    """T6 — "gastei 50" + "mercado 20" registrava R$ 2.050,00.
+
+    O valor já veio no `orig_text`; a resposta é a DESCRIÇÃO. O `_extract_valor`
+    frouxo aceitava "mercado 20" como valor e o combinado virava "gastei
+    mercado 20 50" → 2050.
+    """
+    uid = pro_uid
+    import db
+    resp = _send(uid, "gastei 50")
+    assert "Quanto" in resp or "gastou" in resp.lower(), resp
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, "deveria ter registrado"
+    assert abs(float(lancs[0]["valor"])) == 50.0, lancs[0]
+
+
+@pytest.mark.parametrize("resposta", [
+    "fatura", "investimento", "extrato",
+    # `cartao` cai por OUTRO motivo, anterior a este PR e medido na `main` com o
+    # working tree limpo: o combinado "gastei 50 cartao" é lido como COMPRA NO
+    # CARTÃO e `core/handlers/credit.py:477` responde "não tem cartão padrão",
+    # perdendo os R$ 50. Não é a escotilha (ela nem chega a rodar aqui) e o
+    # conserto é do fluxo de crédito. `strict` de propósito: quando alguém
+    # consertar, este xfail fica vermelho e pede a atualização.
+    pytest.param("cartao", marks=pytest.mark.xfail(
+        strict=True,
+        reason="pré-existente: 'gastei 50 cartao' vira compra no cartão sem cartão padrão")),
+])
+def test_clarification_de_descricao_nao_perde_o_valor_ja_digitado(pro_uid, spy_ai, resposta):
+    """T6b — pergunta de DESCRIÇÃO não tem escotilha: o valor não pode evaporar.
+
+    "fatura", "investimento" e "extrato" classificam como comando confiante, e
+    são descrições perfeitamente plausíveis de um gasto. A escotilha por
+    confiança da rodada 1 largava a pergunta, os R$ 50 que o usuário já tinha
+    digitado sumiam e a resposta falava de outro assunto.
+    """
+    uid = pro_uid
+    import db
+    resp = _send(uid, "gastei 50")
+    assert "gastou" in resp.lower(), resp
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, f"{resposta!r} descartou o valor: nada foi registrado"
+    assert abs(float(lancs[0]["valor"])) == 50.0, lancs[0]
+
+
+def test_clarification_de_recorrente_nao_vira_despesa_avulsa(pro_uid, spy_ai):
+    """Bloqueante 3 — a escotilha matava a `clarification` de `recurring.add`.
+
+    `core/handlers/recurring.py:97` guarda `intent="recurring.add"` só para não
+    perder o contexto: sem a pendência, o "1000 reais" seguinte é classificado
+    do zero e vira despesa avulsa — está escrito lá no comentário. A escotilha
+    por confiança da rodada 1 abandonava a pergunta e reintroduzia esse bug.
+
+    A pergunta é armada pelo PRODUTOR real (`recurring.add` com entities sem
+    valor), não por um payload escrito à mão — em produção quem chega em
+    `recurring.add` é a IA.
+    """
+    uid = pro_uid
+    import db
+    from core.handlers import recurring as h_recurring
+
+    pergunta = h_recurring.add(uid, "gasto fixo aluguel todo dia 10",
+                               {"nome": "aluguel", "dia": 10})
+    assert "Qual o valor desse recorrente" in pergunta, pergunta
+    assert _pendencia(uid)["payload"]["intent"] == "recurring.add", _pendencia(uid)
+
+    resp = _send(uid, "1000 reais")
+
+    assert "Gasto fixo criado" in resp and "1.000,00" in resp, resp
+    assert not db.list_launches(uid, limit=5), "virou despesa avulsa"
+
+
+# ---------------------------------------------------------------------------
+# Porta 3 (numeração em `core/intent_router.py`): a fila do `multi_launch_values`
+# (`core/handlers/launches.py::resolve_multi_launch_value`).
+#
+# Usuário GRÁTIS de propósito: para o Pro a IA sequestra o turno antes
+# (`multi_launch_values` está fora de `_RESUMABLE_PENDING_TYPES`), e a porta
+# fica escondida. É esse mascaramento que fez a rodada 1 concluir, errado, que
+# ela não reproduzia.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def free_uid():
+    """User do Grátis — sem linha em `auth_accounts`."""
+    import uuid as _uuid
+    import db as _db
+
+    uid = int(_uuid.uuid4().int % 1_000_000_000)
+    _db.ensure_user(uid)
+    return uid
+
+
+def _fila_de_dois(uid: int) -> str:
+    resp = _send(uid, "paguei o aluguel e paguei a luz")
+    assert "Faltou o valor de *aluguel*" in resp, resp
+    return resp
+
+
+@pytest.mark.parametrize("resposta,motivo", [
+    ("-10", "gravava R$ 10,00 — parse_money('-10') == 10.0"),
+    ("132 50", "gravava R$ 13.250,00"),
+    ("1.23.456", "gravava R$ 123.456,00"),
+    ("0,001", "gravava 0.001 e dizia 'R$ 0,00 lançado'"),
+    ("0", "apagava a pendência e a luz sumia da fila"),
+    ("1" * 400, "parse_money devolve inf → '⚠️ Ocorreu um erro interno'"),
+])
+def test_multi_launch_recusa_valor_perigoso_e_mantem_a_fila(free_uid, spy_ai, resposta, motivo):
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    resp = _send(uid, resposta)
+
+    assert "erro interno" not in resp.lower(), f"{motivo}: {resp}"
+    assert "Faltou o valor de *aluguel*" in resp, f"{motivo}: {resp}"
+    assert not db.list_launches(uid, limit=5), f"{motivo}: registrou {db.list_launches(uid, limit=5)}"
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "multi_launch_values", pend
+    fila = [i["desc"] for i in pend["payload"]["queue"]]
+    assert fila == ["aluguel", "luz"], f"a fila foi mexida: {fila}"
+
+
+def test_multi_launch_pontuacao_final_nao_infla(free_uid, spy_ai):
+    """`132,50.` gravava R$ 13.250,00 (parse_money lê a vírgula como milhar)."""
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    _send(uid, "132,50.")
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs and abs(float(lancs[0]["valor"])) == 132.5, lancs
+
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132", 132.0),
+    ("132 reais", 132.0),
+    ("cinquenta", 50.0),            # por extenso, sem dígito
+    ("paguei 132 no mercado", 132.0),  # frase: segue com o `_extract_valor`
+])
+def test_multi_launch_positivo_o_aperto_nao_recusa_tudo(free_uid, spy_ai, resposta, esperado):
+    """Controle positivo da porta 3."""
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, f"{resposta!r} deveria ter registrado"
+    assert abs(float(lancs[0]["valor"])) == esperado, lancs[0]
+
+
+def test_multi_launch_texto_sem_valor_ainda_abandona(free_uid, spy_ai):
+    """Controle negativo do aperto: mudar de assunto continua largando a fila."""
+    uid = free_uid
+    _fila_de_dois(uid)
+
+    resp = _send(uid, "saldo")
+
+    assert "Faltou o valor" not in resp, resp
+    assert _pendencia(uid) is None or _pendencia(uid)["action_type"] != "multi_launch_values"
+
+
+# ---------------------------------------------------------------------------
+# Rodada 3: a aceitação voltou a ser a da `main`.
+#
+# A rodada 2 pôs um validador de FORMA (mensagem inteira = número) como portão
+# de "isto é o valor?". Medido pelo Tester na pergunta viva "🐷 Quanto foi no
+# *luz*?": 13 formas que a `main` aceita falhavam aqui, em dois modos de dano —
+# laço (tem dígito, o `elif` não pega, a pergunta se re-arma para sempre) e
+# perda da pergunta (a escotilha dispara e "luz"/`moradia` evaporam).
+#
+# O portão passou a ser o `_extract_valor` — o mesmo do resto do bot — e o
+# filtro de dano roda DEPOIS, sobre o texto.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132 mil", 132000.0),
+    ("2,5 mil", 2500.0),
+    ("10 mil", 10000.0),            # saída literal do Whisper no áudio
+    ("3 milhoes", 3000000.0),       # idem
+    ("132 mil reais", 132000.0),
+    ("132k", 132.0),                # o que a `main` extrai daqui é 132
+    ("paguei 132", 132.0),
+    ("gastei 132", 132.0),
+    ("foi 132 mil", 132000.0),
+    ("ficou em 132", 132.0),
+    ("deu 132 no total", 132.0),
+    ("foi uns 132 no total", 132.0),
+    ("total 132", 132.0),
+    ("132 no boleto", 132.0),
+    # C2 — milhar separado por espaço. O filtro de dano recusava os três; a
+    # `main` (e o `_extract_valor`) acerta todos.
+    ("1 500", 1500.0),
+    ("12 345", 12345.0),
+    ("1 000 000", 1000000.0),
+])
+def test_clarification_aceita_tudo_que_a_main_aceita(pro_uid, spy_ai, resposta, esperado):
+    """B1 — as 17 formas medidas, pela conversa inteira.
+
+    Assere DESCRIÇÃO e CATEGORIA junto com o valor: os dois modos de dano da
+    rodada 2 se distinguem por aí. No laço, nada é registrado; na perda da
+    pergunta, o valor até entra, mas com descrição errada e categoria "outros".
+    """
+    from parsers import _extract_valor
+    uid = pro_uid
+    import db
+    assert _extract_valor(resposta) == esperado, "premissa: a `main` aceita isto"
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, f"{resposta!r} não registrou nada (laço): {resp}"
+    assert abs(float(lancs[0]["valor"])) == esperado, lancs[0]
+    texto = f"{lancs[0].get('alvo') or ''} {lancs[0].get('nota') or ''}".lower()
+    assert "luz" in texto, f"{resposta!r} perdeu a descrição da pergunta: {lancs[0]}"
+    assert lancs[0].get("categoria") == "moradia", lancs[0]
+    assert _pendencia(uid) is None or \
+        _pendencia(uid)["action_type"] != "clarification", _pendencia(uid)
+
+
+# --- B2: os seis perigosos, com e sem palavra na frente, nas DUAS portas. ---
+
+_PERIGOSOS_COM_PREFIXO = [
+    (p + e, s)
+    for e, s in [("-10", "maior que zero"), ("132 50", "Não entendi o valor"),
+                 ("132 50 reais", "Não entendi o valor"),
+                 ("1.23.456", "Não entendi o valor"),
+                 ("0,001", "maior que zero"), ("1" * 400, "maior que zero")]
+    for p in ("", "paguei ")
+]
+
+
+@pytest.mark.parametrize("resposta,recusa", _PERIGOSOS_COM_PREFIXO)
+def test_clarification_dano_nao_some_com_palavra_na_frente(pro_uid, spy_ai, resposta, recusa):
+    """B2, porta da `clarification`: uma palavra na frente não desarma o filtro."""
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, resposta)
+
+    assert "erro interno" not in resp.lower(), resp
+    assert recusa in resp, resp
+    assert "Quanto foi no *luz*?" in resp, resp
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "clarification", pend
+    assert not db.list_launches(uid, limit=5), db.list_launches(uid, limit=5)
+
+
+@pytest.mark.parametrize("resposta,recusa", _PERIGOSOS_COM_PREFIXO)
+def test_multi_launch_dano_nao_some_com_palavra_na_frente(free_uid, spy_ai, resposta, recusa):
+    """B2, porta do multi-lançamento: mesma tabela, mesma fonte de verdade."""
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    resp = _send(uid, resposta)
+
+    assert "erro interno" not in resp.lower(), resp
+    assert recusa in resp, resp
+    assert "Faltou o valor de *aluguel*" in resp, resp
+    assert not db.list_launches(uid, limit=5), db.list_launches(uid, limit=5)
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "multi_launch_values", pend
+    assert [i["desc"] for i in pend["payload"]["queue"]] == ["aluguel", "luz"], pend
+
+
+def test_clarification_de_descricao_com_numero_na_resposta(pro_uid, spy_ai):
+    """Mata o `_ja_tem_o_valor`: sem ele, "mercado 20" vira R$ 20,005.
+
+    O predicado é UMA linha e decide dois caminhos opostos. Apagá-lo faz a
+    pergunta de DESCRIÇÃO parsear a resposta como valor: o combinado vira
+    "gastei R$ 20,00 50" e o `parse_money` cola os dois em 20,005.
+    """
+    uid = pro_uid
+    import db
+    _send(uid, "gastei 50")
+
+    _send(uid, "mercado 20")
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs and abs(float(lancs[0]["valor"])) == 50.0, lancs
+    texto = f"{lancs[0].get('alvo') or ''} {lancs[0].get('nota') or ''}".lower()
+    assert "mercado" in texto, lancs[0]
+
+
+# ---------------------------------------------------------------------------
+# Rodada 4 — o passo 1 nas portas 2 (clarification) e 3 (multi_launch).
+# (A numeração das quatro portas é a de `core/intent_router.py`.)
+#
+# O que separa "gastei 132" (paga) de "apagar 42" (abandona) não é a forma —
+# as duas têm um número — é o intent. A tabela de duas colunas da porta de
+# conta variável está em `tests/test_bill_amount_pending.py`; aqui ficam as
+# duas portas cujo cenário mora neste arquivo.
+# ---------------------------------------------------------------------------
+
+# Comandos com valor dentro: sem o passo 1 eles REGISTRAM dinheiro.
+COMANDOS_COM_NUMERO = ["quanto gastei em 132", "apagar 42"]
+COMANDOS_SEM_NUMERO = ["saldo", "extrato", "resumo do mes"]
+# O BLOQUEANTE: `credit.handle` 0.95, resposta legítima. Com a blacklist da
+# rodada anterior, isto apagava a fila INTEIRA do multi-lançamento.
+RESPOSTAS_QUE_PARECEM_COMANDO = [("132 no cartao", 132.0), ("investi 80", 80.0)]
+
+
+@pytest.mark.parametrize("comando", COMANDOS_COM_NUMERO + COMANDOS_SEM_NUMERO)
+def test_clarification_abandona_comando_mesmo_com_numero(pro_uid, spy_ai, comando):
+    """Porta 2 — "apagar 42" lançava R$ 42,00 na *luz*."""
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    resp = _send(uid, comando)
+
+    assert "Quanto foi no *luz*?" not in resp, resp
+    assert not db.list_launches(uid, limit=5), \
+        f"{comando!r} registrou dinheiro: {db.list_launches(uid, limit=5)}"
+    pend = _pendencia(uid)
+    assert pend is None or pend["action_type"] != "clarification", pend
+
+
+@pytest.mark.parametrize("comando", COMANDOS_COM_NUMERO + COMANDOS_SEM_NUMERO)
+def test_multi_launch_abandona_comando_mesmo_com_numero(free_uid, spy_ai, comando):
+    """Porta 3 — mesma tabela, mesma fonte de verdade."""
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    resp = _send(uid, comando)
+
+    assert "Faltou o valor" not in resp, resp
+    assert not db.list_launches(uid, limit=5), \
+        f"{comando!r} registrou dinheiro: {db.list_launches(uid, limit=5)}"
+    pend = _pendencia(uid)
+    assert pend is None or pend["action_type"] != "multi_launch_values", pend
+
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132 reais", 132.0), ("50 pila", 50.0), ("10 mil", 10000.0),
+])
+def test_multi_launch_continua_registrando_o_valor(free_uid, spy_ai, resposta, esperado):
+    """Coluna 1 da porta 3: o passo 1 não pode sequestrar a resposta certa.
+
+    As três classificam `launches.add` 0.95, que NÃO está no `ABANDONA` — o
+    conjunto é mundo fechado. Se algum intent de valor entrar lá, a fila é
+    largada e o dinheiro some.
+    """
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs and abs(float(lancs[0]["valor"])) == esperado, (resposta, lancs)
+
+
+# ---------------------------------------------------------------------------
+# C3 — número solto respondido a uma pergunta de DESCRIÇÃO.
+#
+# A pergunta "em que você gastou?" já tem o valor; a resposta é a descrição.
+# O `parse_money` cola dois grupos de dígitos separados por espaço, então o
+# combinado "gastei 50 0" virava R$ 500,00 — dinheiro inventado, e nenhum teste
+# pegava. A `main` acertava por acidente (parseava a resposta como valor).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("resposta", ["0", "20 no mercado", "mercado 20", "1"])
+def test_clarification_de_descricao_nao_infla_o_valor_ja_digitado(pro_uid, spy_ai, resposta):
+    """Os R$ 50 já digitados não podem crescer por causa da descrição."""
+    uid = pro_uid
+    import db
+    assert "gastou" in _send(uid, "gastei 50").lower()
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, f"{resposta!r} não registrou nada"
+    assert abs(float(lancs[0]["valor"])) == 50.0, (resposta, lancs[0])
+
+
+def test_controle_negativo_sem_o_separador_a_descricao_infla_o_valor(pro_uid, spy_ai, monkeypatch):
+    """Desligar o " - " tem que ressuscitar o R$ 500,00.
+
+    Injetado no caso verde
+    `test_clarification_de_descricao_nao_infla_o_valor_ja_digitado[0]`. O
+    interruptor é o `_execute`: aqui ele recebe o combinado que o separador
+    deveria ter protegido, e o teste reconstrói o combinado antigo.
+    """
+    import core.intent_router as IR
+
+    real = IR._execute
+
+    def sem_separador(intent, user_id, text, *a, **k):
+        return real(intent, user_id, text.replace(" - ", " "), *a, **k)
+
+    monkeypatch.setattr(IR, "_execute", sem_separador)
+
+    uid = pro_uid
+    import db
+    _send(uid, "gastei 50")
+    _send(uid, "0")
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs and abs(float(lancs[0]["valor"])) == 500.0, \
+        f"sem o separador o combinado 'gastei 50 0' TINHA que virar R$ 500,00: {lancs}"
+
+
+# ---------------------------------------------------------------------------
+# O BLOQUEANTE da rodada anterior, nas portas 2 e 3: resposta de valor que
+# classifica como comando. `classify("132 no cartao")` é `credit.handle` 0.95 e
+# `classify("investi 80")` é `investments.deposit` 0.95 — nenhum dos dois está
+# no `ABANDONA`, que é mundo fechado.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("resposta,esperado", RESPOSTAS_QUE_PARECEM_COMANDO)
+def test_multi_launch_nao_perde_a_fila_com_resposta_que_parece_comando(
+        free_uid, spy_ai, resposta, esperado):
+    """Com a blacklist, isto apagava a fila INTEIRA e não registrava nada."""
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs and abs(float(lancs[0]["valor"])) == esperado, (resposta, lancs)
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "multi_launch_values", \
+        f"{resposta!r} apagou a fila: {pend}"
+    assert [i["desc"] for i in pend["payload"]["queue"]] == ["luz"], pend
+
+
+def test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando(
+        pro_uid, spy_ai):
+    """Porta 2, com `investi 80` (`investments.deposit` 0.95).
+
+    `132 no cartao` fica FORA desta metade por medição, não por esquecimento:
+    nas duas árvores (`main` cf54ffb e este branch) o combinado
+    "gastei 132 no cartao a luz" é lido como compra no cartão e responde
+    "Não achei o cartão 'a luz'", sem registrar nada. É o mesmo defeito
+    pré-existente do `xfail` de `cartao` em
+    `test_clarification_de_descricao_nao_perde_o_valor_ja_digitado`, e o
+    conserto é do fluxo de crédito. O que este PR precisa garantir aqui é que
+    a pergunta não seja LARGADA pelo passo 1 — está no teste da porta 3, onde a
+    fila sobrevive.
+    """
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    _send(uid, "investi 80")
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs, "'investi 80' perdeu a pergunta e não registrou nada"
+    assert abs(float(lancs[0]["valor"])) == 80.0, lancs[0]
+
+
+def test_controle_negativo_credit_handle_no_conjunto_apaga_a_fila(free_uid, spy_ai, monkeypatch):
+    """Pôr `credit.handle` no `ABANDONA` tem que reproduzir o bloqueante.
+
+    Injetado no caso verde
+    `test_multi_launch_nao_perde_a_fila_com_resposta_que_parece_comando`.
+    """
+    import core.intent_router as IR
+    import db
+
+    monkeypatch.setattr(IR, "ABANDONA", IR.ABANDONA | {"credit.handle"})
+
+    uid = free_uid
+    _fila_de_dois(uid)
+
+    _send(uid, "132 no cartao")
+
+    assert not db.list_launches(uid, limit=5), "com credit.handle no conjunto nada registra"
+    pend = _pendencia(uid)
+    assert pend is None or pend["action_type"] != "multi_launch_values", \
+        f"a fila TINHA que ter sido apagada: {pend}"
+
+
+def test_passo_1_da_porta_3_nao_apaga_pergunta_de_outra_tarefa(free_uid, spy_ai, monkeypatch):
+    """O abandono da porta 3 é CAS, não `clear_pending_action`.
+
+    `pending_actions` é UMA linha por usuário: entre o `route()` ler a fila e o
+    handler abandoná-la, outra tarefa pode ter posto ali uma pergunta nova —
+    que já apareceu na tela. `clear_pending_action` a apaga por cima e deixa o
+    usuário respondendo a uma pergunta que não existe mais. A corrida é
+    injetada no próprio predicado, que roda no call site logo antes.
+    """
+    import core.intent_router as IR
+    import db
+
+    uid = free_uid
+    _fila_de_dois(uid)
+
+    nova = {"bill_id": 99, "name": "Internet"}
+    real = IR.abandona_pergunta_de_valor
+
+    def com_corrida(texto):
+        decidiu = real(texto)
+        if decidiu:
+            db.set_pending_action(uid, "bill_pay_amount", nova)
+        return decidiu
+
+    monkeypatch.setattr(IR, "abandona_pergunta_de_valor", com_corrida)
+
+    _send(uid, "apagar 42")
+
+    atual = db.get_pending_action(uid) or {}
+    assert atual.get("action_type") == "bill_pay_amount", \
+        f"o passo 1 apagou a pergunta mais nova: {atual}"
+    assert atual.get("payload") == nova, atual
+
+
+# ---------------------------------------------------------------------------
+# BLOQUEANTE 1 da rodada final, na porta 3: o `limpa_pontuacao_final` ia só
+# para o `_extract_valor` e o `valor_perigoso` recebia o texto CRU. Sem
+# vírgula, o `agrupamento_de_milhar_ok("132.")` via `["132", ""]` — grupo vazio,
+# `len 0` ∉ (1,2,3) — e recusava o que a `main` registrava. O teste de ponto
+# final que já existia aqui só cobria "132,50.", COM vírgula, que é outro ramo.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("resposta,esperado", [
+    ("132.", 132.0), ("1.500.", 1500.0),
+    ("foi 132.", 132.0), ("paguei 132.  ", 132.0),
+])
+def test_multi_launch_ponto_final_sem_virgula_registra(free_uid, spy_ai, resposta, esperado):
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=5)
+    assert lancs and abs(float(lancs[0]["valor"])) == esperado, (resposta, lancs)
+
+
+@pytest.mark.parametrize("resposta", ["132.", "1.500.", "foi 132.", "paguei 132.  "])
+def test_controle_negativo_porta_3_sem_limpar_a_pontuacao_recusa(
+        free_uid, spy_ai, monkeypatch, resposta):
+    """Controle: desliga a limpeza e os quatro casos verdes ficam vermelhos.
+
+    O `import` da porta 3 é local, então o alvo é o `utils_text`.
+    """
+    import db
+    import utils_text
+
+    uid = free_uid
+    _fila_de_dois(uid)
+    monkeypatch.setattr(utils_text, "limpa_pontuacao_final", lambda s: s or "")
+
+    resp = _send(uid, resposta)
+
+    assert "Não entendi o valor" in resp, (resposta, resp)
+    assert not db.list_launches(uid, limit=5), db.list_launches(uid, limit=5)
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "multi_launch_values", pend

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -880,3 +880,201 @@ def test_controle_negativo_porta_3_sem_limpar_a_pontuacao_recusa(
     assert not db.list_launches(uid, limit=5), db.list_launches(uid, limit=5)
     pend = _pendencia(uid)
     assert pend and pend["action_type"] == "multi_launch_values", pend
+
+
+# ---------------------------------------------------------------------------
+# Rodada 5: PROSA. O buraco de teste que deixou passar as quatro rodadas
+# anteriores — todas a mesma classe ("o filtro de dano recusa entrada que a
+# `main` aceita"), todas descobertas por revisor e não por teste.
+#
+# O motivo é sempre o mesmo: os casos testavam o NÚMERO SOZINHO. O fuzz de
+# 42.157 entradas da rodada 3 varreu o alfabeto `0-9 , .` — sem uma palavra
+# sequer. Prefixo e sufixo de prosa nunca entraram, e é exatamente ali que os
+# quatro defeitos moravam:
+#
+#   rodada 2  "132, 50"                espaço depois do separador decimal
+#   rodada 4  "132."                   ponto final sem vírgula
+#   rodada 5  "paguei 132 - da luz"    traço de prosa lido como sinal negativo
+#   rodada 5  "paguei 132. foi isso"   ponto de prosa lido como milhar torto
+#
+# Este bloco fecha o buraco com o produto cartesiano prefixo × número × sufixo.
+# Medido em duas colunas contra a `main` `e8b9875` (1.572 células, quatro
+# portas): zero células em que a `main` aceita e o branch recusa, zero em que
+# os dois aceitam com valores diferentes. As divergências que sobraram são as
+# duas intencionais — o perigoso que o PR aperta, e o `132,50.` que a `main`
+# paga como R$ 13.250,00.
+#
+# A varredura vive na porta 3 porque `valor_perigoso` e `limpa_pontuacao_final`
+# são compartilhados pelas quatro; as outras entram logo abaixo com os
+# reprodutores, que é onde a ACEITAÇÃO de cada porta difere.
+# ---------------------------------------------------------------------------
+
+_PREFIXOS = ["", "paguei ", "acho que foi "]
+_NUMEROS = [("132", 132.0), ("132,50", 132.5), ("1.234,56", 1234.56),
+            ("1 500", 1500.0), ("10 mil", 10000.0)]
+# " -" fica de FORA de propósito: traço que TERMINA a expressão é sinal
+# negativo ("132 -"), e continua recusado — ver `_PROSA_PERIGOSA` abaixo.
+_SUFIXOS = ["", " da luz", " - da luz", " — luz", ". foi isso", " no mercado",
+            ", foi isso", " reais", ".", " total"]
+
+
+def _novo_free_uid() -> int:
+    import uuid as _uuid
+    import db as _db
+    uid = int(_uuid.uuid4().int % 1_000_000_000)
+    _db.ensure_user(uid)
+    return uid
+
+
+def test_corpus_de_prosa_registra_o_valor_certo(spy_ai):
+    """150 células de prosa na porta 3: nenhuma recusa, nenhum valor torto."""
+    import db
+
+    falhas = []
+    for prefixo in _PREFIXOS:
+        for numero, esperado in _NUMEROS:
+            for sufixo in _SUFIXOS:
+                texto = f"{prefixo}{numero}{sufixo}"
+                uid = _novo_free_uid()
+                _fila_de_dois(uid)
+                resp = _send(uid, texto)
+                lancs = db.list_launches(uid, limit=1)
+                valor = abs(float(lancs[0]["valor"])) if lancs else None
+                if valor != esperado:
+                    falhas.append((texto, esperado, valor, resp[:60]))
+    assert not falhas, f"{len(falhas)}/150 células: {falhas[:8]}"
+
+
+# Os reprodutores exatos dos dois P2 da rodada 5, mais o terceiro que a
+# varredura achou sozinha (traço ANTES do número), nas portas 2 e 4 — as duas
+# que têm aceitação própria.
+_PROSA = [("paguei 132 - da luz", 132.0), ("132 — luz", 132.0),
+          ("gastei 50 - mercado", 50.0), ("luz - 132", 132.0),
+          ("paguei 132. foi isso", 132.0), ("132. da luz", 132.0),
+          ("paguei 132,50. foi isso", 132.5), ("1.234,56, foi isso", 1234.56)]
+
+
+@pytest.mark.parametrize("resposta,esperado", _PROSA)
+def test_clarification_prosa_registra_o_valor_certo(pro_uid, spy_ai, resposta, esperado):
+    """Porta 2. `gastei 50 - mercado` é o " - " que ESTE PR pôs no combinado."""
+    uid = pro_uid
+    import db
+    _pergunta_de_valor(uid)
+
+    _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=1)
+    assert lancs, f"{resposta!r} não registrou nada"
+    assert abs(float(lancs[0]["valor"])) == esperado, (resposta, lancs[0])
+
+
+@pytest.mark.parametrize("resposta,esperado", _PROSA)
+def test_botao_ja_paguei_prosa_paga_o_valor_certo(monkeypatch, resposta, esperado):
+    """Porta 4, pelo `process_message` real — a que roda antes do handler."""
+    import uuid
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    from tests.test_bill_amount_pending import (_monta_conta_variavel,
+                                                _manda_texto_no_wa,
+                                                _toca_ja_paguei)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    respostas = _manda_texto_no_wa(monkeypatch, uid, resposta)
+
+    paga = B.list_bills(uid, include_paid=True)[0]
+    assert paga["status"] == "paid", (resposta, respostas)
+    assert float(paga["paid_amount"]) == esperado, (resposta, paga)
+
+
+# --- Controles negativos, um por CAUSA, injetados em caso VERDE -------------
+
+@pytest.mark.parametrize("resposta", ["paguei 132 - da luz", "132 — luz",
+                                      "gastei 50 - mercado", "luz - 132"])
+def test_controle_negativo_traco_de_prosa_como_sinal_recusa(
+        free_uid, spy_ai, monkeypatch, resposta):
+    """Volta a regra antiga do sinal: os quatro casos verdes ficam vermelhos.
+
+    A regra antiga era "traço de qualquer lado do bloco = negativo", e ela
+    cobria as duas metades: o traço DEPOIS ("paguei 132 - da luz") e o traço
+    ANTES ("luz - 132"), que o Codex não apontou e a varredura achou.
+    """
+    import db
+    import re as _re
+    import utils_text
+
+    real = utils_text.valor_perigoso
+
+    def regra_antiga(texto, valor):
+        t = (texto or "").translate(utils_text._TRACOS)
+        bloco = utils_text._BLOCO_NUM_RE.search(t)
+        if bloco:
+            antes = _re.sub(r"r\$\s*$", "", t[:bloco.start()].rstrip(),
+                            flags=_re.I).rstrip().lower()
+            if antes.endswith("-") or t[bloco.end():].lstrip().startswith("-"):
+                return "nao_positivo"
+        return real(texto, valor)
+
+    uid = free_uid
+    _fila_de_dois(uid)
+    monkeypatch.setattr(utils_text, "valor_perigoso", regra_antiga)
+
+    resp = _send(uid, resposta)
+
+    assert "maior que zero" in resp, (resposta, resp)
+    assert not db.list_launches(uid, limit=5), db.list_launches(uid, limit=5)
+
+
+@pytest.mark.parametrize("resposta,inflado", [
+    ("paguei 132. foi isso", None), ("132. da luz", None),
+    ("paguei 132,50. foi isso", 13250.0), ("1.234,56, foi isso", None),
+])
+def test_controle_negativo_pontuacao_so_no_fim_da_mensagem(
+        free_uid, spy_ai, monkeypatch, resposta, inflado):
+    """Volta o `rstrip(" .!")` sozinho — que não alcança a prosa DEPOIS.
+
+    Dois estragos diferentes, e o controle prende os dois: sem vírgula o
+    número vira "milhar malformado" e a resposta é recusada (`inflado is
+    None`); com vírgula o `parse_money` lê a vírgula como milhar e registra
+    R$ 13.250,00 no lugar de R$ 132,50.
+    """
+    import db
+    import utils_text
+
+    uid = free_uid
+    _fila_de_dois(uid)
+    monkeypatch.setattr(utils_text, "limpa_pontuacao_final",
+                        lambda raw: (raw or "").rstrip(" .!"))
+
+    resp = _send(uid, resposta)
+
+    lancs = db.list_launches(uid, limit=1)
+    valor = abs(float(lancs[0]["valor"])) if lancs else None
+    assert valor == inflado, (resposta, resp[:80], lancs)
+
+
+# --- Controle positivo do aperto: o perigoso segue recusado, pergunta viva --
+
+_PROSA_PERIGOSA = [
+    ("132 -", "maior que zero"),      # traço que TERMINA a expressão = sinal
+    ("paguei 132 -", "maior que zero"),
+    ("(10)", "maior que zero"),       # negativo contábil
+    ("132 50 no mercado", "Não entendi o valor"),
+    ("paguei 1.23.456 da luz", "Não entendi o valor"),
+]
+
+
+@pytest.mark.parametrize("resposta,recusa", _PROSA_PERIGOSA)
+def test_prosa_perigosa_recusada_com_a_fila_viva(free_uid, spy_ai, resposta, recusa):
+    uid = free_uid
+    import db
+    _fila_de_dois(uid)
+
+    resp = _send(uid, resposta)
+
+    assert recusa in resp, (resposta, resp)
+    assert "Faltou o valor de *aluguel*" in resp, (resposta, resp)
+    assert not db.list_launches(uid, limit=5), db.list_launches(uid, limit=5)
+    pend = _pendencia(uid)
+    assert pend and pend["action_type"] == "multi_launch_values", pend

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -395,10 +395,12 @@ def test_clarification_de_recorrente_nao_vira_despesa_avulsa(pro_uid, spy_ai):
 # Porta 3 (numeração em `core/intent_router.py`): a fila do `multi_launch_values`
 # (`core/handlers/launches.py::resolve_multi_launch_value`).
 #
-# Usuário GRÁTIS de propósito: para o Pro a IA sequestra o turno antes
-# (`multi_launch_values` está fora de `_RESUMABLE_PENDING_TYPES`), e a porta
-# fica escondida. É esse mascaramento que fez a rodada 1 concluir, errado, que
-# ela não reproduzia.
+# Usuário GRÁTIS de propósito: quando estes casos foram escritos, para o Pro a
+# IA sequestrava o turno antes e a porta ficava escondida — é esse mascaramento
+# que fez a rodada 1 concluir, errado, que ela não reproduzia. O #142 fechou o
+# buraco (`multi_launch_values` ganhou `suprime_ia=True` no `_REGISTRO` de
+# `db/pending.py`, e `tests/test_pending_registry.py` prende isso pelo Pro),
+# então hoje o Grátis é só o caminho mais curto, não o único que enxerga.
 # ---------------------------------------------------------------------------
 
 @pytest.fixture

--- a/tests/test_valor_sinal.py
+++ b/tests/test_valor_sinal.py
@@ -1,0 +1,301 @@
+"""A TABELA-VERDADE do sinal, em forma executável.
+
+Fonte de verdade única (§0.7) da regra que já foi remendada TRÊS vezes neste
+PR — captura do `_VALOR_RE`, depois `endswith("-")`, depois "encosta nos
+dígitos / prefixo inteiro / termina". Cada remendo consertou uma forma e
+quebrou outra; o último aceitava `foi - 10` como R$ 10,00 positivo enquanto
+recusava `foi -10`.
+
+A tabela em prosa está no docstring de `utils_text._sinal_negativo`. Aqui ela é
+enumerada célula a célula, sobre os eixos que o remendo tratava como um só:
+
+    ANTES do bloco numérico : vazio · espaço · moeda · enchimento · verbo ·
+                              outro traço · combinações · palavra de CONTEÚDO
+    DEPOIS do bloco numérico: vazio · espaço · unidade · prosa · `)` ·
+                              traço terminal
+    TRAÇO                   : ASCII + as 9 grafias Unicode do `_TRACOS`,
+                              mais `menos` por extenso
+    COLADO × SEPARADO       : `-10` e `- 10` — MESMO veredito em toda linha,
+                              e é justamente aqui que a rodada 5 quebrou
+
+Este arquivo não toca no banco: exercita o predicado direto. O caminho real
+(as quatro portas, pelo `handle_incoming`/`process_message`) está em
+`tests/test_bill_amount_pending.py` e `tests/test_full_handler_smoke.py`.
+"""
+from __future__ import annotations
+
+import pytest
+
+import utils_text
+from utils_text import limpa_pontuacao_final, parse_money, valor_perigoso
+
+# As dez grafias que viram `-`. O bloco U+2010–U+2015 inteiro, o menos
+# matemático e os dois de largura plena.
+TRACOS = ["-"] + [chr(c) for c in range(0x2010, 0x2016)] + ["−", "﹣",
+                                                            "－"]
+
+# --- Eixo ANTES: o que precede o traço, e o veredito de cada classe ---------
+ANTES = [
+    ("", "sinal"),                 # linha 1  "-10"
+    ("  ", "sinal"),               # linha 2  "  - 10"
+    ("r$ ", "sinal"),              # linha 3  "r$ -10"
+    ("R$", "sinal"),               # linha 3  "R$-10" (sem espaço)
+    ("foi ", "sinal"),             # linha 4  enchimento
+    ("uns ", "sinal"),
+    ("deu ", "sinal"),
+    ("ai ", "sinal"),
+    ("paguei ", "sinal"),          # linha 5  verbo de lançamento
+    ("gastei ", "sinal"),
+    ("recebi ", "sinal"),
+    ("- ", "sinal"),               # linha 6  outro traço
+    ("foi r$ ", "sinal"),          # linha 7  combinação
+    ("acho que foi ", "sinal"),
+    ("luz ", "prosa"),             # linha 8  palavra de CONTEÚDO
+    ("mercado ", "prosa"),
+    ("foi luz ", "prosa"),         # conteúdo em QUALQUER posição antes
+    ("conta de luz ", "prosa"),
+]
+
+# --- Eixo DEPOIS do NÚMERO: não muda o veredito quando o traço vem antes ----
+DEPOIS = ["", " ", " reais", " pila", " da luz", " no mercado"]
+
+
+def _celulas_traco_antes():
+    for antes, classe in ANTES:
+        for traco in TRACOS:
+            for cola in ("", " "):          # colado × separado por espaço
+                for depois in DEPOIS:
+                    texto = f"{antes}{traco}{cola}10{depois}"
+                    yield texto, ("nao_positivo" if classe == "sinal" else None)
+
+
+# --- Eixo DEPOIS: o traço vem DEPOIS do número ------------------------------
+# Só a linha 9 (nada depois do traço) é sinal; qualquer conteúdo é prosa.
+DEPOIS_DO_TRACO = [
+    ("", "sinal"), (" ", "sinal"), ("  ", "sinal"),
+    (" luz", "prosa"), (" da luz", "prosa"), (" reais", "prosa"),
+    (" no mercado", "prosa"),
+]
+PREFIXOS = ["", "paguei ", "luz ", "acho que foi "]
+
+
+def _celulas_traco_depois():
+    for prefixo in PREFIXOS:
+        for traco in TRACOS:
+            for cola in ("", " "):
+                for depois, classe in DEPOIS_DO_TRACO:
+                    texto = f"{prefixo}132{cola}{traco}{depois}"
+                    yield texto, ("nao_positivo" if classe == "sinal" else None)
+
+
+# --- `menos` por extenso: mesmas regras do traço, com duas aproximações -----
+MENOS = [
+    ("menos 10", "nao_positivo"),
+    ("foi menos 10", "nao_positivo"),
+    ("paguei menos 10", "nao_positivo"),
+    ("menos10", "nao_positivo"),          # sem espaço: `\b` não pegava
+    ("menos R$ 10", "nao_positivo"),
+    ("luz menos 10", None),               # conteúdo antes → prosa (linha 8)
+    ("mais ou menos 10", None),           # aproximação, não sinal
+    ("foi mais ou menos 10", None),
+    ("menos de 10", None),                # "abaixo de 10"
+    ("menos que 10", None),
+    ("menosprezei 10", None),             # não é a palavra
+]
+
+# --- Parênteses: negativo contábil ------------------------------------------
+PARENTESES = [
+    ("(10)", "nao_positivo"),
+    ("foi (10)", "nao_positivo"),
+    ("R$ (10)", "nao_positivo"),
+    ("(- 10)", "nao_positivo"),
+    ("(10", None),                        # sem fechar não é notação
+]
+
+# --- Formas SEM traço que a tabela não pode passar a recusar ----------------
+SEM_TRACO_ACEITA = [
+    "132", "paguei 132", "R$ 132,50", "132, 50", "10 mil", "1 500",
+    "12 345", "1 000 000", "1.234,56", "0,50", "132.", "paguei 132. foi isso",
+    "1.234,56, foi isso", "132. da luz", "foi 132; da luz", "132 e 50",
+]
+
+# --- A 7ª forma: separador decimal SEM parte inteira ------------------------
+# `parse_money(",50")` é 50.0 — R$ 50,00 no lugar de R$ 0,50, 100x. Achado
+# nesta rodada, não pelo revisor.
+SEM_PARTE_INTEIRA = [",50", ".50", "R$ ,50", "R$ .50", "foi ,50", "paguei .50"]
+
+# --- As outras formas de `nao_entendi`, para os controles negativos ---------
+AMBIGUAS = ["132 50", "paguei 132 50", "1.23.456", "paguei 1.23.456 da luz",
+            "1.2.3", "132 50 reais"]
+
+
+def _perigo(texto: str) -> str | None:
+    return valor_perigoso(texto, parse_money(limpa_pontuacao_final(texto)))
+
+
+# ---------------------------------------------------------------------------
+# A tabela
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("texto,esperado", list(_celulas_traco_antes()))
+def test_tabela_traco_antes_do_numero(texto, esperado):
+    assert _perigo(texto) == esperado, repr(texto)
+
+
+@pytest.mark.parametrize("texto,esperado", list(_celulas_traco_depois()))
+def test_tabela_traco_depois_do_numero(texto, esperado):
+    assert _perigo(texto) == esperado, repr(texto)
+
+
+@pytest.mark.parametrize("texto,esperado", MENOS + PARENTESES)
+def test_tabela_menos_e_parenteses(texto, esperado):
+    assert _perigo(texto) == esperado, repr(texto)
+
+
+@pytest.mark.parametrize("texto", SEM_TRACO_ACEITA)
+def test_tabela_sem_traco_nao_vira_perigoso(texto):
+    assert _perigo(texto) is None, repr(texto)
+
+
+@pytest.mark.parametrize("texto", SEM_PARTE_INTEIRA)
+def test_separador_decimal_sem_parte_inteira_repergunta(texto):
+    """7ª forma. Sem a guarda o valor é 100x maior — a asserção do meio mede."""
+    assert parse_money(limpa_pontuacao_final(texto)) == 50.0, texto
+    assert _perigo(texto) == "nao_entendi", repr(texto)
+
+
+@pytest.mark.parametrize("texto", AMBIGUAS)
+def test_tabela_digitacao_ambigua(texto):
+    assert _perigo(texto) == "nao_entendi", repr(texto)
+
+
+# ---------------------------------------------------------------------------
+# Os reprodutores exatos do P2 desta rodada, em linha própria: com enchimento
+# ou verbo na frente e o sinal separado por espaço, `cru` terminava em `"- "` e
+# `antes` em `"foi -"` — os dois escapavam das condições empilhadas.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("texto", ["foi - 10", "deu − 10", "uns - 10",
+                                   "paguei - 10", "gastei - 10", "ai - 10",
+                                   "acho que foi - 10", "foi r$ - 10"])
+def test_regressao_enchimento_com_sinal_separado(texto):
+    assert _perigo(texto) == "nao_positivo", repr(texto)
+
+
+# ---------------------------------------------------------------------------
+# Controles negativos, um por CLASSE de célula. Cada um desliga UMA regra e a
+# asserção é dupla: as células daquela classe caem, as das OUTRAS classes não.
+# ---------------------------------------------------------------------------
+
+def test_controle_negativo_regra_do_sinal_desligada(monkeypatch):
+    """Sem a tabela do sinal, TODA célula de sinal vira aceita.
+
+    E nenhuma célula de ponto/espaço/parte-inteira muda — é isso que separa a
+    regra do sinal das outras três.
+    """
+    monkeypatch.setattr(utils_text, "_sinal_negativo", lambda antes, depois: False)
+
+    sinal = [t for t, e in list(_celulas_traco_antes()) + list(_celulas_traco_depois())
+             if e == "nao_positivo"]
+    assert sinal, "a tabela ficou sem célula de sinal"
+    ainda_recusados = [t for t in sinal if _perigo(t) is not None]
+    assert not ainda_recusados, ainda_recusados[:5]
+
+    # as outras classes seguem intactas
+    for t in AMBIGUAS + SEM_PARTE_INTEIRA:
+        assert _perigo(t) == "nao_entendi", t
+    for t in ("0", "0,001"):
+        assert _perigo(t) == "nao_positivo", t
+
+
+def test_controle_negativo_regra_de_prosa_desligada(monkeypatch):
+    """Volta o "traço de qualquer lado = sinal": as células de PROSA caem.
+
+    Foi a regra da rodada 4, e ela recusava `luz - 132` e `132 — luz`, que a
+    `main` paga.
+    """
+    monkeypatch.setattr(
+        utils_text, "_sinal_negativo",
+        lambda antes, depois: "-" in antes or depois.lstrip().startswith("-"))
+
+    prosa = [t for t, e in list(_celulas_traco_antes()) + list(_celulas_traco_depois())
+             if e is None]
+    assert prosa, "a tabela ficou sem célula de prosa"
+    caidos = [t for t in prosa if _perigo(t) == "nao_positivo"]
+    assert len(caidos) == len(prosa), (len(caidos), len(prosa), prosa[:3])
+
+    # ponto e espaço não dependem desta regra
+    for t in AMBIGUAS + SEM_PARTE_INTEIRA:
+        assert _perigo(t) == "nao_entendi", t
+
+
+def test_controle_negativo_colado_e_separado_como_casos_diferentes(monkeypatch):
+    """A formulação DOS TRÊS REMENDOS, reinjetada: `foi - 10` volta a passar.
+
+    `cru.endswith("-")` (colado) + prefixo inteiro + traço terminal. É a versão
+    que estava no branch antes desta rodada, e o controle prova que a diferença
+    entre ela e a tabela não é cosmética.
+    """
+    import re as _re
+
+    def remendo(antes, depois):
+        limpo = _re.sub(r"r\$", "", antes).strip()
+        return (antes.endswith("-") or limpo == "-" or depois.rstrip() == "-"
+                or (antes.rstrip().endswith("(") and depois.lstrip().startswith(")")))
+
+    monkeypatch.setattr(utils_text, "_sinal_negativo", remendo)
+
+    passam = [t for t in ("foi - 10", "deu − 10", "uns - 10", "paguei - 10")
+              if _perigo(t) is None]
+    assert passam == ["foi - 10", "deu − 10", "uns - 10", "paguei - 10"], passam
+
+
+def test_controle_negativo_lista_de_cinco_tracos(monkeypatch):
+    """A lista de cinco grafias deixava `‒` (U+2012) e `―` (U+2015) passarem."""
+    cinco = str.maketrans({"−": "-", "–": "-", "—": "-",
+                           "‐": "-", "‑": "-"})
+    monkeypatch.setattr(utils_text, "_TRACOS", cinco)
+
+    assert _perigo("‒10") is None       # figure dash escapava
+    assert _perigo("―10") is None       # horizontal bar escapava
+    assert _perigo("–10") == "nao_positivo"   # en dash já era pego
+
+
+# ---------------------------------------------------------------------------
+# §0.7: as listas duplicadas comparadas por teste
+# ---------------------------------------------------------------------------
+
+def test_enchimento_do_valor_re_vem_da_mesma_lista():
+    """O `_VALOR_RE` da porta 1 e o `_sinal_negativo` dividem `_ENCHIMENTO`."""
+    import core.handlers.bills as bills
+
+    assert bills._ENCHIMENTO is utils_text._ENCHIMENTO
+    for palavra in utils_text._ENCHIMENTO_PALAVRAS:
+        assert palavra in utils_text._SEM_CONTEUDO, palavra
+        assert bills._VALOR_RE.fullmatch(f"{palavra} 132"), palavra
+
+
+def test_verbos_de_lancamento_nao_divergiram_das_outras_duas_copias():
+    """Duplicação inevitável (§0.7) → um teste compara as três.
+
+    `core.intent_router` corta os MESMOS 12 do prefixo da descrição;
+    `parsers._extract_target_after_amount` usa um SUPERSET, porque lá o
+    trabalho é outro (tirar o verbo de um texto que já tem valor).
+    """
+    import inspect
+    import re
+
+    import core.intent_router as router
+    import parsers
+
+    def verbos(fonte: str) -> set[str]:
+        m = re.search(r"\^\\s\*\(([a-z|]+)\)\\b", fonte)
+        assert m, fonte[:200]
+        return set(m.group(1).split("|"))
+
+    nossos = set(utils_text._VERBOS_LANCAMENTO)
+    do_router = verbos(inspect.getsource(router._resolve_clarification))
+    do_parsers = verbos(inspect.getsource(parsers._extract_target_after_amount))
+
+    assert nossos == do_router, nossos ^ do_router
+    assert nossos <= do_parsers, nossos - do_parsers

--- a/tests/test_whatsapp_confirmations.py
+++ b/tests/test_whatsapp_confirmations.py
@@ -81,7 +81,7 @@ def test_autolink_com_comando_nao_interrompe_para_boas_vindas(monkeypatch):
         lambda to, body, user_id=None: replies.append((to, body, user_id)),
     )
 
-    def fake_handle_incoming(msg):
+    def fake_handle_incoming(msg, **_kw):   # o runtime pode passar `ignora_pendencias`
         handled.append(msg)
         return [OutgoingMessage(text=f"uid={msg.user_id} text={msg.text}")]
 
@@ -171,7 +171,7 @@ def test_numero_sem_conta_com_codigo_de_vinculo_passa_pro_handler(monkeypatch):
         lambda to, body, user_id=None: replies.append((to, body, user_id)),
     )
 
-    def fake_handle_incoming(msg):
+    def fake_handle_incoming(msg, **_kw):   # o runtime pode passar `ignora_pendencias`
         handled.append(msg)
         return [OutgoingMessage(text="✅ WhatsApp vinculado!")]
 

--- a/utils_text.py
+++ b/utils_text.py
@@ -896,8 +896,45 @@ _BLOCO_NUM_RE = re.compile(r"\d[\d.,\s]*")
 # `endswith("-")`, mas `−10` (U+2212, o que o teclado do iOS e o Whisper
 # produzem), `–10` (en dash do autocorretor) e `‑10` (hífen não-quebrável de
 # texto colado) passavam e pagavam R$ 10,00 — `parse_money` ignora o sinal.
-_TRACOS = str.maketrans({"\u2212": "-", "\u2013": "-", "\u2014": "-",
-                         "\u2010": "-", "\u2011": "-"})
+#
+# O BLOCO U+2010–U+2015 inteiro, não uma lista de cinco: a lista anterior
+# pulava o U+2012 (figure dash) e o U+2015 (horizontal bar), e medido
+# `que ‒ 10` pagava R$ 10,00 positivo enquanto `que – 10` era recusado. Mais o
+# menos matemático U+2212 (que é `Sm`, não `Pd`) e as duas formas de largura
+# variante do teclado CJK, U+FE63 (small) e U+FF0D (fullwidth). Dez ao todo.
+_TRACOS = str.maketrans(dict.fromkeys(
+    [chr(c) for c in range(0x2010, 0x2016)] + ["\u2212", "\ufe63", "\uff0d"],
+    "-"))
+
+# Enchimento falado antes do número: "foi 132", "acho que 132", "uns 132".
+# FONTE ÚNICA das duas perguntas que dependem dela: `core.handlers.bills` monta
+# o `_VALOR_RE` (a aceitação da porta 1) com esta lista, e o `_sinal_negativo`
+# abaixo a usa para decidir se o que vem antes de um traço é conteúdo. Divergir
+# faz `foi - 10` voltar a pagar R$ 10,00 positivo.
+_ENCHIMENTO_PALAVRAS = ("foi", "era", "eh", "e", "de", "da", "do", "deu",
+                        "veio", "custou", "saiu", "ficou", "acho", "que", "uns",
+                        "umas", "um", "uma", "tipo", "mais", "ou", "menos",
+                        "deve", "ter", "dado", "ai")
+_ENCHIMENTO = "(?:%s)" % "|".join(_ENCHIMENTO_PALAVRAS)
+# Verbos que ABREM um lançamento. Também não são conteúdo para efeito de sinal:
+# "paguei - 10" é R$ -10, não "paguei — 10". Mesmos 12 do prefixo que o
+# `core.intent_router._resolve_clarification` corta da descrição; o
+# `parsers._extract_target_after_amount` tem um SUPERSET (inclui "entrou",
+# "caiu", "somei"…) porque lá o trabalho é outro. `test_valor_sinal.py`
+# compara as três listas.
+_VERBOS_LANCAMENTO = ("gastei", "gasto", "paguei", "pagar", "comprei",
+                      "debitei", "mandei", "enviei", "pixei", "recebi",
+                      "receita", "ganhei")
+# O que pode preceder um traço sem tirar dele o papel de sinal.
+_SEM_CONTEUDO = (frozenset(_ENCHIMENTO_PALAVRAS) | frozenset(_VERBOS_LANCAMENTO)
+                 | {"r$", "rs"})
+# "menos 10" é sinal com as MESMAS regras do traço, então vira um traço antes
+# de a tabela rodar — em vez de virar mais uma condição empilhada. Duas
+# exceções, as duas medidas e as duas APROXIMAÇÃO, não sinal: "mais ou menos
+# 10" (por volta de 10) e "menos de/que 10" (abaixo de 10).
+# `(?![a-z])` no lugar do `\b` do fim: "menos10" (sem espaço) não tem
+# boundary entre "s" e "1", e medido ele pagava R$ 10,00 positivo.
+_MENOS_RE = re.compile(r"(?<!\bou )\bmenos(?![a-z])(?!\s+(?:de|que)\b)")
 
 
 def limpa_pontuacao_final(raw: str) -> str:
@@ -1013,6 +1050,71 @@ def _espaco_ambiguo(bloco: str) -> bool:
                for anterior, p in zip(partes, partes[1:]) if p[:1].isdigit())
 
 
+def _sinal_negativo(antes: str, depois: str) -> bool:
+    r"""TABELA-VERDADE do sinal: o traço é SINAL ou é separador de PROSA?
+
+    `antes` e `depois` são o que sobra dos dois lados do bloco numérico, já em
+    minúsculas, com as grafias de traço normalizadas para `-` (`_TRACOS`) e com
+    o `menos` por extenso já virado `-` (`_MENOS_RE`). O `parse_money` IGNORA o
+    sinal — `parse_money("-10")` é 10.0 —, então quem decide é esta tabela.
+
+    Ela substitui três remendos que trataram "colado nos dígitos", "prefixo
+    inteiro" e "termina a expressão" como casos diferentes. Cada remendo
+    consertou uma forma e quebrou outra; o último aceitava `foi - 10` como
+    R$ 10,00 positivo e recusava `foi -10`.
+
+    | # | traço  | o que o cerca                     | veredito | exemplo               |
+    |---|--------|-----------------------------------|----------|-----------------------|
+    | 1 | ANTES  | nada                              | SINAL    | `-10`, `- 10`         |
+    | 2 | ANTES  | só espaço                         | SINAL    | `  - 10`              |
+    | 3 | ANTES  | moeda                             | SINAL    | `R$ -10`, `R$ - 10`   |
+    | 4 | ANTES  | enchimento (`_ENCHIMENTO`)        | SINAL    | `foi - 10`, `uns − 10`|
+    | 5 | ANTES  | verbo (`_VERBOS_LANCAMENTO`)      | SINAL    | `paguei - 10`         |
+    | 6 | ANTES  | outro traço                       | SINAL    | `- - 10`, `--10`      |
+    | 7 | ANTES  | combinação de 2-6                 | SINAL    | `foi r$ - 10`         |
+    | 8 | ANTES  | palavra de CONTEÚDO, em qualquer  | prosa    | `luz - 132`,          |
+    |   |        | posição antes do número           |          | `foi - luz 132`       |
+    | 9 | DEPOIS | nada depois do traço              | SINAL    | `132 -`, `10-`, `132 --` |
+    |10 | DEPOIS | qualquer coisa depois do traço    | prosa    | `132 — luz`,          |
+    |   |        |                                   |          | `foi 132 - da luz`    |
+    |11 | ()     | `(` antes e `)` depois            | SINAL    | `(10)`, `foi (10)`    |
+
+    DOIS EIXOS QUE NÃO SÃO EIXOS, e é por isso que os remendos falharam:
+
+    - **colado × separado por espaço**: `-10` e `- 10` têm o MESMO veredito em
+      toda linha. Tratá-los como casos diferentes foi a regressão da rodada 5.
+    - **o que vem depois do NÚMERO** (vazio · espaço · unidade `reais`/`pila` ·
+      prosa `da luz` · `)`): só importa na linha 9/11. Com o traço ANTES,
+      `- 10`, `- 10 reais` e `- 10 da luz` são os três sinal.
+
+    FORMULAÇÃO EM UMA FRASE — o traço é SINAL quando nada de CONTEÚDO o separa
+    do número, de um lado ou do outro: antes dele só espaço, moeda, enchimento
+    ou verbo (linhas 1-7); depois dele, nada (linha 9).
+
+    Isto NÃO é a formulação do plano ("separador de prosa quando uma palavra de
+    conteúdo vem antes dele **e** há conteúdo depois do número"): aquele **e**
+    não fecha a célula `luz - 132`, que não tem nada depois do número e mesmo
+    assim é prosa (a `main` paga R$ 132,00 e o teste
+    `test_clarification_prosa_registra_o_valor_certo` prende). A condição
+    "conteúdo depois" vale só para o traço que vem DEPOIS do número, onde ela é
+    a linha 10 — por isso a tabela separa por POSIÇÃO em vez de somar as duas.
+
+    TETO conhecido: `luz -132` é prosa por esta tabela (linha 8) e paga
+    R$ 132,00. A `main` também paga, e "conteúdo antes" foi a regra escolhida;
+    se um dia o colado tiver que ganhar do conteúdo, mude a linha 8, não
+    acrescente uma 12ª.
+    """
+    # Linha 9: só traço depois do número (um ou vários), nada mais.
+    if depois.strip() and set(depois.strip()) == {"-"}:
+        return True
+    # Linha 11: negativo contábil.
+    if antes.rstrip().endswith("(") and depois.lstrip().startswith(")"):
+        return True
+    # Linhas 1-8. Parênteses não são tokens (senão `(- 10)` escapava da 6).
+    tokens = re.findall(r"-|[^\s\-()]+", antes)
+    return "-" in tokens and all(t == "-" or t in _SEM_CONTEUDO for t in tokens)
+
+
 def valor_perigoso(texto: str, valor: float | None) -> str | None:
     """"Este valor vira dinheiro errado?" — o predicado de dano das 4 portas.
 
@@ -1026,9 +1128,12 @@ def valor_perigoso(texto: str, valor: float | None) -> str | None:
       seria recusado lá no `mark_bill_paid`, DEPOIS de a pendência ter sido
       reivindicada, virando "erro interno" para o usuário);
     - `"nao_entendi"` — o texto fala de um valor mas QUAL valor é ambíguo
-      ("132 50" -> 13.250, "1.23.456" -> 123.456). O bot ACABOU de pedir um
-      número, então isso é digitação errada: quem chama re-pergunta em vez de
-      abandonar a pergunta.
+      ("132 50" -> 13.250, "1.23.456" -> 123.456, ",50" -> 50 em vez de 0,50).
+      O bot ACABOU de pedir um número, então isso é digitação errada: quem
+      chama re-pergunta em vez de abandonar a pergunta.
+
+    Quem decide `"nao_positivo"` por causa de um traço é a TABELA-VERDADE do
+    `_sinal_negativo` acima — não uma condição empilhada aqui.
 
     NÃO impõe aceitação: um texto sem valor nenhum ("saldo") devolve `None`
     daqui, e é a porta que decide o que fazer com ele. Foi a versão anterior
@@ -1038,7 +1143,8 @@ def valor_perigoso(texto: str, valor: float | None) -> str | None:
     TETO do sinal negativo, medido — ele NÃO é "qualquer grafia":
 
     - só é olhado quando existe um bloco de DÍGITOS. `valor_perigoso(
-      "menos cinquenta", 50.0)` devolve `None`, e como `_extract_valor(
+      "menos cinquenta", 50.0)` devolve `None` — o `menos` vira traço, mas não
+      há bloco numérico para ele cercar —, e como `_extract_valor(
       "menos cinquenta")` é 50.0, isso vira R$ 50,00 nas portas 2 e 3;
     - só é olhado em volta do PRIMEIRO bloco. `valor_perigoso(
       "codigo 8888 valor -132", 8888.0)` devolve `None`.
@@ -1052,35 +1158,21 @@ def valor_perigoso(texto: str, valor: float | None) -> str | None:
     # "milhar malformado" e recusava o que a `main` registra. Chamar aqui em vez
     # de confiar no chamador é o que a rodada 4 ensinou — lá o `valor_perigoso`
     # recebeu o texto cru e "132." foi recusado. É idempotente.
-    t = limpa_pontuacao_final(texto).translate(_TRACOS)
+    t = _MENOS_RE.sub("-", limpa_pontuacao_final(texto).translate(_TRACOS).lower())
     bloco = _BLOCO_NUM_RE.search(t)
     if bloco:
         if _espaco_ambiguo(bloco.group(0)) or not agrupamento_de_milhar_ok(t):
             return "nao_entendi"
-        cru = t[:bloco.start()]
-        antes = re.sub(r"r\$\s*$", "", cru.rstrip(), flags=re.I).rstrip().lower()
-        depois = t[bloco.end():].lstrip()
-        # `parse_money` ignora o sinal: sem isto "-10" vira pagamento de R$ 10.
-        #
-        # Mas o traço só é SINAL quando encosta nos dígitos ("-10", "R$ -10"),
-        # quando é o prefixo inteiro ("- 10") ou quando TERMINA a expressão
-        # ("132 -", "10-"). Traço com prosa de um dos lados é pontuação:
-        # "paguei 132 - da luz", "132 — luz" e "luz - 132" são R$ 132,00 e a
-        # `main` paga os três. Como o `_TRACOS` normaliza travessão e en dash
-        # para "-", o `startswith("-")` de antes recusava a lista inteira —
-        # inclusive o " - " que ESTE PR pôs no texto combinado da pergunta de
-        # descrição ("gastei 50 - mercado").
-        negativo = (
-            cru.endswith("-")
-            or re.sub(r"r\$", "", antes).strip() == "-"
-            or depois.rstrip() == "-"
-            # "menos 10" é negativo; "mais ou menos 10" é "por volta de 10" —
-            # `menos` está no `_ENCHIMENTO` da porta 1 justamente por isso.
-            or (re.search(r"(?:^|\s)menos$", antes)
-                and not re.search(r"(?:^|\s)ou\s+menos$", antes))
-            or (antes.endswith("(") and depois.startswith(")"))  # contábil
-        )
-        if negativo:
+        # Separador decimal SEM parte inteira. `parse_money(",50")` e
+        # `parse_money(".50")` devolvem 50.0 — R$ 50,00 no lugar de R$ 0,50,
+        # 100x, e o `_BLOCO_NUM_RE` recorta só o "50" porque exige dígito na
+        # frente. A porta 1 já re-perguntava (`,50` não casa o `_VALOR_RE` e cai
+        # no `_NUMERO_AMBIGUO_RE`); as portas 2, 3 e 4 pagavam, na `main` e no
+        # branch. Mesmo veredito das outras digitações ambíguas: re-pergunta com
+        # a pendência viva, em vez de escolher entre 0,50 e 50 no escuro.
+        if bloco.start() and t[bloco.start() - 1] in ",.":
+            return "nao_entendi"
+        if _sinal_negativo(t[:bloco.start()], t[bloco.end():]):
             return "nao_positivo"
     if valor is None:
         return None

--- a/utils_text.py
+++ b/utils_text.py
@@ -908,11 +908,30 @@ def limpa_pontuacao_final(raw: str) -> str:
     lugar de R$ 132,50 ("0,50." vira 50, "9,99." vira 999). Quem escreve
     "132,50." está respondendo, não mudando de assunto.
 
+    O mesmo ponto no MEIO da frase faz o mesmo estrago, e o `rstrip` não o
+    alcança: medido nas quatro portas, "paguei 132,50. foi isso" paga
+    R$ 13.250,00 na `main` E no branch, porque a pontuação de prosa fica presa
+    dentro do bloco numérico que o `parse_money` recorta. Por isso a limpeza
+    vale para o fim da MENSAGEM e para o fim do BLOCO — os dois são pontuação,
+    não separador decimal:
+
+        paguei 132,50. foi isso  -> paguei 132,50 foi isso   (132,50, não 13.250)
+        1.234,56, foi isso       -> 1.234,56 foi isso        (antes: nada)
+
+    O que sobra depois do número continua no texto: ele é a descrição que
+    categoriza o lançamento na porta 2.
+
     Não corrigido no `parse_money`: o bug é dele e é anterior a este PR, mas ele
     é chamado por dezenas de fluxos e mexer nele aqui é troca de bug conhecido
     por bug novo. Issue separada.
     """
-    return (raw or "").rstrip(" .!")
+    limpo = (raw or "").rstrip(" .!")
+    bloco = _BLOCO_NUM_RE.search(limpo)
+    if not bloco:
+        return limpo
+    resto = limpo[bloco.end():]
+    return (limpo[:bloco.start()] + bloco.group(0).rstrip(" .,")
+            + (" " if resto else "") + resto)
 
 
 def agrupamento_de_milhar_ok(raw: str) -> bool:
@@ -1027,18 +1046,34 @@ def valor_perigoso(texto: str, valor: float | None) -> str | None:
     Nenhum dos dois é regressão (a `main` também pagava), e consertar mexe na
     aceitação das portas, não neste predicado. Fica descrito, não corrigido.
     """
-    t = (texto or "").translate(_TRACOS)
+    # A MESMA limpeza que o chamador aplica antes do `parse_money`, e pelo mesmo
+    # motivo: a pontuação no fim do bloco numérico é prosa, não separador. Sem
+    # ela o grupo vazio depois do ponto de "paguei 132. foi isso" virava
+    # "milhar malformado" e recusava o que a `main` registra. Chamar aqui em vez
+    # de confiar no chamador é o que a rodada 4 ensinou — lá o `valor_perigoso`
+    # recebeu o texto cru e "132." foi recusado. É idempotente.
+    t = limpa_pontuacao_final(texto).translate(_TRACOS)
     bloco = _BLOCO_NUM_RE.search(t)
     if bloco:
         if _espaco_ambiguo(bloco.group(0)) or not agrupamento_de_milhar_ok(t):
             return "nao_entendi"
-        # `parse_money` ignora o sinal: sem isto "-10" vira pagamento de R$ 10.
-        antes = re.sub(r"r\$\s*$", "", t[:bloco.start()].rstrip(),
-                       flags=re.I).rstrip().lower()
+        cru = t[:bloco.start()]
+        antes = re.sub(r"r\$\s*$", "", cru.rstrip(), flags=re.I).rstrip().lower()
         depois = t[bloco.end():].lstrip()
+        # `parse_money` ignora o sinal: sem isto "-10" vira pagamento de R$ 10.
+        #
+        # Mas o traço só é SINAL quando encosta nos dígitos ("-10", "R$ -10"),
+        # quando é o prefixo inteiro ("- 10") ou quando TERMINA a expressão
+        # ("132 -", "10-"). Traço com prosa de um dos lados é pontuação:
+        # "paguei 132 - da luz", "132 — luz" e "luz - 132" são R$ 132,00 e a
+        # `main` paga os três. Como o `_TRACOS` normaliza travessão e en dash
+        # para "-", o `startswith("-")` de antes recusava a lista inteira —
+        # inclusive o " - " que ESTE PR pôs no texto combinado da pergunta de
+        # descrição ("gastei 50 - mercado").
         negativo = (
-            antes.endswith("-")
-            or depois.startswith("-")            # "10-"
+            cru.endswith("-")
+            or re.sub(r"r\$", "", antes).strip() == "-"
+            or depois.rstrip() == "-"
             # "menos 10" é negativo; "mais ou menos 10" é "por volta de 10" —
             # `menos` está no `_ENCHIMENTO` da porta 1 justamente por isso.
             or (re.search(r"(?:^|\s)menos$", antes)

--- a/utils_text.py
+++ b/utils_text.py
@@ -977,13 +977,21 @@ def _espaco_ambiguo(bloco: str) -> bool:
     exatamente 3 dígitos ("1 500"), digitação errada tem outro número deles
     ("132 50"). Só isso é medido aqui.
 
+    EXCEÇÃO, e é a metade que faltava: espaço logo DEPOIS de um separador
+    decimal não é agrupamento nenhum. "132, 50" é R$ 132,50 — o `parse_money`
+    devolve 132.5 e a `main` aceitava —, mas a regra dos 3 dígitos via "50"
+    como milhar malformado e recusava. Idem "132 , 50", "132. 50", "1.234, 56"
+    e "132, 5". Por isso o grupo só é medido quando o pedaço ANTERIOR não
+    termina em `,` ou `.`.
+
     TETO conhecido: "1234 567" (grupo inicial de 4) passa como 1234567, porque
     a regra olha só os grupos depois do primeiro. Não vale código a mais — quem
     digita assim quis mesmo 1.234.567.
     """
     partes = bloco.split()
-    return any(len(re.match(r"\d*", p).group(0)) != 3
-               for p in partes[1:] if p[:1].isdigit())
+    return any(not anterior.endswith((",", "."))
+               and len(re.match(r"\d*", p).group(0)) != 3
+               for anterior, p in zip(partes, partes[1:]) if p[:1].isdigit())
 
 
 def valor_perigoso(texto: str, valor: float | None) -> str | None:

--- a/utils_text.py
+++ b/utils_text.py
@@ -6,6 +6,7 @@ Helpers de texto: normalização, parse de valores, regras locais e utilitários
 import re
 import unicodedata
 from decimal import Decimal
+from math import isfinite
 
 def normalize_text(text: str) -> str:
     text = (text or "").strip().lower()
@@ -877,6 +878,173 @@ def parse_money(text: str) -> float | None:
         return float(raw)
     except ValueError:
         return None
+
+
+# ---------------------------------------------------------------------------
+# Pergunta de valor: o filtro de DANO das quatro portas.
+#
+# As quatro portas estão numeradas UMA vez, em
+# `core.intent_router.abandona_pergunta_de_valor`. Cada uma tem a SUA aceitação
+# ("isto é um valor?") — a porta 1 exige a mensagem inteira, as outras três
+# usam o `_extract_valor` — e todas dividem o predicado abaixo, que só responde
+# "este valor é perigoso?".
+# ---------------------------------------------------------------------------
+
+# O mesmo recorte que o `parse_money` faz sobre a frase.
+_BLOCO_NUM_RE = re.compile(r"\d[\d.,\s]*")
+# O sinal negativo NÃO é um caractere. Medido: `-10` era recusado por
+# `endswith("-")`, mas `−10` (U+2212, o que o teclado do iOS e o Whisper
+# produzem), `–10` (en dash do autocorretor) e `‑10` (hífen não-quebrável de
+# texto colado) passavam e pagavam R$ 10,00 — `parse_money` ignora o sinal.
+_TRACOS = str.maketrans({"\u2212": "-", "\u2013": "-", "\u2014": "-",
+                         "\u2010": "-", "\u2011": "-"})
+
+
+def limpa_pontuacao_final(raw: str) -> str:
+    """Tira o ponto/exclamação do FIM antes de entregar ao `parse_money`.
+
+    "132,50." tem vírgula E ponto, o `parse_money` decide o decimal pelo ÚLTIMO
+    separador, toma a vírgula por milhar e devolve 13250.0 — R$ 13.250,00 no
+    lugar de R$ 132,50 ("0,50." vira 50, "9,99." vira 999). Quem escreve
+    "132,50." está respondendo, não mudando de assunto.
+
+    Não corrigido no `parse_money`: o bug é dele e é anterior a este PR, mas ele
+    é chamado por dezenas de fluxos e mexer nele aqui é troca de bug conhecido
+    por bug novo. Issue separada.
+    """
+    return (raw or "").rstrip(" .!")
+
+
+def agrupamento_de_milhar_ok(raw: str) -> bool:
+    """False quando o ponto de milhar está malformado ("1.23.456").
+
+    O `parse_money` decide o significado do ponto pelo TAMANHO do último grupo:
+    se tem 3 dígitos, apaga TODOS os pontos. Então "1.23.456" (erro de
+    digitação) vira 123456.0 e "1.2.345" vira 12345.0 — a conta seria paga com
+    valor inflado, em silêncio, logo depois de o bot pedir "manda só o número".
+
+    Regra: com dois ou mais pontos, todo grupo depois do primeiro precisa ter
+    exatamente 3 dígitos (1.234.567 OK, 1.23.456 não); com um ponto só, valem 3
+    (milhar: 1.200) ou 1-2 (decimal: 132.50) — a mesma heurística que o
+    `parse_money` já usa. Vírgula presente corta o decimal, e a mesma regra vale
+    para o que sobra antes dela.
+
+    O CRITÉRIO não é "o usuário digitou certo?", é "o erro dele vira dinheiro
+    errado?". Por isso um ponto solto mal agrupado passa quando há vírgula:
+
+        1.23,45   -> 123,45      1.2,34  -> 12,34      12.34,56 -> 1.234,56
+
+    Nos três, apagar o ponto fora do lugar devolve exatamente o valor que a
+    pessoa parecia querer — o bot acerta a intenção, e recusar seria pedir para
+    redigitar algo já entendido. Já com DOIS pontos a leitura muda de ordem de
+    grandeza (1.23.456 -> 123.456,00 quando o provável era 1.234,56), e aí sim
+    recusa. Foi apontado como incoerência na revisão do #133 e mantido de
+    propósito; se um dia isso mudar, mude por medição de dano, não por simetria.
+
+    Não corrigido no `parse_money` pelo mesmo motivo do `limpa_pontuacao_final`:
+    dezenas de fluxos chamam aquilo. Issue separada.
+    """
+    m = _BLOCO_NUM_RE.search(raw or "")
+    if not m:
+        return True
+    num = m.group(0).strip().replace(" ", "")
+    if "," in num:
+        num = num[:num.rfind(",")]
+    grupos = num.split(".")
+    if len(grupos) == 1:
+        return True
+    if len(grupos) == 2:
+        return len(grupos[1]) in (1, 2, 3)
+    return all(len(g) == 3 for g in grupos[1:])
+
+
+def _espaco_ambiguo(bloco: str) -> bool:
+    r"""True quando o espaço DENTRO do número não é agrupamento de milhar.
+
+    O `[\d.,\s]*` do `parse_money` apaga o espaço, então "132 50" vira 13250 e
+    paga R$ 13.250,00 sem confirmação. Mas recusar todo espaço encolhe a
+    aceitação: `1 500`, `1 500,00`, `R$ 1 500`, `12 345` e `1 000 000` são
+    milhar separado por espaço e o `parse_money` acerta os cinco.
+
+    "A `main` aceita os cinco" vale só nas portas 2, 3 e 4. Na porta 1 NÃO:
+    medido, `_VALOR_RE.fullmatch` é False nos cinco (não há `\s` dentro do
+    número), então lá eles caem no `_NUMERO_AMBIGUO_RE` e recebem "Não entendi
+    o valor" com a pergunta viva — que é o que a `main` já fazia em quatro
+    deles; no `R$ 1 500` ela abandonava a pergunta. Ver
+    `test_porta_da_conta_repergunta_no_milhar_com_espaco_como_na_main`.
+
+    O que separa os dois é o TAMANHO do grupo depois do espaço: milhar tem
+    exatamente 3 dígitos ("1 500"), digitação errada tem outro número deles
+    ("132 50"). Só isso é medido aqui.
+
+    TETO conhecido: "1234 567" (grupo inicial de 4) passa como 1234567, porque
+    a regra olha só os grupos depois do primeiro. Não vale código a mais — quem
+    digita assim quis mesmo 1.234.567.
+    """
+    partes = bloco.split()
+    return any(len(re.match(r"\d*", p).group(0)) != 3
+               for p in partes[1:] if p[:1].isdigit())
+
+
+def valor_perigoso(texto: str, valor: float | None) -> str | None:
+    """"Este valor vira dinheiro errado?" — o predicado de dano das 4 portas.
+
+    Recebe o TEXTO do usuário e o valor que a porta JÁ aceitou (cada porta tem
+    a sua aceitação; ver `core.intent_router.abandona_pergunta_de_valor`).
+    Devolve `None` quando não há perigo, ou o motivo:
+
+    - `"nao_positivo"` — negativo escrito com sinal, zero, centavo invisível
+      ("0,001" gravava 0.001 e a mensagem dizia "R$ 0,00 lançado") ou não
+      finito (`parse_money("1" * 400)` devolve `inf`, que passa no `> 0` e só
+      seria recusado lá no `mark_bill_paid`, DEPOIS de a pendência ter sido
+      reivindicada, virando "erro interno" para o usuário);
+    - `"nao_entendi"` — o texto fala de um valor mas QUAL valor é ambíguo
+      ("132 50" -> 13.250, "1.23.456" -> 123.456). O bot ACABOU de pedir um
+      número, então isso é digitação errada: quem chama re-pergunta em vez de
+      abandonar a pergunta.
+
+    NÃO impõe aceitação: um texto sem valor nenhum ("saldo") devolve `None`
+    daqui, e é a porta que decide o que fazer com ele. Foi a versão anterior
+    (uma função só, com a aceitação embutida) que unificou as quatro portas na
+    mais frouxa e fez "codigo 8888 valor 132" pagar R$ 8.888,00.
+
+    TETO do sinal negativo, medido — ele NÃO é "qualquer grafia":
+
+    - só é olhado quando existe um bloco de DÍGITOS. `valor_perigoso(
+      "menos cinquenta", 50.0)` devolve `None`, e como `_extract_valor(
+      "menos cinquenta")` é 50.0, isso vira R$ 50,00 nas portas 2 e 3;
+    - só é olhado em volta do PRIMEIRO bloco. `valor_perigoso(
+      "codigo 8888 valor -132", 8888.0)` devolve `None`.
+
+    Nenhum dos dois é regressão (a `main` também pagava), e consertar mexe na
+    aceitação das portas, não neste predicado. Fica descrito, não corrigido.
+    """
+    t = (texto or "").translate(_TRACOS)
+    bloco = _BLOCO_NUM_RE.search(t)
+    if bloco:
+        if _espaco_ambiguo(bloco.group(0)) or not agrupamento_de_milhar_ok(t):
+            return "nao_entendi"
+        # `parse_money` ignora o sinal: sem isto "-10" vira pagamento de R$ 10.
+        antes = re.sub(r"r\$\s*$", "", t[:bloco.start()].rstrip(),
+                       flags=re.I).rstrip().lower()
+        depois = t[bloco.end():].lstrip()
+        negativo = (
+            antes.endswith("-")
+            or depois.startswith("-")            # "10-"
+            # "menos 10" é negativo; "mais ou menos 10" é "por volta de 10" —
+            # `menos` está no `_ENCHIMENTO` da porta 1 justamente por isso.
+            or (re.search(r"(?:^|\s)menos$", antes)
+                and not re.search(r"(?:^|\s)ou\s+menos$", antes))
+            or (antes.endswith("(") and depois.startswith(")"))  # contábil
+        )
+        if negativo:
+            return "nao_positivo"
+    if valor is None:
+        return None
+    # Arredonda para centavos ANTES de comparar: "0,001" passava no `> 0`.
+    if not isfinite(valor) or round(valor, 2) <= 0:
+        return "nao_positivo"
+    return None
 
 
 def parse_pt_number(text: str) -> float | None:


### PR DESCRIPTION
Fecha #139.

## O que este PR é

> Põe um filtro de dano compartilhado (`utils_text.valor_perigoso`) nas **quatro** portas da pergunta de valor, e uma escotilha de abandono por intent — mundo fechado de 6 intents, sem LLM — em **três** delas.

## ⚠️ Errata — duas afirmações minhas caíram na revisão

O Codex achou dois P2 (`976d231` conserta os dois), e o ataque que fiz depois derrubou mais uma frase. **As duas afirmações abaixo estavam no corpo original e são falsas:**

1. ~~"Sem alterar a aceitação de nenhuma porta."~~ Varredura de 314 formas × 2 portas: **88 células ampliaram** (`1.500.`, `132..`, `99.999.`, `1.234,56.!`) — as portas 2/3 passaram a alimentar o `_extract_valor` com a saída do `limpa_pontuacao_final`. **Nenhuma infla valor**; todas são a leitura plausível. Mas a aceitação mudou.
2. ~~"Nenhuma forma que a `main` aceita passou a ser recusada, **exceto** `132., 50` e `132.,50` (ver errata)."~~ Era falso em **21 células** (`132, 50`, `1.234, 56`, `132. 50`…) — espaço *depois* do separador decimal. Consertado. **Ainda é falso** para `132., 50` e `132.,50`, que são outra classe (grupo vazio no `agrupamento_de_milhar_ok`) e continuam recusados.

Por que passou: a matriz de 224 células foi construída para provar a propriedade 2 e não tinha **nenhum** caso com espaço depois do separador, só entre grupos. Propriedade geral afirmada a partir de exemplos escolhidos por quem escreveu o código — quatro rodadas de ataque e duas auditorias passaram por cima.

O #133 blindou uma das quatro portas. Esta é a mesma classe nas outras três, mais a escotilha que faz um comando deixar de ser engolido pela pergunta.

**Não é regressão do #133** — datado com `git log -S` no corpo da #139. O #133 consertou uma porta; o usuário passou a atingir outra.

## Números, medidos nesta máquina hoje

| | |
|---|---|
| `main` (`cf54ffb`) | **1404 passed, 0 failed** |
| este branch | **1680 passed, 1 xfailed** |
| comparação | por **nome** — 0 testes removidos, 47 funções novas |
| duas colunas | **224 células** (4 portas × 56 formas) contra a `main` |

Nenhuma forma que a `main` aceita passou a ser recusada.

## O desenho

**A aceitação de cada porta é a da `main`.** A porta 1 segue estrita (`_VALOR_RE.fullmatch`), as outras seguem com `_extract_valor`. O que muda é só o passo seguinte: *este valor é perigoso?*

Uma versão anterior deste PR unificou a aceitação e fez `codigo 8888 valor 132` **pagar R$ 8.888,00**. Foi revertida.

**Escotilha de mundo fechado.** `ABANDONA` tem 6 intents, consultados com `allow_ai=False` (tiers 1 e 2, sem rede). Uma versão anterior era blacklist — abandonava tudo que não fosse `launches.add` — e **apagou a fila inteira de um multi-lançamento** quando o usuário respondeu `132 no cartao` (`credit.handle` 0.95). Numa blacklist sobre um oráculo ilimitado, todo intent novo e toda alucinação do LLM nascem destruindo pendência; numa whitelist, nascem inertes.

**Recusar mantém a pergunta viva** nas quatro portas. Descartar a pendência jogaria o usuário no fallback genérico.

## Ataque antes do push

Quatro rodadas de Tester e duas auditorias, **antes** deste PR existir. Acharam **11 defeitos bloqueantes** — e a suíte esteve **verde em todas as rodadas**: nenhum veio dela. Três eram regressão introduzida por um conserto anterior.

Dois que valem registro:

- **A escotilha por confiança sequestrava a resposta da própria pergunta.** `classify("132 reais")` é `launches.add` **0.95** — numa pergunta que pede valor, a resposta certa sempre parece comando. `50 pila` gravava despesa com descrição `"50 pila"` e categoria `outros` em vez de `moradia`.
- **O passo 1 da porta 1 era código morto com justificativa falsa.** Enumeração exaustiva do alfabeto do `_VALOR_RE` — **44.289 strings, 100% casando, 0 no `ABANDONA`** — e os 16 testes daquela porta passavam com o passo 1 desligado. Removido.

## Limitações medidas — não são omissões

1. **Teto do `apaga o gasto 132`**: cai em `out_of_scope 0.4`, **idêntico** a `132 no boleto`, que é valor legítimo. Nenhuma regra de intent as separa; tirar `out_of_scope` do gatilho sequestraria 14 formas legítimas. São ~9 frases (`exclui 132`, `apaga 42`, `tira 132`…). O conserto mora no classificador. Preso em `test_teto_conhecido_*`.
2. **`credit.handle` fora do conjunto**, por medição: `fatura` 1.0 e `132 no cartao` 0.95 são o mesmo intent, e o único corte que os separa derruba `fatura do cartao`. Preço medido por porta: portas 1 e 3 custam **zero**; porta 2 laça e re-arma a pendência (medido **com a IA desligada** — em produção o `classify_with_context` pode despachar antes); porta 4 laça com saída nos 10 min do `expires_at`.
3. **Negativo por extenso não é filtrado**: `menos cinquenta` → R$ 50,00 nas portas 2/3. O sinal só é lido em volta do **primeiro** bloco de dígitos: `codigo 8888 valor -132` → aceito como 8888. Não é regressão (a `main` fazia igual).
4. **Teto do espaço ambíguo**: `1234 567` passa como 1.234.567 (o grupo inicial não é checado).
5. **`parse_money` não foi tocado** (`132,50.` → 13250, `1"*400` → `inf`). As portas contornam; todo chamador fora delas continua exposto. O CLAUDE.md pede PR próprio. Issue separada.
6. **A concatenação do print ("luz saldo") não reproduz nesta suíte.** Aquele ramo exige um `valor` nas entidades, que só entra pelo merge com a IA — e o `conftest` derruba o cliente da OpenAI. O print é real; o caminho passa pelo LLM e **não foi exercitado aqui**.
7. **Duas `set_pending_action` incondicionais permanecem** em `_resolve_clarification` (herdadas da `main`; uma mudou de indentação e alcance, não de semântica). Converter incondicional existente é a #134. Há teste prendendo que uma terceira não apareça.
8. **40 de 46 intents ficam fora do mundo fechado** (fonte: `grep -oE 'intent == "[a-z_.]+"' core/intent_router.py | sort -u`). É deliberado — o default seguro é não abandonar.
9. **`xfail(strict=True)`**: `gastei 50` + `cartao` perde os R$ 50 por defeito pré-existente do fluxo de crédito (`core/handlers/credit.py:477`), medido nas duas árvores.
10. **Nada foi exercitado contra a IA real, nem no WhatsApp real, nem no Discord.** Todo tier 3 é stub na suíte; a porta 4 é exercitada por simulação do `process_message`.

## Mudança de comportamento deliberada

`gastei 50` + `20 no mercado`: a `main` trocava o valor calada para R$ 20; agora grava R$ 50 com a descrição `20 no mercado`. O bot já tinha dito "R$ 50,00" ao usuário — trocar aquilo em silêncio é pior que uma descrição estranha, que aparece na confirmação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
