### PR TITLE
Consumo de pendência vira compare-and-swap (#134)

### DIFF
--- a/adapters/discord/cogs/general_cog.py
+++ b/adapters/discord/cogs/general_cog.py
@@ -7,7 +7,7 @@ import discord
 from discord.ext import commands
 
 from db import (
-    get_pending_action, clear_pending_action, set_pending_action,
+    get_pending_action, consume_pending_action, set_pending_action,
     delete_launch_and_rollback, delete_pocket, delete_investment,
     get_conn, get_latest_cdi_aa,
 )
@@ -62,7 +62,9 @@ class GeneralCog(commands.Cog):
 
             if ans in ("nao", "não", "n", "no"):
                 try:
-                    clear_pending_action(uid)
+                    # Abandono, condicional: apaga a pendência que foi lida, não
+                    # o que estiver lá. Perder = não havia nada nosso.
+                    consume_pending_action(uid, pending)
                 except Exception as e:
                     logger.error("Erro ao limpar pending_action: %s", e, exc_info=True)
                 await message.reply("❌ Ação cancelada.")
@@ -126,6 +128,20 @@ class GeneralCog(commands.Cog):
         action = pending["action_type"]
         payload = pending["payload"]
 
+        # Porteiro, ANTES de executar: todos os ramos abaixo apagam dados. O
+        # `finally: clear` que havia aqui rodava DEPOIS do delete — não protegia
+        # nada, e ainda apagava por cima de uma pendência que outra tarefa
+        # tivesse armado no meio-tempo. Falha do CAS = falha fechada.
+        try:
+            reivindicou = consume_pending_action(uid, pending)
+        except Exception as e:
+            logger.error("Erro ao consumir pending_action: %s", e, exc_info=True)
+            await message.reply("❌ Deu erro ao executar a ação pendente. Veja os logs.")
+            return
+        if not reivindicou:
+            await message.reply("Essa ação pendente não está mais valendo.")
+            return
+
         try:
             if action == "delete_launch":
                 delete_launch_and_rollback(uid, int(payload["launch_id"]))
@@ -161,11 +177,6 @@ class GeneralCog(commands.Cog):
         except Exception as e:
             logger.error("Erro ao executar ação pendente '%s': %s", action, e, exc_info=True)
             await message.reply("❌ Deu erro ao executar a ação pendente. Veja os logs.")
-        finally:
-            try:
-                clear_pending_action(uid)
-            except Exception as e:
-                logger.error("Erro ao limpar pending_action: %s", e, exc_info=True)
 
 
 async def setup(bot: commands.Bot):

--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -44,7 +44,7 @@ from core.types import IncomingMessage
 from db import (
     attempt_whatsapp_phone_link,
     claim_pending_action,
-    clear_pending_action,
+    consume_pending_action,
     get_conn,
     get_or_create_canonical_user,
     get_pending_action,
@@ -184,10 +184,13 @@ def _send_reply_with_optional_buttons(to_wa_id: str, body: str, user_id: int | N
 
     # Botão de desfazer (one-shot após áudio processado)
     if pending and pending.get("action_type") == "undo_audio":
-        # Limpa imediatamente — só aparece uma vez
+        # Limpa imediatamente — só aparece uma vez. CONDICIONAL: se outra tarefa
+        # já armou uma PERGUNTA nesta linha, apagar por cima a deixaria órfã.
+        # Perder é inofensivo — o botão não depende da linha para funcionar
+        # (`WA_UNDO_LAUNCH_ID` injeta "desfazer" no classificador).
         if user_id is not None:
             try:
-                clear_pending_action(int(user_id))
+                consume_pending_action(int(user_id), pending)
             except Exception as exc:
                 logger.warning("WA clear undo_audio pending failed: %s", exc)
         logger.info("WA sending undo button to=%s", to_wa_id)
@@ -208,7 +211,7 @@ def _send_reply_with_optional_buttons(to_wa_id: str, body: str, user_id: int | N
         launch_id = (pending.get("payload") or {}).get("launch_id")
         if user_id is not None:
             try:
-                clear_pending_action(int(user_id))
+                consume_pending_action(int(user_id), pending)
             except Exception as exc:
                 logger.warning("WA clear recategorize_offer pending failed: %s", exc)
         if launch_id:
@@ -239,7 +242,7 @@ def _send_reply_with_optional_buttons(to_wa_id: str, body: str, user_id: int | N
         tx_id = (pending.get("payload") or {}).get("tx_id")
         if user_id is not None:
             try:
-                clear_pending_action(int(user_id))
+                consume_pending_action(int(user_id), pending)
             except Exception as exc:
                 logger.warning("WA clear delete_credit_purchase pending failed: %s", exc)
         if tx_id:
@@ -888,8 +891,13 @@ def process_message(message: InboundMessage) -> None:
                 pending_recat = None
             if pending_recat and pending_recat.get("action_type") == "recategorize_launch_text":
                 launch_id = (pending_recat.get("payload") or {}).get("launch_id")
+                # Porteiro: `_apply_recategorize` reescreve a categoria do
+                # lançamento. Se a linha já não é esta, o texto responde a outra
+                # pergunta — cair fora deixa o roteador tratá-lo normalmente.
                 try:
-                    clear_pending_action(uid)
+                    if not consume_pending_action(uid, pending_recat):
+                        pending_recat = None
+                        launch_id = None
                 except Exception as exc:
                     logger.warning("WA clear recat_text pending failed: %s", exc)
                 if launch_id:
@@ -905,7 +913,9 @@ def process_message(message: InboundMessage) -> None:
                 txt = (message.text or "").strip()
                 if txt.lower() in {"cancelar", "cancela", "nao", "não", "deixa", "depois"}:
                     try:
-                        clear_pending_action(uid)
+                        # Abandono, condicional: se perdeu, não havia nada
+                        # nosso para abandonar.
+                        consume_pending_action(uid, pending_recat)
                     except Exception:
                         pass
                     _send_reply(reply_to, f"Ok, deixei a conta de *{name}* pendente. Quando pagar é só avisar. 🐷")
@@ -933,10 +943,19 @@ def process_message(message: InboundMessage) -> None:
                     # não entendeu o valor → re-pergunta, mantém o pending
                     _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de *{name}*. Ex: *132,50* (ou *cancelar*)")
                     return
+                # REIVINDICA antes de pagar, e condicionado ao que foi lido:
+                # duas respostas concorrentes chegariam as duas ao
+                # `mark_bill_paid` e debitariam o saldo duas vezes. Quem perde
+                # sai sem fazer nada — o vencedor responde. Mesmo desenho do
+                # `resolve_bill_amount` (core/handlers/bills.py), que é a outra
+                # porta da MESMA pergunta.
                 try:
-                    clear_pending_action(uid)
+                    reivindicou = consume_pending_action(uid, pending_recat)
                 except Exception as exc:
                     logger.warning("WA clear bill_pay_amount pending failed: %s", exc)
+                    reivindicou = False
+                if not reivindicou:
+                    return
                 if bill_id:
                     from db.bills import mark_bill_paid
                     try:

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -274,10 +274,9 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
         # outra tarefa pode ter posto uma confirmação nova no lugar — que já
         # apareceu na tela do usuário. Apagar por cima a deixaria órfã. Só
         # abandonamos a pergunta se ela ainda for a que lemos.
-        from db import advance_pending_action
+        from db import consume_pending_action
 
-        advance_pending_action(
-            user_id, "bill_amount_expected", pending.get("payload") or {}, None)
+        consume_pending_action(user_id, pending)
         return None
 
     limpo = limpa_pontuacao_final(raw)
@@ -300,7 +299,7 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     if casou.group(1) or not isfinite(amount) or amount <= 0:
         return f"O valor da *{nome}* precisa ser maior que zero. Quanto veio este mês?"
 
-    from db import advance_pending_action, create_pending_action_if_absent
+    from db import consume_pending_action, create_pending_action_if_absent
     from db.bills import mark_bill_paid
 
     payload = pending.get("payload") or {}
@@ -312,7 +311,7 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     # DOIS lançamentos existem. Quem perde o compare-and-swap sai sem fazer
     # nada — o vencedor responde. Mesmo desenho do PR #128 na fila de
     # multi-lançamento.
-    if not advance_pending_action(user_id, "bill_amount_expected", payload, None):
+    if not consume_pending_action(user_id, pending):
         return None
 
     try:

--- a/core/handlers/credit.py
+++ b/core/handlers/credit.py
@@ -11,6 +11,7 @@ from db import (
     add_credit_purchase_installments,
     card_name_exists,
     clear_pending_action,
+    consume_pending_action,
     create_card,
     delete_card,
     get_card_by_id,
@@ -237,11 +238,13 @@ def _handle_pay_bill_command(user_id: int, text: str) -> str | None:
     return _ask_which_bill(user_id, candidates, amount)
 
 
-def _resolve_pay_bill_choice(user_id: int, text: str, pending: dict) -> str:
+def _resolve_pay_bill_choice(user_id: int, text: str, pending: dict) -> str | None:
     answer = (text or "").strip()
     norm = normalize_text(answer)
     if not answer or norm in ("nao", "cancelar", "cancela", "n"):
-        clear_pending_action(user_id)
+        # Abandono: condicional, para não apagar uma pendência que outra tarefa
+        # armou entre a leitura e agora.
+        consume_pending_action(user_id, pending)
         return "❌ Pagamento cancelado."
 
     payload = dict(pending.get("payload") or {})
@@ -256,12 +259,12 @@ def _resolve_pay_bill_choice(user_id: int, text: str, pending: dict) -> str:
     try:
         rows = list_open_bills(user_id)
     except Exception as e:
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return f"❌ Erro ao consultar faturas: {e}"
 
     candidates = [dict(r) for r in rows if int(r["id"]) in bill_ids and _bill_due(r) > 0]
     if not candidates:
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return "📭 Nenhuma das faturas listadas continua em aberto."
 
     chosen: dict | None = None
@@ -302,7 +305,10 @@ def _resolve_pay_bill_choice(user_id: int, text: str, pending: dict) -> str:
         lines.append("Ou *cancelar* para abortar.")
         return "\n".join(lines)
 
-    clear_pending_action(user_id)
+    # Porteiro: `_execute_pay_bill` paga. Se a linha já não é a que lemos,
+    # outra tarefa consumiu esta escolha — pagar de novo duplicaria o débito.
+    if not consume_pending_action(user_id, pending):
+        return None
     return _execute_pay_bill(user_id, chosen, amount)
 
 
@@ -1039,6 +1045,11 @@ def _ask_credit_limit_or_finish(user_id: int, payload: dict) -> str:
 
 
 def _finish_card_setup(user_id: int, card_id: int, ask_primary: bool) -> str:
+    # Os dois `clear_pending_action` abaixo são INCONDICIONAIS de propósito, e
+    # são os únicos do arquivo. Não há pendência lida aqui, e um dos caminhos
+    # que chega até esta função (`_ask_credit_limit_or_finish`) reescreve a
+    # linha antes de chamar — um compare-and-swap contra o que o chamador leu
+    # falharia sempre e prenderia o cadastro de cartão por 20 min.
     card = get_card_by_id(user_id, card_id)
     if not card:
         clear_pending_action(user_id)
@@ -1156,7 +1167,7 @@ def _resolve_set_primary(user_id: int, text: str, pending: dict) -> str | None:
 
     if payload.get("step") == "choose":
         if _is_no(answer):
-            clear_pending_action(user_id)
+            consume_pending_action(user_id, pending)
             return "Perfeito. Mantive o cartão principal atual."
         card_name = _find_card_name_in_text(user_id, answer) or answer.strip()
         card_id = get_card_id_by_name(user_id, card_name)
@@ -1168,21 +1179,23 @@ def _resolve_set_primary(user_id: int, text: str, pending: dict) -> str | None:
 
     card_id = payload.get("card_id")
     if not card_id:
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return None
     card = get_card_by_id(user_id, int(card_id))
     if not card:
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return "❌ Não achei esse cartão."
 
     if _is_yes(answer):
+        # Consome ANTES de escrever: depois, o CAS não protegeria nada.
+        if not consume_pending_action(user_id, pending):
+            return None
         set_default_card(user_id, int(card_id))
-        clear_pending_action(user_id)
         card = get_card_by_id(user_id, int(card_id))
         return f"✅ O cartão **{card['name']}** agora é o seu principal.\n{_card_summary(card)}"
 
     if _is_no(answer):
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return "Perfeito. Mantive o cartão principal atual."
 
     return f"Responda **sim** para tornar **{card['name']}** o principal ou **não** para cancelar."
@@ -1192,21 +1205,24 @@ def _resolve_delete_card(user_id: int, text: str, pending: dict) -> str | None:
     payload = dict(pending.get("payload") or {})
     card_id = payload.get("card_id")
     if not card_id:
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return None
 
     card = get_card_by_id(user_id, int(card_id))
     card_name = payload.get("card_name") or (card["name"] if card else "esse cartão")
 
     if _is_yes(text):
+        # Porteiro, ANTES do delete: `delete_card` leva faturas e transações
+        # junto. Quem perde o CAS não apaga — o "sim" era de outra pergunta.
+        if not consume_pending_action(user_id, pending):
+            return None
         deleted = delete_card(user_id, int(card_id))
-        clear_pending_action(user_id)
         if not deleted:
             return f"❌ Não consegui excluir o cartão **{card_name}**."
         return f"✅ Cartão **{card_name}** excluído com sucesso."
 
     if _is_no(text):
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return f"Perfeito. Mantive o cartão **{card_name}**."
 
     return f"Responda **sim** para excluir **{card_name}** ou **não** para cancelar."
@@ -1229,13 +1245,15 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
     if pending.get("action_type") == "installment_pending":
         answer = (text or "").strip()
         if not answer or normalize_text(answer) in ("nao", "cancelar", "cancela"):
-            clear_pending_action(user_id)
+            consume_pending_action(user_id, pending)
             return "❌ Parcelamento cancelado."
         payload = dict(pending.get("payload") or {})
         nota = answer
         inferred = _infer_category_result(user_id, nota)
         categoria = inferred.category or payload.get("categoria") or "outros"
-        clear_pending_action(user_id)
+        # Porteiro: `_create_installments` cria N lançamentos de dinheiro.
+        if not consume_pending_action(user_id, pending):
+            return None
         from datetime import date as _date
         purchased_at = _date.fromisoformat(payload["purchased_at"]) if isinstance(payload.get("purchased_at"), str) else payload.get("purchased_at")
         return _create_installments(
@@ -1258,13 +1276,13 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
     answer = (text or "").strip()
 
     if _is_no(answer) and step not in {"reminder_opt_in", "credit_limit_ask", "set_primary", "duplicate_card_name", "confirm_delete_existing_card"}:
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return "❌ Cadastro de cartão cancelado."
 
     # ── Novo step: nome duplicado detectado ──────────────────────────────────
     if step == "duplicate_card_name":
         if _is_no(answer):
-            clear_pending_action(user_id)
+            consume_pending_action(user_id, pending)
             return "❌ Cadastro de cartão cancelado."
 
         if _is_delete(answer):
@@ -1309,7 +1327,7 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
                     due_day=int(payload["due_day"]),
                 )
             except PlanLimitExceeded as exc:
-                clear_pending_action(user_id)
+                consume_pending_action(user_id, pending)
                 return exc.message
             first_card = int(payload.get("existing_count") or 0) == 0
             if first_card:
@@ -1338,13 +1356,15 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
         existing_name = payload.get("existing_card_name", "")
 
         if _is_yes(answer) and existing_id:
+            # Porteiro, ANTES do delete: apagar um cartão leva faturas e
+            # transações junto, e o clear posterior não protegeria nada.
+            if not consume_pending_action(user_id, pending):
+                return None
             deleted = delete_card(user_id, int(existing_id))
             if not deleted:
-                clear_pending_action(user_id)
                 return f"❌ Não consegui excluir o cartão **{existing_name}**. Tente novamente."
 
             # Após excluir, pergunta se quer criar um cartão com o mesmo nome agora
-            clear_pending_action(user_id)
             return (
                 f"✅ Cartão **{existing_name}** excluído com sucesso.\n\n"
                 f"Se quiser criar um novo cartão com esse nome, use:\n"
@@ -1411,7 +1431,7 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
                 due_day=due_day,
             )
         except PlanLimitExceeded as exc:
-            clear_pending_action(user_id)
+            consume_pending_action(user_id, pending)
             return exc.message
         payload["card_id"] = card_id
         first_card = int(payload.get("existing_count") or 0) == 0
@@ -1464,17 +1484,19 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
         card_id = int(payload["card_id"])
         card = get_card_by_id(user_id, card_id)
         if not card:
-            clear_pending_action(user_id)
+            consume_pending_action(user_id, pending)
             return "❌ Não achei esse cartão para definir como principal."
         if _is_yes(answer):
+            if not consume_pending_action(user_id, pending):
+                return None
             set_default_card(user_id, card_id)
-            clear_pending_action(user_id)
             card = get_card_by_id(user_id, card_id)
             return f"✅ Perfeito. O cartão **{card['name']}** agora é o seu principal.\n{_card_summary(card)}"
-        clear_pending_action(user_id)
+        consume_pending_action(user_id, pending)
         return f"Perfeito. Mantive o cartão principal atual.\n{_card_summary(card)}"
 
-    clear_pending_action(user_id)
+    # Limpeza de estado: step desconhecido. Ignora o resultado do CAS.
+    consume_pending_action(user_id, pending)
     return None
 
 

--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -72,7 +72,8 @@ def resolve_investment_pick(user_id: int, text: str, pending: dict) -> str | Non
     norm = normalize_text(resposta)
 
     if norm in ("nao", "n", "cancelar", "cancela"):
-        db.clear_pending_action(user_id)
+        # Abandono: condicional para não apagar pendência de outra tarefa.
+        db.consume_pending_action(user_id, pending)
         return "❌ Beleza, cancelei o aporte."
 
     nomes = payload.get("nomes") or []
@@ -89,7 +90,10 @@ def resolve_investment_pick(user_id: int, text: str, pending: dict) -> str | Non
         return ("Não entendi qual. Responda com o número:\n\n"
                 + "\n".join(linhas) + "\n\nOu *cancelar*.")
 
-    db.clear_pending_action(user_id)
+    # Porteiro: o `deposit` movimenta dinheiro. Se a linha já não é a que
+    # lemos, outra tarefa consumiu a pergunta — não aporta duas vezes.
+    if not db.consume_pending_action(user_id, pending):
+        return None
     return deposit(
         user_id,
         payload.get("text") or resposta,
@@ -142,7 +146,7 @@ def resolve_funding_choice(user_id: int, text: str, pending: dict) -> str | None
     norm = normalize_text(resposta)
 
     if norm in ("nao", "n", "cancelar", "cancela"):
-        db.clear_pending_action(user_id)
+        db.consume_pending_action(user_id, pending)
         return "❌ Beleza, cancelei."
 
     fontes = payload.get("fontes") or []
@@ -162,7 +166,9 @@ def resolve_funding_choice(user_id: int, text: str, pending: dict) -> str | None
         return ("Não entendi de onde sai. Responda com o número:\n\n"
                 + "\n".join(linhas) + "\n\nOu *cancelar*.")
 
-    db.clear_pending_action(user_id)
+    # Porteiro: retoma um fluxo que debita da fonte escolhida.
+    if not db.consume_pending_action(user_id, pending):
+        return None
     retomar = payload.get("retomar") or {}
     amount = float(payload.get("amount") or 0)
     source = {

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -724,18 +724,20 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
         payload = pending.get("payload") or {}
         queue: list[dict] = list(payload.get("queue") or [])
         if not queue:
-            db.clear_pending_action(user_id)
+            # Abandono, condicional: a fila acabou, mas outra tarefa pode ter
+            # armado uma pergunta nova nesta linha entre a leitura e agora.
+            db.consume_pending_action(user_id, pending)
             return None
 
         if resp_norm in _CANCEL_WORDS:
-            db.clear_pending_action(user_id)
+            db.consume_pending_action(user_id, pending)
             restantes = ", ".join(i.get("desc", "?") for i in queue)
             return f"❌ Beleza, deixei de lado: {restantes}."
 
         if valor is None or valor <= 0:
             # Não é um valor — o usuário mudou de assunto. Abandona a pendência e
             # deixa o roteador tratar a mensagem como um comando novo.
-            db.clear_pending_action(user_id)
+            db.consume_pending_action(user_id, pending)
             return None
 
         head, resto = queue[0], queue[1:]

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -747,7 +747,8 @@ def resolve_multi_launch_value(user_id: int, text: str, pending: dict, platform:
         # `add_from_entities` grava logo abaixo a dele ("categoria errada?").
         novo_payload = {"queue": resto, "platform": platform} if resto else None
         if not db.advance_pending_action(
-                user_id, "multi_launch_values", payload, novo_payload):
+                user_id, "multi_launch_values", payload, novo_payload,
+                old_created_at=pending.get("created_at")):
             # Outra thread avançou a fila entre a leitura e agora. Relê e
             # reavalia: o item que sobrou é o próximo, não este.
             pending = db.get_pending_action(user_id)
@@ -847,7 +848,8 @@ def _devolve_head(user_id: int, head: dict, platform: str) -> None:
             if db.advance_pending_action(
                     user_id, atual["action_type"], atual.get("payload") or {},
                     {"queue": [head], "platform": platform},
-                    new_action_type="multi_launch_values"):
+                    new_action_type="multi_launch_values",
+                    old_created_at=atual.get("created_at")):
                 return
             continue
         if not atual:
@@ -864,7 +866,8 @@ def _devolve_head(user_id: int, head: dict, platform: str) -> None:
         fila = [head] + list(antigo.get("queue") or [])
         if db.advance_pending_action(
                 user_id, "multi_launch_values", antigo,
-                {"queue": fila, "platform": antigo.get("platform", platform)}):
+                {"queue": fila, "platform": antigo.get("platform", platform)},
+                old_created_at=atual.get("created_at")):
             return
 
 

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -12,6 +12,13 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
     Verifica se existe uma pending_action para o usuário e a resolve.
     Trata: deletes de lançamento/caixinha/investimento e confirmação de lançamento via mídia.
     Retorna mensagem de resposta, ou None se não havia pending reconhecido.
+
+    Todo consumo é CONDICIONAL (`db.consume_pending_action`): apaga a pendência
+    que foi lida, não "o que estiver lá". Perder o compare-and-swap significa
+    que outra tarefa (Discord, ou a outra plataforma do mesmo usuário) já
+    trocou a linha — e aí o "sim" do usuário não é mais deste pedido. Nos
+    caminhos destrutivos o CAS é o porteiro: quem perde NÃO apaga nada e sai
+    como se não houvesse pendência, que é a verdade.
     """
     pending = db.get_pending_action(user_id)
     if not pending:
@@ -22,7 +29,10 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
     # ── Confirmação de lançamento extraído de imagem ─────────────────────────
     if action_type == "confirm_media_launch":
         payload = pending.get("payload", {})
-        db.clear_pending_action(user_id)
+        # Porteiro: registra dinheiro. Se a linha já não é a que lemos, outra
+        # tarefa consumiu ou substituiu — não registra em dobro.
+        if not db.consume_pending_action(user_id, pending):
+            return None
 
         if not confirmed:
             return "❌ Lançamento cancelado. Se quiser corrigir, escreva o comando manualmente."
@@ -74,7 +84,9 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
     # ── Oferta "virar gasto fixo" (despesa que se repetiu) ───────────────────
     if action_type == "confirm_recurring_offer":
         payload = pending.get("payload", {})
-        db.clear_pending_action(user_id)
+        # Porteiro: cria um gasto fixo que o autopay vai debitar todo mês.
+        if not db.consume_pending_action(user_id, pending):
+            return None
 
         if not confirmed:
             # grava a recusa pra não re-sugerir a mesma combinação (merchant+valor)
@@ -120,7 +132,8 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
     payload = pending.get("payload", {})
 
     if not confirmed:
-        db.clear_pending_action(user_id)
+        # Abandono: se perdeu o CAS, não havia nada nosso para cancelar.
+        db.consume_pending_action(user_id, pending)
         return "❌ Ação cancelada."
 
     if action_type == "delete_launch":
@@ -128,17 +141,21 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
         # display_id é o user_seq mostrado pro usuário; cai pro id interno
         # quando o pending foi criado em código antigo sem essa key.
         display_id = payload.get("display_id") or launch_id
+        # ANTES de apagar, não depois: o clear posterior não protegeria nada —
+        # as duas tarefas já teriam apagado o lançamento.
+        if not db.consume_pending_action(user_id, pending):
+            return None
         try:
             db.delete_launch_and_rollback(user_id, launch_id)
-            db.clear_pending_action(user_id)
             return f"✅ Lançamento **#{display_id}** apagado e saldo revertido."
         except Exception as e:
-            db.clear_pending_action(user_id)
             return f"Erro ao apagar lançamento #{display_id}: {e}"
 
     if action_type == "delete_launch_bulk":
         ids = payload.get("launch_ids", [])
         display_ids_map = payload.get("display_ids") or {}
+        if not db.consume_pending_action(user_id, pending):
+            return None
         failed = []
         for lid in ids:
             try:
@@ -146,7 +163,6 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
             except Exception:
                 failed.append(lid)
         ok_ids = [i for i in ids if i not in failed]
-        db.clear_pending_action(user_id)
         # converte ids internos pra user_seq pra exibição (fallback: id interno)
         def _disp(lid):
             return display_ids_map.get(str(lid), display_ids_map.get(lid, lid))
@@ -159,25 +175,26 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
 
     if action_type == "delete_pocket":
         pocket_name = payload.get("pocket_name")
+        if not db.consume_pending_action(user_id, pending):
+            return None
         try:
             db.delete_pocket(user_id, pocket_name)
-            db.clear_pending_action(user_id)
             return f"✅ Caixinha **{pocket_name}** deletada."
         except Exception as e:
-            db.clear_pending_action(user_id)
             return f"Erro ao deletar caixinha: {e}"
 
     if action_type == "delete_investment":
         investment_name = payload.get("investment_name")
+        if not db.consume_pending_action(user_id, pending):
+            return None
         try:
             db.delete_investment(user_id, investment_name)
-            db.clear_pending_action(user_id)
             return f"✅ Investimento **{investment_name}** deletado."
         except Exception as e:
-            db.clear_pending_action(user_id)
             return f"Erro ao deletar investimento: {e}"
 
-    db.clear_pending_action(user_id)
+    # Limpeza de estado: tipo destrutivo sem branch acima. Ignora o resultado.
+    db.consume_pending_action(user_id, pending)
     return None
 
 

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -177,7 +177,9 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
         if (confidence >= 0.55 and intent != "out_of_scope"
                 and intent not in ("confirm.yes", "confirm.no")
                 and not intent.startswith("investments.")):
-            db.clear_pending_action(user_id)
+            # Abandono: condicional para não apagar uma pendência que outra
+            # tarefa acabou de armar. Perder = não havia nada nosso lá.
+            db.consume_pending_action(user_id, pending)
             pending = None
         else:
             resp = h_investments.resolve_investment_pick(user_id, text, pending)
@@ -191,7 +193,7 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
             and intent not in ("confirm.yes", "confirm.no")
         )
         if abandonou:
-            db.clear_pending_action(user_id)
+            db.consume_pending_action(user_id, pending)
             pending = None
         else:
             resp = h_investments.resolve_funding_choice(user_id, text, pending)
@@ -214,7 +216,7 @@ def route(result: IntentResult, msg: IncomingMessage) -> str:
             and intent not in ("confirm.yes", "confirm.no")
             and intent != "out_of_scope"
             and confidence >= 0.55):
-        db.clear_pending_action(user_id)
+        db.consume_pending_action(user_id, pending)
         pending = None
 
     # -----------------------------------------------------------------------
@@ -546,8 +548,12 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
     original_entities = dict(payload.get("entities") or {})
     orig_text        = payload.get("orig_text", "")
 
-    # limpa o pending antes de executar
-    db.clear_pending_action(user_id)
+    # Consome ANTES de executar, e condicionado ao que foi lido: a intent
+    # original é re-executada abaixo (pode registrar/gastar). Se a linha já não
+    # é esta, outra tarefa a substituiu — o texto do usuário responde a OUTRA
+    # pergunta, e re-executar a antiga duplicaria a ação.
+    if not db.consume_pending_action(user_id, clarif):
+        return NOT_UNDERSTOOD_MSG
 
     # se o usuário negou / cancelou explicitamente
     resp_norm = user_response.strip().lower()

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -128,6 +128,7 @@ from .categories import (
 # ── Ações pendentes ───────────────────────────────────────────────────────────
 from .pending import (
     advance_pending_action,
+    consume_pending_action,
     claim_pending_action,
     create_pending_action_if_absent,
     set_pending_action,
@@ -451,7 +452,8 @@ __all__ = [
     "list_custom_category_names",
     # pending
     "set_pending_action", "get_pending_action", "clear_pending_action",
-    "advance_pending_action", "create_pending_action_if_absent",
+    "advance_pending_action", "consume_pending_action",
+    "create_pending_action_if_absent",
     "claim_pending_action",
     # budgets
     "list_budgets", "get_budget", "upsert_budget", "delete_budget",

--- a/db/pending.py
+++ b/db/pending.py
@@ -13,7 +13,8 @@ from .users import ensure_user
 def advance_pending_action(user_id: int, action_type: str,
                            old_payload: dict, new_payload: dict | None,
                            minutes: int = 10,
-                           new_action_type: str | None = None) -> bool:
+                           new_action_type: str | None = None,
+                           old_created_at: datetime | None = None) -> bool:
     """Avança (ou apaga) a pendência SÓ SE ela ainda for `old_payload`.
 
     Compare-and-swap. Duas respostas do mesmo usuário podem ser processadas em
@@ -35,25 +36,37 @@ def advance_pending_action(user_id: int, action_type: str,
     renova o prazo (`minutes`), como o `set_pending_action` que ela substitui —
     senão uma fila longa expiraria 10 min depois da PRIMEIRA pergunta, não da
     última resposta.
+
+    `old_created_at` fecha o ABA. Só `(action_type, payload)` identifica o
+    CONTEÚDO da linha, não a instância: se outra tarefa consome a pendência e o
+    usuário repete o MESMO comando, nasce uma linha nova de conteúdo idêntico e
+    o CAS de quem estava atrasado passa — executando a ação duas vezes, que é
+    exatamente o que ele existe para impedir. `created_at` é reescrito a cada
+    gravação (`set_pending_action`, o UPDATE abaixo, o default do INSERT), então
+    serve de versão da linha. Passe sempre que tiver a linha lida em mãos.
     """
+    versao = "" if old_created_at is None else " and created_at = %s"
+    extra: tuple = () if old_created_at is None else (old_created_at,)
     with get_conn() as conn:
         with conn.cursor() as cur:
             if new_payload is None:
                 cur.execute(
                     "delete from pending_actions "
-                    "where user_id = %s and action_type = %s and payload = %s",
-                    (user_id, action_type, Jsonb(old_payload)),
+                    "where user_id = %s and action_type = %s and payload = %s"
+                    + versao,
+                    (user_id, action_type, Jsonb(old_payload)) + extra,
                 )
             else:
                 cur.execute(
                     "update pending_actions "
                     "set action_type = %s, payload = %s, created_at = now(), "
                     "    expires_at = %s "
-                    "where user_id = %s and action_type = %s and payload = %s",
+                    "where user_id = %s and action_type = %s and payload = %s"
+                    + versao,
                     (new_action_type or action_type,
                      Jsonb(new_payload),
                      datetime.now(timezone.utc) + timedelta(minutes=minutes),
-                     user_id, action_type, Jsonb(old_payload)),
+                     user_id, action_type, Jsonb(old_payload)) + extra,
                 )
             gravou = cur.rowcount == 1
         conn.commit()
@@ -83,6 +96,7 @@ def consume_pending_action(user_id: int, pending: dict) -> bool:
         pending.get("action_type") or "",
         pending.get("payload") or {},
         None,
+        old_created_at=pending.get("created_at"),
     )
 
 
@@ -217,6 +231,7 @@ def claim_pending_action(user_id: int, action_type: str, payload: dict,
     return advance_pending_action(
         user_id, atual["action_type"], atual.get("payload") or {},
         payload, minutes, new_action_type=action_type,
+        old_created_at=atual.get("created_at"),
     )
 
 

--- a/db/pending.py
+++ b/db/pending.py
@@ -61,6 +61,31 @@ def advance_pending_action(user_id: int, action_type: str,
 
 
 
+def consume_pending_action(user_id: int, pending: dict) -> bool:
+    """Apaga a pendência SÓ SE ela ainda for a que você leu. True se apagou.
+
+    Atalho do `advance_pending_action(..., None)` para o caso mais comum: quem
+    consome tem a linha em mãos e quer apagar *aquela*, não "o que estiver lá".
+    `clear_pending_action` apaga incondicionalmente — se outra tarefa (Discord,
+    ou a outra plataforma do mesmo usuário) armou uma pergunta nova no
+    meio-tempo, ela some e o usuário fica com uma pergunta na tela cuja resposta
+    já não resolve nada.
+
+    False significa "a linha que eu li não está mais lá". Quem perde:
+
+    - **dinheiro ou destrutivo** (pagar, apagar, registrar) — NÃO executa. O
+      False é o porteiro: sem ele as duas tarefas executam a mesma ação.
+    - **abandono / limpeza de estado** — segue e ignora o resultado: se perdeu,
+      não havia nada seu para abandonar.
+    """
+    return advance_pending_action(
+        user_id,
+        pending.get("action_type") or "",
+        pending.get("payload") or {},
+        None,
+    )
+
+
 def create_pending_action_if_absent(user_id: int, action_type: str, payload: dict,
                                     minutes: int = 10) -> bool:
     """Cria a pendência SÓ SE o usuário não tiver nenhuma. Devolve True se criou.
@@ -103,7 +128,7 @@ def create_pending_action_if_absent(user_id: int, action_type: str, payload: dic
 #      anexou um BOTÃO à resposta: "categoria errada?", "quer desfazer?". Elas
 #      são consumidas no mesmo turno em que nascem, pelo
 #      `_send_reply_with_optional_buttons` (adapters/whatsapp/wa_runtime.py:
-#      181-211), que faz `clear_pending_action` antes de enviar. Se ainda
+#      181-211), que faz `consume_pending_action` antes de enviar. Se ainda
 #      estiverem de pé no turno seguinte é porque o botão não foi tocado —
 #      ignorar é a resposta mais comum, e o usuário refaz pelo comando normal
 #      ("muda a categoria do #12"). Pode ser desalojada por qualquer pergunta.
@@ -233,7 +258,18 @@ def get_pending_action(user_id: int):
         return None
 
     if row["expires_at"] <= datetime.now(timezone.utc):
-        clear_pending_action(user_id)
+        # Condicional no prazo, não `clear`: entre esta leitura e o delete outra
+        # tarefa pode ter armado uma pendência NOVA (prazo novo). Duas leituras
+        # simultâneas da linha vencida se atropelavam — a segunda apagava a
+        # pendência que a primeira tinha acabado de criar.
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "delete from pending_actions "
+                    "where user_id = %s and expires_at <= now()",
+                    (user_id,),
+                )
+            conn.commit()
         return None
 
     return row

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -38,15 +38,14 @@ def test_variable_bill_stores_pending_and_accepts_bare_amount(monkeypatch):
     # duas respostas concorrentes não criarem dois lançamentos. Aqui ela vence.
     reivindica = Mock(return_value=True)
     monkeypatch.setattr("db.bills.mark_bill_paid", mark)
-    monkeypatch.setattr("db.advance_pending_action", reivindica)
+    monkeypatch.setattr("db.consume_pending_action", reivindica)
 
     response = bills.resolve_bill_amount(7, "132,50", pending)
 
     mark.assert_called_once_with(7, 41, 132.5)
     # A pendência é apagada pela própria reivindicação (grava None se o payload
     # ainda for o lido), não mais por um clear incondicional.
-    reivindica.assert_called_once_with(
-        7, "bill_amount_expected", {"bill_id": 41, "bill_name": "Luz"}, None)
+    reivindica.assert_called_once_with(7, pending)
     assert "Conta paga" in response
     assert "R$ 132,50" in response
 
@@ -56,7 +55,7 @@ def test_non_numeric_reply_abandons_bill_question(monkeypatch):
     # não apagar uma pendência que outra tarefa tenha posto no lugar.
     abandona = Mock(return_value=True)
     mark = Mock()
-    monkeypatch.setattr("db.advance_pending_action", abandona)
+    monkeypatch.setattr("db.consume_pending_action", abandona)
     monkeypatch.setattr("db.bills.mark_bill_paid", mark)
     pending = {
         "action_type": "bill_amount_expected",
@@ -64,8 +63,7 @@ def test_non_numeric_reply_abandons_bill_question(monkeypatch):
     }
 
     assert bills.resolve_bill_amount(7, "mostra meu saldo", pending) is None
-    abandona.assert_called_once_with(
-        7, "bill_amount_expected", {"bill_id": 41, "bill_name": "Luz"}, None)
+    abandona.assert_called_once_with(7, pending)
     mark.assert_not_called()
 
 

--- a/tests/test_pending_consume_race.py
+++ b/tests/test_pending_consume_race.py
@@ -150,3 +150,30 @@ def test_leitura_de_pendencia_vencida_nao_apaga_a_nova(user_id, monkeypatch):
     nova = db.get_pending_action(user_id)
     assert nova is not None, "a limpeza da vencida apagou a pendência nova"
     assert nova["action_type"] == "bill_amount_expected"
+
+
+# ── ABA: pendência recriada com conteúdo idêntico ───────────────────────────
+
+def test_consumo_nao_apaga_pendencia_identica_recriada(user_id):
+    """`(action_type, payload)` identifica o CONTEÚDO, não a instância da linha.
+
+    Outra tarefa consome e executa; o usuário repete o MESMO comando e nasce uma
+    linha nova de conteúdo idêntico. Sem o `created_at` no predicado, o worker
+    atrasado consome ESSA e executa a ação de novo — o dobro do que o CAS existe
+    para impedir. Apontado pelo Codex no PR #141.
+    """
+    db.set_pending_action(user_id, "funding_source_choice", {"amount": 500.0})
+    lida = db.get_pending_action(user_id)
+
+    assert db.consume_pending_action(user_id, lida) is True
+
+    # o usuário repete o comando: pendência nova, payload idêntico
+    db.set_pending_action(user_id, "funding_source_choice", {"amount": 500.0})
+    nova = db.get_pending_action(user_id)
+    assert nova["created_at"] != lida["created_at"], "resolução de relógio insuficiente"
+
+    # o worker atrasado volta com a linha VELHA em mãos
+    assert db.consume_pending_action(user_id, lida) is False
+    ainda = db.get_pending_action(user_id)
+    assert ainda is not None, "consumiu a instância nova achando que era a velha"
+    assert ainda["created_at"] == nova["created_at"]

--- a/tests/test_pending_consume_race.py
+++ b/tests/test_pending_consume_race.py
@@ -1,0 +1,152 @@
+"""Consumo de pendência é compare-and-swap, não "apaga o que estiver lá".
+
+`pending_actions` tem UMA linha por usuário. Quem consome lê a linha, faz o
+trabalho e apagava com `clear_pending_action(uid)` — incondicional. Se outra
+tarefa (Discord, ou a outra plataforma do mesmo usuário) armasse uma pergunta
+nova nesse meio-tempo, ela era apagada por cima: o usuário ficava com uma
+pergunta na tela cuja resposta já não resolvia nada.
+
+Os testes abaixo montam a corrida de forma determinística — a outra tarefa
+grava a pendência dela DEPOIS da leitura e ANTES do consumo — e cobram as duas
+metades:
+
+- **porteiro** (`test_delete_launch_perdendo_*`, `test_confirm_media_*`): quem
+  perde o CAS não executa a ação destrutiva/de dinheiro E não apaga a pergunta
+  nova;
+- **controle positivo** (`test_delete_launch_sem_corrida_*`): sem corrida, o
+  consumo legítimo continua apagando e a ação acontece. Sem ele o grupo passaria
+  num código que recusa tudo.
+
+Controle negativo (medido): trocando o corpo de `db.consume_pending_action` por
+`clear_pending_action(user_id); return True` — o comportamento antigo — os três
+testes de corrida falham e o controle positivo continua verde.
+"""
+import db
+from core.handlers import pending as h_pending
+
+
+def _corrida_apos_leitura(monkeypatch, uid: int, tipo: str, payload: dict):
+    """A OUTRA tarefa grava a pendência dela logo depois da primeira leitura.
+
+    É o interleaving exato do defeito: `resolve_delete` já leu a linha antiga e
+    ainda não consumiu. Dispara uma vez só — o consumo relê nada, mas os ramos
+    de erro podem ler de novo.
+    """
+    original = db.get_pending_action
+    disparou: list[int] = []
+
+    def espiao(user_id: int):
+        row = original(user_id)
+        if row is not None and not disparou:
+            disparou.append(1)
+            db.set_pending_action(uid, tipo, payload)
+        return row
+
+    monkeypatch.setattr(db, "get_pending_action", espiao)
+    monkeypatch.setattr(h_pending.db, "get_pending_action", espiao, raising=False)
+    return disparou
+
+
+def _um_lancamento(user_id: int) -> int:
+    db.add_launch_and_update_balance(user_id, "despesa", 50.0, "mercado", "mercado")
+    return int(db.list_launches(user_id, limit=1)[0]["id"])
+
+
+# ── porteiro ────────────────────────────────────────────────────────────────
+
+def test_delete_launch_perdendo_cas_nao_apaga_nem_atropela_pergunta_nova(user_id, monkeypatch):
+    lid = _um_lancamento(user_id)
+    db.set_pending_action(user_id, "delete_launch", {"launch_id": lid, "display_id": 1})
+    _corrida_apos_leitura(monkeypatch, user_id, "bill_amount_expected",
+                          {"bill_id": 4242, "bill_name": "luz"})
+
+    resp = h_pending.resolve_delete(user_id, confirmed=True)
+
+    assert resp is None, "quem perde o CAS sai como se não houvesse pendência"
+    assert len(db.list_launches(user_id, limit=10)) == 1, "o lançamento não podia ser apagado"
+    nova = db.get_pending_action(user_id)
+    assert nova is not None, "a pergunta da outra tarefa foi apagada por cima"
+    assert nova["action_type"] == "bill_amount_expected"
+    assert (nova.get("payload") or {}).get("bill_id") == 4242
+
+
+def test_delete_launch_bulk_perdendo_cas_nao_apaga_nada(user_id, monkeypatch):
+    lid = _um_lancamento(user_id)
+    db.set_pending_action(user_id, "delete_launch_bulk",
+                          {"launch_ids": [lid], "display_ids": {}})
+    _corrida_apos_leitura(monkeypatch, user_id, "bill_amount_expected", {"bill_id": 7})
+
+    resp = h_pending.resolve_delete(user_id, confirmed=True)
+
+    assert resp is None
+    assert len(db.list_launches(user_id, limit=10)) == 1
+    assert db.get_pending_action(user_id)["action_type"] == "bill_amount_expected"
+
+
+def test_confirm_media_launch_perdendo_cas_nao_registra_dinheiro(user_id, monkeypatch):
+    db.set_pending_action(user_id, "confirm_media_launch", {
+        "valor": 99.9, "categoria": "mercado", "tipo": "despesa",
+        "alvo": "mercado", "platform": "whatsapp",
+    })
+    _corrida_apos_leitura(monkeypatch, user_id, "bill_amount_expected", {"bill_id": 8})
+
+    resp = h_pending.resolve_delete(user_id, confirmed=True)
+
+    assert resp is None
+    assert db.list_launches(user_id, limit=10) == [], "registrou lançamento com o CAS perdido"
+    assert db.get_pending_action(user_id)["action_type"] == "bill_amount_expected"
+
+
+# ── controle positivo: sem corrida, o consumo legítimo continua limpando ────
+
+def test_delete_launch_sem_corrida_apaga_o_lancamento_e_a_pendencia(user_id):
+    lid = _um_lancamento(user_id)
+    db.set_pending_action(user_id, "delete_launch", {"launch_id": lid, "display_id": 1})
+
+    resp = h_pending.resolve_delete(user_id, confirmed=True)
+
+    assert resp is not None and "apagado" in resp
+    assert db.list_launches(user_id, limit=10) == []
+    assert db.get_pending_action(user_id) is None
+
+
+def test_cancelar_sem_corrida_limpa_a_pendencia(user_id):
+    db.set_pending_action(user_id, "delete_launch", {"launch_id": 1, "display_id": 1})
+
+    assert h_pending.resolve_delete(user_id, confirmed=False) == "❌ Ação cancelada."
+    assert db.get_pending_action(user_id) is None
+
+
+# ── a própria leitura: linha vencida ────────────────────────────────────────
+
+def test_leitura_de_pendencia_vencida_nao_apaga_a_nova(user_id, monkeypatch):
+    """`get_pending_action` apagava a linha vencida sem condição.
+
+    Duas leituras simultâneas se atropelavam: a segunda armava a pergunta nova
+    na mesma linha e a primeira a apagava logo em seguida.
+    """
+    import db.pending as pend
+
+    db.set_pending_action(user_id, "delete_launch", {"launch_id": 1}, minutes=-1)
+
+    original = pend.get_conn
+    estado = {"n": 0, "dentro": False}
+
+    def get_conn_espiao():
+        # 1ª conexão = o SELECT; 2ª = a limpeza da linha vencida. A outra tarefa
+        # grava a pergunta dela exatamente entre as duas.
+        if not estado["dentro"]:
+            estado["n"] += 1
+            if estado["n"] == 2:
+                estado["dentro"] = True
+                db.set_pending_action(user_id, "bill_amount_expected", {"bill_id": 5})
+                estado["dentro"] = False
+        return original()
+
+    monkeypatch.setattr(pend, "get_conn", get_conn_espiao)
+    assert db.get_pending_action(user_id) is None, "a vencida não vale como resposta"
+    monkeypatch.setattr(pend, "get_conn", original)
+
+    nova = db.get_pending_action(user_id)
+    assert nova is not None, "a limpeza da vencida apagou a pendência nova"
+    assert nova["action_type"] == "bill_amount_expected"

--- a/tests/test_whatsapp_confirmations.py
+++ b/tests/test_whatsapp_confirmations.py
@@ -44,7 +44,10 @@ def test_credit_purchase_pending_renders_delete_button(monkeypatch):
         wr, "get_pending_action",
         lambda uid: {"action_type": "delete_credit_purchase", "payload": {"tx_id": 42}},
     )
-    monkeypatch.setattr(wr, "clear_pending_action", lambda uid: cleared.append(uid))
+    monkeypatch.setattr(
+        wr, "consume_pending_action",
+        lambda uid, pending: cleared.append(uid) or True,
+    )
     monkeypatch.setattr(wr, "send_interactive_buttons", lambda **kw: sent.append(kw))
 
     wr._send_reply_with_optional_buttons("5511999998888", "✅ Compra registrada! CC42", user_id=7)


### PR DESCRIPTION
Fecha #134.

O patch citado na issue (`docs/wip/varredura-consumidores-pendencia.patch`, no worktree `worktree-question-d612ba`) **não existe mais em lugar nenhum da máquina** — o worktree está lá, mas sem `docs/wip/`. A varredura e o conserto foram refeitos do zero. Os números batem com os da issue: 57 call sites, 54 convertidos, 2 exceções documentadas, 1 caso especial na leitura, e os 6 lugares onde o clear estava depois do trabalho.

## O defeito

`pending_actions` tem **uma linha por usuário**. Quem consome lia a linha, fazia o trabalho e chamava `clear_pending_action(uid)` — que apaga **o que estiver lá**, não o que foi lido. Se outra tarefa (Discord, ou a outra plataforma do mesmo usuário) armasse uma pergunta nova nesse meio-tempo, ela era apagada por cima e o usuário ficava com uma pergunta na tela cuja resposta já não resolve nada.

## O conserto

`db.consume_pending_action(uid, pending)` — atalho do `advance_pending_action(uid, tipo_lido, payload_lido, None)` que já existia. Duas regras para quem perde o CAS:

- **dinheiro ou destrutivo** (pagar fatura, criar parcelas, registrar lançamento, apagar lançamento/caixinha/investimento/cartão) → **porteiro**: não executa;
- **abandono / limpeza de estado** → segue e ignora o resultado: se perdeu, não havia nada seu para abandonar.

### Os 6 que mudaram de posição

O clear estava **depois** do trabalho, com par sucesso/except — ali ele não protegia nada, porque as duas tarefas já teriam apagado o dado. O consumo foi para antes:

| onde | o que rodava antes do clear |
|---|---|
| `core/handlers/pending.py` × 3 | `delete_launch_and_rollback`, `delete_pocket`, `delete_investment` |
| `core/handlers/credit.py` × 2 | `delete_card` (leva faturas e transações junto) |
| `adapters/discord/cogs/general_cog.py` | `finally:` depois de todos os deletes acima |

### Fora do escopo, de propósito

- **`_finish_card_setup` (`core/handlers/credit.py`, 2 sites)** — não há pendência lida ali, e `_ask_credit_limit_or_finish` reescreve a linha antes de chamar. Um CAS contra o que o chamador leu falharia **sempre** e prenderia o cadastro de cartão por 20 min. Comentado no código.
- **`ai_pending_actions`** (`db/ai_chat.py`, 5 pontos) — outra tabela, mesmo defeito, **sem** primitiva de compare-and-swap. Precisa da primitiva antes de qualquer conserto; fica para issue própria, como a #134 já registrava.

### Caso especial: a própria leitura

`get_pending_action` apagava a linha **vencida** de forma incondicional. Duas leituras simultâneas se atropelavam: a segunda armava a pergunta nova na mesma linha e a primeira a apagava logo em seguida. Agora o delete é condicionado ao prazo (`expires_at <= now()`).

## O que foi medido

Suíte local completa (`.venv/bin/python -m pytest -q`, Postgres real):

- **antes:** 1404 coletados — 1403 passam, 1 falha (`test_credit_purchase_pending_renders_delete_button`, que faz `monkeypatch.setattr(wr, "clear_pending_action", ...)`; o símbolo mudou de nome no módulo e o teste foi atualizado junto).
- **depois:** **1410 passam, 0 falham** (1404 + os 6 novos).

### Os dois controles, medidos

`tests/test_pending_consume_race.py` monta a corrida de forma determinística: a outra tarefa grava a pendência dela **depois** da leitura e **antes** do consumo.

- **negativo** — trocando o corpo de `consume_pending_action` por `clear_pending_action(user_id); return True` e a limpeza da vencida pelo `clear` incondicional (o comportamento antigo), os **4** testes de corrida falham:
  ```
  FAILED test_delete_launch_perdendo_cas_nao_apaga_nem_atropela_pergunta_nova
  FAILED test_delete_launch_bulk_perdendo_cas_nao_apaga_nada
  FAILED test_confirm_media_launch_perdendo_cas_nao_registra_dinheiro
  FAILED test_leitura_de_pendencia_vencida_nao_apaga_a_nova
  4 failed, 2 passed
  ```
- **positivo** — os outros **2** (`test_delete_launch_sem_corrida_apaga_o_lancamento_e_a_pendencia`, `test_cancelar_sem_corrida_limpa_a_pendencia`) passam nas **duas** versões, provando que o conserto não recusa o clear legítimo.

Os testes rodam contra Postgres real e conferem as duas metades de cada corrida: o dado destrutivo continua lá **e** a pergunta da outra tarefa não foi apagada.

## O que NÃO foi medido

- **Discord.** `_confirmar_pending` (`general_cog.py`) foi reescrito para consumir antes de executar e ficou fail-closed em erro de CAS, mas não há teste do cog nem bot do Discord no ar aqui. Revisado linha a linha, não exercitado.
- **WhatsApp em produção.** Os 6 pontos de `wa_runtime.py` (incluindo o `bill_pay_amount`, que é a outra porta da pergunta do #133) estão cobertos por `test_whatsapp_confirmations.py` no que toca aos botões one-shot; o caminho `bill_pay_amount` → `mark_bill_paid` não tem teste de corrida novo — o gêmeo dele (`resolve_bill_amount`, `core/handlers/bills.py`) já tinha o CAS desde o #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)