### PR TITLE
Uma tabela para os três predicados de pendência (#136, fatia 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,15 +564,15 @@ do usuário passou a matar duas pendências de uma vez.
 > abandonar, gravar e consumir — corrigida uma por rodada porque ninguém varreu os irmãos.
 > Antes de fechar qualquer conserto aqui, `grep` os outros pontos.
 
-**Três listas, três perguntas diferentes — avalie o tipo contra cada uma, não copie
-de uma para as outras.** Elas divergem de propósito; pertencer a cada uma significa
-coisas distintas:
+**Uma tabela, três perguntas diferentes.** O `_REGISTRO` (`db/pending.py`) tem uma
+linha por tipo de pendência e três colunas. As perguntas continuam sendo três — elas
+divergem de propósito — mas se respondem no mesmo lugar:
 
-| lista | pertencer significa | pergunta nova… |
+| coluna | pertencer significa | pergunta nova… |
 |---|---|---|
-| `_OFERTAS_DE_CONVENIENCIA` (`db/pending.py`) | **pode ser desalojada** por uma pergunta | fica **fora** — dentro, o `claim_pending_action` a apaga |
-| `_RESUMABLE_PENDING_TYPES` (`core/handle_incoming.py`) | **suprime o fallback da IA** enquanto está de pé | entra **só se** a resposta chegar pelo `handle_incoming` |
-| literal inline (`core/handle_incoming.py`, no ramo de áudio) | **não é sobrescrita** por `undo_audio` | entra se um áudio no meio dela puder atropelá-la |
+| `oferta` | **pode ser desalojada** por uma pergunta | fica **False** — True, o `claim_pending_action` a apaga |
+| `suprime_ia` | **suprime o fallback da IA** enquanto está de pé | True **só se** a resposta chegar pelo `handle_incoming` |
+| `sobrevive_audio` | **não é sobrescrita** por `undo_audio` | True se um áudio no meio dela puder atropelá-la |
 
 O critério de cada uma é observável, não é gosto:
 
@@ -580,15 +580,23 @@ O critério de cada uma é observável, não é gosto:
   (`wa_runtime.py`) a consome no mesmo turno. Se ela espera resposta do usuário, é
   pergunta — mesmo tendo "offer" no nome.
 - **precisa suprimir a IA?** só se a resposta natural do usuário chega até o
-  `handle_incoming`. `bill_pay_amount` está **fora** de propósito: o runtime do WhatsApp
-  a consome antes, e incluí-la suprimiria a IA sem motivo.
+  `handle_incoming` E o classificador não a reconhece. `bill_pay_amount` está **False**
+  de propósito: o runtime do WhatsApp a consome antes, e ligá-la suprimiria a IA sem
+  motivo. Quem é respondida com "sim"/"não" também fica False — o classificador
+  devolve `confirm.yes`/`confirm.no` com confiança alta.
+- **sobrevive a áudio?** só se perdê-la custa trabalho já feito. As confirmações
+  destrutivas ficam **False** de propósito: perdê-las é fail-safe, e protegê-las
+  reintroduz o footgun "apagar #285" → [áudio] → "sim" (o guard anti-órfão do
+  `intent_router` só dispara com comando de TEXTO).
 
-Copiar de uma lista para a outra causa bug silencioso nos dois sentidos: pergunta posta
-em `_OFERTAS_DE_CONVENIENCIA` perde o estado sem aviso; tipo já consumido pelo runtime
-posto em `_RESUMABLE_PENDING_TYPES` tira do usuário Pro a IA que ele paga.
+Marcar errado causa bug silencioso nos dois sentidos: pergunta com `oferta=True` perde o
+estado sem aviso; oferta com `oferta=False` bloqueia a linha por 10 min; tipo já
+consumido pelo runtime com `suprime_ia=True` tira do usuário Pro a IA que ele paga.
 
-**Dívida:** unificar as três é o pré-requisito das issues #130, #134 e #136 — enquanto
-forem três, cada pendência nova exige avaliar os três predicados à mão.
+**Tipo ausente da tabela = as três colunas False** — o comportamento de hoje para um
+tipo não listado, então nada muda em silêncio. O `tests/test_pending_registry.py` varre
+o código com `ast` atrás de todo tipo GRAVADO e reprova o que não estiver na tabela;
+reprova também a linha órfã que nenhum código grava.
 
 ### Validação de entrada: o critério é o dano, não a boa digitação
 

--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -752,7 +752,7 @@ def process_message(message: InboundMessage) -> None:
                 # hora de pagar). Isto não passa pelo `handle_incoming` — o
                 # consumidor está logo abaixo, na linha :896 deste arquivo,
                 # antes da chamada do handle_incoming em :1021 —, então não
-                # precisa de `_RESUMABLE_PENDING_TYPES` e não sofre o sequestro
+                # precisa do `suprime_ia` do registro e não sofre o sequestro
                 # pela IA. Unificar os dois é issue separada: este fluxo tem
                 # "cancelar", valor estimado no texto e re-pergunta própria, e
                 # mexer nele sem teste de botão é troca de bug conhecido por

--- a/core/handle_incoming.py
+++ b/core/handle_incoming.py
@@ -50,43 +50,14 @@ _HELP_FALLBACK_MARKERS: tuple[str, ...] = (
 )
 
 
-# Pendências determinísticas que o route() retoma com PRIORIDADE MÁXIMA — o bot
-# fez uma pergunta e está esperando a resposta. Espelha as checagens do topo do
-# route(): clarification de lançamento ("Em que você gastou?") e os fluxos
-# guiados de cartão. Enquanto uma delas está aberta, a resposta do user TEM que
-# passar pelo route() determinístico — nunca pelo fallback de IA. Sem isso, uma
-# resposta curta ("cinema", "dia 5") classifica como baixa confiança e a IA
-# sequestra o turno, perdendo o contexto (ex: o valor 77,90 já informado) e
-# falhando com "valor precisa ser maior que zero".
-#
-# NÃO inclui ofertas one-shot (recategorize_launch_offer, undo_audio): essas não
-# são perguntas e não devem bloquear a IA nas mensagens seguintes.
-#
-# Esta é UMA das três enumerações de "isto é pergunta?" que existem no código;
-# as outras duas (e o que diverge entre elas) estão listadas em db/pending.py,
-# no bloco de ORDEM DE PRIORIDADE.
-_RESUMABLE_PENDING_TYPES: frozenset[str] = frozenset({
-    "clarification",
-    "credit_card_setup",
-    "credit_card_set_primary",
-    "credit_delete_card",
-    "installment_pending",
-    "pay_bill_choice",
-    "funding_source_choice",
-    "investment_pick",
-    # A pergunta de valor de conta variável ("quanto veio este mês?") é
-    # respondida com um número solto, que classifica como out_of_scope. Sem
-    # estar aqui, o usuário Pro tem a resposta sequestrada pela IA e a conta
-    # fica sem pagar — que é o bug da issue #132 sobrevivendo para quem paga.
-    #
-    # Suprime SEMPRE, sem tentar adivinhar antes se a mensagem "parece um
-    # valor". Medido: o refinamento salvava 1 de 5 mudanças de assunto (as
-    # outras 4 já voltam pra IA pelo fallback 6b abaixo) e, em troca, mandava
-    # pra IA as 5 formas faladas de responder o valor ("foi 132", "acho que
-    # 132", "uns 132", "veio 132 reais", "deu 132,50") — que agora o
-    # `resolve_bill_amount` aceita.
-    "bill_amount_expected",
-})
+# "Isto é pergunta?" tem TRÊS respostas diferentes (cede a linha? suprime a
+# IA? sobrevive a um áudio?) e uma fonte só: o `_REGISTRO` de `db/pending.py`.
+# Este arquivo mantinha duas das três enumerações à mão — uma frozenset e um
+# literal inline — e elas divergiam da terceira sem que nada avisasse. Para
+# adicionar uma pendência nova, edite a tabela lá; o
+# `tests/test_pending_registry.py` reprova qualquer tipo que o código grave sem
+# estar nela.
+from db import sobrevive_a_audio, suprime_fallback_de_ia
 
 
 def _looks_like_help_fallback(response: str | None) -> bool:
@@ -358,13 +329,7 @@ def _handle_audio(msg: IncomingMessage, platform: str) -> list[OutgoingMessage] 
         # quando a resposta do áudio é um lançamento de fato, não uma pergunta.
         _pend = db.get_pending_action(uid)
         _ptype = _pend.get("action_type") if _pend else None
-        # `bill_pay_amount` é a pergunta de valor do botão "✅ Já paguei"
-        # (adapters/whatsapp/wa_runtime.py) — não está em
-        # `_RESUMABLE_PENDING_TYPES` porque o consumidor dela é o próprio
-        # runtime, então precisa ser nomeada aqui à mão. Terceira enumeração de
-        # "isto é pergunta?"; as três estão listadas em db/pending.py.
-        if _ptype not in _RESUMABLE_PENDING_TYPES and _ptype not in (
-                "multi_launch_values", "confirm_recurring_offer", "bill_pay_amount"):
+        if not sobrevive_a_audio(_ptype):
             db.set_pending_action(uid, "undo_audio", {})
 
     return [OutgoingMessage(text=preview + body + undo_hint)]
@@ -711,7 +676,7 @@ def handle_incoming(msg: IncomingMessage) -> list[OutgoingMessage]:
         has_resumable_pending = False
         try:
             _pend = db.get_pending_action(uid)
-            if _pend and _pend.get("action_type") in _RESUMABLE_PENDING_TYPES:
+            if _pend and suprime_fallback_de_ia(_pend.get("action_type")):
                 has_resumable_pending = True
         except Exception:
             has_resumable_pending = False

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -129,6 +129,9 @@ from .categories import (
 from .pending import (
     advance_pending_action,
     consume_pending_action,
+    eh_oferta_de_conveniencia,
+    suprime_fallback_de_ia,
+    sobrevive_a_audio,
     claim_pending_action,
     create_pending_action_if_absent,
     set_pending_action,
@@ -453,6 +456,7 @@ __all__ = [
     # pending
     "set_pending_action", "get_pending_action", "clear_pending_action",
     "advance_pending_action", "consume_pending_action",
+    "eh_oferta_de_conveniencia", "suprime_fallback_de_ia", "sobrevive_a_audio",
     "create_pending_action_if_absent",
     "claim_pending_action",
     # budgets

--- a/db/pending.py
+++ b/db/pending.py
@@ -2,6 +2,7 @@
 db/pending.py — Ações pendentes de confirmação (ex: "apagar lançamento?").
 """
 from datetime import datetime, timedelta, timezone
+from typing import NamedTuple
 
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
@@ -126,48 +127,143 @@ def create_pending_action_if_absent(user_id: int, action_type: str, payload: dic
 
 
 # ---------------------------------------------------------------------------
-# ORDEM DE PRIORIDADE DA LINHA ÚNICA DE `pending_actions`
+# REGISTRO DE PENDÊNCIAS — a fonte de verdade dos três predicados
 # ---------------------------------------------------------------------------
 # `pending_actions` tem UMA linha por usuário (`on conflict (user_id)`), então
-# todo fluxo que quer lembrar de algo disputa o mesmo espaço. Só existem dois
-# degraus, porque só isso é preciso para decidir quem cede:
+# todo fluxo que quer lembrar de algo disputa o mesmo espaço. Três decisões
+# diferentes dependem do TIPO da pendência, e até a issue #136 elas viviam em
+# três listas separadas que ninguém importava da outra — cada pendência nova
+# precisava ser lembrada nos três lugares, e esquecer um era silencioso.
 #
-#   1. PERGUNTAS — o bot parou e espera uma resposta que ele NÃO consegue
-#      reconstruir sozinho: quanto veio a conta, qual cartão, confirma apagar,
-#      qual o valor do item da fila. Perder isso perde dinheiro ou trabalho já
-#      feito pelo usuário. É tudo o que NÃO está na lista abaixo. Nunca é
-#      desalojado: quem chega depois é que se vira sem estado.
+# A tabela abaixo é a única lista. As três perguntas continuam SENDO TRÊS (elas
+# divergem de propósito — ver o que cada coluna significa); o que mudou é que se
+# responde as três no mesmo lugar, uma linha por tipo.
 #
-#   2. OFERTAS DE CONVENIÊNCIA (a lista) — o bot já concluiu o trabalho e
-#      anexou um BOTÃO à resposta: "categoria errada?", "quer desfazer?". Elas
-#      são consumidas no mesmo turno em que nascem, pelo
-#      `_send_reply_with_optional_buttons` (adapters/whatsapp/wa_runtime.py:
-#      181-211), que faz `consume_pending_action` antes de enviar. Se ainda
-#      estiverem de pé no turno seguinte é porque o botão não foi tocado —
-#      ignorar é a resposta mais comum, e o usuário refaz pelo comando normal
-#      ("muda a categoria do #12"). Pode ser desalojada por qualquer pergunta.
+# ── as três colunas, e o teste OBSERVÁVEL de cada uma ──────────────────────
 #
-# `confirm_recurring_offer` ESTEVE nesta lista e não é oferta: o nome engana. O
-# bot pergunta "isso virou gasto fixo? (sim ou não)" em TEXTO e ela NÃO é
-# consumida pelo runtime — sobrevive para o turno seguinte de propósito, porque
-# o "sim" é a resposta dela. Desalojando-a, o "sim" seguinte caía em "não
-# entendi bem o que você quis fazer" e derrubava as DUAS pendências: o Spotify
-# não virava gasto fixo e a pergunta da conta morria junto. É pergunta.
+# `oferta` — pode ser desalojada por uma pergunta?
+#     É oferta SÓ SE o `_send_reply_with_optional_buttons`
+#     (adapters/whatsapp/wa_runtime.py) a consome no MESMO turno em que ela
+#     nasce: o bot já concluiu o trabalho e anexou um botão à resposta
+#     ("categoria errada?", "quer desfazer?"). Se ainda estiver de pé no turno
+#     seguinte é porque o botão não foi tocado — ignorar é a resposta mais
+#     comum, e o usuário refaz pelo comando normal.
+#     Se ela ESPERA resposta do usuário, é PERGUNTA — mesmo tendo "offer" no
+#     nome. `confirm_recurring_offer` esteve marcada como oferta e não é: o bot
+#     pergunta "isso virou gasto fixo?" em TEXTO e o "sim" seguinte é a resposta
+#     dela. Desalojando-a, o "sim" caía em "não entendi" e derrubava DUAS
+#     pendências de uma vez.
+#     Marcar uma PERGUNTA como oferta perde o estado sem aviso; marcar uma
+#     OFERTA como pergunta faz ela bloquear a linha por 10 min — foi o que
+#     acontecia com `delete_credit_purchase` (medido: com a oferta de pé, o
+#     `claim_pending_action` de uma pergunta devolvia False).
 #
-# Sem esse degrau, a gravação condicional recusava por causa de QUALQUER linha:
-# um "gastei 50 no mercado" deixava a oferta de recategorizar de pé por 10 min
-# e o "paguei a luz" seguinte já não conseguia guardar de qual conta falava.
-_OFERTAS_DE_CONVENIENCIA: frozenset[str] = frozenset({
-    "recategorize_launch_offer",
-    "undo_audio",
-})
+# `suprime_ia` — enquanto está de pé, o fallback de IA fica desligado?
+#     Sim SÓ SE a resposta natural do usuário chega até o `handle_incoming` E o
+#     classificador não a reconhece. Um número solto ("1200", "132,50") ou um
+#     substantivo ("cinema") sai como `out_of_scope`/baixa confiança, e o
+#     fallback de IA roda ANTES do `route()` — então sem esta coluna a IA
+#     sequestra a resposta da própria pergunta que o bot fez. É o bug da #132.
+#     Fica FORA quem é consumida pelo runtime do WhatsApp ANTES do
+#     `handle_incoming` (`bill_pay_amount`, `recategorize_launch_text`):
+#     incluí-las desligaria a IA do usuário Pro sem motivo.
+#     Fica FORA também quem é respondida com "sim"/"não", que o classificador
+#     reconhece como `confirm.yes`/`confirm.no` com confiança alta.
+#     Suprime SEMPRE, sem tentar adivinhar antes se a mensagem "parece" uma
+#     resposta: medido no #133, o refinamento salvava 1 mudança de assunto em 5
+#     (as outras 4 voltam pra IA pelo fallback pós-route) e, em troca, mandava
+#     pra IA as 5 formas faladas de responder o valor.
+#
+# `sobrevive_audio` — um áudio no meio NÃO pode sobrescrevê-la?
+#     Sim quando perder a pendência custa trabalho já feito pelo usuário. As
+#     confirmações destrutivas ficam de FORA de propósito: perdê-las é
+#     fail-safe (o delete não acontece), e protegê-las reintroduziria o footgun
+#     "apagar #285" → [áudio] → "sim" apaga #285 — o guard anti-órfão do
+#     `intent_router` só dispara com comando de TEXTO, não com áudio.
+#
+# GAPS CONHECIDOS, deixados como estão para não misturar conserto de
+# comportamento com a unificação (issue #136, fatia 2):
+#   - `confirm_media_launch` e `recategorize_launch_text` são perguntas com
+#     `sobrevive_audio=False`: um áudio no meio apaga a confirmação da nota
+#     fiscal escaneada / a categoria que o usuário ia digitar.
+#
+# Tipo AUSENTE da tabela = as três colunas False, que é exatamente o
+# comportamento de hoje para um tipo não listado. Nada muda em silêncio — e o
+# `tests/test_pending_registry.py` reprova qualquer tipo novo que o código grave
+# sem passar por aqui.
+class _Pendencia(NamedTuple):
+    oferta: bool
+    suprime_ia: bool
+    sobrevive_audio: bool
+
+
+_AUSENTE = _Pendencia(False, False, False)
+
+
+_REGISTRO: dict[str, _Pendencia] = {
+    #                                          oferta suprime_ia sobrevive_audio
+    # ── perguntas retomadas pelo route() ──────────────────────────────────
+    "clarification":             _Pendencia(   False,   True,      True),
+    "credit_card_setup":         _Pendencia(   False,   True,      True),
+    "credit_card_set_primary":   _Pendencia(   False,   True,      True),
+    "credit_delete_card":        _Pendencia(   False,   True,      True),
+    "installment_pending":       _Pendencia(   False,   True,      True),
+    "pay_bill_choice":           _Pendencia(   False,   True,      True),
+    "funding_source_choice":     _Pendencia(   False,   True,      True),
+    "investment_pick":           _Pendencia(   False,   True,      True),
+    "bill_amount_expected":      _Pendencia(   False,   True,      True),
+    # "quanto foi *aluguel*?" — a resposta é um número solto, igualzinho à
+    # conta variável. Estava fora do `suprime_ia` e a IA do usuário Pro
+    # sequestrava a resposta (medido: a IA recebia "1200" e o item da fila
+    # ficava sem valor). Já estava na lista do áudio, o que mostra que a
+    # ausência era esquecimento, não decisão.
+    "multi_launch_values":       _Pendencia(   False,   True,      True),
+
+    # ── perguntas respondidas com "sim"/"não" (classificador reconhece) ───
+    "confirm_recurring_offer":   _Pendencia(   False,   False,     True),
+    "confirm_media_launch":      _Pendencia(   False,   False,     False),
+    "delete_launch":             _Pendencia(   False,   False,     False),
+    "delete_launch_bulk":        _Pendencia(   False,   False,     False),
+    "delete_pocket":             _Pendencia(   False,   False,     False),
+    "delete_investment":         _Pendencia(   False,   False,     False),
+
+    # ── perguntas consumidas pelo runtime do WhatsApp antes do handle_incoming
+    "bill_pay_amount":           _Pendencia(   False,   False,     True),
+    "recategorize_launch_text":  _Pendencia(   False,   False,     False),
+
+    # ── ofertas de conveniência (botão anexado, consumido no mesmo turno) ─
+    "recategorize_launch_offer": _Pendencia(   True,    False,     False),
+    "undo_audio":                _Pendencia(   True,    False,     False),
+    # O botão "🗑️ Apagar" pós-compra no crédito. É consumida pelo
+    # `_send_reply_with_optional_buttons` no mesmo turno, como as duas acima —
+    # mas estava fora da lista de ofertas, então uma que ficasse de pé (botão
+    # não tocado) bloqueava QUALQUER pergunta nova por 10 minutos.
+    "delete_credit_purchase":    _Pendencia(   True,    False,     False),
+}
+
+
+def eh_oferta_de_conveniencia(action_type: str | None) -> bool:
+    """Pode ser desalojada por uma pergunta? Ver a coluna `oferta` acima."""
+    return bool(action_type and _REGISTRO.get(action_type, _AUSENTE).oferta)
+
+
+def suprime_fallback_de_ia(action_type: str | None) -> bool:
+    """Desliga o fallback de IA enquanto está de pé? Coluna `suprime_ia`."""
+    return bool(action_type and _REGISTRO.get(action_type, _AUSENTE).suprime_ia)
+
+
+def sobrevive_a_audio(action_type: str | None) -> bool:
+    """Um áudio no meio NÃO pode sobrescrevê-la? Coluna `sobrevive_audio`."""
+    return bool(action_type and _REGISTRO.get(action_type, _AUSENTE).sobrevive_audio)
+
 
 # A MESMA pergunta ("quanto veio a conta este mês?") feita por DUAS portas: por
 # texto/IA ela vira `bill_amount_expected` (core/handlers/bills.py,
 # core/services/ai_chat/tools/bills.py) e pelo botão "✅ Já paguei" vira
 # `bill_pay_amount` (adapters/whatsapp/wa_runtime.py). Os tipos são diferentes
 # só porque cada porta tem o seu consumidor; para decidir quem cede a linha,
-# contam como uma pergunta só.
+# contam como uma pergunta só. Não é uma quarta coluna: é um grupo de
+# equivalência entre dois tipos, não um predicado sobre um tipo.
 #
 # Sem isto o botão perdia o claim para a pergunta de texto de OUTRA conta: quem
 # tinha dito "paguei a luz" e depois tocou "Já paguei" na ÁGUA via a pergunta da
@@ -177,19 +273,6 @@ _PERGUNTA_DE_VALOR_DE_CONTA: frozenset[str] = frozenset({
     "bill_amount_expected",
     "bill_pay_amount",
 })
-
-# OBSERVAÇÃO (não unificado neste PR): "isto é pergunta?" está enumerado em
-# TRÊS lugares, com conteúdos diferentes e nenhum deles importa o outro:
-#   1. esta lista (pelo avesso: pergunta é o que NÃO está aqui);
-#   2. `_RESUMABLE_PENDING_TYPES` (core/handle_incoming.py), que decide se a IA
-#      é suprimida;
-#   3. um literal inline em core/handle_incoming.py (~:357), que decide se o
-#      `undo_audio` pode sobrescrever a pendência.
-# Divergem: `bill_pay_amount` só existe na (3); `multi_launch_values` e
-# `confirm_recurring_offer` só existem na (3). Cada nova pendência precisa ser
-# lembrada nos três. Unificar é issue separada — as três perguntas são
-# diferentes ("cede a linha?", "suprime a IA?", "pode sobrescrever?") e juntar
-# sem enumerar estado × evento troca bug conhecido por bug novo.
 
 
 def claim_pending_action(user_id: int, action_type: str, payload: dict,
@@ -226,7 +309,7 @@ def claim_pending_action(user_id: int, action_type: str, payload: dict,
         or (atual["action_type"] in _PERGUNTA_DE_VALOR_DE_CONTA
             and action_type in _PERGUNTA_DE_VALOR_DE_CONTA)
     )
-    if atual["action_type"] not in _OFERTAS_DE_CONVENIENCIA and not mesma_pergunta:
+    if not eh_oferta_de_conveniencia(atual["action_type"]) and not mesma_pergunta:
         return False
     return advance_pending_action(
         user_id, atual["action_type"], atual.get("payload") or {},

--- a/tests/test_aporte_entende_o_nome.py
+++ b/tests/test_aporte_entende_o_nome.py
@@ -174,5 +174,5 @@ def test_pendencia_bloqueia_o_fallback_de_ia():
     """Sem isso, a resposta "1" cai como baixa confiança e a IA sequestra o turno
     (core/handle_incoming.py), que foi como a caixinha entrou na conversa."""
     pytest.importorskip("ofxparse", reason="ausente localmente; presente no CI")
-    from core.handle_incoming import _RESUMABLE_PENDING_TYPES
-    assert "investment_pick" in _RESUMABLE_PENDING_TYPES
+    from db import suprime_fallback_de_ia
+    assert suprime_fallback_de_ia("investment_pick")

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -379,7 +379,7 @@ def test_gate_da_ia_nao_deixa_o_numero_chegar_na_ia(ia_espia):
     """Amarra o COMPORTAMENTO do gate, não a presença do tipo numa lista.
 
     Com a pergunta viva, "132" tem que pagar a conta sem passar pela IA. Falha
-    se `bill_amount_expected` sair de `_RESUMABLE_PENDING_TYPES` — e falharia
+    se `bill_amount_expected` perder o `suprime_ia` no registro — e falharia
     também se o gate voltasse a filtrar a mensagem antes de suprimir.
     """
     import uuid

--- a/tests/test_funding_source.py
+++ b/tests/test_funding_source.py
@@ -291,8 +291,8 @@ def test_pendencia_bloqueia_o_fallback_de_ia():
     no CI o pacote existe e o teste roda.
     """
     pytest.importorskip("ofxparse", reason="ausente localmente; presente no CI")
-    from core.handle_incoming import _RESUMABLE_PENDING_TYPES
-    assert "funding_source_choice" in _RESUMABLE_PENDING_TYPES
+    from db import suprime_fallback_de_ia
+    assert suprime_fallback_de_ia("funding_source_choice")
 
 
 # ─── a mensagem que enganou ──────────────────────────────────────────────────

--- a/tests/test_pending_registry.py
+++ b/tests/test_pending_registry.py
@@ -28,11 +28,23 @@ from db.pending import _REGISTRO
 from core.types import IncomingMessage
 
 
+# função → (índice posicional, nome) do argumento que INTRODUZ um tipo.
 _ESCRITORES = {
-    "set_pending_action",
-    "claim_pending_action",
-    "create_pending_action_if_absent",
+    "set_pending_action": (1, "action_type"),
+    "claim_pending_action": (1, "action_type"),
+    "create_pending_action_if_absent": (1, "action_type"),
+    # O `action_type` posicional do `advance_pending_action` é o tipo LIDO, não
+    # um tipo novo — quem introduz tipo ali é o `new_action_type`, e só quando
+    # ele existe. É uma porta de escrita de verdade: o `_devolve_head`
+    # (core/handlers/launches.py) cria a fila `multi_launch_values` por ela.
+    # Sem esta entrada, um tipo que só nascesse de uma transição ficava fora da
+    # varredura — e o teste de órfão ainda mandaria APAGAR a linha legítima
+    # dele do registro. Apontado pelo Codex no PR #142.
+    "advance_pending_action": (5, "new_action_type"),
 }
+# Nestas, o argumento é opcional: ausente = a chamada não introduz tipo nenhum
+# (é um avanço ou um delete), então não é gravação para efeito da varredura.
+_OPCIONAL = {"advance_pending_action"}
 _RAIZ = pathlib.Path(__file__).resolve().parent.parent
 _IGNORADOS = {".venv", ".claude", ".git", "tests", "node_modules"}
 
@@ -43,18 +55,18 @@ _IGNORADOS = {".venv", ".claude", ".git", "tests", "node_modules"}
 _ENCANAMENTO = "db/pending.py"
 
 
-def _arg_action_type(no: ast.Call) -> ast.expr | None:
-    """O `action_type` da chamada, seja posicional ou por palavra-chave.
+def _arg_do_tipo(no: ast.Call, posicao: int, nome: str) -> ast.expr | None:
+    """O argumento que introduz o tipo, seja posicional ou por palavra-chave.
 
     `db.set_pending_action(user_id=uid, action_type="x", payload={})` é uma
     chamada válida e escapava da varredura, que só olhava `no.args[1]` — o tipo
     novo ficaria fora do registro, cairia nas três colunas False e o teste que
     existe para pegar isso passaria. Apontado pelo Codex no PR #142.
     """
-    if len(no.args) >= 2:
-        return no.args[1]
+    if len(no.args) > posicao:
+        return no.args[posicao]
     for kw in no.keywords:
-        if kw.arg == "action_type":
+        if kw.arg == nome:
             return kw.value
     return None
 
@@ -82,9 +94,11 @@ def _varre_gravacoes() -> tuple[dict[str, set[str]], list[str]]:
             nome = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
             if nome not in _ESCRITORES:
                 continue
-            alvo = _arg_action_type(no)
+            alvo = _arg_do_tipo(no, *_ESCRITORES[nome])
             if isinstance(alvo, ast.Constant) and isinstance(alvo.value, str):
                 achados.setdefault(alvo.value, set()).add(rel)
+            elif alvo is None and nome in _OPCIONAL:
+                continue          # avanço/delete: não introduz tipo nenhum
             elif rel != _ENCANAMENTO:
                 dinamicas.append(f"{rel}:{no.lineno} ({nome})")
     return achados, dinamicas

--- a/tests/test_pending_registry.py
+++ b/tests/test_pending_registry.py
@@ -36,12 +36,39 @@ _ESCRITORES = {
 _RAIZ = pathlib.Path(__file__).resolve().parent.parent
 _IGNORADOS = {".venv", ".claude", ".git", "tests", "node_modules"}
 
+# O encanamento genérico: `claim_pending_action` repassa o `action_type` que
+# RECEBEU para o `create_pending_action_if_absent`. Ali o tipo é uma variável de
+# propósito e não há literal para conferir — quem introduz o tipo é o chamador,
+# que a varredura pega. Único arquivo isento, e por esse motivo.
+_ENCANAMENTO = "db/pending.py"
 
-def _tipos_gravados_pelo_codigo() -> dict[str, set[str]]:
-    """tipo → arquivos que o gravam. Por `ast`, não por regex: as chamadas são
-    multilinha e um `grep` de uma linha só perdia 4 dos tipos."""
+
+def _arg_action_type(no: ast.Call) -> ast.expr | None:
+    """O `action_type` da chamada, seja posicional ou por palavra-chave.
+
+    `db.set_pending_action(user_id=uid, action_type="x", payload={})` é uma
+    chamada válida e escapava da varredura, que só olhava `no.args[1]` — o tipo
+    novo ficaria fora do registro, cairia nas três colunas False e o teste que
+    existe para pegar isso passaria. Apontado pelo Codex no PR #142.
+    """
+    if len(no.args) >= 2:
+        return no.args[1]
+    for kw in no.keywords:
+        if kw.arg == "action_type":
+            return kw.value
+    return None
+
+
+def _varre_gravacoes() -> tuple[dict[str, set[str]], list[str]]:
+    """(tipo → arquivos que o gravam, chamadas sem literal).
+
+    Por `ast`, não por regex: as chamadas são multilinha e um `grep` de uma
+    linha só perdia 4 dos tipos.
+    """
     achados: dict[str, set[str]] = {}
+    dinamicas: list[str] = []
     for py in _RAIZ.rglob("*.py"):
+        rel = str(py.relative_to(_RAIZ))
         if _IGNORADOS & set(py.relative_to(_RAIZ).parts):
             continue
         try:
@@ -53,18 +80,28 @@ def _tipos_gravados_pelo_codigo() -> dict[str, set[str]]:
                 continue
             fn = no.func
             nome = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
-            if nome not in _ESCRITORES or len(no.args) < 2:
+            if nome not in _ESCRITORES:
                 continue
-            alvo = no.args[1]
+            alvo = _arg_action_type(no)
             if isinstance(alvo, ast.Constant) and isinstance(alvo.value, str):
-                achados.setdefault(alvo.value, set()).add(
-                    str(py.relative_to(_RAIZ)))
-    return achados
+                achados.setdefault(alvo.value, set()).add(rel)
+            elif rel != _ENCANAMENTO:
+                dinamicas.append(f"{rel}:{no.lineno} ({nome})")
+    return achados, dinamicas
+
+
+def _tipos_gravados_pelo_codigo() -> dict[str, set[str]]:
+    return _varre_gravacoes()[0]
 
 
 def test_todo_tipo_gravado_esta_no_registro():
-    gravados = _tipos_gravados_pelo_codigo()
+    gravados, dinamicas = _varre_gravacoes()
     assert gravados, "a varredura não achou nenhuma gravação — o walk quebrou"
+    assert not dinamicas, (
+        "gravação cujo `action_type` não é literal: a varredura não consegue "
+        "conferir contra o registro, e um tipo novo passaria em silêncio. Use "
+        f"um literal, ou trate o caso aqui de propósito: {dinamicas}"
+    )
     faltando = {t: sorted(f) for t, f in gravados.items() if t not in _REGISTRO}
     assert not faltando, (
         "tipo gravado fora do registro de db/pending.py — as três colunas "

--- a/tests/test_pending_registry.py
+++ b/tests/test_pending_registry.py
@@ -1,0 +1,173 @@
+"""O registro de `db/pending.py` é a única lista de "isto é pergunta?".
+
+Antes da #136 as três respostas (cede a linha? suprime a IA? sobrevive a um
+áudio?) viviam em três enumerações que ninguém importava da outra. Divergiam, e
+esquecer uma era silencioso — foi o que aconteceu com `bill_amount_expected` no
+#133, que precisou de um commit de correção só para entrar na segunda lista.
+
+Este arquivo tem duas metades:
+
+1. **a guarda** — varre o código com `ast` atrás de todo tipo que é GRAVADO e
+   cobra que ele esteja na tabela. É o que impede a próxima pendência de nascer
+   fora dela;
+2. **as duas divergências que a unificação encontrou**, medidas ponta a ponta.
+
+Controle negativo (medido): tirando `multi_launch_values` do `suprime_ia`, o
+teste da fila falha; tirando o `oferta` de `delete_credit_purchase`, o teste do
+botão falha. Os dois positivos (`undo_audio` NÃO suprime a IA; uma pergunta de
+pé ainda recusa outra pergunta) passam nas duas versões.
+"""
+import ast
+import pathlib
+import uuid
+
+import pytest
+
+import db
+from db.pending import _REGISTRO
+from core.types import IncomingMessage
+
+
+_ESCRITORES = {
+    "set_pending_action",
+    "claim_pending_action",
+    "create_pending_action_if_absent",
+}
+_RAIZ = pathlib.Path(__file__).resolve().parent.parent
+_IGNORADOS = {".venv", ".claude", ".git", "tests", "node_modules"}
+
+
+def _tipos_gravados_pelo_codigo() -> dict[str, set[str]]:
+    """tipo → arquivos que o gravam. Por `ast`, não por regex: as chamadas são
+    multilinha e um `grep` de uma linha só perdia 4 dos tipos."""
+    achados: dict[str, set[str]] = {}
+    for py in _RAIZ.rglob("*.py"):
+        if _IGNORADOS & set(py.relative_to(_RAIZ).parts):
+            continue
+        try:
+            arvore = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:                                   # pragma: no cover
+            continue
+        for no in ast.walk(arvore):
+            if not isinstance(no, ast.Call):
+                continue
+            fn = no.func
+            nome = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            if nome not in _ESCRITORES or len(no.args) < 2:
+                continue
+            alvo = no.args[1]
+            if isinstance(alvo, ast.Constant) and isinstance(alvo.value, str):
+                achados.setdefault(alvo.value, set()).add(
+                    str(py.relative_to(_RAIZ)))
+    return achados
+
+
+def test_todo_tipo_gravado_esta_no_registro():
+    gravados = _tipos_gravados_pelo_codigo()
+    assert gravados, "a varredura não achou nenhuma gravação — o walk quebrou"
+    faltando = {t: sorted(f) for t, f in gravados.items() if t not in _REGISTRO}
+    assert not faltando, (
+        "tipo gravado fora do registro de db/pending.py — as três colunas "
+        f"cairiam em False sem ninguém decidir: {faltando}"
+    )
+
+
+def test_registro_nao_tem_tipo_morto():
+    """O contrário: entrada na tabela que nada grava é lixo que confunde."""
+    gravados = set(_tipos_gravados_pelo_codigo())
+    # `undo_audio` é gravado pelo handle_incoming e `clarification` pelos
+    # handlers; se algum dia um tipo sumir do código, a linha tem que sumir junto.
+    orfaos = sorted(set(_REGISTRO) - gravados)
+    assert not orfaos, f"tipos no registro que nenhum código grava: {orfaos}"
+
+
+# ── as duas divergências que a unificação encontrou ─────────────────────────
+
+def _uid_de_whatsapp() -> int:
+    """Abaixo de 2 bilhões de propósito.
+
+    O `_normalize_user_id` do `handle_incoming` COMPRIME qualquer id acima disso
+    para outro id interno — gravar a pendência no id da fixture `user_id` (que
+    sorteia até 10 bilhões) e mandar a mensagem por ele mediria dois usuários
+    diferentes, e o teste ficaria verde ou vermelho por motivo nenhum. Mesmo
+    formato do `tests/test_bill_amount_pending.py`.
+    """
+    return int(uuid.uuid4().int % 1_000_000_000)
+
+
+def _diga(uid, texto):
+    import core.handle_incoming as HI
+
+    msg = IncomingMessage(platform="whatsapp", user_id=uid, text=texto,
+                          message_id="x", attachments=[], external_id="e", raw={})
+    assert HI._normalize_user_id(msg) == uid, "o uid do teste seria comprimido"
+    saida = HI.handle_incoming(msg)
+    return saida[0].text if saida else ""
+
+
+@pytest.fixture
+def ia_espia(monkeypatch):
+    """Mocka a IA e devolve a lista de mensagens que chegaram nela."""
+    import core.services.ai_chat as AC
+
+    vistas: list[str] = []
+    monkeypatch.setattr(AC, "chat", lambda uid, text, **kw: vistas.append(text) or "[IA]")
+    monkeypatch.setattr("core.services.plan_service.ai_chat_allowed", lambda u: True)
+    return vistas
+
+
+def test_pergunta_da_fila_nao_e_sequestrada_pela_ia(ia_espia):
+    """"quanto foi *aluguel*?" → "1200" tem de chegar ao route(), não à IA.
+
+    `multi_launch_values` estava fora do `suprime_ia`. A resposta é um número
+    solto, que classifica como `out_of_scope`, e o fallback de IA roda ANTES do
+    `route()` — então a IA do usuário Pro recebia "1200" e o item da fila ficava
+    sem valor. É a #132 sobrevivendo para quem paga.
+    """
+    user_id = _uid_de_whatsapp()
+    db.set_pending_action(user_id, "multi_launch_values",
+                          {"queue": [{"desc": "aluguel", "tipo": "despesa"}],
+                           "platform": "whatsapp"})
+
+    _diga(user_id, "1200")
+
+    assert ia_espia == [], f"a IA sequestrou a resposta da fila: {ia_espia}"
+    lancamentos = db.list_launches(user_id, limit=5)
+    assert len(lancamentos) == 1, f"o item da fila não foi registrado: {lancamentos}"
+    assert float(lancamentos[0]["valor"]) == 1200.0
+
+
+def test_oferta_do_botao_apagar_nao_bloqueia_uma_pergunta(user_id):
+    """`delete_credit_purchase` é consumida no mesmo turno pelo
+    `_send_reply_with_optional_buttons` — logo é oferta. Fora da coluna
+    `oferta`, uma que ficasse de pé (botão não tocado) travava QUALQUER
+    pergunta nova por 10 minutos."""
+    db.set_pending_action(user_id, "delete_credit_purchase", {"tx_id": 1})
+
+    assert db.claim_pending_action(
+        user_id, "bill_amount_expected", {"bill_id": 7, "bill_name": "Luz"}) is True
+    atual = db.get_pending_action(user_id)
+    assert atual["action_type"] == "bill_amount_expected"
+
+
+# ── controles positivos ────────────────────────────────────────────────────
+
+def test_oferta_de_pe_nao_desliga_a_ia(ia_espia):
+    """Oferta não é pergunta: com uma de pé, o fallback de IA continua valendo.
+    Sem este caso, marcar tudo como `suprime_ia` passaria no grupo."""
+    user_id = _uid_de_whatsapp()
+    db.set_pending_action(user_id, "undo_audio", {})
+
+    _diga(user_id, "qual a capital da mongolia")
+
+    assert ia_espia, "a oferta de pé desligou a IA do usuário Pro"
+
+
+def test_pergunta_de_pe_ainda_recusa_outra_pergunta(user_id):
+    """O degrau continua existindo: pergunta NÃO é desalojada por pergunta.
+    Sem este caso, marcar tudo como `oferta` passaria no grupo."""
+    db.set_pending_action(user_id, "clarification", {"intent": "launches.list"})
+
+    assert db.claim_pending_action(
+        user_id, "investment_pick", {"nomes": ["cdb"]}) is False
+    assert db.get_pending_action(user_id)["action_type"] == "clarification"


### PR DESCRIPTION
Fatia 1 da #136 — o **pré-requisito** que a própria issue aponta: enquanto "isto é pergunta?" estiver enumerado em três lugares, as 38 perguntas novas viram 38 chances de esquecer um deles. Não mexe em nenhuma das 38 ainda.

## O problema

Três decisões diferentes dependem do tipo da pendência, e cada uma tinha a sua lista, sem nenhuma importar a outra:

| onde | pergunta |
|---|---|
| `_OFERTAS_DE_CONVENIENCIA` (`db/pending.py`) | cede a linha para uma pergunta? |
| `_RESUMABLE_PENDING_TYPES` (`core/handle_incoming.py`) | suprime o fallback da IA? |
| literal inline (`core/handle_incoming.py`, ramo de áudio) | sobrevive a um `undo_audio`? |

Adicionar uma pendência exigia lembrar dos três, e esquecer era silencioso — o `bill_amount_expected` do #133 precisou de um commit de correção (`0e7ab40`) só para entrar na segunda.

## O que este PR faz

**Não** colapsa as três numa só: elas divergem de propósito, e juntar sem enumerar estado × evento trocaria bug conhecido por bug novo. O que muda é que se respondem no mesmo lugar — `_REGISTRO`, **uma linha por tipo, três colunas**, com o teste *observável* de cada coluna escrito ao lado dela.

Os 21 tipos foram levantados por `ast` sobre todas as chamadas de gravação (`set_pending_action` / `claim_pending_action` / `create_pending_action_if_absent`). **Um `grep` de uma linha perdia 4 deles** — `credit_delete_card`, `installment_pending`, `investment_pick` e `pay_bill_choice` são gravados em chamadas multilinha.

`core/handle_incoming.py` perde as duas enumerações locais e passa a chamar `suprime_fallback_de_ia()` / `sobrevive_a_audio()`. O `sobrevive_audio` da tabela reproduz **exatamente** o literal inline de hoje — nenhuma mudança de comportamento nessa coluna.

## As duas divergências que a enumeração achou

As duas medidas ponta a ponta, não deduzidas:

**1. `multi_launch_values` estava fora do `suprime_ia`.** O bot pergunta *"quanto foi *aluguel*?"*; a resposta é um número solto, que classifica como `out_of_scope`; e o fallback de IA roda **antes** do `route()`. Medido: a IA do usuário Pro recebia `"1200"` e o item da fila ficava sem valor. É a #132 sobrevivendo para quem paga. Ele **já estava** na lista do áudio, o que mostra que a ausência era esquecimento e não decisão.

**2. `delete_credit_purchase` estava fora das ofertas.** Pelo critério observável do próprio repositório (é oferta sse o `_send_reply_with_optional_buttons` a consome no mesmo turno), ela é oferta — igual às outras duas do mesmo bloco. Tratada como pergunta, uma que ficasse de pé (botão "🗑️ Apagar" não tocado) fazia o `claim_pending_action` de **qualquer** pergunta nova devolver `False` por 10 minutos.

## Como isto impede o próximo esquecimento

- **Tipo ausente da tabela = as três colunas `False`**, que é exatamente o comportamento de hoje para um tipo não listado. Nada muda em silêncio.
- `tests/test_pending_registry.py` varre o código com `ast` e **reprova todo tipo gravado que não esteja na tabela** — e também a linha órfã que nenhum código grava.

## O que foi medido

Suíte local completa: **1417 passam** (baseline `main` = 1411, +6 novos). Nenhuma falha.

**Três controles negativos**, cada um injetado onde discrimina e derrubando exatamente um teste:

| conserto desligado | teste que falha |
|---|---|
| `multi_launch_values` volta a `suprime_ia=False` | `test_pergunta_da_fila_nao_e_sequestrada_pela_ia` |
| `delete_credit_purchase` volta a `oferta=False` | `test_oferta_do_botao_apagar_nao_bloqueia_uma_pergunta` |
| gravar um `"tipo_inventado"` fora da tabela | `test_todo_tipo_gravado_esta_no_registro` |

**Dois controles positivos**, verdes nas quatro versões: oferta de pé **não** desliga a IA do Pro; pergunta de pé **ainda** recusa outra pergunta. Sem eles o grupo passaria num código que marcasse tudo como `suprime_ia` ou tudo como `oferta`.

Uma armadilha vale registro porque quase produziu um resultado falso: a fixture `user_id` sorteia até 10 bilhões, e o `_normalize_user_id` do `handle_incoming` **comprime** qualquer id acima de 2 bilhões para outro id interno. A primeira medição gravava a pendência num usuário e mandava a mensagem por outro. Os testes ponta a ponta agora usam um uid abaixo do teto e **afirmam** que ele não é comprimido.

## O que NÃO foi medido

- **Discord.** O registro é consultado só pelo `handle_incoming` e pelo `claim_pending_action`; o cog do Discord não passa por nenhum dos dois. Nada muda para ele neste PR.
- **As 38 perguntas sem estado da #136** continuam sem estado. Este PR só monta o mecanismo; a fatia 2 (as 5 que gravam despesa que o usuário não pediu) vem em PR próprio.

## Gaps conhecidos, deixados de propósito

Anotados na tabela para não misturar conserto de comportamento com a unificação: `confirm_media_launch` e `recategorize_launch_text` são perguntas com `sobrevive_audio=False` — um áudio no meio apaga a confirmação da nota fiscal escaneada / a categoria que o usuário ia digitar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)