### PR TITLE
Categoria digitada colapsa numa grafia só em todas as portas

### DIFF
--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -321,13 +321,20 @@ def _apply_recategorize(user_id: int, launch_id: int, raw_categoria: str) -> str
 
     `launch_id` é o id INTERNO (vem do payload do botão). O display usa user_seq.
     """
-    from utils_text import canonicalize_category_label  # local import (evita ciclo)
-    from db import display_id_for
+    from db import display_id_for, ensure_user_category, resolve_category_input  # local (evita ciclo)
 
     cat = (raw_categoria or "").strip()
     if not cat:
         return "Categoria inválida. Tente novamente."
-    canon = canonicalize_category_label(cat) or cat.lower()
+    try:
+        # lê o catálogo do usuário: exceção de banco aqui matava o turno inteiro
+        # (a pendência já foi apagada) e o usuário não recebia resposta nenhuma.
+        canon = resolve_category_input(user_id, cat, create=True)
+    except Exception as exc:
+        logger.exception("WA recategorize resolve failed launch=%s: %s", launch_id, exc)
+        return "Não consegui atualizar agora. Tente de novo em instantes."
+    if not canon:
+        return "Categoria inválida. Tente novamente."
     try:
         ok = update_launch_category(user_id, launch_id, canon)
     except Exception as exc:
@@ -335,6 +342,7 @@ def _apply_recategorize(user_id: int, launch_id: int, raw_categoria: str) -> str
         return "Não consegui atualizar agora. Tente de novo em instantes."
     if not ok:
         return "Lançamento não encontrado (talvez já tenha sido apagado)."
+    ensure_user_category(user_id, canon)
     display = display_id_for(user_id, launch_id)
     return f"✅ Categoria do lançamento #{display} atualizada para *{canon}*."
 

--- a/core/budget_alerts.py
+++ b/core/budget_alerts.py
@@ -22,7 +22,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Iterable
 
-from db.connection import get_conn, cat_norm_sql
+from db.connection import get_conn, cat_norm_sql, CAT_CANON_ORDER
 from utils_text import fmt_brl
 
 # Comparacao de categoria case- E acento-insensivel (fonte unica: db/connection.py).
@@ -113,7 +113,7 @@ def evaluate_after_expense(
             with conn.cursor() as cur:
                 cur.execute(
                     "select categoria, budget from category_budgets "
-                    f"where user_id = %s and {_CAT_EQ}",
+                    f"where user_id = %s and {_CAT_EQ}{CAT_CANON_ORDER}",
                     (user_id, cat),
                 )
                 bgt_row = cur.fetchone()

--- a/core/budget_alerts.py
+++ b/core/budget_alerts.py
@@ -22,8 +22,11 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Iterable
 
-from db.connection import get_conn
+from db.connection import get_conn, cat_norm_sql
 from utils_text import fmt_brl
+
+# Comparacao de categoria case- E acento-insensivel (fonte unica: db/connection.py).
+_CAT_EQ = f"{cat_norm_sql('categoria')} = {cat_norm_sql('%s')}"
 
 
 THRESHOLDS = (80, 100, 120)
@@ -110,7 +113,7 @@ def evaluate_after_expense(
             with conn.cursor() as cur:
                 cur.execute(
                     "select categoria, budget from category_budgets "
-                    "where user_id = %s and lower(categoria) = lower(%s)",
+                    f"where user_id = %s and {_CAT_EQ}",
                     (user_id, cat),
                 )
                 bgt_row = cur.fetchone()
@@ -122,12 +125,12 @@ def evaluate_after_expense(
                     return None
 
                 cur.execute(
-                    """
+                    f"""
                     select coalesce(sum(valor), 0) as total
                     from launches
                     where user_id = %s
                       and tipo in ('despesa', 'saida')
-                      and lower(categoria) = lower(%s)
+                      and {_CAT_EQ}
                       and is_internal_movement = false
                       and date_part('year',  criado_em) = %s
                       and date_part('month', criado_em) = %s
@@ -143,7 +146,7 @@ def evaluate_after_expense(
 
                 cur.execute(
                     "select threshold from budget_alert_sent "
-                    "where user_id = %s and lower(categoria) = lower(%s) and ym = %s",
+                    f"where user_id = %s and {_CAT_EQ} and ym = %s",
                     (user_id, cat_canon, ym),
                 )
                 already = {int(r["threshold"]) for r in cur.fetchall()}

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -427,7 +427,7 @@ def add_from_entities(
             # pra "alimentação"). Faz cross-check com as regras determinísticas:
             # um match confiante de regra do usuário / ticker / LOCAL_RULES que
             # CONTRADIZ a IA vence. allow_ai=False pra não gastar 2ª chamada de LLM.
-            categoria_ai = canonicalize_category_label(categoria) or categoria
+            categoria_ai = infer_category(user_id, "", categoria).category
             local = infer_category(user_id, nota_clean, None, allow_ai=False)
             if local.reason in {"user_rule", "user_category", "ticker_match", "local_rule"} and local.category != categoria_ai:
                 logger.info(
@@ -439,7 +439,7 @@ def add_from_entities(
             else:
                 categoria_final = categoria_ai
         else:
-            categoria_final = categoria
+            categoria_final = infer_category(user_id, "", categoria).category
     else:
         res = infer_category(user_id, nota_clean, None)
         categoria_final = res.category or "outros"

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -27,9 +27,11 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
         if not confirmed:
             return "❌ Lançamento cancelado. Se quiser corrigir, escreva o comando manualmente."
 
-        # Caminho novo: prévia estruturada. Registra EXATAMENTE o que o usuário
-        # confirmou — categoria e data da prévia — sem re-inferir do texto. É o
-        # que corrige "Amazônia" virar "compras online" na re-classificação.
+        # Caminho novo: prévia estruturada. Registra a categoria e a data DA
+        # PRÉVIA, sem re-inferir do texto — é o que corrige "Amazônia" virar
+        # "compras online" na re-classificação. A grafia ainda passa pela
+        # normalização de storage (`_normalize_category_name`): 'Comida
+        # Japonesa' é gravado como 'comida japonesa'.
         if payload.get("valor") is not None and payload.get("categoria"):
             from core.handlers.launches import add_from_entities
 

--- a/core/services/ai_chat/tools/categories.py
+++ b/core/services/ai_chat/tools/categories.py
@@ -89,10 +89,18 @@ def _recategorize_launch_summary(args: dict[str, Any]) -> str:
 
 def _recategorize_launch_execute(user_id: int, args: dict[str, Any]) -> str:
     from db.accounts import update_launch_fields
+    from db.categories import ensure_user_category, resolve_category_input
     launch_id = int(args.get("launch_id") or 0)
-    new_category = (args.get("new_category") or "").strip()
+    new_category = resolve_category_input(
+        user_id, args.get("new_category") or "", create=True
+    )
+    if not new_category:
+        return "🐷 Faltou a categoria nova. Manda de novo."
     ok = update_launch_fields(user_id, launch_id, categoria=new_category)
     if ok:
+        # criar só depois do UPDATE: launch_id inexistente não pode deixar
+        # categoria órfã no catálogo.
+        ensure_user_category(user_id, new_category)
         return f"✅ Lançamento #{launch_id} agora é {new_category}."
     return f"🐷 Não consegui atualizar o lançamento #{launch_id}."
 

--- a/core/services/category_service.py
+++ b/core/services/category_service.py
@@ -22,6 +22,7 @@ from db import (
     get_memorized_category,
     upsert_category_rule,
     list_custom_category_names,
+    resolve_category_input,
 )
 
 
@@ -174,7 +175,13 @@ def infer_category(user_id: int, text_base: str, explicit_category: str | None =
     pra fazer cross-check, sem gastar uma segunda chamada de LLM.
     """
     if explicit_category:
-        cat = canonicalize_category_label(explicit_category)
+        # Texto livre do usuário (hashtag `#McDonald's`, `categoria` da tool
+        # `add_launch`): tem de virar a grafia do catálogo, senão o lançamento
+        # nasce em `mcdonald s` e abre fatia gêmea da `mcdonald's` que já
+        # existe. `create=False`: inferência é READ-ONLY (ver
+        # `user_category_display_map`); quem grava é a porta.
+        cat = resolve_category_input(user_id, explicit_category, create=False) \
+            or canonicalize_category_label(explicit_category)
         return InferResult(category=cat or "outros", reason="explicit")
 
     # C) ticker BR em MAIÚSCULAS — convenção do mercado, baixíssimo risco
@@ -194,7 +201,16 @@ def infer_category(user_id: int, text_base: str, explicit_category: str | None =
     # B) regras do usuário (mesma fonte do comando "criar categoria ... linkar ...")
     cat = get_memorized_category(user_id, t)
     if cat:
-        return InferResult(category=canonicalize_category_label(cat), reason="user_rule")
+        # A regra guarda a categoria NORMALIZADA (sem acento) — é índice interno.
+        # A forma de exibição vem de user_categories; o canonicalize é o
+        # fallback de quando a regra aponta pra categoria que não existe lá.
+        # ponytail: +1 query por inferência que bate em regra do usuário. Se
+        # pesar, o display_map vira cache por request (os importadores já o
+        # pré-carregam uma vez, que é onde o N+1 doeria).
+        return InferResult(
+            category=resolve_category_input(user_id, cat, create=False) or canonicalize_category_label(cat),
+            reason="user_rule",
+        )
 
     # B2) categoria CUSTOM criada pelo usuário (na tela) sem regra de keyword.
     #     Se o lançamento menciona um token distintivo do nome dela, usa. Vem

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -387,6 +387,30 @@ def agent_kind_allowed(user_id: int, kind: str) -> bool:
     return agents_energy_budget(int(user_id)) > 0
 
 
+# Tier mínimo de cada feature paga da escada v2. Fonte única: o gate HTTP
+# (_require_pro/require_pro_feature no monólito) e os gates fora do HTTP
+# (ex.: criar categoria custom por uma correção do WhatsApp/IA) leem daqui.
+FEATURE_MIN_TIER_V2 = {
+    "recurring_expenses": "essencial",
+    "ofx_import": "essencial",
+    "investments": "essencial",
+    "export": "essencial",
+    "custom_categories": "essencial",
+    "forecast": "pro",
+    "generic": "essencial",
+}
+
+
+def plan_gate_ok(user_id: int, feature: str) -> bool:
+    """True se o usuário pode usar `feature`. v1: Pro binário. v2: tier mínimo
+    da escada; 'ai_chat' é cota mensal, não tier."""
+    if not plans_v2_enabled():
+        return is_pro(user_id)
+    if feature == "ai_chat":
+        return ai_chat_allowed(user_id)
+    return require_min_tier(user_id, FEATURE_MIN_TIER_V2.get(feature, "essencial"))
+
+
 def require_min_tier(user_id: int, minimum: str) -> bool:
     """True se o tier efetivo do usuário é >= minimum ('essencial'|'plus'|'pro').
     Com v2 off, cai na semântica legada (is_pro pra qualquer exigência paga)."""

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -123,6 +123,10 @@ from .categories import (
     resolve_category_rule_target,
     get_uncategorized_launches,
     list_custom_category_names,
+    resolve_category_input,
+    user_category_display_map,
+    ensure_user_category,
+    CATEGORY_NAME_MAX_LEN,
 )
 
 # ── Ações pendentes ───────────────────────────────────────────────────────────
@@ -449,6 +453,8 @@ __all__ = [
     "get_memorized_category", "upsert_category_rule", "list_user_category_rules",
     "resolve_category_rule_target", "get_uncategorized_launches",
     "list_custom_category_names",
+    "resolve_category_input", "user_category_display_map",
+    "ensure_user_category", "CATEGORY_NAME_MAX_LEN",
     # pending
     "set_pending_action", "get_pending_action", "clear_pending_action",
     "advance_pending_action", "create_pending_action_if_absent",

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -21,7 +21,13 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn
+from .connection import get_conn, cat_norm_sql
+
+# Comparação de categoria case- E acento-insensível (fonte única: db/connection.py).
+_CAT_EQ = "{} = {}".format(cat_norm_sql("COALESCE(categoria, '')"), cat_norm_sql("%s"))
+_CAT_CT_EQ = "{} = {}".format(
+    cat_norm_sql("COALESCE(ct.categoria, '')"), cat_norm_sql("%s")
+)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -353,10 +359,10 @@ def compute_categories(
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 WITH despesas AS (
                   SELECT COALESCE(NULLIF(categoria, ''), 'sem categoria') AS categoria,
-                         valor
+                         valor, criado_em AS dt
                   FROM launches
                   WHERE user_id = %s
                     AND tipo IN ('despesa', 'saida')
@@ -364,7 +370,7 @@ def compute_categories(
                     AND criado_em >= %s AND criado_em < %s
                   UNION ALL
                   SELECT COALESCE(NULLIF(ct.categoria, ''), 'sem categoria') AS categoria,
-                         ct.valor
+                         ct.valor, b.period_end::timestamptz AS dt
                   FROM credit_transactions ct
                   JOIN credit_bills b ON b.id = ct.bill_id
                   WHERE ct.user_id = %s
@@ -372,11 +378,13 @@ def compute_categories(
                     AND b.period_end >= %s AND b.period_end < %s
                 ),
                 agg AS (
-                  SELECT categoria,
+                  -- rótulo do grupo = grafia do lançamento MAIS RECENTE (as
+                  -- gravações novas já saem na grafia do catálogo).
+                  SELECT (array_agg(categoria ORDER BY dt DESC))[1] AS categoria,
                          SUM(valor) AS total,
                          COUNT(*)   AS count
                   FROM despesas
-                  GROUP BY categoria
+                  GROUP BY {cat_norm_sql('categoria')}
                 )
                 SELECT a.categoria AS name,
                        a.total,
@@ -385,7 +393,7 @@ def compute_categories(
                        uc.color
                 FROM agg a
                 LEFT JOIN user_categories uc
-                  ON uc.user_id = %s AND LOWER(uc.name) = LOWER(a.categoria)
+                  ON uc.user_id = %s AND {cat_norm_sql('uc.name')} = {cat_norm_sql('a.categoria')}
                 ORDER BY a.total DESC
                 LIMIT %s
                 """,
@@ -727,7 +735,7 @@ def list_history(
             clauses.append("criado_em < %s")
             launches_params.append(to_date)
         if categoria:
-            clauses.append("LOWER(COALESCE(categoria, '')) = LOWER(%s)")
+            clauses.append(_CAT_EQ)
             launches_params.append(categoria)
         if uncategorized:
             clauses.append("(categoria IS NULL OR categoria = '')")
@@ -775,7 +783,7 @@ def list_history(
             clauses.append("b.period_end < %s")
             credit_params.append(to_date)
         if categoria:
-            clauses.append("LOWER(COALESCE(ct.categoria, '')) = LOWER(%s)")
+            clauses.append(_CAT_CT_EQ)
             credit_params.append(categoria)
         if uncategorized:
             clauses.append("(ct.categoria IS NULL OR ct.categoria = '')")

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -21,7 +21,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_norm_sql
+from .connection import get_conn, cat_norm_sql, CAT_META_SQL
 
 # Comparação de categoria case- E acento-insensível (fonte única: db/connection.py).
 _CAT_EQ = "{} = {}".format(cat_norm_sql("COALESCE(categoria, '')"), cat_norm_sql("%s"))
@@ -385,6 +385,9 @@ def compute_categories(
                          COUNT(*)   AS count
                   FROM despesas
                   GROUP BY {cat_norm_sql('categoria')}
+                ),
+                cat_meta AS (
+                  {CAT_META_SQL}
                 )
                 SELECT a.categoria AS name,
                        a.total,
@@ -392,8 +395,7 @@ def compute_categories(
                        uc.emoji,
                        uc.color
                 FROM agg a
-                LEFT JOIN user_categories uc
-                  ON uc.user_id = %s AND {cat_norm_sql('uc.name')} = {cat_norm_sql('a.categoria')}
+                LEFT JOIN cat_meta uc ON uc.cat = {cat_norm_sql('a.categoria')}
                 ORDER BY a.total DESC
                 LIMIT %s
                 """,

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -26,6 +26,10 @@ from .connection import get_conn, cat_norm_sql
 from .users import ensure_user
 
 
+# Comparação de categoria case- E acento-insensível (fonte única: db/connection.py).
+_CAT_EQ    = f"{cat_norm_sql('categoria')} = {cat_norm_sql('%s')}"
+_CAT_CT_EQ = f"{cat_norm_sql('ct.categoria')} = {cat_norm_sql('%s')}"
+
 # Mesma lista que `core/budget_alerts.py` filtra como interna.
 _INTERNAL_CATEGORIES = {
     "investimento_aporte",
@@ -58,7 +62,7 @@ def get_budget(user_id: int, categoria: str) -> dict[str, Any] | None:
         with conn.cursor() as cur:
             cur.execute(
                 "select categoria, budget from category_budgets "
-                "where user_id=%s and lower(categoria) = lower(%s)",
+                f"where user_id=%s and {_CAT_EQ}",
                 (user_id, categoria),
             )
             row = cur.fetchone()
@@ -86,7 +90,7 @@ def upsert_budget(user_id: int, categoria: str, budget: float) -> tuple[str, boo
         with conn.cursor() as cur:
             cur.execute(
                 "select categoria from category_budgets "
-                "where user_id=%s and lower(categoria) = lower(%s)",
+                f"where user_id=%s and {_CAT_EQ}",
                 (user_id, cat),
             )
             existing = cur.fetchone()
@@ -94,7 +98,7 @@ def upsert_budget(user_id: int, categoria: str, budget: float) -> tuple[str, boo
                 canon = existing["categoria"]
                 cur.execute(
                     "update category_budgets set budget=%s "
-                    "where user_id=%s and lower(categoria)=lower(%s)",
+                    f"where user_id=%s and {_CAT_EQ}",
                     (Decimal(str(budget)), user_id, cat),
                 )
                 conn.commit()
@@ -116,7 +120,7 @@ def delete_budget(user_id: int, categoria: str) -> bool:
         with conn.cursor() as cur:
             cur.execute(
                 "delete from category_budgets "
-                "where user_id=%s and lower(categoria) = lower(%s)",
+                f"where user_id=%s and {_CAT_EQ}",
                 (user_id, categoria),
             )
             n = cur.rowcount
@@ -186,13 +190,13 @@ def sum_spent_in_category_this_month(user_id: int, categoria: str) -> float:
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 select
                   coalesce((
                     select sum(valor) from launches
                     where user_id=%s
                       and tipo in ('despesa', 'saida')
-                      and lower(categoria) = lower(%s)
+                      and {_CAT_EQ}
                       and is_internal_movement = false
                       and date_part('year',  criado_em) = %s
                       and date_part('month', criado_em) = %s
@@ -202,7 +206,7 @@ def sum_spent_in_category_this_month(user_id: int, categoria: str) -> float:
                     from credit_transactions ct
                     join credit_bills b on b.id = ct.bill_id
                     where ct.user_id=%s
-                      and lower(ct.categoria) = lower(%s)
+                      and {_CAT_CT_EQ}
                       and ct.is_refund = false
                       and date_part('year',  b.period_end) = %s
                       and date_part('month', b.period_end) = %s
@@ -314,14 +318,14 @@ def get_budgets_status_for_month(
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 with budgets as (
                   select id, categoria, budget
                   from category_budgets
                   where user_id=%s
                 ),
                 spent_launches as (
-                  select lower(categoria) as cat, sum(valor)::numeric as total
+                  select {cat_norm_sql('categoria')} as cat, sum(valor)::numeric as total
                   from launches
                   where user_id=%s
                     and tipo in ('despesa', 'saida')
@@ -329,10 +333,10 @@ def get_budgets_status_for_month(
                     and date_part('year',  criado_em) = %s
                     and date_part('month', criado_em) = %s
                     and categoria is not null
-                  group by lower(categoria)
+                  group by {cat_norm_sql('categoria')}
                 ),
                 spent_cards as (
-                  select lower(ct.categoria) as cat, sum(ct.valor)::numeric as total
+                  select {cat_norm_sql('ct.categoria')} as cat, sum(ct.valor)::numeric as total
                   from credit_transactions ct
                   join credit_bills b on b.id = ct.bill_id
                   where ct.user_id=%s
@@ -340,7 +344,7 @@ def get_budgets_status_for_month(
                     and date_part('year',  b.period_end) = %s
                     and date_part('month', b.period_end) = %s
                     and ct.categoria is not null
-                  group by lower(ct.categoria)
+                  group by {cat_norm_sql('ct.categoria')}
                 ),
                 spent_all as (
                   select cat, sum(total) as total from (
@@ -356,9 +360,9 @@ def get_budgets_status_for_month(
                   uc.emoji,
                   uc.color
                 from budgets b
-                left join spent_all sa on sa.cat = lower(b.categoria)
+                left join spent_all sa on sa.cat = {cat_norm_sql('b.categoria')}
                 left join user_categories uc
-                  on uc.user_id=%s and uc.name = lower(b.categoria)
+                  on uc.user_id=%s and {cat_norm_sql('uc.name')} = {cat_norm_sql('b.categoria')}
                 order by lower(b.categoria)
                 """,
                 (

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -30,6 +30,13 @@ from .users import ensure_user
 _CAT_EQ    = f"{cat_norm_sql('categoria')} = {cat_norm_sql('%s')}"
 _CAT_CT_EQ = f"{cat_norm_sql('ct.categoria')} = {cat_norm_sql('%s')}"
 
+# `category_budgets` é única só no par EXATO (user_id, categoria): 'cafe' e
+# 'café' coexistem em dado legado, então um WHERE normalizado casa as DUAS.
+# Desempate = o mesmo do catálogo (`CAT_META_SQL`, db/connection.py): menor
+# nome alfabético (não há `is_system` aqui). Sem isto, qual linha o fetchone
+# devolve depende da ordem de inserção — medido no Postgres local.
+_CANON_ORDER = " order by categoria limit 1"
+
 # Mesma lista que `core/budget_alerts.py` filtra como interna.
 _INTERNAL_CATEGORIES = {
     "investimento_aporte",
@@ -62,7 +69,7 @@ def get_budget(user_id: int, categoria: str) -> dict[str, Any] | None:
         with conn.cursor() as cur:
             cur.execute(
                 "select categoria, budget from category_budgets "
-                f"where user_id=%s and {_CAT_EQ}",
+                f"where user_id=%s and {_CAT_EQ}{_CANON_ORDER}",
                 (user_id, categoria),
             )
             row = cur.fetchone()
@@ -90,16 +97,18 @@ def upsert_budget(user_id: int, categoria: str, budget: float) -> tuple[str, boo
         with conn.cursor() as cur:
             cur.execute(
                 "select categoria from category_budgets "
-                f"where user_id=%s and {_CAT_EQ}",
+                f"where user_id=%s and {_CAT_EQ}{_CANON_ORDER}",
                 (user_id, cat),
             )
             existing = cur.fetchone()
             if existing:
                 canon = existing["categoria"]
+                # Pela grafia EXATA da canônica: com gêmeas legadas o
+                # `{_CAT_EQ}` casa as duas e o update apagaria o limite da outra.
                 cur.execute(
                     "update category_budgets set budget=%s "
-                    f"where user_id=%s and {_CAT_EQ}",
-                    (Decimal(str(budget)), user_id, cat),
+                    "where user_id=%s and categoria=%s",
+                    (Decimal(str(budget)), user_id, canon),
                 )
                 conn.commit()
                 return canon, False
@@ -358,6 +367,7 @@ def get_budgets_status_for_month(
                 )
                 select
                   b.categoria,
+                  {cat_norm_sql('b.categoria')} as cat_key,
                   b.budget::float as budget,
                   coalesce(sa.total, 0)::float as spent,
                   uc.emoji,
@@ -378,7 +388,12 @@ def get_budgets_status_for_month(
 
     total_budget = 0.0
     total_spent = 0.0
-    at_risk = 0
+    # Gêmeas legadas ('cafe' e 'café' na mesma conta) casam com o MESMO gasto:
+    # cada linha mostra o gasto contra o próprio limite, mas o total soma o
+    # gasto UMA vez por categoria normalizada. `total_budget` NÃO deduplica —
+    # os dois limites foram criados pelo usuário.
+    spent_counted: set[str] = set()
+    at_risk_cats: set[str] = set()
     budgets_out: list[dict[str, Any]] = []
     for r in rows:
         budget = float(r["budget"] or 0)
@@ -391,9 +406,11 @@ def get_budgets_status_for_month(
         else:
             status = "verde"
         if status != "verde":
-            at_risk += 1
+            at_risk_cats.add(r["cat_key"])
         total_budget += budget
-        total_spent += spent
+        if r["cat_key"] not in spent_counted:
+            spent_counted.add(r["cat_key"])
+            total_spent += spent
         budgets_out.append({
             "categoria": r["categoria"],
             "emoji": r["emoji"] or "🏷️",
@@ -414,7 +431,7 @@ def get_budgets_status_for_month(
             "spent": round(total_spent, 2),
             "pct": round(total_pct, 1),
             "remaining": round(total_budget - total_spent, 2),
-            "at_risk": at_risk,
+            "at_risk": len(at_risk_cats),
         },
     }
 

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -22,7 +22,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_norm_sql
+from .connection import get_conn, cat_norm_sql, CAT_META_SQL
 from .users import ensure_user
 
 
@@ -352,6 +352,9 @@ def get_budgets_status_for_month(
                     union all
                     select * from spent_cards
                   ) s group by cat
+                ),
+                cat_meta as (
+                  {CAT_META_SQL}
                 )
                 select
                   b.categoria,
@@ -361,8 +364,7 @@ def get_budgets_status_for_month(
                   uc.color
                 from budgets b
                 left join spent_all sa on sa.cat = {cat_norm_sql('b.categoria')}
-                left join user_categories uc
-                  on uc.user_id=%s and {cat_norm_sql('uc.name')} = {cat_norm_sql('b.categoria')}
+                left join cat_meta uc on uc.cat = {cat_norm_sql('b.categoria')}
                 order by lower(b.categoria)
                 """,
                 (

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -22,20 +22,13 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_norm_sql, CAT_META_SQL
+from .connection import get_conn, cat_norm_sql, CAT_META_SQL, CAT_CANON_ORDER
 from .users import ensure_user
 
 
 # Comparação de categoria case- E acento-insensível (fonte única: db/connection.py).
 _CAT_EQ    = f"{cat_norm_sql('categoria')} = {cat_norm_sql('%s')}"
 _CAT_CT_EQ = f"{cat_norm_sql('ct.categoria')} = {cat_norm_sql('%s')}"
-
-# `category_budgets` é única só no par EXATO (user_id, categoria): 'cafe' e
-# 'café' coexistem em dado legado, então um WHERE normalizado casa as DUAS.
-# Desempate = o mesmo do catálogo (`CAT_META_SQL`, db/connection.py): menor
-# nome alfabético (não há `is_system` aqui). Sem isto, qual linha o fetchone
-# devolve depende da ordem de inserção — medido no Postgres local.
-_CANON_ORDER = " order by categoria limit 1"
 
 # Mesma lista que `core/budget_alerts.py` filtra como interna.
 _INTERNAL_CATEGORIES = {
@@ -69,7 +62,7 @@ def get_budget(user_id: int, categoria: str) -> dict[str, Any] | None:
         with conn.cursor() as cur:
             cur.execute(
                 "select categoria, budget from category_budgets "
-                f"where user_id=%s and {_CAT_EQ}{_CANON_ORDER}",
+                f"where user_id=%s and {_CAT_EQ}{CAT_CANON_ORDER}",
                 (user_id, categoria),
             )
             row = cur.fetchone()
@@ -97,7 +90,7 @@ def upsert_budget(user_id: int, categoria: str, budget: float) -> tuple[str, boo
         with conn.cursor() as cur:
             cur.execute(
                 "select categoria from category_budgets "
-                f"where user_id=%s and {_CAT_EQ}{_CANON_ORDER}",
+                f"where user_id=%s and {_CAT_EQ}{CAT_CANON_ORDER}",
                 (user_id, cat),
             )
             existing = cur.fetchone()

--- a/db/categories.py
+++ b/db/categories.py
@@ -10,7 +10,7 @@ Duas tabelas distintas:
   texto da categoria.
 """
 import logging
-import re
+import unicodedata
 
 from .connection import get_conn
 from .users import ensure_user
@@ -231,15 +231,19 @@ def get_uncategorized_launches(user_id: int, limit: int = 20) -> list[dict]:
 def _normalize_category_name(name: str) -> str:
     """Normaliza nome de categoria pro storage (lowercase, trim, espaços únicos).
 
-    Caracteres de controle viram espaço antes do collapse: o Postgres RECUSA
-    o NUL em texto (`psycopg.DataError`), então um PATCH com NUL na categoria
-    virava 500 — a `main` respondia 200 porque passava pelo `normalize_text`,
-    que já filtrava. `str.split()` só quebra em whitespace: os controles
-    abaixo de 0x20 fora dela passavam inteiros e ficavam gravados."""
-    return " ".join(_CONTROL_CHARS_RE.sub(" ", name or "").lower().strip().split())
-
-
-_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+    Controles (Cc) e formatadores invisíveis (Cf) viram espaço antes do
+    collapse. Cc porque o Postgres RECUSA o NUL em texto (`psycopg.DataError`),
+    e um PATCH com NUL na categoria virava 500 — a `main` respondia 200 porque
+    passava pelo `normalize_text`, que já filtrava. Cf porque zero-width
+    (U+200B) e override bidi (U+202E) são invisíveis: "cafe" e "cafe"+U+200B
+    ficariam como duas fatias idênticas na tela, que é exatamente o bug que
+    esta normalização existe pra matar. `str.split()` só quebra em whitespace —
+    nenhuma das duas classes passa por ela."""
+    limpo = "".join(
+        " " if unicodedata.category(c) in ("Cc", "Cf") else c
+        for c in (name or "")
+    )
+    return " ".join(limpo.lower().split())
 
 
 def ensure_user_categories_seeded(user_id: int) -> None:

--- a/db/categories.py
+++ b/db/categories.py
@@ -9,9 +9,14 @@ Duas tabelas distintas:
   livre. Rename emite UPDATE em cascata nas 5 tabelas que referenciam o
   texto da categoria.
 """
+import logging
+import re
+
 from .connection import get_conn
 from .users import ensure_user
 from utils_text import normalize_text
+
+log = logging.getLogger(__name__)
 
 
 # ─── Seed das 15 categorias canônicas (Sprint 3) ─────────────────────────────
@@ -224,8 +229,17 @@ def get_uncategorized_launches(user_id: int, limit: int = 20) -> list[dict]:
 
 
 def _normalize_category_name(name: str) -> str:
-    """Normaliza nome de categoria pro storage (lowercase, trim, espaços únicos)."""
-    return " ".join((name or "").lower().strip().split())
+    """Normaliza nome de categoria pro storage (lowercase, trim, espaços únicos).
+
+    Caracteres de controle viram espaço antes do collapse: o Postgres RECUSA
+    o NUL em texto (`psycopg.DataError`), então um PATCH com NUL na categoria
+    virava 500 — a `main` respondia 200 porque passava pelo `normalize_text`,
+    que já filtrava. `str.split()` só quebra em whitespace: os controles
+    abaixo de 0x20 fora dela passavam inteiros e ficavam gravados."""
+    return " ".join(_CONTROL_CHARS_RE.sub(" ", name or "").lower().strip().split())
+
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def ensure_user_categories_seeded(user_id: int) -> None:
@@ -577,3 +591,149 @@ def resolve_category_rule_target(user_id: int, target: str) -> tuple[str, str, i
         return ("category", category, count)
 
     return ("", "", 0)
+
+
+# ─── Texto livre do usuário → nome de categoria ──────────────────────────────
+
+
+# Teto do nome de categoria vindo de texto livre. Uma fonte só — as portas
+# (PATCH /launches, /credit-transactions, /installments, tool da IA, WhatsApp)
+# citam esta constante em vez de repetir o número.
+CATEGORY_NAME_MAX_LEN = 80
+
+
+def user_category_display_map(user_id: int, *, strict: bool = False) -> dict[str, str]:
+    """`normalize_text(name)` → `name` como está gravado em `user_categories`.
+
+    Pré-carregado uma vez pelos importadores de extrato (evita N+1: uma query
+    por transação). Inclui arquivadas — o nome digitado tem de reencontrar a
+    categoria existente em vez de criar uma gêmea.
+
+    READ-ONLY, como o resto do caminho quente da inferência (ver
+    `list_custom_category_names`): NÃO semeia. O seed não muda o resultado —
+    os 15 nomes canônicos são resolvidos no passo 1 de `resolve_category_input`,
+    antes de o mapa ser consultado — e semear aqui punha 15 INSERT em toda
+    inferência que bate em regra do usuário. O desempate é determinístico pela
+    própria ordenação, sem depender do seed.
+
+    Falha de banco devolve mapa vazio em vez de estourar — nas 3 chamadas de
+    importação de extrato uma exceção aqui abortaria o arquivo inteiro por
+    causa de um enfeite de grafia, e o import não dependia desta tabela antes
+    deste PR.
+
+    `strict=True` faz a falha SUBIR, e é o que as portas de correção usam:
+    lá a resposta vira DADO. Mapa vazio numa falha transitória não acha a
+    categoria que o usuário já tem, o nome digitado é aceito como novo e
+    `ensure_user_category` grava a gêmea — exatamente o que este módulo
+    existe pra impedir. Medido: usuário com "Café da Manhã" digitando
+    "Cafe da Manha" ficava com as duas linhas no catálogo.
+    """
+    try:
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                # Desempate determinístico e independente de id: nomes
+                # distintos podem colapsar no mesmo normalizado ("mcdonald s" e
+                # "mcdonald's"). Vence o do seed (is_system) — é a grafia
+                # oficial — e, entre iguais, o menor nome em ordem alfabética.
+                # Ordenar por id deixava o resultado dependente de quem foi
+                # criado/apagado antes.
+                cur.execute(
+                    "select name from user_categories where user_id=%s "
+                    "order by is_system asc, name desc",
+                    (user_id,),
+                )
+                rows = cur.fetchall() or []
+    except Exception:
+        if strict:
+            raise
+        log.warning("user_category_display_map falhou user=%s", user_id, exc_info=True)
+        return {}
+    return {normalize_text(r["name"]): r["name"] for r in rows if (r["name"] or "").strip()}
+
+
+def resolve_category_input(
+    user_id: int,
+    raw: str,
+    *,
+    create: bool = False,
+    display_map: dict[str, str] | None = None,
+) -> str | None:
+    """Texto livre → nome de categoria pra gravar em `launches.categoria`.
+
+    Normalizado é chave, forma de exibição é valor: devolve o nome que já
+    existe em `user_categories` sempre que houver um, pra não criar fatias
+    gêmeas no dashboard. NÃO escreve no banco: `create=True` só significa
+    "aceito nome novo" e devolve o nome já no formato de storage — quem grava
+    a linha é `ensure_user_category`, DEPOIS de o UPDATE ter dado certo (criar
+    antes deixava categoria órfã quando o lançamento não existia).
+    """
+    from utils_text import CATEGORY_LABELS, canonicalize_category_label
+
+    norm = normalize_text(raw or "")
+    if not norm:
+        return None
+
+    # 1) rótulo do sistema: "Alimentação"/"alimentacao"/"ALIMENTACAO" → "alimentação"
+    if norm in CATEGORY_LABELS or norm.replace(" ", "_") in CATEGORY_LABELS:
+        return canonicalize_category_label(norm)
+
+    # 2) categoria que o usuário já tem, na grafia dele
+    if display_map is None:
+        display_map = user_category_display_map(user_id, strict=create)
+    existing = display_map.get(norm)
+    if existing:
+        return existing
+
+    if not create:
+        return None
+
+    # 3) nome novo. Preservar a grafia só vale pra quem VAI ganhar a linha em
+    #    `user_categories` — é o catálogo que de-duplica as grafias seguintes.
+    #    Sem plano de categoria custom não há catálogo, e preservar faria
+    #    "Padaria do Zé" e "Padaria do Ze" virarem duas fatias no dashboard,
+    #    onde a `main` colapsava as duas. Aí a de-duplicação é o próprio
+    #    `normalize_text`, que é o que a `main` grava.
+    # Mede o que VAI SER GRAVADO, não o normalizado: `normalize_text` tira
+    # acento/emoji/pontuação e ENCOLHE a entrada, então medir por ele deixava
+    # passar nome de 5000 caracteres (emoji + uma letra normaliza pra 1 char).
+    stored = _normalize_category_name(raw) if _custom_categories_allowed(user_id) else norm
+    if not stored or len(stored) > CATEGORY_NAME_MAX_LEN:
+        return None
+    return stored
+
+
+def _custom_categories_allowed(user_id: int) -> bool:
+    """Fonte única do gate de categoria custom fora do HTTP. Mesma feature do
+    `POST /categories` (`require_pro_feature("custom_categories")`)."""
+    from core.services.plan_service import plan_gate_ok  # local: db <-> plan_service
+
+    return plan_gate_ok(user_id, "custom_categories")
+
+
+def ensure_user_category(user_id: int, name: str) -> None:
+    """Garante a linha em `user_categories` do nome que acabou de ser gravado.
+
+    Idempotente e best-effort: roda DEPOIS do UPDATE (senão sobra categoria
+    órfã quando o alvo não existe) e nunca derruba a resposta — a correção já
+    está no banco. No-op pra rótulo do sistema, pra nome que já existe e pra
+    quem não tem plano com categoria custom (aí o texto fica só no lançamento,
+    como era antes da normalização).
+    """
+    from utils_text import CATEGORY_LABELS
+
+    norm = normalize_text(name or "")
+    if not norm or norm in CATEGORY_LABELS or norm.replace(" ", "_") in CATEGORY_LABELS:
+        return
+    try:
+        if norm in user_category_display_map(user_id):
+            return
+        # ponytail: 2ª leitura de plano no mesmo PATCH (a 1ª é o
+        # `resolve_category_input`). Fica porque esta função é pública e GRAVA;
+        # se pesar, passa o veredito como argumento.
+        if not _custom_categories_allowed(user_id):
+            return
+        create_user_category(user_id, name)
+    except ValueError:
+        pass  # CATEGORIA_DUPLICADA/INVALIDA: corrida ou nome vazio
+    except Exception:
+        log.warning("ensure_user_category falhou user=%s name=%r", user_id, name, exc_info=True)

--- a/db/connection.py
+++ b/db/connection.py
@@ -109,3 +109,11 @@ CAT_META_SQL = (
     "  from user_categories where user_id = %s "
     f" order by {cat_norm_sql('name')}, is_system desc, name asc"
 )
+
+
+# Desempate canônico entre GÊMEAS de `category_budgets` (única só no par EXATO
+# (user_id, categoria): 'cafe' e 'café' coexistem em dado legado). Mesma regra
+# do `CAT_META_SQL` acima, sem o `is_system` — que essa tabela não tem: vence o
+# menor nome alfabético. Fonte única de quem ganha; sem isto cada leitor
+# desempata pela ordem de inserção e o donut mostra um limite e o bot outro.
+CAT_CANON_ORDER = " order by categoria limit 1"

--- a/db/connection.py
+++ b/db/connection.py
@@ -94,3 +94,18 @@ def cat_norm_sql(expr: str) -> str:
     """Fragmento SQL que normaliza `expr` (coluna ou placeholder %s) pra
     comparação de categoria case- e acento-insensível."""
     return f"translate(lower({expr}), '{_CAT_ACCENTS_FROM}', '{_CAT_ACCENTS_TO}')"
+
+
+# Catálogo deduplicado por nome normalizado, pronto pra virar CTE de join.
+# `user_categories` é única só no par EXATO (user_id, name), então 'cafe' e
+# 'café' coexistem: um join por valor normalizado contra a tabela crua devolve
+# a mesma linha de orçamento/gasto duas vezes e dobra dinheiro na tela.
+# Desempate idêntico ao de `user_category_display_map` (db/categories.py):
+# vence a do seed (is_system) e, entre iguais, o menor nome alfabético — não
+# pode depender de `id`, que muda com quem foi criado/apagado antes.
+CAT_META_SQL = (
+    f"select distinct on ({cat_norm_sql('name')}) "
+    f"       {cat_norm_sql('name')} as cat, emoji, color "
+    "  from user_categories where user_id = %s "
+    f" order by {cat_norm_sql('name')}, is_system desc, name asc"
+)

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -1844,7 +1844,7 @@ function _renderCategoryPill(cat, idx = 0) {
     : (cat.is_system ? '<span style="font-size:.62rem;color:var(--text-3);margin-left:6px">padrão</span>' : '');
   const delay = 200 + idx * 30;
   return `
-    <div class="cat-pill" style="cursor:pointer;${dim}animation-delay:${delay}ms" onclick='openCategoryEditModal(${JSON.stringify(cat)})'>
+    <div class="cat-pill" style="cursor:pointer;${dim}animation-delay:${delay}ms" onclick='openCategoryEditModal(${escapeHtmlSafe(JSON.stringify(cat))})'>
       <span class="cat-dot" style="background:${escapeHtmlSafe(cat.color)}"></span>
       <div class="cat-body">
         <div class="cat-name">${phIcon(cat.emoji)} ${escapeHtmlSafe(cat.name)}${tag}</div>
@@ -9817,11 +9817,11 @@ function render(d) {
             const hb  = c.budget != null;
             const bw  = hb ? Math.min(c.budget_pct,100) : Math.round(c.total/mx*100);
             const bc  = hb ? (c.budget_pct>100?"var(--red)":c.budget_pct>85?"var(--yellow)":"var(--green)") : catColors()[i%catColors().length];
-            const catSafe = c.categoria.replace(/'/g,"\\'");
+            const catSafe = escapeJsString(c.categoria);
             return `<div class="cat-row">
               <div class="cat-hdr">
-                <span class="cat-lbl">${c.categoria==="sem categoria"?"<i class='ph ph-warning' aria-hidden='true'></i> Sem Categoria":c.categoria}</span>
-                <span class="cat-val" data-num="cat_${c.categoria}" data-val="${c.total}">${fmt(c.total)}</span>
+                <span class="cat-lbl">${c.categoria==="sem categoria"?"<i class='ph ph-warning' aria-hidden='true'></i> Sem Categoria":esc(c.categoria)}</span>
+                <span class="cat-val" data-num="cat_${esc(c.categoria)}" data-val="${c.total}">${fmt(c.total)}</span>
                 <button class="bgt-btn" onclick="openBudget('${catSafe}')" title="Definir limite de orçamento"><i class="ph ph-pencil-simple" aria-hidden="true"></i></button>
               </div>
               ${hb?`<div class="cat-budget-info">${c.budget_pct}% de ${fmt(c.budget)}</div>`:""}

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -887,8 +887,8 @@ function _renderCardItem(c, idx = 0) {
           </div>` : ""}
         <div class="cc-detail-actions">
           ${c.open_bill?.id ? `<button class="mock-cta" onclick='event.stopPropagation(); openCardBillDetail(${c.id}, ${c.open_bill.id})'><i class="ph ph-file-text" aria-hidden="true"></i> Ver fatura</button>` : ""}
-          <button class="mock-cta outline" onclick='event.stopPropagation(); openCardEditModal(${JSON.stringify(c)})'><i class="ph ph-pencil-simple" aria-hidden="true"></i> Editar</button>
-          <button class="inst-delete-btn" onclick="event.stopPropagation(); openCardDeleteModal(${c.id}, ${JSON.stringify(c.name || '').replace(/"/g, '&quot;')})"><i class="ph ph-trash" aria-hidden="true"></i> Excluir</button>
+          <button class="mock-cta outline" onclick='event.stopPropagation(); openCardEditModal(${escapeHtmlSafe(JSON.stringify(c))})'><i class="ph ph-pencil-simple" aria-hidden="true"></i> Editar</button>
+          <button class="inst-delete-btn" onclick="event.stopPropagation(); openCardDeleteModal(${c.id}, ${escapeHtmlSafe(JSON.stringify(c.name || ""))})"><i class="ph ph-trash" aria-hidden="true"></i> Excluir</button>
         </div>
       </div>
     </details>
@@ -1415,7 +1415,7 @@ function _renderInstallmentItem(g, idx = 0) {
 
   const valorParcela = g.valor_parcela || 0;
   const anticipateBtn = g.n_pending > 0
-    ? `<button class="mock-cta outline" onclick='event.stopPropagation(); openInstAnticipateModal(${JSON.stringify(g.group_id)}, ${JSON.stringify(g.name)}, ${valorParcela}, ${parcelas.find(p => p.is_next)?.installment_no || 0}, ${g.installments_total})'><i class="ph ph-lightning" aria-hidden="true"></i> Antecipar próxima</button>`
+    ? `<button class="mock-cta outline" onclick='event.stopPropagation(); openInstAnticipateModal(${escapeHtmlSafe(JSON.stringify(g.group_id))}, ${escapeHtmlSafe(JSON.stringify(g.name))}, ${valorParcela}, ${parcelas.find(p => p.is_next)?.installment_no || 0}, ${g.installments_total})'><i class="ph ph-lightning" aria-hidden="true"></i> Antecipar próxima</button>`
     : "";
 
   return `
@@ -2175,7 +2175,7 @@ function _renderBudgetRow(b, idx = 0) {
   } else if (b.status === "amarelo") {
     subText = `${pct.toFixed(0)}%, ${_fmtBRL(b.remaining)} restantes. Piggy te avisa via WhatsApp.`;
   }
-  const safeCatJson = JSON.stringify(b).replace(/'/g, "&apos;");
+  const safeCatJson = escapeHtmlSafe(JSON.stringify(b));
   const delay = 240 + idx * 60;
   return `
     <div class="bar-row" style="cursor:pointer;animation-delay:${delay}ms" onclick='openBudgetEditModal(${safeCatJson})'>
@@ -3456,7 +3456,7 @@ function _renderRecurringRow(r) {
     }
   }
   const startText = _futureStartHint(r.start_date);
-  const safeRecJson = JSON.stringify(r).replace(/"/g, "&quot;");
+  const safeRecJson = escapeHtmlSafe(JSON.stringify(r));
   return `
     <div class="tx-row" style="cursor:pointer" onclick="openRecurringEditModal(${safeRecJson})">
       <div class="tx-icon">${phIcon(_recurringEmoji(r))}</div>
@@ -4186,7 +4186,7 @@ function _renderBillRow(b) {
   const amtLabel = variavel
     ? (temEstimativa ? `~-${_fmtBRL(b.amount)}` : "a confirmar")
     : `-${_fmtBRL(b.amount)}`;
-  const nameSafe = escapeHtmlSafe(b.name || "").replace(/'/g, "\\'");
+  const nameSafe = escapeJsString(b.name || "");
   return `
     <div class="tx-row">
       <div class="tx-icon" style="color:${color}"><i class="ph ph-receipt" aria-hidden="true"></i></div>
@@ -4702,7 +4702,7 @@ function _renderRecurringIncomeRow(r) {
       adjustText = ` · <span style="color:${color}">${_fmtBRL(r.last_amount)} → ${_fmtBRL(r.amount)} ${arrow}</span>`;
     }
   }
-  const safeRecJson = JSON.stringify(r).replace(/"/g, "&quot;");
+  const safeRecJson = escapeHtmlSafe(JSON.stringify(r));
   return `
     <div class="tx-row" style="cursor:pointer" onclick="openRecurringIncomeEditModal(${safeRecJson})">
       <div class="tx-icon">${phIcon(_recurringIncomeEmoji(r))}</div>

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -5018,7 +5018,7 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
     from core.services.category_service import infer_category, learn_from_inference
     from core.services.plan_limits import PlanLimitExceeded
     from core.services.plan_service import check_can_create_launch
-    from utils_text import is_internal_category, canonicalize_category_label
+    from utils_text import is_internal_category
 
     # Teto mensal de lançamentos do tier (Grátis no v2; no-op com v2 off).
     try:
@@ -5071,8 +5071,13 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
         card_name = card.get("name") or "cartão"
 
         nota = nota_in or alvo or f"compra no crédito ({card_name})"
+        # Sinal de aprendizado: SÓ o que o usuário escreveu. A nota acima e o
+        # `card_name` trazem o nome do CARTÃO — aprender deles criava a regra
+        # "nubank → <categoria>", que casa por substring e sequestrava todo
+        # gasto que citasse o cartão. Sem texto do usuário, não se aprende.
+        sinal_aprendizado = nota_in or alvo or ""
         inferred = await asyncio.to_thread(infer_category, int(user_id), nota, explicit)
-        categoria = canonicalize_category_label(inferred.category) or "outros"
+        categoria = inferred.category or "outros"
 
         purchased_at = await asyncio.to_thread(today_tz)
 
@@ -5092,9 +5097,9 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
                 await asyncio.to_thread(
                     learn_from_inference,
                     int(user_id),
-                    nota,
+                    sinal_aprendizado,
                     categoria,
-                    target_hint=alvo or card_name,
+                    target_hint=alvo,
                     reason=inferred.reason,
                 )
             except ValueError as exc:
@@ -5133,9 +5138,9 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
             await asyncio.to_thread(
                 learn_from_inference,
                 int(user_id),
-                nota,
+                sinal_aprendizado,
                 categoria,
-                target_hint=alvo or card_name,
+                target_hint=alvo,
                 reason=inferred.reason,
             )
         except ValueError as exc:
@@ -5162,7 +5167,7 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
 
     nota = nota_in or alvo or ("receita registrada pelo dashboard" if tipo == "receita" else "despesa registrada pelo dashboard")
     inferred = await asyncio.to_thread(infer_category, int(user_id), nota, explicit)
-    categoria = canonicalize_category_label(inferred.category) or "outros"
+    categoria = inferred.category or "outros"
     is_internal = is_internal_category(categoria)
 
     try:
@@ -5234,14 +5239,19 @@ async def update_launch_route(
 
     import sys
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-    from utils_text import canonicalize_category_label
+    from db import CATEGORY_NAME_MAX_LEN, ensure_user_category, resolve_category_input
 
     categoria_norm: str | None = None
     if payload.categoria is not None:
         raw = payload.categoria.strip()
         if not raw:
             raise HTTPException(status_code=400, detail="Categoria não pode ser vazia.")
-        categoria_norm = canonicalize_category_label(raw) or raw.lower()
+        categoria_norm = await asyncio.to_thread(resolve_category_input, user_id, raw, create=True)
+        if not categoria_norm:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Categoria inválida (máx. {CATEGORY_NAME_MAX_LEN} caracteres).",
+            )
 
     nota_norm: str | None = None
     if payload.nota is not None:
@@ -5273,6 +5283,10 @@ async def update_launch_route(
     )
     if not changed:
         raise HTTPException(status_code=404, detail="Lançamento não encontrado.")
+    if categoria_norm:
+        # criar a categoria só DEPOIS do UPDATE: antes, um id inexistente
+        # devolvia 404 e ainda assim deixava a categoria órfã no catálogo.
+        await asyncio.to_thread(ensure_user_category, user_id, categoria_norm)
     _invalidate_dashboard_current_cache(user_id)
     return {
         "ok": True,
@@ -5326,14 +5340,19 @@ async def update_credit_transaction_route(
 
     import sys
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-    from utils_text import canonicalize_category_label
+    from db import CATEGORY_NAME_MAX_LEN, ensure_user_category, resolve_category_input
 
     categoria_norm: str | None = None
     if payload.categoria is not None:
         raw = payload.categoria.strip()
         if not raw:
             raise HTTPException(status_code=400, detail="Categoria não pode ser vazia.")
-        categoria_norm = canonicalize_category_label(raw) or raw.lower()
+        categoria_norm = await asyncio.to_thread(resolve_category_input, user_id, raw, create=True)
+        if not categoria_norm:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Categoria inválida (máx. {CATEGORY_NAME_MAX_LEN} caracteres).",
+            )
 
     nota_norm: str | None = None
     if payload.nota is not None:
@@ -5353,6 +5372,11 @@ async def update_credit_transaction_route(
     )
     if not changed:
         raise HTTPException(status_code=404, detail="Compra no crédito não encontrada.")
+    if categoria_norm:
+        # crédito não guarda `alvo` — só a `nota`, que pode ser frase gerada
+        # ("compra no crédito (Nubank)"). Aprender dela ensinava o nome do
+        # CARTÃO como estabelecimento, então aqui só se garante o catálogo.
+        await asyncio.to_thread(ensure_user_category, user_id, categoria_norm)
     _invalidate_dashboard_current_cache(user_id)
     return {
         "ok": True,

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2226,31 +2226,13 @@ async def _get_current_user(
     return user_id
 
 
-# Planos v2: tier mínimo de cada feature paga na escada. Quase TODAS as features
-# gated são Essencial+ (o corte Plus é OF multi-banco/agentes, gated à parte).
-# "forecast" (previsão de saldo 30/60/90) é a exceção Pro+, como anunciado na
-# /precos. "ai_chat" é especial: no v2 o Grátis tem cota mensal — checada via
-# ai_chat_allowed, não por tier.
-_FEATURE_MIN_TIER_V2 = {
-    "recurring_expenses": "essencial",
-    "ofx_import": "essencial",
-    "investments": "essencial",
-    "export": "essencial",
-    "custom_categories": "essencial",
-    "forecast": "pro",
-    "generic": "essencial",
-}
-
-
+# Planos v2: o tier mínimo de cada feature paga mora em
+# core.services.plan_service.FEATURE_MIN_TIER_V2 — fonte única, porque gates
+# fora do HTTP (criar categoria custom por correção do WhatsApp/IA) leem a
+# mesma regra. Aqui fica só o wrapper que os endpoints já usavam.
 def _plan_gate_ok(user_id: int, feature: str) -> bool:
-    from core.services.plan_service import (
-        plans_v2_enabled, is_pro, require_min_tier, ai_chat_allowed,
-    )
-    if not plans_v2_enabled():
-        return is_pro(user_id)
-    if feature == "ai_chat":
-        return ai_chat_allowed(user_id)
-    return require_min_tier(user_id, _FEATURE_MIN_TIER_V2.get(feature, "essencial"))
+    from core.services.plan_service import plan_gate_ok
+    return plan_gate_ok(user_id, feature)
 
 
 def require_pro_feature(feature: str = "generic"):

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -665,9 +665,16 @@ async def get_financial_data(
             (user_id, query_start, month_end),
         ),
         # 10) Budgets per category
+        # ORDER BY ... DESC é DE PROPÓSITO, não engano: `budget_by_key` abaixo é
+        # um dict por cat_key, então a ÚLTIMA linha lida vence. Com gêmeas
+        # legadas ('cafe' 100 e 'café' 250 na mesma conta) o donut tem que
+        # mostrar o MESMO limite que o `get_budget` devolve, e esse desempate é
+        # `CAT_CANON_ORDER` (db/connection.py): menor nome alfabético, que em
+        # DESC vem por último e ganha o dict. Trocar para ASC inverte o
+        # desempate: a tela passa a mostrar um limite e o bot a responder outro.
         _q(
             f"SELECT categoria, budget, {cat_norm_sql('categoria')} AS cat_key "
-            "FROM category_budgets WHERE user_id = %s",
+            "FROM category_budgets WHERE user_id = %s ORDER BY categoria DESC",
             (user_id,),
         ),
     )

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -67,6 +67,7 @@ from core.sessions import (
     revoke_session,
     touch_session,
 )
+from db.connection import cat_norm_sql
 from db import (
     accrue_all_pockets,
     accrue_all_investments,
@@ -287,6 +288,11 @@ async def list_users() -> list:
         async with conn.cursor() as cur:
             await cur.execute("SELECT id FROM users ORDER BY created_at")
             return await cur.fetchall()
+
+# Chave de agrupamento do donut de categorias: case- E acento-insensível, pra
+# "cafe da manha" e "café da manhã" virarem UMA fatia (fonte: db/connection.py).
+_CAT_KEY_DONUT = cat_norm_sql("COALESCE(categoria, 'sem categoria')")
+
 
 def _month_range(year: int, month: int):
     """Returns (start_date, exclusive_end_date) for the given month."""
@@ -548,26 +554,28 @@ async def get_financial_data(
         # 6) Categories (despesas do mês — credit_transactions alocadas por
         # `bill.period_end`, igual query 5).
         _q(
-            """
-            SELECT COALESCE(categoria, 'sem categoria') AS categoria,
+            f"""
+            SELECT (array_agg(COALESCE(categoria, 'sem categoria')
+                              ORDER BY dt DESC))[1] AS categoria,
+                   {_CAT_KEY_DONUT} AS cat_key,
                    SUM(valor) AS total,
                    SUM(cnt)   AS count
             FROM (
-                SELECT categoria, valor, 1 AS cnt
+                SELECT categoria, valor, 1 AS cnt, criado_em AS dt
                 FROM launches
                 WHERE user_id = %s
                   AND tipo = 'despesa'
                   AND is_internal_movement = false
                   AND criado_em >= %s AND criado_em < %s
                 UNION ALL
-                SELECT ct.categoria, ct.valor, 1 AS cnt
+                SELECT ct.categoria, ct.valor, 1 AS cnt, b.period_end::timestamptz
                 FROM credit_transactions ct
                 JOIN credit_bills b ON b.id = ct.bill_id
                 WHERE ct.user_id = %s
                   AND ct.is_refund = false
                   AND b.period_end >= %s AND b.period_end < %s
             ) merged
-            GROUP BY COALESCE(categoria, 'sem categoria')
+            GROUP BY {_CAT_KEY_DONUT}
             ORDER BY total DESC
             LIMIT 10
             """,
@@ -657,7 +665,11 @@ async def get_financial_data(
             (user_id, query_start, month_end),
         ),
         # 10) Budgets per category
-        _q("SELECT categoria, budget FROM category_budgets WHERE user_id = %s", (user_id,)),
+        _q(
+            f"SELECT categoria, budget, {cat_norm_sql('categoria')} AS cat_key "
+            "FROM category_budgets WHERE user_id = %s",
+            (user_id,),
+        ),
     )
 
     # Desempacota fetchone-style
@@ -714,6 +726,10 @@ async def get_financial_data(
     # Build maps
     monthly_map = {row["tipo"]: float(row["total"]) for row in monthly}
     budget_map  = {r["categoria"]: float(r["budget"]) for r in budget_rows}
+    # Casa gasto×orçamento pela chave normalizada (case- e acento-insensível):
+    # o orçamento pode ter sido criado em "cafe da manha" e o gasto gravado em
+    # "café da manhã" — mesma categoria, e o alerta de 85% tem que disparar.
+    budget_by_key = {r["cat_key"]: float(r["budget"]) for r in budget_rows}
 
     # Merge budgets into categories + detect alerts
     cat_list = []
@@ -723,9 +739,9 @@ async def get_financial_data(
         cat_name = cat["categoria"]
         spent    = float(cat["total"])
         cat["total"] = spent
+        bgt = budget_by_key.get(cat.pop("cat_key", None))
 
-        if cat_name in budget_map:
-            bgt = budget_map[cat_name]
+        if bgt:
             pct = round(spent / bgt * 100, 1)
             cat["budget"]     = bgt
             cat["budget_pct"] = pct

--- a/frontend/routes/cards.py
+++ b/frontend/routes/cards.py
@@ -414,17 +414,32 @@ async def installment_update_route(
         n = (payload.nome or "").strip()
         if len(n) > 200:
             raise HTTPException(status_code=400, detail="Nome muito longo (máx. 200 caracteres).")
-    if payload.categoria is not None:
-        c = (payload.categoria or "").strip()
-        if len(c) > 80:
-            raise HTTPException(status_code=400, detail="Categoria muito longa (máx. 80 caracteres).")
+    categoria: str | None = payload.categoria
+    if payload.categoria is not None and payload.categoria.strip():
+        from db import CATEGORY_NAME_MAX_LEN, resolve_category_input
+        # vazio/só espaços passa direto: é "limpar o campo", como em `nome`
+        # (o update faz `.strip() or None`). O teto é medido dentro do
+        # resolve, sobre o nome que vai ser gravado.
+        categoria = await asyncio.to_thread(
+            resolve_category_input, user_id, payload.categoria.strip(), create=True
+        )
+        if not categoria:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Categoria inválida (máx. {CATEGORY_NAME_MAX_LEN} caracteres).",
+            )
 
     updated = await asyncio.to_thread(
         update_installment_group_meta, user_id, group_id,
-        nome=payload.nome, categoria=payload.categoria,
+        nome=payload.nome, categoria=categoria,
     )
     if not updated:
         raise HTTPException(status_code=404, detail="Parcelamento não encontrado ou nenhum campo alterado.")
+    if categoria:
+        # depois do UPDATE (senão sobra categoria órfã com group_id inexistente).
+        # Não aprende: crédito não tem `alvo`, só `nota` — ver update_credit_transaction_route.
+        from db import ensure_user_category
+        await asyncio.to_thread(ensure_user_category, user_id, categoria)
     shared.invalidate_dashboard_current_cache(user_id)
     return {"ok": True}
 

--- a/ofx_credit_import.py
+++ b/ofx_credit_import.py
@@ -21,6 +21,7 @@ from ofxparse import OfxParser
 from utils_date import _tz
 from utils_text import normalize_text, contains_word, LOCAL_RULES, keyword_blocked
 from db import import_credit_ofx_bulk, list_user_category_rules
+from db import resolve_category_input, user_category_display_map
 
 logger = logging.getLogger(__name__)
 
@@ -222,6 +223,9 @@ def import_credit_ofx_bytes(
         for kw, cat in _rules_raw
         if kw and cat
     ]
+    # nomes de categoria do usuário UMA vez (evita N+1): a regra guarda o
+    # normalizado; a transação tem de gravar a forma de exibição.
+    _display_map = user_category_display_map(user_id)
 
     # ── Pré-conta quantas vezes cada FITID aparece ───────────────────────────
     # O Nubank agrupa a antecipação de parcelas sob um único FITID para todas
@@ -310,6 +314,9 @@ def import_credit_ofx_bytes(
         # Categorização
         memo_norm = normalize_text(memo)
         categoria = _categorize(memo_norm, rules_norm)
+        categoria = resolve_category_input(
+            user_id, categoria, display_map=_display_map
+        ) or categoria
 
         # Parcelamento
         installment = _parse_installment(memo)

--- a/ofx_import.py
+++ b/ofx_import.py
@@ -8,7 +8,7 @@ from unittest import result
 from ofxparse import OfxParser
 from utils_date import _tz
 from db import set_balance, import_ofx_launches_bulk, get_last_ofx_import_end_date
-from db import list_user_category_rules
+from db import list_user_category_rules, resolve_category_input, user_category_display_map
 from utils_text import normalize_text, contains_word, LOCAL_RULES, INTERNAL_MOVEMENT_CATEGORIES, keyword_blocked
 
 # Hard cap defensivo: parser OFX vira DoS se receber arquivo gigante (memória
@@ -143,6 +143,9 @@ def import_ofx_bytes(user_id: int, ofx_bytes: bytes, filename: str | None = None
 
     # carrega regras UMA vez (evita N+1 no Postgres)
     _rules_norm = load_user_rules_norm(user_id)
+    # nomes de categoria do usuário UMA vez (evita N+1): a regra guarda o
+    # normalizado; o launch tem de gravar a forma de exibição.
+    _display_map = user_category_display_map(user_id)
 
     for trn in txs:
         fitid = getattr(trn, "id", None) or getattr(trn, "fitid", None)
@@ -197,6 +200,9 @@ def import_ofx_bytes(user_id: int, ofx_bytes: bytes, filename: str | None = None
 
         memo_norm = normalize_text(memo)
         categoria = resolve_category(memo_norm, _rules_norm)
+        categoria = resolve_category_input(
+            user_id, categoria, display_map=_display_map
+        ) or categoria
 
         is_internal = normalize_text(categoria) in INTERNAL_MOVEMENT_CATEGORIES
 

--- a/statement_import.py
+++ b/statement_import.py
@@ -579,7 +579,7 @@ def import_statement_bytes(
     o mesmo bulk idempotente do OFX. Retorna o report pro bot responder.
     """
     # imports tardios: mantém os parsers utilizáveis/testáveis sem DB
-    from db import import_ofx_launches_bulk
+    from db import import_ofx_launches_bulk, resolve_category_input, user_category_display_map
     from ofx_import import load_user_rules_norm, resolve_category
 
     if kind not in {"csv", "pdf"}:
@@ -612,6 +612,7 @@ def import_statement_bytes(
     tz = _tz()
 
     rules_norm = load_user_rules_norm(user_id)
+    display_map = user_category_display_map(user_id)
 
     launches_rows: list[dict] = []
     occurrences: Counter[tuple] = Counter()
@@ -639,6 +640,9 @@ def import_statement_bytes(
 
         memo_norm = normalize_text(memo)
         categoria = resolve_category(memo_norm, rules_norm)
+        categoria = resolve_category_input(
+            user_id, categoria, display_map=display_map
+        ) or categoria
         is_internal = normalize_text(categoria) in INTERNAL_MOVEMENT_CATEGORIES
 
         if trn.get("external_id"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from db import init_db, ensure_user, get_conn
 
 
 # ── Coleta: arquivos que dependem de `ofxparse` ──────────────────────────────
-# Sem o pacote, estes 9 arquivos estouram no IMPORT e o pytest aborta a suíte
+# Sem o pacote, estes 10 arquivos estouram no IMPORT e o pytest aborta a suíte
 # inteira antes de rodar um teste — o resultado não é "alguns testes falham",
 # é sinal nenhum, nem verde nem vermelho.
 #
@@ -33,10 +33,11 @@ from db import init_db, ensure_user, get_conn
 # sintaxe recém-introduzido, e o arquivo quebrado nunca mais rodaria.
 #
 # A condição é a ausência do pacote, não o erro: no CI o ofxparse está no
-# requirements.txt, então nada aqui é ignorado e os 9 rodam normalmente.
+# requirements.txt, então nada aqui é ignorado e os 10 rodam normalmente.
 _OFXPARSE_DEPENDENTES = [
     "test_audio_clarification.py",
     "test_audio_multi_launch_ask_value.py",
+    "test_category_normalization.py",
     "test_full_handler_smoke.py",
     "test_handle_incoming_routing.py",
     "test_recurring_value.py",
@@ -383,14 +384,9 @@ def user_id():
     _cleanup_user(uid)
 
 
-@pytest.fixture()
-def pro_user_id(user_id: int):
-    """user_id já promovido para plano Pro — use em testes que precisam criar
-    múltiplas caixinhas/cartões ou exercem features Pro.
-
-    Garante uma row em auth_accounts (necessária pra is_pro() ler o plano)
-    e seta plan='pro'. plan_expires_at=None significa "ilimitado".
-    """
+def promote_to_pro(user_id: int) -> int:
+    """Mesma promoção da fixture `pro_user_id`, chamável no meio de um teste
+    (quando o user vem de outra fixture, ex.: id pequeno pro WhatsApp)."""
     import uuid as _uuid
     from db.connection import get_conn
     fake_email = f"pro-{_uuid.uuid4().hex[:8]}@test.local"
@@ -410,3 +406,10 @@ def pro_user_id(user_id: int):
                 )
         conn.commit()
     return user_id
+
+
+@pytest.fixture()
+def pro_user_id(user_id: int):
+    """user_id já promovido para plano Pro — use em testes que precisam criar
+    múltiplas caixinhas/cartões ou exercem features Pro."""
+    return promote_to_pro(user_id)

--- a/tests/frontend/dashboard_category_escape.test.mjs
+++ b/tests/frontend/dashboard_category_escape.test.mjs
@@ -178,3 +178,116 @@ test("visão geral: categoria com aspas duplas não escapa do data-num", async (
   assert.equal(r.budget, 'pao " quente');
   await page.close();
 });
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Varredura por CONSTRUTO (não por nome de variável).
+ *
+ * O caso da pílula (acima) foi achado procurando `${...categoria...}`. Isso
+ * deixou passar 6 irmãos, porque o dado entrava por `JSON.stringify(obj)` ou
+ * por uma variável com outro nome (`safeCatJson`, `safeRecJson`, `nameSafe`).
+ * O construto é sempre o mesmo: **texto do usuário dentro de um atributo
+ * `on*=` de HTML**, com escape artesanal que cobre só metade dos caracteres.
+ *
+ * O que cada um fazia antes:
+ *   dashboard.js:890  `onclick='…openCardEditModal(${JSON.stringify(c)})'`    sem escape
+ *   dashboard.js:891  `onclick="…(${JSON.stringify(n).replace(/"/g,'&quot;')})"` só `"`
+ *   dashboard.js:1418 `onclick='…openInstAnticipateModal(${JSON.stringify(g.name)}…)'` sem escape
+ *   dashboard.js:2178 `JSON.stringify(b).replace(/'/g, "&apos;")`             só `'`
+ *   dashboard.js:3459 `JSON.stringify(r).replace(/"/g, "&quot;")`             só `"`
+ *   dashboard.js:4189 `escapeHtmlSafe(name).replace(/'/g, "\\'")`             ordem invertida
+ *   dashboard.js:4705 `JSON.stringify(r).replace(/"/g, "&quot;")`             só `"`
+ *
+ * O `&` é o furo comum: nenhum deles escapava. Um nome com `&quot;` LITERAL
+ * (que é como o texto chega quando alguém escreve HTML no WhatsApp) é
+ * decodificado pelo parser DEPOIS do escape e vira `"` cru dentro do JSON —
+ * SyntaxError na compilação do handler, linha inclicável. O `4189` é a mesma
+ * doença por outra porta: escapar HTML ANTES de escapar a string JS faz o
+ * `&#39;` voltar a ser `'` dentro de `'…'` e fechar o literal.
+ *
+ * VENENO cobre os três de uma vez: entidade literal, `&` solto e apóstrofo.
+ * ────────────────────────────────────────────────────────────────────── */
+
+const VENENO = `pao &quot;quente&quot; & mcdonald's`;
+
+/** Renderiza `window[fn](arg)`, injeta no DOM, clica em `sel` e devolve o que
+    o handler recebeu. `got === "NADA"` = handler não rodou (atributo quebrado). */
+const clicar = (page, fn, arg, sel, handler) => page.evaluate(([fn, arg, sel, handler]) => {
+  window.__got = "NADA";
+  window[handler] = (...a) => { window.__got = a; };
+  const host = document.createElement("div");
+  host.innerHTML = window[fn](arg);
+  document.body.appendChild(host);
+  const el = host.querySelector(sel);
+  let erro = null;
+  try { el.click(); } catch (e) { erro = String(e); }
+  return { achou: !!el, onclick: el?.getAttribute("onclick"), got: window.__got, erro };
+}, [fn, arg, sel, handler]);
+
+/** Um fixture por renderer: [rótulo, função, objeto, seletor, handler, ler o nome]. */
+const casos = (nome) => [
+  ["_renderBudgetRow (:2181, aspas simples)",
+   "_renderBudgetRow",
+   { categoria: nome, spent: 30, budget: 100, pct: 30, remaining: 70, status: "verde", color: "#22c55e", emoji: "🍞" },
+   ".bar-row", "openBudgetEditModal", (a) => a[0]?.categoria],
+
+  ["_renderCardItem editar (:890, aspas simples)",
+   "_renderCardItem",
+   { id: 7, name: nome, color: "purple", credit_limit: 1000, credit_used: 100, closing_day: 5, due_day: 12 },
+   ".cc-detail-actions .mock-cta.outline", "openCardEditModal", (a) => a[0]?.name],
+
+  ["_renderCardItem excluir (:891, aspas DUPLAS)",
+   "_renderCardItem",
+   { id: 7, name: nome, color: "purple", credit_limit: 1000, credit_used: 100, closing_day: 5, due_day: 12 },
+   ".cc-detail-actions .inst-delete-btn", "openCardDeleteModal", (a) => a[1]],
+
+  ["_renderInstallmentItem antecipar (:1418, aspas simples)",
+   "_renderInstallmentItem",
+   { group_id: "g1", name: nome, categoria: "mercado", total: 300, paid_amount: 100, remaining_amount: 200,
+     installments_total: 3, n_paid: 1, n_pending: 2, valor_parcela: 100, next_due_date: "2026-09-10",
+     purchased_at: "2026-07-10",
+     parcelas: [
+       { installment_no: 1, valor: 100, due_date: "2026-07-10", is_paid: true },
+       { installment_no: 2, valor: 100, due_date: "2026-08-10", is_next: true },
+       { installment_no: 3, valor: 100, due_date: "2026-09-10" },
+     ] },
+   ".inst-detail-body .mock-cta.outline", "openInstAnticipateModal", (a) => a[1]],
+
+  ["_renderRecurringRow (:3459, aspas DUPLAS)",
+   "_renderRecurringRow",
+   { id: 3, name: nome, amount: 50, frequency: "monthly", pay_day: 10, payment_type: "debit" },
+   ".tx-row", "openRecurringEditModal", (a) => a[0]?.name],
+
+  ["_renderRecurringIncomeRow (:4705, aspas DUPLAS)",
+   "_renderRecurringIncomeRow",
+   { id: 4, name: nome, amount: 900, frequency: "monthly", pay_day: 5, is_primary: true },
+   ".tx-row", "openRecurringIncomeEditModal", (a) => a[0]?.name],
+
+  ["_renderBillRow apagar (:4189, string JS dentro do atributo)",
+   "_renderBillRow",
+   { id: 9, name: nome, amount: 80, due_date: "2026-09-15" },
+   'button[title="Apagar"]', "deleteBoleto", (a) => a[1]],
+];
+
+for (const [rotulo, fn, obj, sel, handler, ler] of casos(VENENO)) {
+  test(`${rotulo}: nome com & e apóstrofo não quebra o handler`, async () => {
+    const page = await loadDashboardJs();
+    const r = await clicar(page, fn, obj, sel, handler);
+    assert.equal(r.achou, true, `seletor ${sel} não achou nada`);
+    assert.equal(r.erro, null);
+    assert.notEqual(r.got, "NADA", `handler não rodou; onclick saiu: ${r.onclick}`);
+    assert.equal(ler(r.got), VENENO, "o handler recebeu o nome corrompido");
+    await page.close();
+  });
+}
+
+// Controle positivo do grupo: o caminho legítimo (nome sem nada especial)
+// continua entregando o objeto inteiro ao handler.
+for (const [rotulo, fn, obj, sel, handler, ler] of casos("padaria do ze")) {
+  test(`${rotulo}: nome comum continua funcionando (controle positivo)`, async () => {
+    const page = await loadDashboardJs();
+    const r = await clicar(page, fn, obj, sel, handler);
+    assert.equal(r.erro, null);
+    assert.equal(ler(r.got), "padaria do ze");
+    await page.close();
+  });
+}

--- a/tests/frontend/dashboard_category_escape.test.mjs
+++ b/tests/frontend/dashboard_category_escape.test.mjs
@@ -1,0 +1,180 @@
+/**
+ * Nome de categoria escrito pelo usuário × HTML do dashboard.
+ *
+ * O backend passou a PRESERVAR a grafia digitada (acento, apóstrofo,
+ * pontuação) em `user_categories` — `McDonald's` vira categoria de verdade.
+ * O render tem que aguentar isso:
+ *
+ *  1. `_renderCategoryPill` monta `onclick='openCategoryEditModal({...})'` com
+ *     aspas SIMPLES. `JSON.stringify` não escapa `'`, então um apóstrofo no
+ *     nome FECHA o atributo no meio: o resto do JSON vira atributo solto, o
+ *     handler sai truncado e o clique estoura SyntaxError — a categoria fica
+ *     impossível de renomear/arquivar. O conserto é `escapeHtmlSafe` por fora
+ *     do JSON, igual `dashboard.js:1454` já faz nos parcelamentos.
+ *  2. O card "Categorias (mês)" da visão geral injetava `c.categoria` cru em
+ *     texto, em `data-num="cat_…"` (atributo de aspas DUPLAS) e num
+ *     `onclick="openBudget('…')"` que só escapava `'`. A fonte é
+ *     `get_top_expense_categories`, que soma `launches` + `credit_transactions`
+ *     — e `launches.categoria` recebe texto de terceiro (a tool da IA).
+ *
+ * Como roda: o `dashboard.js` é script CLÁSSICO de 10 mil linhas. Ele é
+ * injetado inteiro numa página com o DOM mínimo que o topo dele exige (os
+ * `getElementById(...).addEventListener` de nível superior estouram sem os
+ * elementos, e um throw ali abortaria o resto do arquivo). O `fetch` vira uma
+ * promessa que nunca resolve pra que o IIFE de boot não navegue nem apague o
+ * body. Zero `pageerror` no carregamento é a prova de que o arquivo executou
+ * até o fim — sem isso, os `const` do topo ficariam em TDZ e o teste mediria
+ * um arquivo pela metade.
+ *
+ * Rodar:  npm run test:frontend
+ *         (ou só este: node --test tests/frontend/dashboard_category_escape.test.mjs)
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const DASHBOARD_JS = join(
+  dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend", "dashboard.js",
+);
+
+/** IDs que o nível superior do dashboard.js acessa sem `?.` (grep:
+    `^document.getElementById("…").`) mais os que o `render()` toca. */
+const IDS = [
+  "grid", "bgt-overlay", "bgt-input", "investment-detail-overlay",
+  "investment-help-overlay", "edit-launch-overlay", "launch-overlay",
+  "launch-valor", "pocket-overlay", "pocket-name", "pocket-history-overlay",
+  "card-overlay", "card-name", "card-closing-day", "card-due-day",
+  "bill-detail-overlay", "pay-bill-overlay", "pay-bill-receipt-overlay",
+  "pay-bill-amount", "overview-heading", "launches-title", "launches-wrap",
+  "charts-title", "charts-grid", "alert-banner", "last-update",
+];
+
+let browser;
+before(async () => { browser = await chromium.launch(); });
+after(async () => { await browser?.close(); });
+
+async function loadDashboardJs() {
+  const page = await browser.newPage();
+  const errs = [];
+  page.on("pageerror", (e) => errs.push(String(e)));
+  await page.setContent(IDS.map((i) => `<div id="${i}"></div>`).join(""));
+  await page.evaluate(() => { window.fetch = () => new Promise(() => {}); });
+  await page.addScriptTag({ path: DASHBOARD_JS });
+  assert.deepEqual(errs, [], "dashboard.js não executou até o fim");
+  return page;
+}
+
+/** Renderiza uma pílula, injeta no documento e clica nela. */
+const clicarPilula = (page, cat) => page.evaluate((c) => {
+  window.__got = "NADA";
+  window.openCategoryEditModal = (arg) => { window.__got = arg; };
+  const host = document.createElement("div");
+  host.innerHTML = _renderCategoryPill(c);
+  document.body.appendChild(host);
+  const pill = host.querySelector(".cat-pill");
+  let erro = null;
+  try { pill.click(); } catch (e) { erro = String(e); }
+  return {
+    attrs: [...pill.attributes].map((a) => a.name),
+    onclick: pill.getAttribute("onclick"),
+    scripts: host.querySelectorAll("script").length,
+    nome: pill.querySelector(".cat-name").textContent.trim(),
+    got: window.__got,
+    erro,
+  };
+}, cat);
+
+const CAT = { id: 2, emoji: "🍔", color: "#FF2D8E", usage_count: 3, is_system: false };
+
+test("pílula com apóstrofo: atributo íntegro e clique abre o modal", async () => {
+  const page = await loadDashboardJs();
+  const r = await clicarPilula(page, { ...CAT, name: "McDonald's" });
+
+  // O bug deixava o JSON vazando pra fora do onclick como atributos soltos.
+  assert.deepEqual(r.attrs, ["class", "style", "onclick"]);
+  assert.equal(r.erro, null);
+  assert.equal(r.got?.name, "McDonald's", "o modal recebeu o nome errado");
+  assert.equal(r.got?.id, 2);
+  assert.match(r.nome, /McDonald's$/);
+  await page.close();
+});
+
+test("pílula sem apóstrofo continua funcionando (controle positivo)", async () => {
+  const page = await loadDashboardJs();
+  const r = await clicarPilula(page, { ...CAT, name: "padaria do ze" });
+  assert.equal(r.erro, null);
+  assert.equal(r.got?.name, "padaria do ze");
+  await page.close();
+});
+
+test("pílula com <script> no nome: vira texto, não vira nó", async () => {
+  const page = await loadDashboardJs();
+  const nome = "<script>window.__pwned=1</" + "script>";
+  const r = await clicarPilula(page, { ...CAT, name: nome });
+  assert.equal(r.scripts, 0, "<script> virou nó dentro da pílula");
+  assert.match(r.nome, /<script>window\.__pwned=1<\/script>$/);
+  assert.equal(await page.evaluate(() => !!window.__pwned), false);
+  await page.close();
+});
+
+/** Roda o `render(d)` real com um mês mínimo e devolve o que saiu no #grid.
+    O tail do render (investimentos, gráficos) estoura com o DOM reduzido —
+    depois de o #grid já estar montado, por isso o try/catch. A asserção de
+    que o card de categorias existe é o que prova que chegamos lá. */
+const renderOverview = (page, categorias) => page.evaluate((cats) => {
+  window.__pwned = false;
+  window.__budget = "NADA";
+  window.openBudget = (c) => { window.__budget = c; };
+  try {
+    render({
+      year: 2026, month: 8, balance: 0, monthly_income: 0, monthly_expense: 0,
+      expense_categories: cats.map((c) => ({ categoria: c, total: 10 })),
+      launches: [], pockets: [], investments: [], credit_cards: [], budgets: {},
+    });
+  } catch { /* tail do render, fora do que este teste mede */ }
+  const grid = document.getElementById("grid");
+  const btns = [...grid.querySelectorAll(".bgt-btn")];
+  let erro = null;
+  try { btns[0]?.click(); } catch (e) { erro = String(e); }
+  return {
+    labels: [...grid.querySelectorAll(".cat-lbl")].map((e) => e.textContent),
+    nums: [...grid.querySelectorAll(".cat-val[data-num]")].map((e) => e.dataset.num),
+    scripts: grid.querySelectorAll("script").length,
+    pwned: !!window.__pwned,
+    budget: window.__budget,
+    erro,
+  };
+}, categorias);
+
+test("visão geral: <script> na categoria vira texto, não vira nó", async () => {
+  const page = await loadDashboardJs();
+  const nome = "<script>window.__pwned=1</" + "script>";
+  const r = await renderOverview(page, [nome]);
+
+  assert.equal(r.labels.length, 1, "o card de categorias não foi renderizado");
+  assert.equal(r.scripts, 0, "<script> virou nó no card de categorias");
+  assert.equal(r.pwned, false);
+  assert.equal(r.labels[0], nome, "o nome não chegou íntegro na tela");
+  // data-num é a chave da animação de contador: tem que continuar sendo o
+  // nome CRU depois do escape (dataset lê o atributo já decodificado).
+  assert.deepEqual(r.nums, [`cat_${nome}`]);
+  await page.close();
+});
+
+test("visão geral: apóstrofo não quebra o botão de orçamento", async () => {
+  const page = await loadDashboardJs();
+  const r = await renderOverview(page, ["mcdonald's"]);
+  assert.equal(r.erro, null);
+  assert.equal(r.budget, "mcdonald's");
+  await page.close();
+});
+
+test("visão geral: categoria com aspas duplas não escapa do data-num", async () => {
+  const page = await loadDashboardJs();
+  const r = await renderOverview(page, ['pao " quente']);
+  assert.deepEqual(r.nums, ['cat_pao " quente']);
+  assert.equal(r.budget, 'pao " quente');
+  await page.close();
+});

--- a/tests/test_budget_category_accent.py
+++ b/tests/test_budget_category_accent.py
@@ -225,3 +225,86 @@ def test_catalogo_normal_continua_trazendo_emoji_de_cada_categoria(user_id):
     assert {c["name"]: (c["total"], c["emoji"]) for c in cats} == {
         "cafe": (11.0, "☕"), "carne": (73.0, "🥩"),
     }
+
+
+# ── orçamentos gêmeos legados: 2 linhas, mas o gasto conta UMA vez no total ──
+# `category_budgets` também é única só no par EXATO (user_id, categoria), então
+# 'cafe' e 'café' coexistem em dado gravado antes da normalização. Com o gasto
+# casado por valor normalizado (c48f554), o MESMO gasto entra nas duas linhas e
+# dobrava `totals.spent`/`at_risk`. Decisão do dono: as duas linhas continuam,
+# cada uma com o limite que o usuário criou; só o TOTAL conta o gasto uma vez.
+
+def _orcamento_bruto(user_id: int, *linhas: tuple[str, float]):
+    """Insere direto: `upsert_budget` não cria mais gêmea (cai na existente)."""
+    from db.connection import get_conn
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            for cat, val in linhas:
+                cur.execute(
+                    "insert into category_budgets (user_id, categoria, budget) "
+                    "values (%s, %s, %s)",
+                    (user_id, cat, val),
+                )
+        conn.commit()
+
+
+def test_orcamentos_gemeos_contam_o_gasto_uma_vez_no_total(user_id):
+    """Controle negativo: trocando o `if r["cat_key"] not in spent_counted`
+    por `total_spent += spent` incondicional (db/budgets.py), medido no
+    Postgres local: totals.spent volta a 74.2 e remaining a 275.8."""
+    _orcamento_bruto(user_id, ("cafe", 100.0), ("café", 250.0))
+    _gasto(user_id, "café", 37.10)
+
+    status = get_budgets_status_for_month(user_id)
+    # nada é fundido: as duas linhas aparecem com o limite que o user criou
+    assert [(b["categoria"], b["budget"], b["spent"]) for b in status["budgets"]] == [
+        ("cafe", 100.0, 37.1), ("café", 250.0, 37.1),
+    ]
+    # e o total soma o gasto UMA vez (limites NÃO deduplicam: 100 + 250)
+    assert status["totals"]["budget"] == 350.0
+    assert status["totals"]["spent"] == 37.1
+    assert status["totals"]["remaining"] == 312.9
+
+
+def test_at_risk_conta_uma_vez_por_categoria_normalizada(user_id):
+    """Controle negativo: voltando `at_risk` para o contador `+= 1` por linha,
+    medido: at_risk 2 com uma categoria só em risco."""
+    _orcamento_bruto(user_id, ("cafe", 40.0), ("café", 45.0))
+    _gasto(user_id, "café", 37.10)
+
+    status = get_budgets_status_for_month(user_id)
+    assert [b["status"] for b in status["budgets"]] == ["amarelo", "amarelo"]
+    assert status["totals"]["at_risk"] == 1
+    assert status["totals"]["spent"] == 37.1
+
+
+def test_sem_gemeas_os_totais_continuam_somando_tudo(user_id):
+    """Controle positivo: a dedup não pode subtrair gasto de categorias
+    genuinamente diferentes, nem esconder a segunda em risco."""
+    _orcamento_bruto(user_id, ("cafe", 40.0), ("carne", 80.0))
+    _gasto(user_id, "cafe", 37.10)
+    _gasto(user_id, "carne", 75.0)
+
+    totals = get_budgets_status_for_month(user_id)["totals"]
+    assert totals["budget"] == 120.0
+    assert totals["spent"] == 112.1
+    assert totals["at_risk"] == 2
+
+
+def test_get_budget_e_upsert_deterministicos_com_gemeas(user_id):
+    """Com gêmeas, `fetchone()` sem `order by` devolvia a linha da ORDEM DE
+    INSERÇÃO (medido: 'café' quando ela é inserida primeiro) e o UPDATE casava
+    as DUAS, apagando o limite da outra (medido: 777.0 nas duas).
+
+    Desempate = o mesmo do catálogo: menor nome alfabético → 'cafe'.
+    """
+    _orcamento_bruto(user_id, ("café", 250.0), ("cafe", 100.0))  # acentuada 1º
+
+    assert db.budgets.get_budget(user_id, "CAFÉ") == {"categoria": "cafe", "budget": 100.0}
+
+    canon, created = db.budgets.upsert_budget(user_id, "Café", 777.0)
+    assert (canon, created) == ("cafe", False)
+    assert {b["categoria"]: b["budget"] for b in db.budgets.list_budgets(user_id)} == {
+        "cafe": 777.0, "café": 250.0,  # o limite da gêmea sobrevive
+    }

--- a/tests/test_budget_category_accent.py
+++ b/tests/test_budget_category_accent.py
@@ -136,3 +136,92 @@ def test_crud_de_orcamento_acha_a_linha_com_a_outra_grafia(user_id):
     assert len(db.budgets.list_budgets(user_id)) == 1
     assert db.budgets.delete_budget(user_id, "café") is True
     assert db.budgets.list_budgets(user_id) == []
+
+
+# ── catálogo com gêmeas de acento: join normalizado não pode multiplicar ─────
+# `user_categories` é única só no par EXATO (user_id, name), então 'cafe' e
+# 'café' coexistem em dado legado. Com o join de emoji/cor feito por valor
+# NORMALIZADO, as duas casavam com o mesmo orçamento/fatia e dobravam
+# `total_budget`, `total_spent` e `at_risk` (P1 do Codex no PR #143).
+
+def _catalogo(user_id: int, *linhas: tuple[str, str, bool]):
+    """(name, emoji, is_system) direto no catálogo.
+
+    Direto em SQL de propósito: `ensure_user_category` não cria mais gêmea —
+    quem tem duas grafias é dado gravado antes da normalização.
+    """
+    from db.connection import get_conn
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            for name, emoji, is_system in linhas:
+                cur.execute(
+                    "insert into user_categories (user_id, name, emoji, color, is_system) "
+                    "values (%s, %s, %s, '#123456', %s)",
+                    (user_id, name, emoji, is_system),
+                )
+        conn.commit()
+
+
+def test_catalogo_com_gemeas_nao_dobra_orcamento(user_id):
+    """Controle negativo: trocando a CTE `cat_meta` de volta pelo
+    `left join user_categories uc on uc.user_id=%s and <norm> = <norm>`
+    (db/budgets.py, db/analytics.py), medido no Postgres local:
+    2 linhas, budget 80.0, spent 74.2, at_risk 2, e o donut com duas fatias
+    de 37.1 (pct 50.0 cada)."""
+    _catalogo(user_id, ("cafe da manha", "🅰️", False), ("café da manhã", "🅱️", False))
+    upsert_budget(user_id, "cafe da manha", 40.0)
+    _gasto(user_id, "café da manhã", 37.10)
+
+    status = get_budgets_status_for_month(user_id)
+    assert len(status["budgets"]) == 1, status["budgets"]
+    linha = status["budgets"][0]
+    assert (linha["budget"], linha["spent"]) == (40.0, 37.1)
+    assert linha["status"] == "amarelo"
+    assert linha["emoji"] == "🅰️"  # metadado veio, não sumiu com a dedup
+    assert status["totals"]["budget"] == 40.0
+    assert status["totals"]["spent"] == 37.1
+    assert status["totals"]["at_risk"] == 1
+
+    hoje = date.today()
+    cats = compute_categories(user_id, hoje.replace(day=1), hoje + timedelta(days=1))
+    assert len(cats) == 1, cats
+    assert (cats[0]["total"], cats[0]["pct"], cats[0]["emoji"]) == (37.1, 100.0, "🅰️")
+
+
+def test_desempate_do_catalogo_e_o_mesmo_do_display_map(user_id):
+    """Uma fonte só pro desempate: vence a do seed (is_system) e, entre iguais,
+    o menor nome — igual a `user_category_display_map` (db/categories.py)."""
+    _catalogo(user_id, ("cafe", "🅰️", False), ("café", "🅱️", True))
+    upsert_budget(user_id, "CAFE", 40.0)
+    _gasto(user_id, "Café", 10.0)
+
+    assert db.categories.user_category_display_map(user_id)["cafe"] == "café"
+    linhas = get_budgets_status_for_month(user_id)["budgets"]
+    assert len(linhas) == 1 and linhas[0]["emoji"] == "🅱️"
+
+    hoje = date.today()
+    cats = compute_categories(user_id, hoje.replace(day=1), hoje + timedelta(days=1))
+    assert len(cats) == 1 and cats[0]["emoji"] == "🅱️"
+
+
+def test_catalogo_normal_continua_trazendo_emoji_de_cada_categoria(user_id):
+    """Controle positivo: sem gêmeas, cada categoria mantém a linha e o
+    metadado dela — a dedup não pode colapsar catálogo legítimo."""
+    _catalogo(user_id, ("cafe", "☕", False), ("carne", "🥩", False))
+    upsert_budget(user_id, "cafe", 100.0)
+    upsert_budget(user_id, "carne", 100.0)
+    _gasto(user_id, "cafe", 11.0)
+    _gasto(user_id, "carne", 73.0)
+
+    linhas = get_budgets_status_for_month(user_id)["budgets"]
+    assert {b["categoria"]: (b["spent"], b["emoji"]) for b in linhas} == {
+        "cafe": (11.0, "☕"), "carne": (73.0, "🥩"),
+    }
+    assert get_budgets_status_for_month(user_id)["totals"]["spent"] == 84.0
+
+    hoje = date.today()
+    cats = compute_categories(user_id, hoje.replace(day=1), hoje + timedelta(days=1))
+    assert {c["name"]: (c["total"], c["emoji"]) for c in cats} == {
+        "cafe": (11.0, "☕"), "carne": (73.0, "🥩"),
+    }

--- a/tests/test_budget_category_accent.py
+++ b/tests/test_budget_category_accent.py
@@ -308,3 +308,56 @@ def test_get_budget_e_upsert_deterministicos_com_gemeas(user_id):
     assert {b["categoria"]: b["budget"] for b in db.budgets.list_budgets(user_id)} == {
         "cafe": 777.0, "café": 250.0,  # o limite da gêmea sobrevive
     }
+
+
+# ── donut × get_budget: com gêmeas, os dois têm que mostrar o MESMO limite ───
+# O SELECT de orçamentos do donut (`finance_bot_websocket_custom.py:675`) vira
+# `budget_by_key = {cat_key: budget}` — dict, última linha vence. Sem `order
+# by`, quem vencia era a ordem de inserção: a tela mostrava 250 e o bot
+# respondia 100 pela MESMA categoria. Daí o `ORDER BY categoria DESC` lá (o
+# menor nome vem por último e ganha o dict) = `CAT_CANON_ORDER` do `get_budget`.
+
+def _donut(user_id: int) -> tuple[dict[str, float | None], list[str]]:
+    """({categoria da fatia: budget exibido}, [tipos de alerta])."""
+    data = asyncio.run(dashboard.get_financial_data(user_id))
+    return (
+        {c["categoria"]: c.get("budget") for c in data["expense_categories"]},
+        [a["type"] for a in data["alerts"]],
+    )
+
+
+def _cenario_gemeas(user_id: int, *orcamentos: tuple[str, float]) -> None:
+    """Par gêmeo ('cafe' 40 × 'café' 250) + uma categoria sem gêmea (controle
+    positivo). Gasto de 37,10 cruza 80% de 40 e NÃO cruza 80% de 250."""
+    _orcamento_bruto(user_id, *orcamentos)
+    _orcamento_bruto(user_id, ("carne", 80.0))
+    _gasto(user_id, "café", 37.10)
+    _gasto(user_id, "carne", 20.0)
+
+
+def _assert_gemeas_coerentes(user_id: int) -> None:
+    assert db.budgets.get_budget(user_id, "CAFÉ") == {"categoria": "cafe", "budget": 40.0}
+    fatias, alertas = _donut(user_id)
+    # a fatia gêmea mostra o limite canônico (40), não o da outra grafia (250);
+    # 'carne' é o controle positivo: sem gêmea, o limite não muda
+    assert fatias == {"café": 40.0, "carne": 80.0}
+    # e o alerta de 85% do donut só sai porque grudou o limite certo (92.8%)
+    assert alertas == ["budget_warning"]
+    # o alerta do bot (core/budget_alerts) usa o mesmo desempate
+    alerta = evaluate_after_expense(user_id, "café", 37.10, datetime.now(timezone.utc))
+    assert alerta is not None and (alerta.categoria, alerta.budget) == ("cafe", 40.0)
+
+
+def test_donut_com_gemeas_sem_acento_inserida_primeiro(user_id):
+    """Controle negativo: tirando o `ORDER BY categoria DESC` do SELECT 10 do
+    donut, medido no Postgres local — 'café' vence o dict e a fatia sai com
+    budget 250.0, sem alerta nenhum."""
+    _cenario_gemeas(user_id, ("cafe", 40.0), ("café", 250.0))
+    _assert_gemeas_coerentes(user_id)
+
+
+def test_donut_com_gemeas_com_acento_inserida_primeiro(user_id):
+    """Mesma asserção com a ordem de inserção invertida — é a ordem que decidia
+    o vencedor antes do `ORDER BY`."""
+    _cenario_gemeas(user_id, ("café", 250.0), ("cafe", 40.0))
+    _assert_gemeas_coerentes(user_id)

--- a/tests/test_budget_category_accent.py
+++ b/tests/test_budget_category_accent.py
@@ -1,0 +1,138 @@
+"""
+tests/test_budget_category_accent.py — orçamento e gasto casam mesmo com
+grafias diferentes da MESMA categoria (acento e caixa).
+
+Caso real (medido pelo Manager no Postgres local): orçamento cadastrado como
+'cafe da manha', lançamento gravado como 'café da manhã' (grafia do catálogo,
+que a leitura de categoria passou a devolver). O orçamento enxergava R$ 0,00,
+o gasto real era R$ 50,00, e o alerta de 80% nunca disparava — silencioso.
+
+A comparação passou a usar `cat_norm_sql` (`db/connection.py:93`), que é
+insensível a caixa E a acento. Controle positivo obrigatório: categorias
+genuinamente diferentes ('cafe' × 'carne') continuam separadas.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime, timedelta, timezone
+
+import db
+from core.budget_alerts import evaluate_after_expense
+from db.accounts import add_launch_and_update_balance
+from db.analytics import compute_categories
+from db.budgets import (
+    get_budgets_status_for_month,
+    sum_spent_in_category_this_month,
+    upsert_budget,
+)
+import frontend.finance_bot_websocket_custom as dashboard
+
+
+def _gasto(user_id: int, categoria: str, valor: float):
+    add_launch_and_update_balance(
+        user_id, "despesa", valor, "teste", "teste", categoria=categoria
+    )
+
+
+# ── o cenário do Manager ────────────────────────────────────────────────────
+
+def test_orcamento_sem_acento_conta_gasto_com_acento(user_id):
+    """Controle negativo: revertendo `_CAT_EQ` para `lower(categoria)=lower(%s)`
+    em `db/budgets.py`, `spent` volta a 0.0 e as três asserções caem."""
+    upsert_budget(user_id, "cafe da manha", 200.0)
+    _gasto(user_id, "café da manhã", 50.0)
+
+    assert sum_spent_in_category_this_month(user_id, "cafe da manha") == 50.0
+
+    status = get_budgets_status_for_month(user_id)
+    linha = [b for b in status["budgets"] if b["categoria"] == "cafe da manha"]
+    assert len(linha) == 1, status["budgets"]
+    assert linha[0]["spent"] == 50.0
+    assert status["totals"]["spent"] == 50.0
+
+
+def test_alerta_dispara_com_as_duas_grafias(user_id):
+    """Threshold de 80% (`core/budget_alerts.THRESHOLDS`) cruzado quando o gasto
+    entra na grafia acentuada e o orçamento está na grafia sem acento — e
+    vice-versa, na segunda metade."""
+    upsert_budget(user_id, "cafe da manha", 100.0)
+    _gasto(user_id, "café da manhã", 90.0)
+    alerta = evaluate_after_expense(
+        user_id, "café da manhã", 90.0, datetime.now(timezone.utc)
+    )
+    assert alerta is not None and alerta.threshold == 80
+
+    # grafias trocadas de lado: orçamento COM acento, gasto SEM
+    upsert_budget(user_id, "pizzaría", 100.0)
+    _gasto(user_id, "pizzaria", 90.0)
+    alerta2 = evaluate_after_expense(
+        user_id, "pizzaria", 90.0, datetime.now(timezone.utc)
+    )
+    assert alerta2 is not None and alerta2.threshold == 80
+
+
+def test_donut_nao_duplica_a_mesma_categoria(user_id):
+    """As duas grafias viram UMA fatia, com o total somado, e o orçamento
+    cadastrado na terceira grafia (caixa alta) gruda nessa fatia."""
+    upsert_budget(user_id, "CAFE DA MANHA", 100.0)
+    _gasto(user_id, "cafe da manha", 30.0)
+    _gasto(user_id, "café da manhã", 60.0)
+
+    data = asyncio.run(dashboard.get_financial_data(user_id))
+    fatias = [
+        c for c in data["expense_categories"]
+        if c["categoria"].lower().startswith(("cafe", "café"))
+    ]
+    assert len(fatias) == 1, data["expense_categories"]
+    assert fatias[0]["total"] == 90.0
+    # rótulo = grafia do lançamento MAIS RECENTE
+    assert fatias[0]["categoria"] == "café da manhã"
+    assert fatias[0]["budget"] == 100.0
+    assert fatias[0]["budget_pct"] == 90.0
+    assert "cat_key" not in fatias[0]
+    # o alerta de 85% da dashboard (mesmo laço) só aparece se o orçamento grudou
+    assert [a["type"] for a in data["alerts"]] == ["budget_warning"]
+
+    # o outro donut (aba Análises, `db/analytics.py`) tem que agrupar igual
+    hoje = date.today()
+    analytics = compute_categories(user_id, hoje.replace(day=1), hoje + timedelta(days=1))
+    cafes = [c for c in analytics if c["name"].lower().startswith(("cafe", "café"))]
+    assert len(cafes) == 1, analytics
+    assert cafes[0]["total"] == 90.0 and cafes[0]["name"] == "café da manhã"
+
+
+# ── controle positivo: o normalizador não pode colapsar o que não é gêmeo ────
+
+def test_categorias_diferentes_continuam_separadas(user_id):
+    upsert_budget(user_id, "cafe", 100.0)
+    upsert_budget(user_id, "carne", 100.0)
+    _gasto(user_id, "cafe", 10.0)
+    _gasto(user_id, "carne", 70.0)
+
+    por_cat = {b["categoria"]: b["spent"] for b in get_budgets_status_for_month(user_id)["budgets"]}
+    assert por_cat == {"cafe": 10.0, "carne": 70.0}
+    assert sum_spent_in_category_this_month(user_id, "cafe") == 10.0
+
+    data = asyncio.run(dashboard.get_financial_data(user_id))
+    fatias = {c["categoria"]: c["total"] for c in data["expense_categories"]}
+    assert fatias == {"cafe": 10.0, "carne": 70.0}
+    hoje = date.today()
+    analytics = compute_categories(user_id, hoje.replace(day=1), hoje + timedelta(days=1))
+    assert {c["name"]: c["total"] for c in analytics} == {"cafe": 10.0, "carne": 70.0}
+
+    # e o alerta de uma não pode ser disparado pelo gasto da outra
+    assert evaluate_after_expense(
+        user_id, "cafe", 10.0, datetime.now(timezone.utc)
+    ) is None
+
+
+def test_crud_de_orcamento_acha_a_linha_com_a_outra_grafia(user_id):
+    """`upsert_budget` não pode criar orçamento gêmeo: 'café' cai na linha
+    'cafe' que já existe, mantendo a grafia original."""
+    upsert_budget(user_id, "cafe", 100.0)
+    canon, created = upsert_budget(user_id, "Café", 300.0)
+    assert (canon, created) == ("cafe", False)
+    assert db.budgets.get_budget(user_id, "CAFÉ") == {"categoria": "cafe", "budget": 300.0}
+    assert len(db.budgets.list_budgets(user_id)) == 1
+    assert db.budgets.delete_budget(user_id, "café") is True
+    assert db.budgets.list_budgets(user_id) == []

--- a/tests/test_category_normalization.py
+++ b/tests/test_category_normalization.py
@@ -530,8 +530,8 @@ def test_nul_byte_na_categoria_nao_derruba_a_rota(pro_user_id, porta):
     `psycopg.DataError` — 500 onde a `main` dava 200 (ela passava pelo
     `normalize_text`, que filtra).
 
-    Controle negativo: sem o `_CONTROL_CHARS_RE` no
-    `_normalize_category_name`, as duas portas devolvem 500.
+    Controle negativo: sem o filtro de Cc no `_normalize_category_name`, as
+    duas portas devolvem 500.
     """
     alvo_id = {
         "launches": _novo_launch,
@@ -556,6 +556,35 @@ def test_nul_byte_na_categoria_nao_derruba_a_rota(pro_user_id, porta):
     assert all(
         ord(c) >= 0x20 for nome in _todos_os_nomes(pro_user_id) for c in nome
     ), _todos_os_nomes(pro_user_id)
+
+
+def test_invisivel_nao_fica_gravado(pro_user_id):
+    """Zero-width (U+200B) e override bidi (U+202E) são INVISÍVEIS e o filtro
+    antigo parava em \\x7f. `str.split()` não os vê (não são whitespace), então
+    eles ficavam GRAVADOS no lançamento e na linha de `user_categories` —
+    "cafe" e "cafe\u200b" viram duas fatias visualmente idênticas no dashboard
+    (é o bug que este PR existe pra matar, por outro eixo), e o U+202E ainda
+    inverte a ordem do que a tela mostra.
+
+    Digitado UMA vez só, de propósito: na segunda vez o `display_map` já
+    reencontra o nome pelo `normalize_text` e o teste passaria sem o conserto.
+
+    Controle negativo: com o filtro só em Cc, o gravado volta com os dois
+    invisíveis e os dois asserts caem.
+    """
+    launch_id = _novo_launch(pro_user_id)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+
+    r = client.patch(
+        f"/launches/{pro_user_id}/{launch_id}",
+        json={"categoria": "\u202ecafe\u200b da manha"}, headers=headers,
+    )
+    assert r.status_code == 200, r.text
+
+    gravado = _categoria_do_launch(pro_user_id, launch_id)
+    assert gravado == "cafe da manha", repr(gravado)
+    assert _nomes_custom(pro_user_id) == ["cafe da manha"], _nomes_custom(pro_user_id)
 
 
 @pytest.mark.parametrize("pago", [False, True])

--- a/tests/test_category_normalization.py
+++ b/tests/test_category_normalization.py
@@ -1,0 +1,1016 @@
+"""
+tests/test_category_normalization.py — texto livre de categoria colapsa numa
+forma só (`resolve_category_input`), em TODAS as portas que gravam categoria.
+
+Caso real que originou o arquivo: o usuário corrige um lançamento pelo WhatsApp
+digitando "McDonald's" e o lançamento virava `mcdonald s` — apóstrofo virava
+espaço, e a categoria `mcdonald's` que ele tinha criado na tela ganhava uma
+fatia gêmea no dashboard.
+
+ESCOPO: só a forma gravada (bug A). Fazer a correção manual ENSINAR (bug B) é
+PR próprio — a especificação do dono é que override manual tem escopo restrito
+e precedência controlada, e nunca sobrescreve keyword canônica globalmente.
+
+Convenção travada aqui (não "conserte"):
+  user_categories.name      → forma de exibição (minúscula, COM acento/pontuação)
+  launches.categoria        → sempre igual a algum user_categories.name
+  user_category_rules.category → índice interno, NORMALIZADO (sem acento)
+
+Duas invariantes que valem pra TODA porta e são testadas uma a uma:
+  • a linha em `user_categories` só nasce DEPOIS de o UPDATE dar certo
+    (alvo inexistente = 404 e catálogo intacto);
+  • quem NÃO tem plano com categoria custom grava sem acento, como a `main` —
+    sem catálogo não há de-duplicação, e preservar a grafia criaria as gêmeas
+    que este PR existe pra matar.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+import db
+from adapters.whatsapp import wa_runtime
+from adapters.whatsapp.wa_parse import InboundMessage
+from conftest import promote_to_pro
+from core.services.category_service import infer_category
+from db.categories import (
+    CATEGORY_NAME_MAX_LEN,
+    create_user_category,
+    delete_user_category,
+    resolve_category_input,
+)
+import frontend.finance_bot_websocket_custom as dashboard
+
+
+@pytest.fixture()
+def wa_user_id():
+    """user_id < 2 bilhões. Acima disso o `_normalize_user_id` do
+    handle_incoming COMPRIME o id (hash), e o lançamento cairia num usuário
+    diferente do que o wa_runtime usa nas correções. Em produção o
+    `get_or_create_canonical_user` já devolve id pequeno; a fixture padrão
+    `user_id` sorteia até 10 bilhões."""
+    uid = int(uuid.uuid4().int % 1_900_000_000) + 1
+    db.ensure_user(uid)
+    return promote_to_pro(uid)
+
+
+# ─── helpers ────────────────────────────────────────────────────────────────
+
+
+def _novo_launch(user_id: int, *, alvo="mcdonalds", nota="mcdonalds", categoria="alimentação") -> int:
+    launch_id, _seq, _bal = db.add_launch_and_update_balance(
+        user_id=user_id, tipo="despesa", valor=39.90,
+        alvo=alvo, nota=nota, categoria=categoria,
+    )
+    return launch_id
+
+
+def _categoria_do_launch(user_id: int, launch_id: int) -> str | None:
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select categoria from launches where user_id=%s and id=%s",
+                (user_id, launch_id),
+            )
+            row = cur.fetchone()
+    return row["categoria"] if row else None
+
+
+def _ultimo_launch(user_id: int) -> dict:
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select id, categoria, alvo, nota from launches "
+                "where user_id=%s order by id desc limit 1",
+                (user_id,),
+            )
+            return cur.fetchone()
+
+
+def _nomes_custom(user_id: int) -> list[str]:
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select name from user_categories where user_id=%s and is_system=false order by name",
+                (user_id,),
+            )
+            return [r["name"] for r in (cur.fetchall() or [])]
+
+
+def _todos_os_nomes(user_id: int) -> list[str]:
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select name from user_categories where user_id=%s order by name",
+                (user_id,),
+            )
+            return [r["name"] for r in (cur.fetchall() or [])]
+
+
+def _regra(user_id: int, keyword: str) -> str | None:
+    for kw, cat in db.list_user_category_rules(user_id):
+        if kw == keyword:
+            return cat
+    return None
+
+
+def _auth(client: TestClient, user_id: int) -> dict:
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(user_id, "cat@t.com"))
+    client.cookies.set(dashboard.DASHBOARD_COOKIE_NAME, dashboard.make_dashboard_token(user_id, hours=1))
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, "test-csrf-token")
+    return {dashboard.CSRF_HEADER_NAME: "test-csrf-token", "Content-Type": "application/json"}
+
+
+def _wa(monkeypatch, user_id: int) -> list[str]:
+    """Faz `process_message` cair sempre neste user_id e captura as respostas."""
+    respostas: list[str] = []
+    monkeypatch.setattr(wa_runtime, "get_or_create_canonical_user", lambda p, e: user_id)
+    monkeypatch.setattr(
+        wa_runtime, "attempt_whatsapp_phone_link",
+        lambda wa_id, current_user_id=None: {"status": "already_linked", "user_id": user_id},
+    )
+    monkeypatch.setattr(wa_runtime, "_seen_recent", lambda message_id: False)
+    monkeypatch.setattr(wa_runtime, "send_typing_indicator", lambda *a, **k: None)
+    monkeypatch.setattr(wa_runtime, "_send_reply", lambda to, body: respostas.append(body))
+    monkeypatch.setattr(
+        wa_runtime, "_send_reply_with_optional_buttons",
+        lambda to, body, user_id=None: respostas.append(body),
+    )
+    monkeypatch.setattr(wa_runtime, "send_interactive_buttons", lambda **kw: respostas.append(kw["body"]))
+    monkeypatch.setattr(wa_runtime, "send_interactive_list", lambda **kw: respostas.append(kw["body"]))
+    return respostas
+
+
+def _msg(texto: str, user_id: int) -> InboundMessage:
+    return InboundMessage(
+        wa_id="5511999990000", text=texto, timestamp=None, attachments=[],
+        raw={"id": f"wamid.{texto[:8]}.{user_id}", "type": "text"},
+    )
+
+
+def _botao(button_id: str, user_id: int) -> InboundMessage:
+    """Toque num botão interativo (mesmo payload que a Meta manda)."""
+    return InboundMessage(
+        wa_id="5511999990000", text="", timestamp=None, attachments=[],
+        raw={
+            "id": f"wamid.btn.{button_id}.{user_id}",
+            "type": "interactive",
+            "interactive": {"type": "button_reply", "button_reply": {"id": button_id, "title": "x"}},
+        },
+    )
+
+
+_OFX_BANCO = """OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX><BANKMSGSRSV1><STMTTRNRS><TRNUID>1<STATUS><CODE>0<SEVERITY>INFO</STATUS>
+<STMTRS><CURDEF>BRL<BANKACCTFROM><BANKID>0001<ACCTID>{acct}<ACCTTYPE>CHECKING</BANKACCTFROM>
+<BANKTRANLIST><DTSTART>20260801<DTEND>20260831
+<STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20260803<TRNAMT>-39.90<FITID>{acct}TX1<MEMO>MCDONALDS 1234</STMTTRN>
+</BANKTRANLIST><LEDGERBAL><BALAMT>100.00<DTASOF>20260831</LEDGERBAL></STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>
+"""
+
+_OFX_CARTAO = """OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX><CREDITCARDMSGSRSV1><CCSTMTTRNRS><TRNUID>1<STATUS><CODE>0<SEVERITY>INFO</STATUS>
+<CCSTMTRS><CURDEF>BRL<CCACCTFROM><ACCTID>{acct}</CCACCTFROM>
+<BANKTRANLIST><DTSTART>20260801<DTEND>20260831
+<STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20260803<TRNAMT>-39.90<FITID>{acct}CC1<MEMO>MCDONALDS 1234</STMTTRN>
+</BANKTRANLIST><LEDGERBAL><BALAMT>-39.90<DTASOF>20260831</LEDGERBAL></CCSTMTRS></CCSTMTTRNRS></CREDITCARDMSGSRSV1></OFX>
+"""
+
+
+# ─── porta 1: WhatsApp "Outra (digitar)" ────────────────────────────────────
+
+
+def test_wa_corrige_para_nome_custom_existente(pro_user_id):
+    """Digitar "McDonald's" tem que reencontrar o `mcdonald's` criado na tela.
+
+    Controle negativo: com `canonicalize_category_label` no lugar do
+    `resolve_category_input`, o launch grava `mcdonald s` e este teste falha.
+    """
+    create_user_category(pro_user_id, "McDonald's")
+    launch_id = _novo_launch(pro_user_id)
+
+    wa_runtime._apply_recategorize(pro_user_id, launch_id, "McDonald's")
+
+    assert _categoria_do_launch(pro_user_id, launch_id) == "mcdonald's"
+    # e não criou gêmea
+    assert _nomes_custom(pro_user_id) == ["mcdonald's"]
+
+
+def test_categoria_nova_legitima_e_criada(pro_user_id):
+    """CONTROLE POSITIVO: nome novo continua passando — e vira categoria de
+    verdade (com emoji/cor/orçamento possíveis), não texto órfão."""
+    launch_id = _novo_launch(pro_user_id)
+
+    wa_runtime._apply_recategorize(pro_user_id, launch_id, "Padaria do Zé")
+
+    assert _categoria_do_launch(pro_user_id, launch_id) == "padaria do zé"
+    assert "padaria do zé" in _nomes_custom(pro_user_id)
+
+
+@pytest.mark.parametrize("digitado", ["Alimentação", "alimentacao", "ALIMENTAÇÃO"])
+def test_rotulo_do_sistema_intacto(pro_user_id, digitado):
+    """CONTROLE POSITIVO: as três formas colapsam no rótulo do sistema e
+    NENHUMA cria linha nova em user_categories."""
+    launch_id = _novo_launch(pro_user_id, categoria="outros")
+
+    wa_runtime._apply_recategorize(pro_user_id, launch_id, digitado)
+
+    assert _categoria_do_launch(pro_user_id, launch_id) == "alimentação"
+    assert _nomes_custom(pro_user_id) == []
+
+
+# ─── caminho de LEITURA (passo B do infer_category) ─────────────────────────
+
+
+def test_regra_custom_volta_com_acento(pro_user_id):
+    """Controle negativo: com `canonicalize_category_label(cat)` no passo B, a
+    inferência devolve `saude da familia` e este teste falha."""
+    create_user_category(pro_user_id, "saúde da família")
+    db.upsert_category_rule(pro_user_id, "familia", "saude da familia")
+
+    res = infer_category(pro_user_id, "gastei 100 com a familia", allow_ai=False)
+
+    assert res.reason == "user_rule"
+    assert res.category == "saúde da família"
+
+
+def test_regra_orfa_mantem_comportamento_de_hoje(pro_user_id):
+    """CONTROLE POSITIVO do passo B: regra apontando pra categoria que NÃO
+    existe em user_categories continua devolvendo o canonicalize de antes."""
+    db.upsert_category_rule(pro_user_id, "cinema", "lazer")
+
+    res = infer_category(pro_user_id, "gastei 40 no cinema", allow_ai=False)
+
+    assert res.category == "lazer"
+
+
+def test_inferencia_nao_escreve_no_banco(pro_user_id):
+    """D8a: o caminho quente da inferência é READ-ONLY.
+
+    `user_category_display_map` chegou a semear antes de ler — 15 INSERT em
+    toda inferência que bate em regra do usuário, contra o que
+    `list_custom_category_names` documenta a duas funções de distância.
+
+    Controle negativo: devolver o `ensure_user_categories_seeded` pro topo do
+    `user_category_display_map` faz os dois asserts falharem (o catálogo nasce
+    com as 15 canônicas e o INSERT aparece na contagem).
+    """
+    # a regra tem que apontar pra categoria NÃO canônica: rótulo do sistema é
+    # resolvido no passo 1, antes de o mapa ser consultado, e aí o teste não
+    # discrimina o seed.
+    db.upsert_category_rule(pro_user_id, "mcdonalds", "mcdonald s")
+
+    statements: list[str] = []
+    import psycopg
+    original = psycopg.Cursor.execute
+
+    def _spy(self, query, *a, **k):
+        q = " ".join((query.decode() if isinstance(query, bytes) else str(query)).lower().split())
+        statements.append(q)
+        return original(self, query, *a, **k)
+
+    psycopg.Cursor.execute = _spy
+    try:
+        res = infer_category(pro_user_id, "gastei 39,90 no mcdonalds", allow_ai=False)
+    finally:
+        psycopg.Cursor.execute = original
+
+    escritas = [q[:60] for q in statements if q.split(" ", 1)[0] in {"insert", "update", "delete"}]
+    assert res.reason == "user_rule"
+    # os 2 INSERT que sobram são o `ensure_user` que já existia na main
+    # (users/accounts, on conflict do nothing) — nenhum toca user_categories.
+    assert [q for q in escritas if "user_categories" in q] == [], escritas
+    assert len(statements) <= 4, len(statements)   # main: 3 · com o seed: 22
+    assert _todos_os_nomes(pro_user_id) == []
+
+
+def test_display_map_desempate_nao_depende_de_id(pro_user_id):
+    """D8b: com gêmeas ("cafe" e "café") o resultado não pode mudar quando a
+    mais nova é apagada — antes o `order by id` fazia a resposta depender de
+    quem foi criado/apagado por último."""
+    velha = create_user_category(pro_user_id, "Cafe")
+    nova = create_user_category(pro_user_id, "Café")
+
+    antes = resolve_category_input(pro_user_id, "cafe")
+    delete_user_category(pro_user_id, nova["id"])
+    depois = resolve_category_input(pro_user_id, "cafe")
+
+    assert antes == depois
+    assert velha["name"] in {"cafe", "café"}
+
+
+def test_display_map_com_banco_fora_degrada_so_na_leitura(pro_user_id, monkeypatch):
+    """As 3 chamadas de importação de extrato (`create=False`) degradam: mapa
+    vazio, grava o normalizado — o import não dependia de `user_categories`
+    antes deste PR e não pode abortar o arquivo por um enfeite de grafia.
+
+    As portas de correção (`create=True`) NÃO degradam: ali o mapa vazio não
+    acha a categoria que o usuário já tem e o nome digitado é gravado como se
+    fosse outro — vira fatia gêmea no dashboard, que agrupa por
+    `launches.categoria` (`db/accounts.py:601`).
+
+    Controle negativo: tirando o `strict=create` do `resolve_category_input`,
+    a última linha para de levantar.
+    """
+    from db import categories as db_categories
+
+    def _boom(*a, **k):
+        raise RuntimeError("banco fora")
+
+    monkeypatch.setattr(db_categories, "get_conn", _boom)
+
+    assert db_categories.user_category_display_map(pro_user_id) == {}
+    assert db_categories.resolve_category_input(pro_user_id, "Padaria do Zé") is None
+    with pytest.raises(RuntimeError):
+        db_categories.resolve_category_input(pro_user_id, "Padaria do Zé", create=True)
+
+
+def test_falha_transitoria_nao_cria_gemea_no_catalogo(pro_user_id, monkeypatch):
+    """O mesmo D7 pelo CAMINHO REAL (PATCH /launches), com estado no banco: a
+    categoria já existe e a leitura do catálogo PISCA — falha uma vez e volta.
+
+    Medido com o `try/except → {}` (mesma piscada, mesmo request):
+        status 200 · launches.categoria = 'cafe da manha' · catálogo = ['café da manhã']
+    Ou seja: 200 com dado sujo — o lançamento aponta pra uma string que não é
+    o nome do catálogo, e o dashboard, que agrupa por `launches.categoria`
+    (`db/accounts.py:601`), passa a mostrar DUAS fatias do mesmo café.
+    (A linha gêmea em `user_categories` não chega a nascer porque o
+    `ensure_user_category` já reencontra o mapa; o estrago é o lançamento.)
+
+    Com a correção: 500, lançamento intacto, nada gravado.
+    Controle negativo: devolvendo o `return {}` incondicional ao
+    `user_category_display_map`, o status vira 200 e o último assert cai.
+    """
+    from db import categories as db_categories
+
+    create_user_category(pro_user_id, "Café da Manhã")
+    launch_id = _novo_launch(pro_user_id)
+
+    original = db_categories.get_conn
+    restantes = {"falhas": 1}
+
+    def _piscada(*a, **k):
+        if restantes["falhas"]:
+            restantes["falhas"] -= 1
+            raise RuntimeError("banco piscou")
+        return original(*a, **k)
+
+    monkeypatch.setattr(db_categories, "get_conn", _piscada)
+
+    client = TestClient(dashboard.app, raise_server_exceptions=False)
+    headers = _auth(client, pro_user_id)
+    resp = client.patch(
+        f"/launches/{pro_user_id}/{launch_id}",
+        json={"categoria": "Cafe da Manha"}, headers=headers,
+    )
+
+    assert restantes["falhas"] == 0, "a piscada não chegou a acontecer"
+    assert resp.status_code >= 500, resp.text[:200]
+    assert _nomes_custom(pro_user_id) == ["café da manhã"]
+    assert _categoria_do_launch(pro_user_id, launch_id) == "alimentação"
+
+
+# ─── porta 2: PATCH /launches ───────────────────────────────────────────────
+
+
+def test_patch_launch_inexistente_nao_cria_categoria(pro_user_id):
+    """D5: a linha em user_categories só nasce DEPOIS do UPDATE. Antes, um id
+    inexistente devolvia 404 e ainda assim sujava o catálogo — em loop, o
+    usuário perdia a tela de categorias."""
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+
+    resp = client.patch(
+        f"/launches/{pro_user_id}/999999999",
+        json={"categoria": "categoria fantasma"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 404
+    assert _nomes_custom(pro_user_id) == []
+
+
+# Entradas que furam o teto quando ele é medido no NORMALIZADO em vez de no
+# nome gravado. `normalize_text` tira emoji/pontuação e encolhe: o 3º caso
+# normaliza pra 1 caractere e gravava 5001 no `launches.categoria` — que pelo
+# WhatsApp vira resposta acima do limite de 4096 da Meta.
+_NOMES_GIGANTES = [
+    "A" * (CATEGORY_NAME_MAX_LEN + 1),
+    "A" * 3000,
+    "🐷" * 5000 + "a",
+    "." * 5000 + "a",
+]
+
+
+@pytest.mark.parametrize("nome", _NOMES_GIGANTES)
+def test_nome_de_categoria_gigante_recusado(pro_user_id, nome):
+    """D6: `CATEGORY_NAME_MAX_LEN` é a fonte única — as 5 portas recusam pelo
+    mesmo número, medido sobre o que VAI SER GRAVADO.
+
+    Controle negativo: medir `normalize_text(raw)` (como na rodada 2) deixa os
+    dois últimos casos passarem com 5001 caracteres no banco.
+    """
+    launch_id = _novo_launch(pro_user_id)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+
+    resp = client.patch(
+        f"/launches/{pro_user_id}/{launch_id}",
+        json={"categoria": nome},
+        headers=headers,
+    )
+
+    assert resp.status_code == 400, resp.text[:200]
+    assert _nomes_custom(pro_user_id) == []
+    assert _categoria_do_launch(pro_user_id, launch_id) == "alimentação"
+
+
+def test_nome_gigante_recusado_no_whatsapp(wa_user_id, monkeypatch):
+    """Mesma entrada pela porta do WhatsApp: a resposta tem que caber no limite
+    de 4096 caracteres da Meta e o lançamento não pode mudar.
+
+    Controle POSITIVO junto: um nome normal passa pela mesma porta.
+    """
+    respostas = _wa(monkeypatch, wa_user_id)
+    launch_id = _novo_launch(wa_user_id)
+
+    recusa = wa_runtime._apply_recategorize(wa_user_id, launch_id, "🐷" * 5000 + "a")
+    assert len(recusa) < 4096
+    assert _categoria_do_launch(wa_user_id, launch_id) == "alimentação"
+
+    ok = wa_runtime._apply_recategorize(wa_user_id, launch_id, "Lazer")
+    assert len(ok) < 4096
+    assert _categoria_do_launch(wa_user_id, launch_id) == "lazer"
+    assert respostas == []
+
+
+def test_free_nao_cria_categoria_custom(user_id):
+    """D4: `POST /categories` exige plano pago (custom_categories). As portas
+    de correção criavam a MESMA entidade sem gate.
+
+    Comportamento pra quem não tem o plano: grava o texto no lançamento SEM
+    ACENTO, exatamente como a `main`, e NÃO cria linha no catálogo.
+    """
+    launch_id = _novo_launch(user_id)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id)
+
+    negado = client.post(
+        f"/categories/{user_id}", json={"name": "padaria do zé"}, headers=headers,
+    )
+    assert negado.status_code == 403, negado.text
+
+    resp = client.patch(
+        f"/launches/{user_id}/{launch_id}",
+        json={"categoria": "Padaria do Zé"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _categoria_do_launch(user_id, launch_id) == "padaria do ze"
+    assert _nomes_custom(user_id) == []
+
+
+def test_free_duas_grafias_colapsam_numa_so(user_id):
+    """B-1, o furo que este PR TINHA: sem plano pago não nasce linha em
+    `user_categories`, e sem catálogo não existe de-duplicação. Preservar a
+    grafia fazia "Padaria do Zé" e "Padaria do Ze" virarem DUAS fatias no
+    dashboard — onde a `main` colapsava as duas em `padaria do ze`.
+
+    O mesmo usuário corrigindo DUAS vezes é o que os 47 testes da rodada
+    anterior nunca faziam; por isso o furo passou.
+
+    Controle negativo: `stored = _normalize_category_name(raw)` incondicional
+    (sem o `_custom_categories_allowed`) devolve 'padaria do zé' != 'padaria
+    do ze' e o assert de igualdade cai.
+    """
+    a_id = _novo_launch(user_id)
+    b_id = _novo_launch(user_id)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id)
+
+    for launch_id, digitado in ((a_id, "Padaria do Zé"), (b_id, "Padaria do Ze")):
+        r = client.patch(
+            f"/launches/{user_id}/{launch_id}",
+            json={"categoria": digitado}, headers=headers,
+        )
+        assert r.status_code == 200, r.text
+
+    a = _categoria_do_launch(user_id, a_id)
+    b = _categoria_do_launch(user_id, b_id)
+    assert a == b == "padaria do ze", (a, b)
+    assert _nomes_custom(user_id) == []
+
+
+@pytest.mark.parametrize("porta", ["launches", "credit-transactions", "installments"])
+def test_nul_byte_na_categoria_nao_derruba_a_rota(pro_user_id, porta):
+    """Regressão que este PR introduziu: `_normalize_category_name` não
+    filtrava caracteres de controle e o NUL chegava ao Postgres, que responde
+    `psycopg.DataError` — 500 onde a `main` dava 200 (ela passava pelo
+    `normalize_text`, que filtra).
+
+    Controle negativo: sem o `_CONTROL_CHARS_RE` no
+    `_normalize_category_name`, as duas portas devolvem 500.
+    """
+    alvo_id = {
+        "launches": _novo_launch,
+        "credit-transactions": _compra_no_credito,
+        "installments": _parcelado,
+    }[porta](pro_user_id)
+
+    client = TestClient(dashboard.app, raise_server_exceptions=False)
+    headers = _auth(client, pro_user_id)
+    resp = client.patch(
+        f"/{porta}/{pro_user_id}/{alvo_id}",
+        json={"categoria": "a\u0000b"}, headers=headers,
+    )
+
+    assert resp.status_code == 200, (resp.status_code, resp.text[:200])
+    # e os demais controles (\x01-\x1f) não ficam gravados
+    resp2 = client.patch(
+        f"/{porta}/{pro_user_id}/{alvo_id}",
+        json={"categoria": "cafe\u0001 manha"}, headers=headers,
+    )
+    assert resp2.status_code == 200, resp2.text[:200]
+    assert all(
+        ord(c) >= 0x20 for nome in _todos_os_nomes(pro_user_id) for c in nome
+    ), _todos_os_nomes(pro_user_id)
+
+
+@pytest.mark.parametrize("pago", [False, True])
+def test_gate_de_categoria_custom_com_planos_v2(user_id, monkeypatch, pago):
+    """O `conftest` força PLANS_V2_ENABLED="0", mas o DEFAULT de produção é
+    LIGADO — e o gate saiu do monólito pro `plan_service.plan_gate_ok` neste
+    PR. Este é o único teste do PR que roda o ramo v2.
+
+    Grátis não cria categoria custom; pago (tier >= essencial) cria — os dois
+    gravam o texto no lançamento de qualquer jeito.
+    """
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    if pago:
+        promote_to_pro(user_id)
+    launch_id = _novo_launch(user_id)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id)
+
+    resp = client.patch(
+        f"/launches/{user_id}/{launch_id}",
+        json={"categoria": "Padaria do Zé"}, headers=headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _categoria_do_launch(user_id, launch_id) == ("padaria do zé" if pago else "padaria do ze")
+    assert _nomes_custom(user_id) == (["padaria do zé"] if pago else [])
+
+
+# ─── porta 3: PATCH /credit-transactions ────────────────────────────────────
+
+
+def _compra_no_credito(user_id: int, categoria="outros", nota="mcdonalds") -> int:
+    card_id = db.create_card(user_id, "Nubank", closing_day=10, due_day=17)
+    tx_id, _due, _bill = db.add_credit_purchase(user_id, card_id, 39.90, categoria, nota, date.today())
+    return tx_id
+
+
+def test_credit_transaction_patch_resolve_categoria(pro_user_id):
+    """Porta 3 (sem teste nenhum antes): digitar "McDonald's" no dashboard tem
+    que reencontrar o `mcdonald's` do catálogo.
+
+    Controle negativo: voltando pro `canonicalize_category_label(raw) or
+    raw.lower()`, a compra grava `mcdonald s` e o assert falha.
+    """
+    create_user_category(pro_user_id, "McDonald's")
+    tx_id = _compra_no_credito(pro_user_id)
+
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+    resp = client.patch(
+        f"/credit-transactions/{pro_user_id}/{tx_id}",
+        json={"categoria": "McDonald's"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select categoria from credit_transactions where user_id=%s and id=%s",
+                (pro_user_id, tx_id),
+            )
+            assert cur.fetchone()["categoria"] == "mcdonald's"
+
+
+def test_installment_categoria_vazia_limpa_o_campo(pro_user_id):
+    """Simetria com `nome`: vazio/espaços LIMPA a categoria (o
+    `update_installment_group_meta` faz `.strip() or None`).
+
+    Controle negativo: mandar o vazio pro `resolve_category_input` devolve None
+    e a rota responde 400 — que foi a regressão da rodada 2.
+    """
+    group_id = _parcelado(pro_user_id)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+
+    resp = client.patch(
+        f"/installments/{pro_user_id}/{group_id}",
+        json={"categoria": "   "}, headers=headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select distinct categoria from credit_transactions "
+                "where user_id=%s and group_id=%s::uuid",
+                (pro_user_id, group_id),
+            )
+            assert [r["categoria"] for r in cur.fetchall()] == [None]
+
+
+# ─── porta 4: tool da IA ────────────────────────────────────────────────────
+
+
+def _tool_recategorize(user_id: int, launch_id: int, categoria: str) -> str:
+    from core.services.ai_chat.tools.categories import _recategorize_launch_execute
+    return _recategorize_launch_execute(
+        user_id, {"launch_id": launch_id, "new_category": categoria}
+    )
+
+
+def test_ai_tool_resolve_categoria(pro_user_id):
+    """Porta 4 (sem teste nenhum antes). Controle negativo: passando
+    `args["new_category"]` cru pro update, grava "McDonald's" com maiúscula e
+    apóstrofo fora do catálogo."""
+    create_user_category(pro_user_id, "McDonald's")
+    launch_id = _novo_launch(pro_user_id)
+
+    _tool_recategorize(pro_user_id, launch_id, "McDonald's")
+
+    assert _categoria_do_launch(pro_user_id, launch_id) == "mcdonald's"
+    assert _nomes_custom(pro_user_id) == ["mcdonald's"]
+
+
+def test_ai_tool_launch_inexistente_nao_cria_categoria(pro_user_id):
+    """D5 na porta da IA."""
+    _tool_recategorize(pro_user_id, 999999999, "fantasma ia")
+
+    assert _nomes_custom(pro_user_id) == []
+
+
+# ─── porta 5: PATCH /installments ───────────────────────────────────────────
+
+
+def _parcelado(user_id: int, card_name: str = "Nubank") -> str:
+    card_id = db.create_card(user_id, card_name, closing_day=10, due_day=17)
+    info, _total = db.add_credit_purchase_installments(
+        user_id, card_id, 120.0, "outros", "mcdonalds", date.today(), 3,
+    )
+    return info["group_id"]
+
+
+def test_installment_patch_resolve_categoria(pro_user_id):
+    create_user_category(pro_user_id, "McDonald's")
+    group_id = _parcelado(pro_user_id)
+
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+    resp = client.patch(
+        f"/installments/{pro_user_id}/{group_id}",
+        json={"categoria": "McDonald's"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select distinct categoria from credit_transactions "
+                "where user_id=%s and group_id=%s::uuid",
+                (pro_user_id, group_id),
+            )
+            cats = [r["categoria"] for r in cur.fetchall()]
+    assert cats == ["mcdonald's"]
+
+
+def test_installment_inexistente_nao_cria_categoria(pro_user_id):
+    """D5 na porta do parcelamento."""
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+
+    resp = client.patch(
+        f"/installments/{pro_user_id}/{uuid.uuid4()}",
+        json={"categoria": "fantasma parcelado"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 404
+    assert _nomes_custom(pro_user_id) == []
+
+
+# ─── porta 6: importação de extrato (CSV, OFX de conta, OFX de fatura) ──────
+
+
+def test_import_extrato_nao_cria_gemea(pro_user_id):
+    """A regra guarda `mcdonald s`; o extrato tem que gravar `mcdonald's`.
+
+    A categoria de exibição é PRÉ-CRIADA de propósito: a importação resolve
+    contra o catálogo, mas nunca CRIA categoria (inferência não cria efeito
+    colateral). Sem a linha em user_categories, o import grava o normalizado —
+    é o comportamento esperado, não um furo deste teste.
+
+    Controle negativo: sem a conversão no write site, grava `mcdonald s` e cria
+    a fatia gêmea no dashboard.
+    """
+    from statement_import import import_statement_bytes
+
+    create_user_category(pro_user_id, "McDonald's")
+    db.upsert_category_rule(pro_user_id, "mcdonalds", "mcdonald s")
+
+    csv_bytes = (
+        "Data,Descrição,Valor\n"
+        "03/08/2026,MCDONALDS 1234,\"-39,90\"\n"
+        "04/08/2026,PADARIA CENTRAL,\"-12,00\"\n"
+    ).encode("utf-8")
+
+    rep = import_statement_bytes(pro_user_id, csv_bytes, "extrato.csv", "csv")
+    assert rep["inserted"] == 2
+
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select categoria from launches where user_id=%s and nota ilike %s",
+                (pro_user_id, "%MCDONALDS%"),
+            )
+            cats = [r["categoria"] for r in cur.fetchall()]
+    assert cats == ["mcdonald's"]
+
+
+def test_import_ofx_conta_nao_cria_gemea(pro_user_id):
+    """Porta 6-ofx (sem teste nenhum antes): mesmo write site do CSV, arquivo
+    diferente. Controle negativo: sem o `resolve_category_input` no
+    `import_ofx_bytes`, grava `mcdonald s`."""
+    from ofx_import import import_ofx_bytes
+
+    create_user_category(pro_user_id, "McDonald's")
+    db.upsert_category_rule(pro_user_id, "mcdonalds", "mcdonald s")
+
+    rep = import_ofx_bytes(
+        pro_user_id, _OFX_BANCO.format(acct=pro_user_id % 100000).encode(), "extrato.ofx",
+    )
+    assert rep["inserted"] == 1
+
+    assert _ultimo_launch(pro_user_id)["categoria"] == "mcdonald's"
+
+
+def test_import_ofx_fatura_nao_cria_gemea(pro_user_id):
+    """8ª porta: `ofx_credit_import._categorize` é cópia do `resolve_category`
+    e grava direto em credit_transactions.categoria."""
+    from ofx_credit_import import import_credit_ofx_bytes
+
+    create_user_category(pro_user_id, "McDonald's")
+    db.upsert_category_rule(pro_user_id, "mcdonalds", "mcdonald s")
+    card_id = db.create_card(pro_user_id, "Nubank", closing_day=10, due_day=17)
+
+    rep = import_credit_ofx_bytes(
+        pro_user_id, card_id, _OFX_CARTAO.format(acct=pro_user_id % 100000).encode(), "fatura.ofx",
+    )
+    assert rep["inserted"] == 1
+
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select categoria from credit_transactions where user_id=%s order by id desc limit 1",
+                (pro_user_id,),
+            )
+            assert cur.fetchone()["categoria"] == "mcdonald's"
+
+
+# ─── porta 7: POST /launches (categoria inferida) ───────────────────────────
+
+
+def test_launch_novo_usa_grafia_do_catalogo(pro_user_id):
+    """Porta 7 (sem teste nenhum antes): o lançamento nasce com a grafia do
+    catálogo. Controle negativo: com `canonicalize_category_label(inferred)`
+    de volta, nasce `mcdonald s` e abre fatia gêmea já no primeiro gasto."""
+    create_user_category(pro_user_id, "McDonald's")
+    db.upsert_category_rule(pro_user_id, "mcdonalds", "mcdonald s")
+
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+    resp = client.post(
+        f"/launches/{pro_user_id}",
+        json={"tipo": "despesa", "valor": 39.9, "alvo": "mcdonalds"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert _ultimo_launch(pro_user_id)["categoria"] == "mcdonald's"
+
+
+def test_compra_no_credito_nova_usa_grafia_do_catalogo(pro_user_id):
+    """Mesma porta 7, o outro write site (compra no crédito, :5091)."""
+    create_user_category(pro_user_id, "McDonald's")
+    db.upsert_category_rule(pro_user_id, "mcdonalds", "mcdonald s")
+    card_id = db.create_card(pro_user_id, "Nubank", closing_day=10, due_day=17)
+
+    client = TestClient(dashboard.app)
+    headers = _auth(client, pro_user_id)
+    resp = client.post(
+        f"/launches/{pro_user_id}",
+        json={"tipo": "credito", "valor": 39.9, "alvo": "mcdonalds", "card_id": card_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select categoria from credit_transactions where user_id=%s order by id desc limit 1",
+                (pro_user_id,),
+            )
+            assert cur.fetchone()["categoria"] == "mcdonald's"
+
+
+@pytest.mark.parametrize("reason", ["ai", "explicit"])
+def test_categoria_digitada_pela_ia_usa_grafia_do_catalogo(pro_user_id, reason):
+    """B-2, a string do chamado. `add_from_entities` é por onde entram a tool
+    `add_launch` (reason="ai") e a hashtag `#McDonald's` (reason="explicit").
+
+    Medido antes desta correção, usuário Pro que JÁ TEM "McDonald's":
+        reason=ai       -> 'mcdonald s'   (canonicalize_category_label)
+        reason=explicit -> "McDonald's"   (texto cru, com maiúscula)
+    As duas abriam fatia gêmea no PRIMEIRO lançamento.
+
+    Controle negativo: `canonicalize_category_label(categoria) or categoria` de
+    volta em `core/handlers/launches.py` derruba o caso "ai"; devolver
+    `categoria_final = categoria` cru derruba o "explicit".
+    """
+    from core.handlers.launches import add_from_entities
+
+    create_user_category(pro_user_id, "McDonald's")
+    # alvo sem regra local: senão o cross-check do ramo "ai" (que existe e tem
+    # de continuar existindo) sobrepõe a categoria da IA e o teste mede outra coisa.
+    add_from_entities(
+        pro_user_id, tipo="despesa", valor=39.9,
+        alvo="zzq comercio", nota="zzq comercio",
+        categoria="McDonald's", category_reason=reason,
+    )
+
+    assert _ultimo_launch(pro_user_id)["categoria"] == "mcdonald's"
+
+
+def test_cross_check_da_ia_continua_de_pe(pro_user_id):
+    """CONTROLE POSITIVO do B-2: rotear o ramo "ai" pelo `infer_category` não
+    pode desligar o cross-check — regra do usuário que contradiz a IA vence."""
+    from core.handlers.launches import add_from_entities
+
+    db.upsert_category_rule(pro_user_id, "zzq comercio", "moradia")
+    add_from_entities(
+        pro_user_id, tipo="despesa", valor=39.9,
+        alvo="zzq comercio", nota="zzq comercio",
+        categoria="Alimentação", category_reason="ai",
+    )
+
+    assert _ultimo_launch(pro_user_id)["categoria"] == "moradia"
+
+
+# ─── conversa: handle_incoming de verdade, estado real no banco ─────────────
+
+
+def _mock_gpt(monkeypatch, categoria: str) -> None:
+    """Faz o passo E do infer_category devolver `categoria` sem rede."""
+    import ai_router
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(ai_router, "classify_category_with_gpt", lambda *a, **k: categoria)
+    monkeypatch.setattr("core.services.plan_service.is_pro", lambda uid: True)
+
+
+def test_round_trip_duas_grafias_uma_categoria(wa_user_id, monkeypatch):
+    """Round trip do bug A: duas grafias do MESMO nome, corrigidas pelo mesmo
+    usuário em dois lançamentos, gravam a MESMA string e deixam UMA linha no
+    catálogo.
+
+    Quatro mensagens, um usuário, estado real no banco — a segunda correção só
+    reencontra a categoria porque a primeira criou a linha.
+
+    Controle negativo: com `canonicalize_category_label(cat) or cat.lower()` de
+    volta no `_apply_recategorize` (o código da `main`), grava `padaria do ze`
+    nas duas e o catálogo fica vazio — os dois asserts caem.
+    """
+    respostas = _wa(monkeypatch, wa_user_id)
+    _mock_gpt(monkeypatch, "alimentação")
+
+    wa_runtime.process_message(_msg("gastei 39,90 no mcdonalds", wa_user_id))
+    primeiro = _ultimo_launch(wa_user_id)
+    assert primeiro is not None and primeiro["categoria"] == "alimentação", respostas
+
+    wa_runtime.process_message(_msg("gastei 20 no mcdonalds", wa_user_id))
+    segundo = _ultimo_launch(wa_user_id)
+    assert segundo["id"] != primeiro["id"], respostas
+
+    # "Padaria do Zé" e "Padaria do Ze" normalizam pra mesma chave
+    for launch_id, digitado in ((primeiro["id"], "Padaria do Zé"), (segundo["id"], "Padaria do Ze")):
+        wa_runtime.process_message(_botao(f"{wa_runtime.WA_RECAT_OTHER_PREFIX}{launch_id}", wa_user_id))
+        wa_runtime.process_message(_msg(digitado, wa_user_id))
+
+    a = _categoria_do_launch(wa_user_id, primeiro["id"])
+    b = _categoria_do_launch(wa_user_id, segundo["id"])
+    assert a == b == "padaria do zé", (a, b, respostas)
+    assert _nomes_custom(wa_user_id) == ["padaria do zé"]
+
+
+@pytest.mark.parametrize("parcelas", [1, 3])  # à vista e parcelado: dois call sites
+def test_compra_no_credito_sem_nota_nao_aprende_o_cartao(wa_user_id, monkeypatch, parcelas):
+    """B1, o OUTRO site (pré-existente na main): a compra no crédito criada sem
+    nota nem alvo aprendia com `target_hint=alvo or card_name` e com a nota
+    gerada "compra no crédito (Nubank)" — nascendo a regra `nubank → X`, que
+    casa por substring e sequestra todo gasto que cite o cartão.
+
+    Controle negativo: voltando `target_hint=alvo or card_name` (e `nota` como
+    text_base), a regra reaparece e os dois asserts caem.
+    """
+    _mock_gpt(monkeypatch, "compras online")
+    card_id = db.create_card(wa_user_id, "Nubank", closing_day=10, due_day=17)
+
+    client = TestClient(dashboard.app)
+    headers = _auth(client, wa_user_id)
+    resp = client.post(
+        f"/launches/{wa_user_id}",
+        json={"tipo": "credito", "valor": 300, "card_id": card_id, "parcelas": parcelas},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert db.list_user_category_rules(wa_user_id) == []
+    assert infer_category(wa_user_id, "gastei 300 no mercado com o nubank", allow_ai=False).reason != "user_rule"
+
+
+def test_erro_de_banco_na_correcao_nao_come_o_turno(wa_user_id, monkeypatch):
+    """D7: a pendência já foi apagada quando `_apply_recategorize` roda. Se a
+    leitura do catálogo estourar, o turno morria em silêncio — o usuário
+    digitava a categoria e não recebia resposta nenhuma.
+
+    Controle negativo: tirando o try/except em volta do
+    `resolve_category_input`, a exceção sobe até o handler de topo (que só
+    loga) e `respostas` fica sem a mensagem de erro.
+    """
+    respostas = _wa(monkeypatch, wa_user_id)
+    launch_id = _novo_launch(wa_user_id)
+
+    def _boom(*a, **k):
+        raise RuntimeError("banco caiu no meio")
+
+    wa_runtime.process_message(_botao(f"{wa_runtime.WA_RECAT_OTHER_PREFIX}{launch_id}", wa_user_id))
+    monkeypatch.setattr(db, "resolve_category_input", _boom)
+    wa_runtime.process_message(_msg("McDonald's", wa_user_id))
+
+    assert any("Não consegui atualizar agora" in r for r in respostas), respostas
+
+
+def test_botao_outra_digitar_atropela_pendencia(wa_user_id, monkeypatch):
+    """Documenta o estado ATUAL pelo CAMINHO REAL (toque no botão "Outra
+    (digitar)" → `process_message`), não por um `set_pending_action` do
+    próprio teste: o botão grava `recategorize_launch_text` CRU
+    (`wa_runtime.py`), fora da disciplina claim/advance do CLAUDE.md §5, e
+    apaga a pergunta de outro fluxo que estava de pé.
+
+    Não é regressão deste PR; é o comportamento de hoje, escrito pra virar
+    issue separada. Quando o atropelo for consertado, este teste vira o
+    contrário — e é ele quem avisa.
+    """
+    respostas = _wa(monkeypatch, wa_user_id)
+    launch_id = _novo_launch(wa_user_id)
+
+    # pergunta de outro fluxo, de pé
+    db.claim_pending_action(wa_user_id, "bill_amount_expected", {"bill_id": 41, "bill_name": "Luz"})
+
+    # o usuário toca "Outra (digitar)" — o botão grava por cima
+    wa_runtime.process_message(_botao(f"{wa_runtime.WA_RECAT_OTHER_PREFIX}{launch_id}", wa_user_id))
+    assert db.get_pending_action(wa_user_id)["action_type"] == "recategorize_launch_text", respostas
+
+    wa_runtime.process_message(_msg("McDonald's", wa_user_id))
+
+    assert _categoria_do_launch(wa_user_id, launch_id) == "mcdonald's", respostas
+    # a pergunta da conta se perdeu (estado atual, documentado)
+    assert db.get_pending_action(wa_user_id) is None

--- a/tests/test_category_normalization.py
+++ b/tests/test_category_normalization.py
@@ -1,6 +1,9 @@
 """
 tests/test_category_normalization.py — texto livre de categoria colapsa numa
-forma só (`resolve_category_input`), em TODAS as portas que gravam categoria.
+forma só (`resolve_category_input`) nas portas que CHAMAM esse resolver — não
+em todas as que gravam categoria. Fora daqui, e não coberta: o cobrador de
+recorrentes (`core/services/recurring_charger.py:302,461`) grava
+`recurring_expenses.category` verbatim (`db/recurring.py:212` só faz `.strip()`).
 
 Caso real que originou o arquivo: o usuário corrige um lançamento pelo WhatsApp
 digitando "McDonald's" e o lançamento virava `mcdonald s` — apóstrofo virava
@@ -317,7 +320,7 @@ def test_display_map_desempate_nao_depende_de_id(pro_user_id):
     depois = resolve_category_input(pro_user_id, "cafe")
 
     assert antes == depois
-    assert velha["name"] in {"cafe", "café"}
+    assert velha["name"] == "cafe"   # grafia digitada, minúscula (a "Café" é a nova)
 
 
 def test_display_map_com_banco_fora_degrada_so_na_leitura(pro_user_id, monkeypatch):


### PR DESCRIPTION
## O caso

`gastei 39,90 no mcdonalds` → o GPT categorizou como alimentação e gravou a regra. O usuário tocou **📂 Trocar categoria → ✏️ Outra (digitar)** e escreveu `McDonald's`. O lançamento ficou com a categoria **`mcdonald s`** — o apóstrofo virou espaço.

A causa não era uma linha: **oito portas** normalizavam texto livre de jeitos diferentes.

| porta | `McDonald's` virava |
|---|---|
| botão do WhatsApp | `mcdonald s` |
| `PATCH /launches` | `mcdonald s` (mesma linha copiada) |
| `PATCH /credit-transactions` | `mcdonald s` (idem) |
| `PATCH /installments` | `McDonald's` cru (só `.strip()`) |
| tool `recategorize_launch` da IA | `McDonald's` cru |
| importação OFX / CSV / PDF | sempre sem acento |
| importação de fatura OFX | sempre sem acento |
| criar categoria na tela | `mcdonald's` ← a forma correta |

Efeito: duas fatias no dashboard para a mesma categoria, e orçamento numa que não conta os gastos da gêmea. Além disso a categoria ficava **órfã** — existia como texto no lançamento e não em `user_categories`, então não aceitava emoji, cor nem orçamento.

## A decisão

> **Normalizado é chave. Forma de exibição é valor. UMA função converte.**

- `user_categories.name` — fonte de verdade do nome (minúscula, **com** acento e pontuação)
- `launches.categoria` / `credit_transactions.categoria` — sempre igual a algum `user_categories.name` do usuário
- `user_category_rules.category` — índice interno, **continua normalizado**; `learn_from_signals` não foi tocado

`db.categories.resolve_category_input` é a porta única: rótulo do sistema → categoria existente casada sem acento/case → cria custom nova. A leitura desfaz a normalização no passo B do `infer_category`.

**Usuário sem plano pago grava sem acento**, exatamente como hoje. Sem isso o PR *piorava* para o grátis: sem catálogo não há de-duplicação, e nós tínhamos removido o `normalize_text` que fazia esse papel. Medido em duas colunas:

```
                    main                     branch
GRÁTIS 2 grafias    'padaria do ze' ×2       'padaria do ze' ×2   ← sem regressão
PAGO   2 grafias    'padaria do ze' ×2       'padaria do zé' ×2 + linha no catálogo
reason=ai           'mcdonald s'             "mcdonald's"          ← a string do chamado
```

## O que entrou junto, e por quê

**Comparação de categoria insensível a acento** (`cat_norm_sql`, que já existia e estava em 2 de ~6 lugares). Sem isso o próprio conserto quebrava o orçamento de quem já tinha um:

```
orçamento cadastrado:          'cafe da manha'
categoria que passa a gravar:  'café da manhã'
gasto que o orçamento enxerga: R$ 0,00
gasto real:                    R$ 50,00
```

17 pontos trocados em 5 arquivos. De quebra conserta o donut duplicado, e um bug que **já existe hoje**: `finance_bot_websocket_custom.py:727` casava rótulo do donut com categoria do orçamento por string exata — `Mercado` × `mercado` já falhava.

**Escape de 7 handlers inline no `dashboard.js`.** Ao passar a preservar apóstrofo, o backend produz nomes que o frontend não renderiza: `onclick='...(${JSON.stringify(cat)})'` em atributo de aspas simples trunca no `'`, sobra lixo como atributo e dá `SyntaxError` — a categoria fica impossível de editar. Varredura por **construto** (não por nome de variável) achou 7 pontos, todos com a mesma raiz: **nenhum escapava `&`**. Um deles (`:4189`) tinha a ordem invertida — `escapeHtmlSafe` antes do JS-escape, deixando o `.replace` seguinte como código morto.

**Zero-width e bidi** (`U+200B`, `U+202E`) ficavam gravados: `cafe` e `cafe​` viravam duas fatias visualmente idênticas. Filtro passou a ser por categoria Unicode `Cc`+`Cf`.

**`plan_service.py` em commit próprio** (`671851b`): o tier mínimo por feature saiu do monólito porque o gate passou a ser chamado fora do HTTP. Validado em 6 planos × 10 features × 2 valores de `PLANS_V2_ENABLED` = 120 combinações, zero divergência.

## Verificação

| | |
|---|---|
| suíte Python | **1453 passed / 0 failed** (main: 1404) |
| suíte frontend | **51 pass / 0 fail** (`npm run test:frontend`) |
| comparação | por **nome** de teste, main × branch — nenhum teste da main removido ou renomeado |
| `EXPLAIN` | mesmo plano nos 3 pontos com índice; nada virou seq scan |

Controles negativos, cada peça desligada uma por vez e revertida depois: gate do grátis (3 vermelhos), filtro de controle (3), `strict=create` (2), ramo `ai` (1), ramo `explicit` (1), passo B (3), `_CAT_EQ` do orçamento (2), `_CAT_EQ` do alerta (1), `GROUP BY` dos dois donuts (2), e os 7 escapes do frontend (7 vermelhos, um por conserto).

Controles positivos: rótulo do sistema intacto, categoria nova legítima é criada, `cafe` × `carne` seguem separadas, cross-check da IA continua de pé, pílula sem apóstrofo continua funcionando.

## Fora deste PR, de propósito

- **A correção não ensina.** Estava aqui e saiu inteira: sem guarda, corrigir `supermercado extra` sequestrava a keyword canônica `mercado`, e editar só a descrição gravava regra do nada (`dashboard.js:8038` manda a categoria em todo PATCH). Volta em PR próprio com a política definida: override de escopo restrito, precedência controlada, e termo genérico/canônico nunca promovido a regra global sem contexto.
- **Sem backfill.** Quem já tem `mcdonald s` gravado continua com ele; o PR só impede novos.
- **Open Finance** (`db/open_finance.py`) grava a categoria da Pluggy crua, em inglês. Pré-existente, maior que este PR.
- **`recurring_charger.py`** grava `recurring_expenses.category` verbatim — porta fora deste inventário.
- **CRUD de orçamento do dashboard e cascata de rename** continuam casando por texto exato. Trocar só o gate seria pior que não trocar (o `ON CONFLICT` continuaria por texto exato); exige decidir a unicidade do catálogo.
- **`_render_pdf`** passa texto do usuário por `reportlab.Paragraph`, que interpreta mini-XML. Medido: `<b>` derruba a exportação com 500 permanente, `<img src="/etc/hosts">` faz o processo abrir arquivo do servidor. **Já existe na main pelo campo `nota`** — não é regressão daqui, mas vira issue de segurança.
- `esc` e `escapeHtmlSafe` são a mesma função no mesmo arquivo; unificar toca ~80 call sites.

## Não verificado

Nada foi exercitado em produção nem no app iOS/WKWebView. O `EXPLAIN` é de Postgres local com tabelas quase vazias — `translate()` por linha num `GROUP BY` de milhares de lançamentos não foi medido em volume real. O repro do produto (conta paga → mensagem → botão → dashboard) não foi executado ponta a ponta; o que rodou foram os renderers reais no Chromium com dados montados à mão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
