### PR TITLE
Devolve a pergunta quando o trabalho estoura depois do consumo

### DIFF
--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -48,6 +48,7 @@ from db import (
     get_conn,
     get_or_create_canonical_user,
     get_pending_action,
+    restore_pending_on_error,
     set_pending_action,
     set_whatsapp_updates_opt_out,
     update_launch_category,
@@ -959,7 +960,13 @@ def process_message(message: InboundMessage) -> None:
                 if bill_id:
                     from db.bills import mark_bill_paid
                     try:
-                        paid = mark_bill_paid(uid, int(bill_id), amount)
+                        # Devolve a pergunta se o pagamento estourar: sem isso o
+                        # "Tente em instantes" é mentira — a pendência já foi e o
+                        # próximo número não paga nada. Prazo 30 min, o mesmo com
+                        # que ela foi armada (:773). Mesmo desenho da outra porta
+                        # desta pergunta (core/handlers/bills.py::resolve_bill_amount).
+                        with restore_pending_on_error(uid, pending_recat, 30):
+                            paid = mark_bill_paid(uid, int(bill_id), amount)
                     except Exception as exc:
                         logger.exception("WA bill_pay_amount mark failed bill=%s: %s", bill_id, exc)
                         _send_reply(reply_to, "Não consegui registrar o pagamento agora. Tente em instantes.")

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -299,7 +299,7 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     if casou.group(1) or not isfinite(amount) or amount <= 0:
         return f"O valor da *{nome}* precisa ser maior que zero. Quanto veio este mês?"
 
-    from db import consume_pending_action, create_pending_action_if_absent
+    from db import consume_pending_action, restore_pending_on_error
     from db.bills import mark_bill_paid
 
     payload = pending.get("payload") or {}
@@ -314,20 +314,11 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
     if not consume_pending_action(user_id, pending):
         return None
 
-    try:
+    # Devolve a pergunta se o pagamento estourar: sem isso o usuário perde a
+    # pendência e o valor que digitou, e a conta continua em aberto sem ninguém
+    # avisar. Prazo 10 min, o mesmo do `claim` que a armou (:144).
+    with restore_pending_on_error(user_id, pending):
         paid = mark_bill_paid(user_id, int(payload["bill_id"]), amount)
-    except Exception:
-        # Devolve a pergunta: sem isso o usuário perde a pendência e o valor
-        # que digitou, e a conta continua em aberto sem ninguém avisar.
-        #
-        # CONDICIONAL, não upsert: entre a reivindicação e a falha, outra
-        # tarefa pode ter armado uma pendência nova (uma confirmação que já
-        # apareceu na tela do usuário). Gravar por cima deixaria aquela órfã.
-        # Se já há algo lá, a pergunta desta conta é a que se perde — e ela é
-        # recuperável mandando "paguei a luz" de novo.
-        create_pending_action_if_absent(
-            user_id, "bill_amount_expected", payload)
-        raise
     if paid is None:
         return "Essa conta não está mais pendente."
     val = paid.get("paid_amount") or paid.get("amount") or 0

--- a/core/handlers/credit.py
+++ b/core/handlers/credit.py
@@ -27,6 +27,7 @@ from db import (
     list_open_bills,
     pay_bill_amount,
     resolve_installment_group_id,
+    restore_pending_on_error,
     set_card_limit,
     set_default_card,
     set_pending_action,
@@ -1190,8 +1191,10 @@ def _resolve_set_primary(user_id: int, text: str, pending: dict) -> str | None:
         # Consome ANTES de escrever: depois, o CAS não protegeria nada.
         if not consume_pending_action(user_id, pending):
             return None
-        set_default_card(user_id, int(card_id))
-        card = get_card_by_id(user_id, int(card_id))
+        # Devolve a pergunta se a escrita estourar — senão a confirmação some.
+        with restore_pending_on_error(user_id, pending, 20):
+            set_default_card(user_id, int(card_id))
+            card = get_card_by_id(user_id, int(card_id))
         return f"✅ O cartão **{card['name']}** agora é o seu principal.\n{_card_summary(card)}"
 
     if _is_no(answer):
@@ -1216,7 +1219,10 @@ def _resolve_delete_card(user_id: int, text: str, pending: dict) -> str | None:
         # junto. Quem perde o CAS não apaga — o "sim" era de outra pergunta.
         if not consume_pending_action(user_id, pending):
             return None
-        deleted = delete_card(user_id, int(card_id))
+        # Devolve a confirmação se o delete em cascata estourar (FK, timeout):
+        # sem isso o usuário perde a pergunta e refaz "excluir cartão X".
+        with restore_pending_on_error(user_id, pending, 20):
+            deleted = delete_card(user_id, int(card_id))
         if not deleted:
             return f"❌ Não consegui excluir o cartão **{card_name}**."
         return f"✅ Cartão **{card_name}** excluído com sucesso."
@@ -1360,7 +1366,11 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
             # transações junto, e o clear posterior não protegeria nada.
             if not consume_pending_action(user_id, pending):
                 return None
-            deleted = delete_card(user_id, int(existing_id))
+            # O que se perde aqui não é só a confirmação: o payload carrega o
+            # cadastro inteiro (card_name, closing_day, due_day, ask_primary),
+            # e a mensagem de erro abaixo ainda diz "Tente novamente".
+            with restore_pending_on_error(user_id, pending, 20):
+                deleted = delete_card(user_id, int(existing_id))
             if not deleted:
                 return f"❌ Não consegui excluir o cartão **{existing_name}**. Tente novamente."
 
@@ -1489,8 +1499,9 @@ def resolve_pending(user_id: int, text: str, pending: dict | None = None) -> str
         if _is_yes(answer):
             if not consume_pending_action(user_id, pending):
                 return None
-            set_default_card(user_id, card_id)
-            card = get_card_by_id(user_id, card_id)
+            with restore_pending_on_error(user_id, pending, 20):
+                set_default_card(user_id, card_id)
+                card = get_card_by_id(user_id, card_id)
             return f"✅ Perfeito. O cartão **{card['name']}** agora é o seu principal.\n{_card_summary(card)}"
         consume_pending_action(user_id, pending)
         return f"Perfeito. Mantive o cartão principal atual.\n{_card_summary(card)}"

--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -94,10 +94,11 @@ def resolve_investment_pick(user_id: int, text: str, pending: dict) -> str | Non
     # lemos, outra tarefa consumiu a pergunta — não aporta duas vezes.
     if not db.consume_pending_action(user_id, pending):
         return None
-    # `_aporta` já trata o que falha DEPOIS de o dinheiro andar; o que sobe até
-    # aqui é o que estoura ANTES (teto de plano, falha ao ler a carteira). Nesses
-    # casos nada se moveu e a pergunta tem de voltar, senão o usuário responde
-    # "2", leva a mensagem de upgrade e a escolha some junto.
+    # O que sobe até aqui é só o que estoura ANTES de o dinheiro andar: a leitura
+    # da carteira (`db.accrue_all_investments`), a resolução da origem
+    # (`funding.resolve`) e a transação do aporte, que faz commit no fim. O que
+    # falha DEPOIS do commit o `_aporta` engole de propósito — devolver a pergunta
+    # ali faria a próxima resposta aportar duas vezes.
     with db.restore_pending_on_error(user_id, pending):
         return deposit(
             user_id,
@@ -182,6 +183,10 @@ def resolve_funding_choice(user_id: int, text: str, pending: dict) -> str | None
         "label": escolhida.get("label"),
     }
 
+    # Mesma regra do site acima: sobe o que estourou antes do commit (e só isso —
+    # `_aporta` e `deposita_com_origem` engolem o que falha depois). Recusa
+    # legítima (saldo insuficiente, caixinha inexistente, valor inválido) volta
+    # como TEXTO e não re-arma: repetir a escolha daria o mesmo resultado.
     with db.restore_pending_on_error(user_id, pending):
         if retomar.get("fluxo") == "investment_deposit":
             return _aporta(user_id, retomar.get("name"), amount,
@@ -394,15 +399,32 @@ def _aporta(user_id: int, investment_name: str, amount: float, text: str, source
     except PlanLimitExceeded:
         raise  # handle_incoming responde com a mensagem amigável de upgrade
     except Exception:
+        # SOBE, não vira texto. `investment_deposit_from_account` é uma transação
+        # só, com o commit no fim: o que estoura nela não moveu dinheiro. Enquanto
+        # isto devolvia "Não consegui registrar esse aporte agora", o
+        # `restore_pending_on_error` de `resolve_funding_choice` nunca via a falha
+        # — a pendência ficava consumida e responder a origem de novo não repetia
+        # o aporte. Mesmo defeito da caixinha, apontado pelo Codex no PR #144.
+        # O usuário continua recebendo uma mensagem de "tente em instantes": a do
+        # `handle_incoming`, que ainda registra o erro no dashboard.
         logger.exception("deposit falhou user=%s inv=%s", user_id, investment_name)
-        return "Não consegui registrar esse aporte agora. Tente de novo em instantes."
+        raise
 
-    display_id = db.display_id_for(user_id, launch_id)
-    msg = (f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**"
-           f"{funding.origem_txt(source)}. ID #{display_id}.")
-    if source["kind"] == funding.BANK:
-        msg += "\n\n" + funding.nota_sync()
-    return msg
+    # DEPOIS do commit: o dinheiro JÁ ANDOU e a exceção NÃO pode subir daqui —
+    # a devolução re-armaria a pergunta e a próxima resposta aportaria de novo.
+    # `db.display_id_for` lê o banco, então falha pela mesma causa transitória.
+    try:
+        display_id = db.display_id_for(user_id, launch_id)
+        msg = (f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}**"
+               f"{funding.origem_txt(source)}. ID #{display_id}.")
+        if source["kind"] == funding.BANK:
+            msg += "\n\n" + funding.nota_sync()
+        return msg
+    except Exception:
+        logger.exception(
+            "aporte %s registrado, mas a mensagem falhou (user=%s)", launch_id, user_id)
+        return (f"✅ Aporte de **{fmt_brl(float(amount))}** em **{canon}** "
+                f"registrado (ID interno #{launch_id}).")
 
 
 def check_cdi() -> str:

--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -94,11 +94,16 @@ def resolve_investment_pick(user_id: int, text: str, pending: dict) -> str | Non
     # lemos, outra tarefa consumiu a pergunta — não aporta duas vezes.
     if not db.consume_pending_action(user_id, pending):
         return None
-    return deposit(
-        user_id,
-        payload.get("text") or resposta,
-        {"investment_name": escolhido, "amount": float(payload.get("amount") or 0)},
-    )
+    # `_aporta` já trata o que falha DEPOIS de o dinheiro andar; o que sobe até
+    # aqui é o que estoura ANTES (teto de plano, falha ao ler a carteira). Nesses
+    # casos nada se moveu e a pergunta tem de voltar, senão o usuário responde
+    # "2", leva a mensagem de upgrade e a escolha some junto.
+    with db.restore_pending_on_error(user_id, pending):
+        return deposit(
+            user_id,
+            payload.get("text") or resposta,
+            {"investment_name": escolhido, "amount": float(payload.get("amount") or 0)},
+        )
 
 
 def _pergunta_origem(user_id: int, fontes: list, amount: float, retomar: dict) -> str:
@@ -177,13 +182,14 @@ def resolve_funding_choice(user_id: int, text: str, pending: dict) -> str | None
         "label": escolhida.get("label"),
     }
 
-    if retomar.get("fluxo") == "investment_deposit":
-        return _aporta(user_id, retomar.get("name"), amount,
-                       retomar.get("text") or resposta, source)
-    if retomar.get("fluxo") == "pocket_deposit":
-        from core.handlers import pockets as _pockets
-        return _pockets.deposita_com_origem(
-            user_id, retomar.get("name"), amount, retomar.get("text") or resposta, source)
+    with db.restore_pending_on_error(user_id, pending):
+        if retomar.get("fluxo") == "investment_deposit":
+            return _aporta(user_id, retomar.get("name"), amount,
+                           retomar.get("text") or resposta, source)
+        if retomar.get("fluxo") == "pocket_deposit":
+            from core.handlers import pockets as _pockets
+            return _pockets.deposita_com_origem(
+                user_id, retomar.get("name"), amount, retomar.get("text") or resposta, source)
     return None
 
 

--- a/core/handlers/pockets.py
+++ b/core/handlers/pockets.py
@@ -1,8 +1,11 @@
 # core/handlers/pockets.py
 from __future__ import annotations
+import logging
 import re
 import db
 from utils_text import fmt_brl, parse_pocket_deposit_natural
+
+logger = logging.getLogger(__name__)
 
 
 def list_pockets(user_id: int) -> str:
@@ -94,11 +97,35 @@ def deposita_com_origem(user_id: int, pocket_name: str, amount: float, text: str
     """Depósito com a origem já decidida — retomado também pela resposta da pergunta."""
     from core.services import funding
 
+    # ── ANTES do commit: nada se moveu ───────────────────────────────────────
+    # As três recusas abaixo viram TEXTO: repetir a escolha daria o mesmo
+    # resultado, então re-armar a pergunta só prenderia o usuário no fluxo.
+    # O resto SOBE. `pocket_deposit_from_account` é uma transação só, com o
+    # commit no fim: o que estoura nela não tirou dinheiro de lugar nenhum, e
+    # quem chamou precisa da exceção para devolver a pergunta "de onde sai?"
+    # (core/handlers/investments.py::resolve_funding_choice). Enquanto isto
+    # devolvia `f"Erro ao depositar: {e}"`, o `restore_pending_on_error` daquele
+    # site nunca via falha nenhuma — a pendência ficava consumida e responder a
+    # origem de novo não repetia o depósito. Apontado pelo Codex no PR #144.
     try:
         launch_id, new_acc, new_pocket, canon = db.pocket_deposit_from_account(
             user_id, pocket_name, float(amount), text,
             funding_source=funding.to_db_arg(source),
         )
+    except LookupError:
+        return f"Caixinha **{pocket_name}** não encontrada. Use *criar caixinha {pocket_name}*."
+    except ValueError as e:
+        if "OF_POCKET_READONLY" in str(e):
+            return "Essa caixinha é sincronizada com seu banco — mova o dinheiro pelo app do banco."
+        if "INSUFFICIENT_ACCOUNT" in str(e):
+            return funding.msg_insuficiente(user_id, float(amount), acao="depósito")
+        return "Valor inválido."
+
+    # ── DEPOIS do commit: o dinheiro JÁ ANDOU ────────────────────────────────
+    # Aqui a exceção NÃO pode subir: a devolução re-armaria a pergunta e a
+    # próxima resposta do usuário depositaria de novo. `db.display_id_for` lê o
+    # banco, então este bloco falha pela mesma causa transitória do de cima.
+    try:
         msg = (
             f"✅ Depósito na caixinha **{canon}**: +{fmt_brl(float(amount))}"
             f"{funding.origem_txt(source)}\n"
@@ -108,16 +135,11 @@ def deposita_com_origem(user_id: int, pocket_name: str, amount: float, text: str
         if source["kind"] == funding.BANK:
             msg += "\n\n" + funding.nota_sync()
         return msg
-    except LookupError:
-        return f"Caixinha **{pocket_name}** não encontrada. Use *criar caixinha {pocket_name}*."
-    except ValueError as e:
-        if "OF_POCKET_READONLY" in str(e):
-            return "Essa caixinha é sincronizada com seu banco — mova o dinheiro pelo app do banco."
-        if "INSUFFICIENT_ACCOUNT" in str(e):
-            return funding.msg_insuficiente(user_id, float(amount), acao="depósito")
-        return "Valor inválido."
-    except Exception as e:
-        return f"Erro ao depositar: {e}"
+    except Exception:
+        logger.exception(
+            "depósito %s registrado, mas a mensagem falhou (user=%s)", launch_id, user_id)
+        return (f"✅ Depósito de {fmt_brl(float(amount))} na caixinha **{canon}** "
+                f"registrado (ID interno #{launch_id}).")
 
 
 _WITHDRAW_VERBS = [

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -134,6 +134,7 @@ from .pending import (
     sobrevive_a_audio,
     claim_pending_action,
     create_pending_action_if_absent,
+    restore_pending_on_error,
     set_pending_action,
     get_pending_action,
     clear_pending_action,
@@ -457,7 +458,7 @@ __all__ = [
     "set_pending_action", "get_pending_action", "clear_pending_action",
     "advance_pending_action", "consume_pending_action",
     "eh_oferta_de_conveniencia", "suprime_fallback_de_ia", "sobrevive_a_audio",
-    "create_pending_action_if_absent",
+    "create_pending_action_if_absent", "restore_pending_on_error",
     "claim_pending_action",
     # budgets
     "list_budgets", "get_budget", "upsert_budget", "delete_budget",

--- a/db/connection.py
+++ b/db/connection.py
@@ -11,6 +11,8 @@ existentes não precisam mudar.
 """
 import os
 import threading
+from contextvars import ContextVar
+
 import psycopg
 from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
@@ -18,6 +20,44 @@ from psycopg_pool import ConnectionPool
 
 _pool: ConnectionPool | None = None
 _pool_lock = threading.Lock()
+
+# Quantas vezes um `commit()` LEVANTOU nesta thread. Só isso: commit que volta
+# sem erro não é ambíguo, e falha antes do commit não gravou nada.
+_commits_ambiguos: ContextVar[int] = ContextVar("db_commits_ambiguos", default=0)
+
+
+def commits_ambiguos() -> int:
+    """Contador monotônico de commits que estouraram — leia antes e depois.
+
+    Quando a conexão cai ENQUANTO o Postgres confirma o COMMIT, a chamada
+    levanta mas a transação pode ter sido gravada assim mesmo. De fora, isso é
+    indistinguível de uma falha ANTES do commit, e a diferença decide se dá para
+    repetir o trabalho: repetir um aporte já commitado debita a origem e credita
+    o destino DUAS vezes (Codex, PR #144).
+
+    Quem precisa distinguir compara o valor de antes com o de depois — delta 0
+    significa "nada chegou a ser confirmado", e só aí repetir é seguro. É o que
+    `db.restore_pending_on_error` faz para decidir se devolve a pergunta.
+
+    Contador, e não flag booleana, porque não há onde zerar: um erro engolido
+    lá atrás deixaria a flag ligada para sempre.
+    """
+    return _commits_ambiguos.get()
+
+
+class _Conn(psycopg.Connection):
+    """Conexão que marca o commit ambíguo. Ver `commits_ambiguos`.
+
+    Cobre também o commit implícito do `with get_conn() as conn:` — o
+    `Connection.__exit__` do psycopg chama este mesmo `commit()`.
+    """
+
+    def commit(self) -> None:
+        try:
+            super().commit()
+        except BaseException:
+            _commits_ambiguos.set(_commits_ambiguos.get() + 1)
+            raise
 
 
 def _get_pool() -> ConnectionPool:
@@ -32,6 +72,7 @@ def _get_pool() -> ConnectionPool:
             raise RuntimeError("DATABASE_URL não está definido.")
         _pool = ConnectionPool(
             database_url,
+            connection_class=_Conn,
             min_size=1,
             max_size=int(os.getenv("DB_POOL_MAX_SYNC", "8")),
             timeout=float(os.getenv("DB_CONNECT_TIMEOUT", "30")),

--- a/db/pending.py
+++ b/db/pending.py
@@ -1,6 +1,7 @@
 """
 db/pending.py — Ações pendentes de confirmação (ex: "apagar lançamento?").
 """
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
@@ -124,6 +125,37 @@ def create_pending_action_if_absent(user_id: int, action_type: str, payload: dic
             criou = cur.rowcount == 1
         conn.commit()
     return criou
+
+
+@contextmanager
+def restore_pending_on_error(user_id: int, pending: dict, minutes: int = 10):
+    """Devolve a pendência se o trabalho reivindicado estourar, e re-levanta.
+
+    `consume_pending_action` roda ANTES do trabalho (é o porteiro que impede a
+    segunda thread de executar a mesma ação). Se o trabalho levanta, a pergunta
+    já foi apagada: o usuário perde a confirmação, não recebe nada útil e refaz
+    o fluxo do zero — regressão contra o `clear` que vinha DEPOIS.
+
+    A devolução é `create_pending_action_if_absent`, nunca `set_pending_action`:
+    entre a reivindicação e a falha outra tarefa pode ter armado uma pergunta
+    nova, que já apareceu na tela do usuário. Gravar por cima a deixaria órfã —
+    uma operação antiga não sobrescreve uma pendência mais nova. Se já há algo
+    lá, o que se perde é a pendência desta operação, recuperável repetindo o
+    comando.
+
+    `minutes` é o prazo do fluxo que armou a pergunta (crédito usa 20, o valor
+    de conta do WhatsApp usa 30) — devolver com o default encurtaria o prazo.
+    """
+    try:
+        yield
+    except Exception:
+        create_pending_action_if_absent(
+            user_id,
+            pending.get("action_type") or "",
+            pending.get("payload") or {},
+            minutes,
+        )
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/db/pending.py
+++ b/db/pending.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
-from .connection import get_conn
+from .connection import commits_ambiguos, get_conn
 from .users import ensure_user
 
 
@@ -145,16 +145,32 @@ def restore_pending_on_error(user_id: int, pending: dict, minutes: int = 10):
 
     `minutes` é o prazo do fluxo que armou a pergunta (crédito usa 20, o valor
     de conta do WhatsApp usa 30) — devolver com o default encurtaria o prazo.
+
+    NÃO devolve se algum `commit()` chegou a estourar no meio (`commits_ambiguos`):
+    a conexão que cai ENQUANTO o Postgres confirma o COMMIT levanta com a
+    transação possivelmente gravada, e de fora isso é idêntico a uma falha antes
+    dela. Devolver a pergunta ali faz a próxima resposta REPETIR um trabalho já
+    commitado — um aporte debita a origem e credita o destino duas vezes, sem
+    chave de idempotência que segure (Codex, PR #144). Errar para o lado de não
+    devolver custa a pergunta, que o usuário refaz repetindo o comando; errar
+    para o outro custa dinheiro, que não tem retentativa.
+
+    A fronteira NÃO é o `return` da função transacional: é a primeira tentativa
+    de commit. Por isso a checagem é genérica (vale para os 8 sites e para
+    qualquer commit no caminho, inclusive o implícito do `with get_conn()`) em
+    vez de uma lista de exceções "seguras" por site.
     """
+    antes = commits_ambiguos()
     try:
         yield
     except Exception:
-        create_pending_action_if_absent(
-            user_id,
-            pending.get("action_type") or "",
-            pending.get("payload") or {},
-            minutes,
-        )
+        if commits_ambiguos() == antes:
+            create_pending_action_if_absent(
+                user_id,
+                pending.get("action_type") or "",
+                pending.get("payload") or {},
+                minutes,
+            )
         raise
 
 

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -1622,3 +1622,73 @@ def test_botao_devolucao_nao_atropela_pergunta_mais_nova(monkeypatch):
     volta = db.get_pending_action(uid) or {}
     assert volta.get("action_type") == "clarification", (
         f"a devolução atropelou a pergunta mais nova — ficou {volta.get('action_type')!r}")
+
+
+def test_commit_ambiguo_do_pagamento_nao_rearma_a_pergunta(monkeypatch):
+    """A janela ambígua do P1 do Codex, no caminho da conta.
+
+    `mark_bill_paid` reserva a conta, cria o lançamento que debita e só então
+    liga o `launch_id`. Se a conexão cai ENQUANTO o Postgres confirma o COMMIT
+    do lançamento, o débito passa e a chamada levanta — e o `except` de
+    `mark_bill_paid` devolve a conta para `pending`, achando que nada gravou.
+
+    Medido (`db.connection.commits_ambiguos` sobe 1): saldo 1000 → 900 com a
+    conta de volta em `pending`; responder o valor de novo leva a 800. Débito
+    dobrado, sem retentativa. Por isso a devolução da pergunta não pode
+    acontecer aqui.
+
+    Negativo por causa: com o `if commits_ambiguos() == antes` fora de
+    `db/pending.py`, a pendência volta e este caso fica vermelho.
+    """
+    import contextlib
+    import datetime
+    import uuid
+    import psycopg
+    import db
+    import db.accounts
+    import db.bills
+    from core.handlers import bills as H
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    db.add_launch_and_update_balance(uid, "receita", 1000.0, None, "seed")
+    bill = db.bills.create_boleto(uid, "Luz", 100.0, datetime.date.today(),
+                                  category="moradia")
+    payload = {"bill_id": int(bill["id"]), "bill_name": "Luz"}
+    db.set_pending_action(uid, "bill_amount_expected", payload)
+    pending = db.get_pending_action(uid)
+
+    armado = {"on": False}
+    commit_real = psycopg.Connection.commit
+
+    def commit_e_perde_a_conexao(self):
+        commit_real(self)  # o Postgres CONFIRMA o débito
+        if armado["on"]:
+            armado["on"] = False
+            raise psycopg.OperationalError("connection lost while committing")
+
+    monkeypatch.setattr(psycopg.Connection, "commit", commit_e_perde_a_conexao)
+
+    # Arma só a transação do lançamento (a que move o dinheiro): a reserva da
+    # conta e a devolução compensatória usam outros `get_conn`, de db/bills.py.
+    gc_real = db.accounts.get_conn
+
+    @contextlib.contextmanager
+    def gc_armado():
+        with gc_real() as conn:
+            armado["on"] = True
+            try:
+                yield conn
+            finally:
+                armado["on"] = False
+
+    monkeypatch.setattr(db.accounts, "get_conn", gc_armado)
+
+    with pytest.raises(psycopg.OperationalError):
+        H.resolve_bill_amount(uid, "100", pending)
+
+    assert float(db.get_balance(uid)) == 900.0, (
+        "o commit não passou — a janela ambígua não foi simulada")
+    assert db.get_pending_action(uid) is None, (
+        "pergunta re-armada com o débito já confirmado — responder o valor de "
+        "novo debitaria a conta duas vezes")

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -197,6 +197,39 @@ def test_valor_negativo_mantem_a_pergunta_e_nao_paga(monkeypatch):
     assert pagou == [], f"valor negativo virou pagamento: {pagou}"
 
 
+def test_devolucao_repoe_a_pergunta_quando_o_pagamento_estoura(monkeypatch):
+    """Controle NEGATIVO que faltava para a devolução da porta de texto.
+
+    Medido: o grupo só tinha a corrida abaixo, e ela passa igual com a
+    devolução desligada (com o rollback fora, ninguém escreve e a pergunta nova
+    sobrevive do mesmo jeito). Sem este caso, tirar o `with` de
+    `resolve_bill_amount` não deixava uma linha vermelha.
+    """
+    import uuid
+    import db
+    import db.bills
+    from core.handlers import bills as H
+
+    uid = int(uuid.uuid4().int % 10_000_000_000)
+    db.ensure_user(uid)
+    payload = {"bill_id": 41, "bill_name": "Luz"}
+    db.set_pending_action(uid, "bill_amount_expected", payload)
+    pending = db.get_pending_action(uid)
+
+    def _estoura(u, b, a):
+        raise RuntimeError("banco caiu")
+
+    monkeypatch.setattr(db.bills, "mark_bill_paid", _estoura)
+
+    with pytest.raises(RuntimeError):
+        H.resolve_bill_amount(uid, "132", pending)
+
+    volta = db.get_pending_action(uid) or {}
+    assert volta.get("action_type") == "bill_amount_expected", (
+        f"a pergunta não voltou — ficou {volta.get('action_type')!r}")
+    assert volta.get("payload") == payload, volta
+
+
 def test_devolucao_nao_atropela_pendencia_mais_nova(monkeypatch):
     """P2 do Codex: a devolução usava upsert incondicional.
 
@@ -1535,3 +1568,57 @@ def test_botao_ja_paguei_com_pergunta_viva_tambem_nao_anuncia_o_comando(monkeypa
     assert "132,50" not in corpo, corpo
     assert "Qual foi o valor?" in corpo, corpo
     assert (db.get_pending_action(uid) or {}).get("action_type") == "clarification"
+
+
+# ── devolução da pergunta quando o pagamento estoura (porta do BOTÃO) ────────
+# A porta de texto (`resolve_bill_amount`) já devolve desde o PR #133; esta é a
+# outra porta da MESMA pergunta e prometia "Tente em instantes" sem ter para
+# onde voltar — a pendência tinha sido reivindicada e o próximo número não
+# pagaria nada.
+
+def test_botao_devolve_pergunta_quando_o_pagamento_estoura(monkeypatch):
+    """Negativo: sem o `with` em wa_runtime.py, a pendência some e isto fica vermelho."""
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+    payload = (db.get_pending_action(uid) or {}).get("payload")
+
+    def _estoura(*a, **k):
+        raise RuntimeError("banco caiu")
+
+    monkeypatch.setattr(B, "mark_bill_paid", _estoura)
+    respostas = _manda_texto_no_wa(monkeypatch, uid, "132,50")
+
+    assert "Tente em instantes" in respostas[-1], respostas
+    volta = db.get_pending_action(uid) or {}
+    assert volta.get("action_type") == "bill_pay_amount", (
+        f"a pergunta não voltou — ficou {volta.get('action_type')!r}; "
+        "'Tente em instantes' vira mentira")
+    assert volta.get("payload") == payload, volta
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
+
+
+def test_botao_devolucao_nao_atropela_pergunta_mais_nova(monkeypatch):
+    """Corrida: a devolução é condicional, não upsert."""
+    import uuid
+    import db
+    import db.bills as B
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    conta = _monta_conta_variavel(uid)
+    _toca_ja_paguei(monkeypatch, uid, int(conta["id"]))
+
+    def _estoura(*a, **k):
+        db.set_pending_action(uid, "clarification", {"valor": 77.9})
+        raise RuntimeError("banco caiu")
+
+    monkeypatch.setattr(B, "mark_bill_paid", _estoura)
+    _manda_texto_no_wa(monkeypatch, uid, "132,50")
+
+    volta = db.get_pending_action(uid) or {}
+    assert volta.get("action_type") == "clarification", (
+        f"a devolução atropelou a pergunta mais nova — ficou {volta.get('action_type')!r}")

--- a/tests/test_pending_rollback.py
+++ b/tests/test_pending_rollback.py
@@ -1,0 +1,263 @@
+"""A pendência volta quando o trabalho reivindicado estoura.
+
+O PR #141 trocou `clear_pending_action` (depois do trabalho) por
+`consume_pending_action` (antes do trabalho). Onde o trabalho pode levantar, a
+pergunta passou a morrer junto com a exceção: o usuário perde a confirmação,
+não recebe nada útil e refaz o fluxo do zero. Antes o `clear` vinha depois, e a
+pergunta sobrevivia — é regressão.
+
+`db.restore_pending_on_error` devolve, e devolve CONDICIONALMENTE
+(`create_pending_action_if_absent`): se outra tarefa armou uma pergunta nova
+entre a reivindicação e a falha, a devolução não escreve — operação antiga não
+sobrescreve pendência mais nova.
+
+Cada site tem os três controles:
+
+- **negativo** — o trabalho levanta → a pendência voltou com o mesmo
+  `action_type` e `payload`. Desligado o conserto (tirar o `with` do site), o
+  caso fica vermelho.
+- **positivo** — caminho feliz continua consumindo e não deixa pendência.
+- **corrida** — o trabalho levanta E outra tarefa já ocupou a linha → a
+  devolução não escreve, a pergunta nova sobrevive intacta.
+
+Os quatro sites de crédito rodam pela CONVERSA (`handle_incoming`), não pela
+função isolada: é o caminho que o "sim" do usuário percorre de verdade.
+"""
+import uuid
+
+import pytest
+
+import db
+import db.cards
+from core.handlers import credit as H_credit
+from core.handlers import investments as H_inv
+
+
+class Estourou(RuntimeError):
+    pass
+
+
+def _uid() -> int:
+    """Abaixo de 2 bilhões DE PROPÓSITO.
+
+    `core.handle_incoming._normalize_user_id` comprime qualquer id acima disso
+    (regra dos ids gigantes do WhatsApp), então um uid da fixture `user_id`
+    (`% 10_000_000_000`) roteia para OUTRO usuário: o `handle_incoming` não vê a
+    pendência, responde o fallback genérico e o teste passa sem exercitar nada.
+    Mesma escolha de tests/test_bill_amount_pending.py.
+    """
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    return uid
+
+
+def _diga(uid: int, texto: str) -> str:
+    from core.types import IncomingMessage
+    import core.handle_incoming as HI
+
+    msg = IncomingMessage(platform="whatsapp", user_id=uid, text=texto,
+                          message_id=f"m{uuid.uuid4().hex[:8]}", attachments=[],
+                          external_id="e", raw={})
+    saida = HI.handle_incoming(msg)
+    return "\n".join(m.text for m in (saida or []) if getattr(m, "text", None))
+
+
+def _cartao(uid: int) -> int:
+    return int(db.cards.create_card(user_id=uid, name="Nubank",
+                                    closing_day=1, due_day=8))
+
+
+# ── os quatro sites de crédito ───────────────────────────────────────────────
+# (nome, action_type, monta_payload(card_id), nome_da_funcao_que_estoura)
+SITES_CREDITO = [
+    ("delete_card",
+     "credit_delete_card",
+     lambda cid: {"card_id": cid, "card_name": "Nubank"},
+     "delete_card"),
+    ("set_primary",
+     "credit_card_set_primary",
+     lambda cid: {"card_id": cid},
+     "set_default_card"),
+    ("setup/confirm_delete_existing_card",
+     "credit_card_setup",
+     lambda cid: {"step": "confirm_delete_existing_card", "existing_card_id": cid,
+                  "existing_card_name": "Nubank", "card_name": "Nubank",
+                  "closing_day": 1, "due_day": 8, "ask_primary": True},
+     "delete_card"),
+    ("setup/set_primary",
+     "credit_card_setup",
+     lambda cid: {"step": "set_primary", "card_id": cid, "ask_primary": True},
+     "set_default_card"),
+]
+
+IDS = [s[0] for s in SITES_CREDITO]
+
+
+@pytest.mark.parametrize("nome,tipo,monta,alvo", SITES_CREDITO, ids=IDS)
+def test_credito_devolve_pendencia_quando_o_trabalho_estoura(
+        monkeypatch, nome, tipo, monta, alvo):
+    """Negativo: sem o `with` no site, a pendência some e este caso fica vermelho."""
+    user_id = _uid()
+    cid = _cartao(user_id)
+    payload = monta(cid)
+    db.set_pending_action(user_id, tipo, payload, minutes=20)
+
+    def _estoura(*a, **k):
+        raise Estourou("banco caiu no meio")
+
+    monkeypatch.setattr(H_credit, alvo, _estoura)
+
+    _diga(user_id, "sim")  # handle_incoming engole a exceção e responde genérico
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == tipo, (
+        f"{nome}: a pendência não voltou — ficou {volta.get('action_type')!r}")
+    assert volta.get("payload") == payload, f"{nome}: payload perdido: {volta.get('payload')}"
+
+
+@pytest.mark.parametrize("nome,tipo,monta,alvo", SITES_CREDITO, ids=IDS)
+def test_credito_caminho_feliz_consome_e_nao_deixa_pendencia(
+        monkeypatch, nome, tipo, monta, alvo):
+    """Positivo: sem falha o site continua consumindo. Sem isto o grupo passaria
+    num código que só devolve pendência e nunca executa."""
+    user_id = _uid()
+    cid = _cartao(user_id)
+    db.set_pending_action(user_id, tipo, monta(cid), minutes=20)
+
+    resposta = _diga(user_id, "sim")
+
+    assert db.get_pending_action(user_id) is None, (
+        f"{nome}: pendência ficou para trás no caminho feliz")
+    assert "✅" in resposta, f"{nome}: não confirmou nada — {resposta!r}"
+
+
+@pytest.mark.parametrize("nome,tipo,monta,alvo", SITES_CREDITO, ids=IDS)
+def test_credito_devolucao_nao_atropela_pergunta_mais_nova(
+        monkeypatch, nome, tipo, monta, alvo):
+    """Corrida: prova que a devolução é condicional, não upsert."""
+    user_id = _uid()
+    cid = _cartao(user_id)
+    db.set_pending_action(user_id, tipo, monta(cid), minutes=20)
+
+    def _estoura(*a, **k):
+        # a outra tarefa armou a pergunta dela enquanto esta trabalhava
+        db.set_pending_action(user_id, "bill_amount_expected",
+                              {"bill_id": 4242, "bill_name": "luz"})
+        raise Estourou("banco caiu no meio")
+
+    monkeypatch.setattr(H_credit, alvo, _estoura)
+
+    _diga(user_id, "sim")
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == "bill_amount_expected", (
+        f"{nome}: a devolução atropelou a pergunta mais nova — ficou "
+        f"{volta.get('action_type')!r}")
+    assert (volta.get("payload") or {}).get("bill_id") == 4242
+
+
+# ── investimentos: o que sobe até o resolver é o que estourou ANTES de o
+#    dinheiro andar (teto de plano, falha ao ler a carteira) ──────────────────
+
+def _pending_pick(uid: int) -> dict:
+    db.set_pending_action(uid, "investment_pick",
+                          {"amount": 500.0, "text": "aportar 500",
+                           "nomes": ["CDB Nubank", "Tesouro"]})
+    return db.get_pending_action(uid)
+
+
+def _pending_funding(uid: int) -> dict:
+    db.set_pending_action(uid, "funding_source_choice", {
+        "amount": 500.0,
+        "retomar": {"fluxo": "investment_deposit", "name": "CDB Nubank",
+                    "text": "aportar 500"},
+        "fontes": [{"kind": "account", "of_account_id": None,
+                    "label": "Carteira", "balance": 900.0}],
+    })
+    return db.get_pending_action(uid)
+
+
+def test_investment_pick_devolve_pergunta_quando_o_aporte_estoura(monkeypatch):
+    user_id = _uid()
+    pending = _pending_pick(user_id)
+
+    def _estoura(*a, **k):
+        raise Estourou("teto de plano")
+
+    monkeypatch.setattr(H_inv, "deposit", _estoura)
+
+    with pytest.raises(Estourou):
+        H_inv.resolve_investment_pick(user_id, "1", pending)
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == "investment_pick", volta
+    assert (volta.get("payload") or {}).get("amount") == 500.0
+
+
+def test_investment_pick_caminho_feliz_consome(monkeypatch):
+    user_id = _uid()
+    pending = _pending_pick(user_id)
+    monkeypatch.setattr(H_inv, "deposit", lambda *a, **k: "✅ aportado")
+
+    assert H_inv.resolve_investment_pick(user_id, "1", pending) == "✅ aportado"
+    assert db.get_pending_action(user_id) is None
+
+
+def test_investment_pick_devolucao_nao_atropela_pergunta_mais_nova(monkeypatch):
+    user_id = _uid()
+    pending = _pending_pick(user_id)
+
+    def _estoura(*a, **k):
+        db.set_pending_action(user_id, "bill_amount_expected", {"bill_id": 4242})
+        raise Estourou("teto de plano")
+
+    monkeypatch.setattr(H_inv, "deposit", _estoura)
+
+    with pytest.raises(Estourou):
+        H_inv.resolve_investment_pick(user_id, "1", pending)
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == "bill_amount_expected", volta
+
+
+def test_funding_choice_devolve_pergunta_quando_o_aporte_estoura(monkeypatch):
+    user_id = _uid()
+    pending = _pending_funding(user_id)
+
+    def _estoura(*a, **k):
+        raise Estourou("teto de plano")
+
+    monkeypatch.setattr(H_inv, "_aporta", _estoura)
+
+    with pytest.raises(Estourou):
+        H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == "funding_source_choice", volta
+    assert (volta.get("payload") or {}).get("amount") == 500.0
+
+
+def test_funding_choice_caminho_feliz_consome(monkeypatch):
+    user_id = _uid()
+    pending = _pending_funding(user_id)
+    monkeypatch.setattr(H_inv, "_aporta", lambda *a, **k: "✅ aportado")
+
+    assert H_inv.resolve_funding_choice(user_id, "1", pending) == "✅ aportado"
+    assert db.get_pending_action(user_id) is None
+
+
+def test_funding_choice_devolucao_nao_atropela_pergunta_mais_nova(monkeypatch):
+    user_id = _uid()
+    pending = _pending_funding(user_id)
+
+    def _estoura(*a, **k):
+        db.set_pending_action(user_id, "bill_amount_expected", {"bill_id": 4242})
+        raise Estourou("teto de plano")
+
+    monkeypatch.setattr(H_inv, "_aporta", _estoura)
+
+    with pytest.raises(Estourou):
+        H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == "bill_amount_expected", volta

--- a/tests/test_pending_rollback.py
+++ b/tests/test_pending_rollback.py
@@ -261,3 +261,145 @@ def test_funding_choice_devolucao_nao_atropela_pergunta_mais_nova(monkeypatch):
 
     volta = db.get_pending_action(user_id) or {}
     assert volta.get("action_type") == "bill_amount_expected", volta
+
+
+# ── o CAMINHO DE PRODUÇÃO dos dois fluxos de `funding_source_choice` ─────────
+# Os seis casos acima trocam `_aporta`/`deposit` por uma função que levanta —
+# o que EU escrevi, não o que roda. Em produção quem executa é
+# `_pockets.deposita_com_origem` / `_aporta`, e as duas ENGOLIAM toda `Exception`
+# e devolviam string: o `restore_pending_on_error` nunca via falha operacional
+# nenhuma, a pendência ficava consumida e responder a origem de novo não repetia
+# o depósito. P2 do Codex no PR #144.
+#
+# Aqui a falha é de banco DE VERDADE, dentro de `pocket_deposit_from_account` /
+# `investment_deposit_from_account`: o `get_conn` do módulo de `db/` levanta
+# `OperationalError`, como se o Postgres tivesse caído no meio.
+
+def _pending_funding_para(uid: int, fluxo: str, nome: str) -> dict:
+    db.set_pending_action(uid, "funding_source_choice", {
+        "amount": 500.0,
+        "retomar": {"fluxo": fluxo, "name": nome, "text": f"coloquei 500 em {nome}"},
+        "fontes": [{"kind": "account", "of_account_id": None,
+                    "label": "Carteira", "balance": 900.0}],
+    })
+    return db.get_pending_action(uid)
+
+
+def _carteira(uid: int, valor: float = 900.0) -> None:
+    db.add_launch_and_update_balance(uid, "receita", valor, None, "seed")
+
+
+FLUXOS = [
+    ("pocket_deposit", "Viagem", "db.pockets"),
+    ("investment_deposit", "CDB Nubank", "db.investments"),
+]
+FLUXO_IDS = [f[0] for f in FLUXOS]
+
+
+def _cria_destino(uid: int, fluxo: str, nome: str) -> None:
+    if fluxo == "pocket_deposit":
+        db.create_pocket(uid, nome)
+    else:
+        db.create_investment(uid, nome, 0.1, "yearly")
+
+
+@pytest.mark.parametrize("fluxo,nome,modulo", FLUXOS, ids=FLUXO_IDS)
+def test_funding_choice_devolve_quando_o_banco_cai_de_verdade(
+        monkeypatch, fluxo, nome, modulo):
+    """Negativo do conserto do P2: com o `except Exception` devolvendo string
+    (o código de antes), nada sobe, a pendência não volta e isto fica vermelho."""
+    import importlib
+    import psycopg
+
+    user_id = _uid()
+    _carteira(user_id)
+    _cria_destino(user_id, fluxo, nome)
+    pending = _pending_funding_para(user_id, fluxo, nome)
+
+    def _banco_fora(*a, **k):
+        raise psycopg.OperationalError("connection to server was lost")
+
+    monkeypatch.setattr(importlib.import_module(modulo), "get_conn", _banco_fora)
+
+    with pytest.raises(psycopg.OperationalError):
+        H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    volta = db.get_pending_action(user_id) or {}
+    assert volta.get("action_type") == "funding_source_choice", (
+        f"{fluxo}: a pendência não voltou — ficou {volta.get('action_type')!r}; "
+        "responder a origem de novo não repetiria o depósito")
+    assert (volta.get("payload") or {}).get("retomar", {}).get("fluxo") == fluxo
+    assert float(db.get_balance(user_id)) == 900.0, "o dinheiro andou mesmo assim"
+
+
+@pytest.mark.parametrize("fluxo,nome,modulo", FLUXOS, ids=FLUXO_IDS)
+def test_funding_choice_caminho_feliz_de_verdade_consome(monkeypatch, fluxo, nome, modulo):
+    """Positivo do mesmo grupo: sem falha o depósito acontece de verdade e a
+    pendência não fica para trás. Sem isto o grupo passaria num código que só
+    devolve pendência e nunca deposita."""
+    user_id = _uid()
+    _carteira(user_id)
+    _cria_destino(user_id, fluxo, nome)
+    pending = _pending_funding_para(user_id, fluxo, nome)
+
+    resposta = H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    assert "✅" in (resposta or ""), resposta
+    assert db.get_pending_action(user_id) is None
+    assert float(db.get_balance(user_id)) == 400.0
+
+
+# ── o outro lado: recusa legítima NÃO re-arma ────────────────────────────────
+# Saldo insuficiente / destino inexistente se repetiriam igual. Re-armar
+# prenderia o usuário respondendo uma escolha que nunca vai funcionar — e a
+# pendência `funding_source_choice` suprime o fallback de IA por 10 minutos.
+
+RECUSAS = [
+    ("pocket_deposit", "Viagem", 100.0, True, "saldo insuficiente"),
+    ("pocket_deposit", "Nao Existe", 900.0, False, "caixinha inexistente"),
+    ("investment_deposit", "CDB Nubank", 100.0, True, "saldo insuficiente"),
+    ("investment_deposit", "Nao Existe", 900.0, False, "investimento inexistente"),
+]
+
+
+@pytest.mark.parametrize("fluxo,nome,saldo,cria,caso", RECUSAS,
+                         ids=[f"{r[0]}-{r[4]}" for r in RECUSAS])
+def test_funding_choice_recusa_legitima_nao_rearma(fluxo, nome, saldo, cria, caso):
+    user_id = _uid()
+    _carteira(user_id, saldo)
+    if cria:
+        _cria_destino(user_id, fluxo, nome)
+    pending = _pending_funding_para(user_id, fluxo, nome)
+
+    resposta = H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    assert resposta, f"{caso}: recusa sem texto nenhum"
+    assert db.get_pending_action(user_id) is None, (
+        f"{caso}: a pergunta foi re-armada — o usuário fica preso repetindo "
+        "uma escolha que nunca vai funcionar")
+    assert float(db.get_balance(user_id)) == saldo
+
+
+# ── falha DEPOIS do commit: o dinheiro andou, re-armar depositaria duas vezes ─
+
+@pytest.mark.parametrize("fluxo,nome,modulo", FLUXOS, ids=FLUXO_IDS)
+def test_funding_choice_falha_depois_do_commit_nao_rearma(monkeypatch, fluxo, nome, modulo):
+    """`db.display_id_for` roda DEPOIS do commit. Se ela subisse, a devolução
+    re-armaria a pergunta e a próxima resposta do usuário depositaria de novo."""
+    user_id = _uid()
+    _carteira(user_id)
+    _cria_destino(user_id, fluxo, nome)
+    pending = _pending_funding_para(user_id, fluxo, nome)
+
+    def _estoura(*a, **k):
+        raise Estourou("banco caiu logo depois do commit")
+
+    monkeypatch.setattr(db, "display_id_for", _estoura)
+
+    resposta = H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    assert "✅" in (resposta or ""), f"{fluxo}: o sucesso virou erro — {resposta!r}"
+    assert db.get_pending_action(user_id) is None, (
+        f"{fluxo}: pergunta re-armada com o dinheiro já debitado — a próxima "
+        "resposta depositaria de novo")
+    assert float(db.get_balance(user_id)) == 400.0

--- a/tests/test_pending_rollback.py
+++ b/tests/test_pending_rollback.py
@@ -403,3 +403,68 @@ def test_funding_choice_falha_depois_do_commit_nao_rearma(monkeypatch, fluxo, no
         f"{fluxo}: pergunta re-armada com o dinheiro já debitado — a próxima "
         "resposta depositaria de novo")
     assert float(db.get_balance(user_id)) == 400.0
+
+
+# ── a JANELA AMBÍGUA: a exceção sai DO PRÓPRIO `conn.commit()` ───────────────
+# P1 do Codex no PR #144. A fronteira do "dá para repetir" não é o `return` da
+# função transacional: é a primeira TENTATIVA de commit. Se a conexão cai
+# enquanto o Postgres confirma o COMMIT, a chamada levanta com a transação já
+# gravada — de fora, idêntico a uma falha antes dela. Devolver a pergunta ali
+# faz a próxima resposta do usuário aportar/depositar DE NOVO, e não há chave de
+# idempotência que segure.
+#
+# A simulação é fiel, não é mock de conveniência: o commit é executado DE
+# VERDADE (o dinheiro anda, e o teste confere o saldo) e só então a chamada
+# levanta. `db.connection.commits_ambiguos` é o que separa este caso do de cima.
+
+@pytest.mark.parametrize("fluxo,nome,modulo", FLUXOS, ids=FLUXO_IDS)
+def test_funding_choice_commit_ambiguo_nao_rearma(monkeypatch, fluxo, nome, modulo):
+    """Negativo por causa: sem o `if commits_ambiguos() == antes` em
+    `db/pending.py`, a pendência volta e ESTE caso fica vermelho — e só ele.
+    Os dois `..._devolve_quando_o_banco_cai_de_verdade` (falha ANTES do commit)
+    continuam verdes, que é o controle positivo do par."""
+    import contextlib
+    import importlib
+    import psycopg
+
+    user_id = _uid()
+    _carteira(user_id)
+    _cria_destino(user_id, fluxo, nome)
+    pending = _pending_funding_para(user_id, fluxo, nome)
+
+    armado = {"on": False}
+    commit_real = psycopg.Connection.commit
+
+    def commit_e_perde_a_conexao(self):
+        commit_real(self)  # o Postgres CONFIRMA
+        if armado["on"]:
+            armado["on"] = False
+            raise psycopg.OperationalError("connection lost while committing")
+
+    monkeypatch.setattr(psycopg.Connection, "commit", commit_e_perde_a_conexao)
+
+    # Arma só a transação do dinheiro: o `ensure_user` da mesma função commita
+    # antes, por outro `get_conn` (o de db/users.py), e não pode disparar.
+    M = importlib.import_module(modulo)
+    get_conn_real = M.get_conn
+
+    @contextlib.contextmanager
+    def get_conn_armado():
+        with get_conn_real() as conn:
+            armado["on"] = True
+            try:
+                yield conn
+            finally:
+                armado["on"] = False
+
+    monkeypatch.setattr(M, "get_conn", get_conn_armado)
+
+    with pytest.raises(psycopg.OperationalError):
+        H_inv.resolve_funding_choice(user_id, "1", pending)
+
+    assert float(db.get_balance(user_id)) == 400.0, (
+        f"{fluxo}: o commit não passou — a janela ambígua não foi simulada, "
+        "o teste não mede nada")
+    assert db.get_pending_action(user_id) is None, (
+        f"{fluxo}: pergunta re-armada com o commit já confirmado — responder a "
+        "origem de novo debitaria a carteira duas vezes")


### PR DESCRIPTION
Continuação do #141. Ele tornou o consumo condicional (CAS), que era o conserto certo — mas onde o consumo passou a acontecer **antes** de um trabalho que pode falhar, **não há devolução em ramo nenhum**.

## O defeito

```python
if not consume_pending_action(user_id, pending):
    return None
deleted = delete_card(user_id, int(card_id))   # ← sem try/except
```

`delete_card` apaga faturas e transações em cascata. Se estourar, a pendência **já foi**: o usuário perde a confirmação, a exceção sobe sem mensagem útil, e ele refaz do zero.

Nos quatro sites de `credit.py` isso é **regressão contra o comportamento anterior** — antes do #141 o `clear` vinha **depois**, então a pergunta sobrevivia à exceção. O pior (`confirm_delete_existing_card`) não perde uma confirmação: perde o **payload do cadastro de cartão inteiro** (`card_name`, `closing_day`, `due_day`, `ask_primary`), e a mensagem de erro ainda diz *"Tente novamente"*, coisa que deixou de ser possível.

## O conserto

Um context manager de 10 linhas em `db/pending.py`, em cima do `create_pending_action_if_absent` que já existia. Oito sites viram uma linha cada.

**A devolução é condicional, e é esse o ponto.** `create_pending_action_if_absent` (`on conflict do nothing`), **não** `set_pending_action`. Se A reservou, B pôs uma pergunta nova na linha, e A falhou, a devolução de A **não escreve** — B sobrevive. Trocar o helper por `set_pending_action` deixa os **8 testes de corrida vermelhos**.

> Uma operação antiga nunca pode sobrescrever silenciosamente uma pendência mais nova.

## Sites tratados (8)

| site | trabalho | prazo |
|---|---|---|
| `credit.py::_resolve_set_primary` | `set_default_card` | 20 |
| `credit.py::_resolve_delete_card` | `delete_card` | 20 |
| `credit.py::resolve_pending`/`confirm_delete_existing_card` | `delete_card` | 20 |
| `credit.py::resolve_pending`/`set_primary` | `set_default_card` | 20 |
| `wa_runtime.py` botão "Já paguei" | `mark_bill_paid` | 30 |
| `investments.py::resolve_investment_pick` | `deposit` | — |
| `investments.py::resolve_funding_choice` | `_aporta` | — |
| `bills.py` | já tinha o bloco inline; passou a usar o mesmo helper (§0.1) |

## Não tratados, com a medição

- **`_execute_pay_bill`** e **`_create_installments`**: o corpo inteiro está em `try/except Exception` que responde ao usuário; nada escapa. E `pay_bill_amount` **não é idempotente** — re-armar depois de um pagamento parcial ofereceria um **segundo débito**.
- **Os quatro deletes de `pending.py`** e o **cog do Discord**: `try/except` cobre.
- **`confirm_recurring_offer`**: aqui um erro de banco **escaparia** (o `except` só pega `ValueError`/`TypeError`), mas devolver faria o "sim" seguinte criar um **segundo** recorrente. É oferta de conveniência e reaparece sozinha.
- **`core/intent_router.py::_resolve_clarification`** — **buraco real do mesmo tipo**: consome e depois `_execute()` pode levantar (`PlanLimitExceeded`), levando junto o valor que o usuário já digitou. Não tocado porque o #140 está reescrevendo essa função e dois branches nela é conflito garantido. **Entra no #140 ou num PR seguinte.**

## Números, medidos nesta máquina

| | |
|---|---|
| `main` `bfb5f9f` | **1411 passed, 0 failed** |
| este branch | **1432 passed, 0 failed** |

## Controle negativo por SITE

Mutando cada `with` para `if True:` (mantém o corpo, desliga só a devolução), um de cada vez:

```
credit.py:1195   → ...devolve_pendencia_quando_o_trabalho_estoura[set_primary]
credit.py:1224   → ...[delete_card]
credit.py:1372   → ...[setup/confirm_delete_existing_card]
credit.py:1502   → ...[setup/set_primary]
bills.py:320     → test_devolucao_repoe_a_pergunta_quando_o_pagamento_estoura
wa_runtime.py:968 → test_botao_devolve_pergunta_quando_o_pagamento_estoura
investments.py:101 → test_investment_pick_devolve_pergunta_...
investments.py:185 → test_funding_choice_devolve_pergunta_...
```

**Oito sites, oito testes vermelhos, um para cada, nenhum sobreposto.**

Essa matriz achou um buraco pré-existente: a devolução que o #133 mergeou em `bills.py` dava **nenhum teste vermelho** quando desligada — só tinha teste de corrida, e corrida passa igual com a devolução desligada. O negativo que faltava entrou.

## Um bug nos próprios testes, que vale para o repositório inteiro

A primeira versão usava a fixture `user_id` do `conftest` (`uuid % 10_000_000_000`). **`core/handle_incoming._normalize_user_id:135` comprime qualquer id acima de 2 bilhões** — então ~80% das execuções roteavam para **outro usuário**, o `handle_incoming` nem via a pendência, e os testes negativos **passavam sem exercitar nada**. Só apareceu porque os positivos falhavam de forma intermitente.

Os testes de conversa agora usam `% 1_000_000_000`, a convenção já adotada em `tests/test_bill_amount_pending.py`. **Vale auditar outros testes que combinam a fixture `user_id` com `handle_incoming`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)