### PR TITLE
a11y: trap de Tab nos 7 diálogos e Esc que só fecha o que está aberto (#76)

### DIFF
--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -178,6 +178,16 @@ async function loadUserMenuState() {
   } catch {}
 }
 
+/* Fecha só o que está aberto. Os dois listeners globais de Escape que fechavam
+   os modais de fatura e os de investimento chamavam os `close*` sem checar
+   nada: um Esc destinado a um diálogo aberto por cima derrubava os de baixo
+   junto — foi o que colidiu com a confirmação de antecipar fatura no #73, que
+   precisou de captura + stopPropagation para se defender. */
+function _fechaSeAberto(overlayId, close) {
+  const ov = document.getElementById(overlayId);
+  if (ov && ov.classList.contains("open")) close();
+}
+
 function closeUserMenu() {
   const dropdown = document.getElementById("user-dropdown");
   const button = document.getElementById("user-menu-btn");
@@ -6223,12 +6233,9 @@ document.addEventListener("click", (e) => {
 }, true);  // capture: pega antes dos onclicks inline
 
 // Esc fecha o modal
-document.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") {
-    const ov = document.getElementById("upgrade-overlay");
-    if (ov && ov.classList.contains("open")) closeUpgradeModal();
-  }
-});
+// Tinha Esc próprio e nenhum trap de Tab — o foco vazava para o dashboard
+// atrás do overlay. Pelo helper, ganha os dois (issue #76).
+window.pigModalKeys && pigModalKeys("upgrade-overlay", closeUpgradeModal);
 
 // Interceptor global: qualquer fetch que volte 403 com pro_required abre o
 // modal automaticamente. Cobre casos onde o user fura o gate visual (ex:
@@ -7733,12 +7740,16 @@ document.getElementById("bgt-input").addEventListener("keydown", e => {
   if (e.key === "Enter") saveBudget();
   if (e.key === "Escape") closeBudget();
 });
+/* Condicionado a cada overlay, um por um. Antes fechava os três SEMPRE — e
+   fechar o que já está fechado não é inofensivo aqui: o Esc de um diálogo
+   aberto POR CIMA levava junto os de baixo. Irmão do listener das faturas
+   (issue #76); a enumeração dos 8 keydown globais deste arquivo achou este,
+   que a issue não listava. */
 document.addEventListener("keydown", e => {
-  if (e.key === "Escape") {
-    closeInvestmentDetail();
-    closeInvestmentHelp();
-    closeLaunchModal();
-  }
+  if (e.key !== "Escape") return;
+  _fechaSeAberto("investment-detail-overlay", closeInvestmentDetail);
+  _fechaSeAberto("investment-help-overlay", closeInvestmentHelp);
+  _fechaSeAberto("launch-overlay", closeLaunchModal);
 });
 
 /* ═══════════════════════════════════════════════════════════════════════
@@ -9283,11 +9294,10 @@ document.getElementById("pay-bill-amount").addEventListener("keydown", e => {
   if (e.key === "Enter") submitPayBill();
 });
 document.addEventListener("keydown", e => {
-  if (e.key === "Escape") {
-    closeBillDetailModal();
-    closePayBillModal();
-    closePayReceiptModal();
-  }
+  if (e.key !== "Escape") return;
+  _fechaSeAberto("bill-detail-overlay", closeBillDetailModal);
+  _fechaSeAberto("pay-bill-overlay", closePayBillModal);
+  _fechaSeAberto("pay-bill-receipt-overlay", closePayReceiptModal);
 });
 
 
@@ -9350,6 +9360,7 @@ function closeOfxResult() {
   const ov = document.getElementById("ofx-result-overlay");
   if (ov) ov.classList.remove("open");
 }
+window.pigModalKeys && pigModalKeys("ofx-result-overlay", closeOfxResult);
 
 function getCsrfToken() {
   const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1613,6 +1613,9 @@ function closeMfaOnboardingOverlay() {
   const ov = document.getElementById("mfa-onboarding-overlay");
   if (ov) ov.classList.remove("open");
 }
+// Esc = "Agora não", não o fechamento cru: o dismiss marca como visto no
+// servidor. Fechando sem marcar, o overlay volta no próximo login.
+window.pigModalKeys && pigModalKeys("mfa-onboarding-overlay", function () { mfaOnboardingDismiss(); });
 
 async function _markMfaOnboardingSeen() {
   try {

--- a/frontend/modals.js
+++ b/frontend/modals.js
@@ -273,10 +273,38 @@
     document.addEventListener("keydown", function (e) {
       const ov = document.getElementById(overlayId);
       if (!ov || !ov.classList.contains("open")) return;
+      if (!noTopo(ov)) return;
       if (e.key === "Escape") { close(); return; }
       window.pigTrapTab(e, ov);
     });
   };
+
+  /* `ov` é o diálogo de cima, ou tem outro cobrindo ele?
+
+     Dois diálogos abertos ao mesmo tempo acontecem de verdade: na Início, um
+     retorno de checkout de quem ainda não tem MFA abre o onboarding de
+     segurança pelo `loadHomeData` e, ~450ms depois, o `openWelcomePro` sobe o
+     card de boas-vindas POR CIMA. Sem esta checagem, um Esc para dispensar o
+     card de cima disparava TAMBÉM o handler de baixo — e ali o Esc faz um POST
+     que marca o onboarding como visto PARA SEMPRE. O usuário dispensaria uma
+     celebração e perderia, calado, o convite de proteger a conta.
+
+     A alternativa seria exigir que todo diálogo que abre por cima registre em
+     captura e consuma a tecla, como faz o `#generic-confirm-overlay` do
+     dashboard. Isso funciona, e é o que já existe lá — mas é convenção que se
+     esquece em silêncio, e agora que registrar um diálogo aqui custa uma linha
+     a chance de esquecer só cresce. A pergunta é respondida no helper.
+
+     Quem responde é o hit-test do próprio navegador: estes overlays cobrem a
+     viewport inteira, então o que está no CENTRO da tela é o de cima. Sem
+     z-index lido à mão, sem pilha para manter em sincronia. `null` (layout
+     ainda não aconteceu) conta como "estou no topo": o custo de errar para esse
+     lado é o comportamento de antes, não um diálogo mudo. */
+  function noTopo(ov) {
+    const el = document.elementFromPoint(
+      Math.floor(window.innerWidth / 2), Math.floor(window.innerHeight / 2));
+    return !el || ov.contains(el);
+  }
 
   window.alertModal = function (message, opts) {
     return openModal({ kind: "alert", message, opts });

--- a/frontend/modals.js
+++ b/frontend/modals.js
@@ -253,6 +253,31 @@
     }
   };
 
+  /* Registra Esc + trap de Tab para um diálogo que abre e fecha pela classe
+     `.open` no overlay. Um listener persistente, guardado pelo `.open`: não faz
+     nada enquanto o diálogo estiver fechado, e não há `removeEventListener`
+     para alguém esquecer de chamar no fechamento.
+
+     Existe porque o `pigTrapTab` sozinho NÃO fechava a classe. Ele resolve o
+     Tab e deixa para cada chamador o bloco de "o meu overlay está aberto? o Esc
+     fecha?" — que era exatamente o que faltava em SETE diálogos (issue #76).
+     Copiar o bloco pela oitava vez era o erro que este arquivo já tinha
+     aprendido a não cometer.
+
+     Em fase de BOLHA, sem `stopPropagation`, de propósito: quem precisa vencer
+     um listener de baixo (o `#generic-confirm-overlay` do dashboard.js, que
+     abre POR CIMA de um fluxo de pagamento) registra em captura e consome a
+     tecla. Se este helper consumisse o Esc, ele é que atropelaria o diálogo de
+     cima. */
+  window.pigModalKeys = function (overlayId, close) {
+    document.addEventListener("keydown", function (e) {
+      const ov = document.getElementById(overlayId);
+      if (!ov || !ov.classList.contains("open")) return;
+      if (e.key === "Escape") { close(); return; }
+      window.pigTrapTab(e, ov);
+    });
+  };
+
   window.alertModal = function (message, opts) {
     return openModal({ kind: "alert", message, opts });
   };

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -2158,6 +2158,7 @@ function closeActivityModal() {
   const overlay = document.getElementById("activity-modal-overlay");
   if (overlay) overlay.classList.remove("open");
 }
+window.pigModalKeys && pigModalKeys("activity-modal-overlay", closeActivityModal);
 
 function formatSessionWhen(iso, prefix) {
   if (!iso) return "";
@@ -3267,6 +3268,14 @@ function openMfaSetupModal() {
 function closeMfaSetupModal() {
   document.getElementById("mfa-setup-overlay").classList.remove("open");
 }
+window.pigModalKeys && pigModalKeys("mfa-setup-overlay", function () {
+  // O passo 3 mostra os códigos de backup UMA vez ("Você não verá esses
+  // códigos novamente"). Um Esc por engano ali tranca a pessoa fora da
+  // recuperação de MFA — então o Esc não fecha enquanto eles estão na tela.
+  // O botão "Concluído" continua fechando, e o trap de Tab vale nos 3 passos.
+  if (document.getElementById("mfa-setup-step3").style.display !== "none") return;
+  closeMfaSetupModal();
+});
 
 async function mfaSetupStep1Submit() {
   const password = document.getElementById("mfa-setup-password").value;
@@ -3342,6 +3351,7 @@ function openMfaDisableModal() {
 function closeMfaDisableModal() {
   document.getElementById("mfa-disable-overlay").classList.remove("open");
 }
+window.pigModalKeys && pigModalKeys("mfa-disable-overlay", closeMfaDisableModal);
 
 async function mfaDisableSubmit() {
   const password = document.getElementById("mfa-disable-password").value;
@@ -3378,6 +3388,12 @@ function openMfaRegenerateModal() {
 function closeMfaRegenerateModal() {
   document.getElementById("mfa-regen-overlay").classList.remove("open");
 }
+window.pigModalKeys && pigModalKeys("mfa-regen-overlay", function () {
+  // Mesmo cuidado do setup, e pior: aqui os códigos ANTIGOS já foram
+  // invalidados quando estes aparecem. Perder a tela é perder os dois lados.
+  if (document.getElementById("mfa-regen-result").style.display !== "none") return;
+  closeMfaRegenerateModal();
+});
 
 async function mfaRegenerateSubmit() {
   const password = document.getElementById("mfa-regen-password").value;

--- a/tests/frontend/modal_keys.test.mjs
+++ b/tests/frontend/modal_keys.test.mjs
@@ -280,3 +280,45 @@ test("home: Esc no onboarding de MFA marca como visto, não só fecha", async ()
     assert.equal(vistos.length, 1, "o Esc fechou sem marcar como visto");
   } finally { await page.close(); }
 });
+
+// ── empilhamento: só o diálogo de cima responde ao Esc ──────────────────────
+
+test("home: Esc não dispensa o onboarding de MFA quando há diálogo por cima", async () => {
+  const page = await newPage();
+  const vistos = [];
+  try {
+    // Cenário real: retorno de checkout de quem ainda não tem MFA. O
+    // `loadHomeData` abre o onboarding de segurança e, ~450ms depois, o
+    // `openWelcomePro` sobe o card de boas-vindas POR CIMA. Os dois handlers
+    // são de bolha e o de baixo faz um POST que marca "visto" PARA SEMPRE:
+    // dispensar a celebração perdia, calado, o convite de proteger a conta.
+    //
+    // Os dois overlays são abertos pela classe, e não pelas funções que os
+    // abrem, porque na home elas NÃO são globais (contrato do PBPages). O par
+    // que discrimina é com o teste anterior: descoberto, o Esc marca; coberto,
+    // não encosta.
+    await page.route("**/auth/mfa/onboarding-seen", (route) => {
+      vistos.push(1);
+      route.fulfill(json({}));
+    });
+    await page.goto(`${ORIGIN}/home.html`);
+    await page.waitForFunction(() => !!document.getElementById("welcome-pro-overlay"));
+
+    const cobre = await page.evaluate(() => {
+      document.getElementById("mfa-onboarding-overlay").classList.add("open");
+      document.getElementById("welcome-pro-overlay").classList.add("open");
+      const topo = document.elementFromPoint(
+        Math.floor(innerWidth / 2), Math.floor(innerHeight / 2));
+      return document.getElementById("welcome-pro-overlay").contains(topo);
+    });
+    assert.equal(cobre, true, "pré-condição: o card de boas-vindas tem que estar por cima");
+
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(150);
+
+    assert.equal(vistos.length, 0,
+      "o Esc do diálogo de cima marcou o onboarding de MFA como visto para sempre");
+    assert.equal(await aberto(page, "mfa-onboarding-overlay"), true,
+      "o diálogo de baixo tinha que continuar de pé");
+  } finally { await page.close(); }
+});

--- a/tests/frontend/modal_keys.test.mjs
+++ b/tests/frontend/modal_keys.test.mjs
@@ -1,0 +1,282 @@
+/**
+ * Teclado dos diálogos: trap de Tab e Esc condicionado (issue #76).
+ *
+ * UM invariante: enquanto um diálogo está aberto, o Tab não sai dele e o Esc
+ * fecha — MENOS quando fechar destrói algo que não volta.
+ *
+ * A exceção não é detalhe: `#mfa-setup-overlay` (passo 3) e `#mfa-regen-overlay`
+ * (resultado) mostram os códigos de backup UMA vez, e no regen os antigos já
+ * foram invalidados quando os novos aparecem. Um Esc por engano ali tranca a
+ * pessoa fora da recuperação de MFA. Por isso o Esc é recusado NESSE estado e
+ * aceito no estado de formulário do MESMO diálogo — é o par que discrimina uma
+ * guarda de verdade de um `return` que só desliga o Esc.
+ *
+ * Armadilha registrada na #76 e que vale para qualquer teste desta página: a
+ * `settings.html` tem guarda de sessão que redireciona em laço sem backend. Sem
+ * responder `/auth/validate`, a navegação destrói o contexto no meio da
+ * medição. O `newPage()` abaixo responde.
+ *
+ * Rodar:  npm run test:frontend
+ * Precisa de `npm ci` na raiz (playwright) + `npx playwright install chromium`.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+// Porta própria: a 8899 é do settings_security_fanout e a 8901 é do hiw_rail.
+// Repetir uma delas faz o http.server morrer com "Address already in use" e o
+// arquivo inteiro fica vermelho por colisão, não por defeito — foi o que
+// aconteceu na primeira versão deste teste.
+const PORT = Number(process.env.PB_MODALS_TEST_PORT || 8903);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const json = (body) => ({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+async function startServer() {
+  const proc = spawn("python3", ["-m", "http.server", String(PORT), "--bind", "127.0.0.1", "--directory", FRONTEND],
+    { stdio: "ignore" });
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    if (proc.exitCode !== null) throw new Error(`http.server morreu (porta ${PORT} ocupada?)`);
+    try { if ((await fetch(`${ORIGIN}/settings.html`)).ok) return proc; } catch { /* ainda subindo */ }
+  }
+  proc.kill();
+  throw new Error(`http.server não subiu em ${ORIGIN}`);
+}
+
+let server, browser;
+before(async () => { server = await startServer(); browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+async function newPage() {
+  const page = await browser.newPage();
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin !== ORIGIN) return route.abort();          // CDN bloqueado
+    if (/\.[a-z0-9]+$/i.test(url.pathname)) return route.continue();
+    return route.fulfill(json({}));
+  });
+  await page.route("**/static/auth-refresh.js", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript",
+                    body: readFileSync(join(FRONTEND, "auth-refresh.js"), "utf8") }));
+  await page.route("**/auth/validate", (route) => route.fulfill(json({ user_id: 1 })));
+  await page.route("**/auth/me", (route) => route.fulfill(json({})));
+  await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+  return page;
+}
+
+const aberto = (page, id) => page.evaluate(
+  (i) => document.getElementById(i).classList.contains("open"), id);
+
+/** Onde o foco está: dentro do overlay, ou escapou? */
+const focoDentro = (page, id) => page.evaluate((i) => {
+  const ov = document.getElementById(i);
+  return !!(ov && document.activeElement && ov.contains(document.activeElement));
+}, id);
+
+/**
+ * Tab N vezes e devolve quantas vezes o foco estava FORA do overlay.
+ * Mais voltas que controles focáveis de propósito: o vazamento só acontece na
+ * borda, e uma volta só passaria mesmo sem trap nenhum.
+ */
+async function tabAndoCount(page, id, voltas = 12) {
+  let fora = 0;
+  for (let i = 0; i < voltas; i++) {
+    await page.keyboard.press("Tab");
+    if (!(await focoDentro(page, id))) fora++;
+  }
+  return fora;
+}
+
+async function abreSettings(query = "") {
+  const page = await newPage();
+  await page.goto(`${ORIGIN}/settings.html${query}`);
+  await page.waitForFunction(() => typeof window.pigModalKeys !== "undefined"
+                                || typeof window.pigTrapTab !== "undefined");
+  return page;
+}
+
+// ── trap de Tab ─────────────────────────────────────────────────────────────
+
+test("settings: diálogo aberto prende o Tab", async () => {
+  const page = await abreSettings();
+  try {
+    await page.evaluate(() => openMfaDisableModal());
+    assert.equal(await aberto(page, "mfa-disable-overlay"), true);
+    assert.equal(await tabAndoCount(page, "mfa-disable-overlay"), 0,
+      "o foco vazou do diálogo para a página atrás");
+  } finally { await page.close(); }
+});
+
+test("settings: atividade recente prende o Tab e fecha no Esc", async () => {
+  const page = await abreSettings();
+  try {
+    await page.evaluate(() => openActivityModal());
+    assert.equal(await aberto(page, "activity-modal-overlay"), true);
+    assert.equal(await tabAndoCount(page, "activity-modal-overlay"), 0, "foco vazou");
+    await page.keyboard.press("Escape");
+    assert.equal(await aberto(page, "activity-modal-overlay"), false, "Esc não fechou");
+  } finally { await page.close(); }
+});
+
+// ── Esc: o par que discrimina ───────────────────────────────────────────────
+
+test("settings: Esc fecha o setup de MFA no formulário", async () => {
+  const page = await abreSettings();
+  try {
+    await page.evaluate(() => openMfaSetupModal());   // abre no passo 1
+    await page.keyboard.press("Escape");
+    assert.equal(await aberto(page, "mfa-setup-overlay"), false,
+      "no passo do formulário o Esc TEM que fechar — senão a guarda só desligou o Esc");
+  } finally { await page.close(); }
+});
+
+test("settings: Esc NÃO fecha o setup na tela dos códigos de backup", async () => {
+  const page = await abreSettings();
+  try {
+    await page.evaluate(() => {
+      openMfaSetupModal();
+      document.getElementById("mfa-setup-step1").style.display = "none";
+      document.getElementById("mfa-setup-step3").style.display = "";
+    });
+    await page.keyboard.press("Escape");
+    assert.equal(await aberto(page, "mfa-setup-overlay"), true,
+      "o Esc apagou os códigos de backup, que aparecem uma vez só");
+    assert.equal(await tabAndoCount(page, "mfa-setup-overlay"), 0,
+      "o trap de Tab vale nos dois estados");
+  } finally { await page.close(); }
+});
+
+test("settings: Esc NÃO fecha os novos códigos de backup do regenerar", async () => {
+  const page = await abreSettings();
+  try {
+    await page.evaluate(() => {
+      openMfaRegenerateModal();
+      document.getElementById("mfa-regen-form").style.display = "none";
+      document.getElementById("mfa-regen-result").style.display = "";
+    });
+    await page.keyboard.press("Escape");
+    assert.equal(await aberto(page, "mfa-regen-overlay"), true,
+      "os antigos já foram invalidados: fechar aqui perde os dois lados");
+  } finally { await page.close(); }
+});
+
+test("settings: Esc fecha o regenerar enquanto é formulário", async () => {
+  const page = await abreSettings();
+  try {
+    await page.evaluate(() => openMfaRegenerateModal());
+    await page.keyboard.press("Escape");
+    assert.equal(await aberto(page, "mfa-regen-overlay"), false);
+  } finally { await page.close(); }
+});
+
+// ── dashboard: Esc não pode fechar o que não está aberto ────────────────────
+//
+// Dois listeners globais chamavam os `close*` sem checar nada. Fechar o que já
+// está fechado parece inofensivo e não é: um Esc destinado a um diálogo aberto
+// POR CIMA derrubava os de baixo junto — foi o que colidiu com a confirmação de
+// antecipar fatura no #73, que precisou de captura + stopPropagation só para se
+// defender. O observável não é o DOM (fechado continua fechado): é a CHAMADA.
+
+const FECHADORES = [
+  "closeBillDetailModal", "closePayBillModal", "closePayReceiptModal",
+  "closeInvestmentDetail", "closeInvestmentHelp", "closeLaunchModal",
+];
+
+test("dashboard: Esc com tudo fechado não chama nenhum fechador", async () => {
+  const page = await newPage();
+  try {
+    await page.goto(`${ORIGIN}/dashboard.html`);
+    await page.waitForFunction(
+      (fs) => fs.every((f) => typeof window[f] === "function"), FECHADORES);
+
+    const chamados = await page.evaluate((fs) => {
+      window.__chamados = [];
+      for (const f of fs) {
+        const orig = window[f];
+        window[f] = function () { window.__chamados.push(f); return orig.apply(this, arguments); };
+      }
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      return window.__chamados;
+    }, FECHADORES);
+
+    assert.deepEqual(chamados, [],
+      `Esc fechou diálogo que não estava aberto: ${chamados.join(", ")}`);
+  } finally { await page.close(); }
+});
+
+test("dashboard: Esc fecha o diálogo que ESTÁ aberto", async () => {
+  const page = await newPage();
+  try {
+    await page.goto(`${ORIGIN}/dashboard.html`);
+    await page.waitForFunction(
+      (fs) => fs.every((f) => typeof window[f] === "function"), FECHADORES);
+
+    const r = await page.evaluate((fs) => {
+      window.__chamados = [];
+      for (const f of fs) {
+        const orig = window[f];
+        window[f] = function () { window.__chamados.push(f); return orig.apply(this, arguments); };
+      }
+      document.getElementById("launch-overlay").classList.add("open");
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      return { chamados: window.__chamados,
+               aberto: document.getElementById("launch-overlay").classList.contains("open") };
+    }, FECHADORES);
+
+    assert.deepEqual(r.chamados, ["closeLaunchModal"],
+      "só o fechador do diálogo aberto podia rodar");
+    assert.equal(r.aberto, false, "o Esc tem que fechar o que está aberto");
+  } finally { await page.close(); }
+});
+
+// ── os outros três dos sete ─────────────────────────────────────────────────
+
+test("dashboard: upgrade e resultado do OFX prendem o Tab e fecham no Esc", async () => {
+  const page = await newPage();
+  try {
+    await page.goto(`${ORIGIN}/dashboard.html`);
+    await page.waitForFunction(() => typeof window.closeUpgradeModal === "function");
+
+    for (const id of ["upgrade-overlay", "ofx-result-overlay"]) {
+      await page.evaluate((i) => document.getElementById(i).classList.add("open"), id);
+      assert.equal(await tabAndoCount(page, id), 0, `${id}: o foco vazou do diálogo`);
+      await page.keyboard.press("Escape");
+      assert.equal(await aberto(page, id), false, `${id}: o Esc não fechou`);
+    }
+  } finally { await page.close(); }
+});
+
+test("home: Esc no onboarding de MFA marca como visto, não só fecha", async () => {
+  const page = await newPage();
+  const vistos = [];
+  try {
+    // As funções da home NÃO são globais: os scripts dela estão embrulhados em
+    // `PBPages.home.inits` (contrato do POC de SPA, frontend/pb-nav.js). Então o
+    // observável aqui é o EFEITO — o POST que marca o onboarding como visto —
+    // e não o nome de uma função, que nem existe no window.
+    await page.route("**/auth/mfa/onboarding-seen", (route) => {
+      vistos.push(1);
+      route.fulfill(json({}));
+    });
+    await page.goto(`${ORIGIN}/home.html`);
+    await page.waitForFunction(() => !!document.getElementById("mfa-onboarding-overlay"));
+
+    await page.evaluate(() =>
+      document.getElementById("mfa-onboarding-overlay").classList.add("open"));
+    await page.keyboard.press("Escape");
+
+    await page.waitForFunction(() =>
+      !document.getElementById("mfa-onboarding-overlay").classList.contains("open"));
+    // Fechar cru não marca nada, e o overlay voltaria no próximo login — o Esc
+    // viraria um jeito de nunca se livrar dele.
+    assert.equal(vistos.length, 1, "o Esc fechou sem marcar como visto");
+  } finally { await page.close(); }
+});


### PR DESCRIPTION
Fecha a #76 (partes 1 e 2). A parte 3 — consolidar as duas implementações de `confirm`/`alert` — fica de fora, como a própria issue determina: é refactor **visual**, não correção de acessibilidade.

## 1. Trap de Tab nos 7 diálogos

O `pigTrapTab` já existia e resolve o Tab, mas deixava para cada chamador o bloco de *"o meu overlay está aberto? o Esc fecha?"* — que era exatamente o que faltava nos sete. Copiar esse bloco pela **oitava** vez era o erro que o `modals.js` já tinha aprendido a não cometer (o comentário dele conta a história das quatro cópias anteriores).

Então ele ganhou um vizinho: `pigModalKeys(overlayId, close)` — um listener persistente, guardado pelo `.open`, sem `removeEventListener` para alguém esquecer de chamar no fechamento. Cada diálogo vira **uma linha**.

**Em bolha e sem `stopPropagation`, de propósito.** Quem precisa vencer um listener de baixo — o `#generic-confirm-overlay` do `dashboard.js`, que abre POR CIMA de um fluxo de pagamento — registra em captura e consome a tecla. Se este helper consumisse o Esc, ele é que passaria a atropelar o diálogo de cima, invertendo o bug em vez de resolvê-lo.

## 2. O Esc é recusado onde fechar destrói algo que não volta

A issue avisa: *"o de códigos de backup mostra os códigos uma única vez. Qualquer mexida ali merece cuidado redobrado."* Conferido no markup, e é pior do que uma tela só:

- `#mfa-setup-overlay` passo 3 — *"Você não verá esses códigos novamente. Salve agora."*
- `#mfa-regen-overlay` resultado — *"Os anteriores foram invalidados. Salve estes agora."*

No regen os códigos **antigos já foram invalidados** quando os novos aparecem: fechar por engano perde os dois lados e tranca a pessoa fora da recuperação de MFA. Nesses dois estados o Esc não fecha. No estado de **formulário do mesmo diálogo**, fecha normalmente — é o par que separa uma guarda de verdade de um `return` que só desligou o Esc. O botão "Concluído" continua fechando nos dois estados, e o trap de Tab vale em todos eles.

Na home, o Esc chama `mfaOnboardingDismiss()` e não o fechamento cru: o dismiss marca "visto" no servidor, e fechar sem marcar faria o overlay voltar no próximo login — o Esc viraria um jeito de nunca se livrar dele.

## 3. Esc condicionado — e a issue listava só metade

A #76 pede a *"enumeração dos listeners globais de Escape do dashboard.js, que é o que faltava desde o começo"*. Feita: são **8** `keydown` globais, e **dois** são incondicionais, não um.

| listener | condicionado? | |
|---|---|---|
| `:201` menu do usuário | **não** | fecha um dropdown idempotente, não um diálogo — **fica** |
| `:2371` generic-confirm | sim | captura + `stopPropagation` |
| `:6028` sidenav | sim | |
| `:6226` upgrade | sim | passou pelo helper, ver abaixo |
| `:7524` launch-detail | sim | |
| `:7589` sobrou-detail | sim | + trap |
| `:7736` investimento + lançamento | **não** | **a issue não lista este** — corrigido |
| `:9285` faturas | **não** | o que a issue nomeia — corrigido |

Os dois passaram a fechar só o que está aberto, via `_fechaSeAberto`.

**Correção de rota na issue:** a tabela dela marca `Esc: não` para o diálogo de upgrade, mas ele **já tinha** Esc próprio (`:6226`). O que faltava nele era só o trap. Agora passa pelo helper e ganha os dois.

## O que foi medido

`npm run test:frontend`: **41 passam** — 30 de antes, mais 11 em `tests/frontend/modal_keys.test.mjs`. Suíte Python: **1417 passam**, intocada.

**Três controles negativos**, cada um injetado onde discrimina:

| conserto desligado | vermelhos |
|---|---|
| registros do helper, nos 3 arquivos | **7** |
| registro mantido, só a guarda dos códigos de backup removida | exatamente os **2** de códigos de backup |
| `_fechaSeAberto` sem a condição | exatamente os **2** do dashboard |

O segundo controle existe porque o primeiro **não discrimina** os dois testes de códigos de backup: sem listener nenhum o Esc não faz nada e o modal fica aberto por vazio — o teste passaria medindo coisa nenhuma. Foi preciso manter o registro e tirar só a guarda.

**Positivos**, verdes em todas as versões: "Esc fecha o setup no formulário" e "Esc fecha o regenerar enquanto é formulário". Sem eles, a guarda poderia ter simplesmente desligado o Esc dos dois diálogos e o grupo passaria.

Duas armadilhas de medição que a issue registra e que valeram: a guarda de sessão da `settings.html` redireciona em laço sem backend (o harness responde `/auth/validate`), e as funções da `home.html` **não são globais** — os scripts dela estão embrulhados em `PBPages.home.inits` pelo contrato do POC de SPA, então o observável ali é o POST de `onboarding-seen`, não o nome de uma função.

Uma terceira, minha: a primeira versão do teste usou a porta 8901, que é a do `hiw_rail` — os dois juntos derrubavam 11 testes por `Address already in use`, vermelho por colisão e não por defeito. O arquivo agora tem porta própria (8903) e a razão está comentada.

## O que NÃO foi medido

- **Leitor de tela.** Nada aqui foi testado com VoiceOver/NVDA. O que se mede é travessia de foco, não anúncio do diálogo — mesma ressalva que a #76 já fazia.
- **Devolver o foco a quem abriu** ficou de fora: precisa de gancho no lado do `open*` de cada diálogo, e a issue pede Esc + Tab. Os seis diálogos que já tinham trap (`#bankpick-overlay`, `#generic-confirm-overlay`, …) fazem isso; os sete novos não. Candidato natural a um PR seguinte.
- **Os 6 diálogos de fatura/investimento** ganharam Esc condicionado, mas **não** ganharam trap de Tab — não foram auditados pela #76 e dar trap a diálogo não auditado é mudar o que não se mediu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)