### PR TITLE
Descer de plano passa a valer para o que já existe (#77, parte 2)

### DIFF
--- a/core/services/agents_energy_sweep.py
+++ b/core/services/agents_energy_sweep.py
@@ -1,0 +1,74 @@
+"""
+core/services/agents_energy_sweep.py — pausa agentes acima do orçamento de
+energia do plano vigente.
+
+O `agents_energy_budget` só era cobrado na ATIVAÇÃO. Quem descia de plano
+mantinha tudo ligado: um Pro (orçamento 14, cabem os 7 agentes) que cai para o
+Plus (orçamento 4) seguia com os 7 disparando.
+
+A queda para um tier SEM energia (Grátis e Essencial, orçamento 0) já era
+tratada — os runners filtram por `agent_kind_allowed`, que é
+`agents_energy_budget(uid) > 0`. O buraco era só de pago para pago, hoje um
+caso só na escada: Pro (14) → Plus (4).
+
+Pausar, e não apagar: `pause_agent` deixa a linha e o histórico de disparos de
+pé, então voltar ao plano maior é reativar num clique. Mesma decisão de produto
+da conexão de Open Finance pausada.
+
+CAI O MAIS RECENTE, igual à varredura de OF: ordena por `id` crescente e pausa
+do fim para o começo até caber. Determinístico e explicável ("os que você
+ativou por último saíram").
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from core.services import plan_service
+from core.services.plan_limits import agent_energy_cost
+from db import list_users_with_active_agents, pause_agent
+
+
+def enforce_agents_energy_budget() -> dict:
+    """Um tick da varredura. Devolve o resumo, no formato das outras."""
+    if not plan_service.plans_v2_enabled():
+        return {"ok": True, "disabled": True, "checked_users": 0, "paused": 0, "errors": 0}
+
+    by_user: dict[int, list[dict]] = defaultdict(list)
+    for row in list_users_with_active_agents():
+        by_user[int(row["user_id"])].append(row)
+
+    checked = 0
+    paused = 0
+    errors = 0
+
+    for user_id, ativos in by_user.items():
+        # Testers do beta usam qualquer agente independente do tier (é o que o
+        # `agent_kind_allowed` já faz nos runners). Sem esta saída, a varredura
+        # desligaria justamente os agentes de quem está testando o beta.
+        try:
+            if plan_service.agents_beta_tester(user_id):
+                continue
+            budget = plan_service.agents_energy_budget(user_id)
+        except Exception:
+            errors += 1
+            continue
+
+        checked += 1
+        usada = sum(agent_energy_cost(a["kind"]) for a in ativos)
+        if usada <= budget:
+            continue
+
+        # Do mais novo para o mais velho, até caber.
+        for a in sorted(ativos, key=lambda r: int(r["agent_id"]), reverse=True):
+            if usada <= budget:
+                break
+            try:
+                if pause_agent(user_id, a["kind"]):
+                    usada -= agent_energy_cost(a["kind"])
+                    paused += 1
+            except Exception:
+                errors += 1
+                break                      # não insiste no mesmo usuário neste tick
+
+    return {"ok": True, "disabled": False, "checked_users": checked,
+            "paused": paused, "errors": errors}

--- a/core/services/open_finance_trial_expiry.py
+++ b/core/services/open_finance_trial_expiry.py
@@ -26,10 +26,27 @@ from core.services.pluggy import create_pluggy_api_key, delete_pluggy_item
 from db import list_pluggy_connections_for_trial_sweep, pause_open_finance_connection
 
 
-def pause_expired_trial_connections() -> dict:
-    """Um tick da varredura. Best-effort por conexão: se o delete na Pluggy falhar,
-    a conexão NÃO é pausada (fica pro próximo tick — nunca marca PAUSED com o item
-    ainda vivo lá, senão o slot pago vaza pra sempre)."""
+def enforce_of_bank_limits() -> dict:
+    """Um tick da varredura: pausa conexões ACIMA do teto do plano vigente.
+
+    Antes isto só tratava o trial vencido (`tier == "free"`). Hoje trata toda
+    queda de plano, e o caso antigo virou o caso `of_banks_max == 0` — quem cai
+    pro Grátis perde todas, quem cai de Pro (5) para Essencial (1) perde 4. Sem
+    isto, o teto só barrava conexão NOVA: quem tinha 5 bancos e descia para o
+    Essencial seguia com os 5 sincronizando, ocupando slot pago na Pluggy.
+
+    CAI O MAIS RECENTE. Ordena por `id` crescente e pausa do fim para o começo:
+    o banco principal costuma ser o primeiro conectado, e o que veio depois foi
+    o que o plano maior habilitou. Determinístico e explicável ao usuário.
+
+    Best-effort por conexão: se o delete na Pluggy falhar, a conexão NÃO é
+    pausada (fica pro próximo tick — nunca marca PAUSED com o item ainda vivo
+    lá, senão o slot pago vaza pra sempre).
+
+    ponytail: o arquivo e o teste ainda se chamam `*_trial_expiry`. Renomear
+    custa mexer em ~8 referências e engorda o diff de revisão; se outro caso de
+    queda de plano entrar aqui, aí vale `git mv` para `plan_downgrade.py`.
+    """
     if not plan_service.plans_v2_enabled():
         return {"ok": True, "disabled": True, "checked_users": 0, "paused": 0, "errors": 0}
 
@@ -48,14 +65,16 @@ def pause_expired_trial_connections() -> dict:
             continue
         checked += 1
         try:
-            tier = plan_service.get_plan_tier(user_id)
+            limit = plan_service.get_user_limits(user_id).get("of_banks_max")
         except Exception:
             errors += 1
             continue
-        if tier != "free":
-            continue
+        if limit is None:
+            continue                      # ilimitado (Premium futuro)
 
-        for conn in conns:
+        # `[limit:]` já cobre o caso do Grátis: com teto 0, sobra a lista toda.
+        excedentes = sorted(conns, key=lambda c: int(c["id"]))[int(limit):]
+        for conn in excedentes:
             try:
                 if api_key is None:
                     api_key = create_pluggy_api_key()

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -1669,13 +1669,19 @@ async def lifespan(app: FastAPI):
         # pago da Pluggy; dados importados ficam). Inerte com PLANS_V2_ENABLED off —
         # o flag é relido a cada tick dentro do serviço (liga/desliga sem redeploy).
         interval = int(os.getenv("OF_TRIAL_EXPIRY_INTERVAL_SEC", str(6 * 60 * 60)))
-        from core.services.open_finance_trial_expiry import pause_expired_trial_connections
+        from core.services.agents_energy_sweep import enforce_agents_energy_budget
+        from core.services.open_finance_trial_expiry import enforce_of_bank_limits
         from core.services.trial_downsell import send_trial_downsell_emails
         while True:
             try:
-                res = await asyncio.to_thread(pause_expired_trial_connections)
+                res = await asyncio.to_thread(enforce_of_bank_limits)
                 if not res.get("disabled"):
-                    print(f"[of_trial_expiry] {res}", flush=True)
+                    print(f"[of_bank_limits] {res}", flush=True)
+                # Mesmo tick, mesma pergunta: o que ficou acima do teto depois
+                # de uma queda de plano. Agentes acima do orçamento de energia.
+                res_ag = await asyncio.to_thread(enforce_agents_energy_budget)
+                if not res_ag.get("disabled") and (res_ag.get("paused") or res_ag.get("errors")):
+                    print(f"[agents_energy] {res_ag}", flush=True)
                 # Mesmo tick: downsell de fim de trial (1 e-mail por conta, na
                 # vida; janela de 7 dias). Inerte com o flag off.
                 res_ds = await asyncio.to_thread(send_trial_downsell_emails)

--- a/tests/test_agents_energy_sweep.py
+++ b/tests/test_agents_energy_sweep.py
@@ -1,0 +1,113 @@
+"""Queda de plano desliga agente acima do orçamento de energia.
+
+O `agents_energy_budget` só era cobrado na ATIVAÇÃO. A queda para um tier SEM
+energia (Grátis e Essencial, orçamento 0) já era tratada — os runners filtram
+por `agent_kind_allowed`, que é `agents_energy_budget(uid) > 0`. O buraco era
+de pago para pago, hoje um caso só na escada: Pro (14, cabem os 7) → Plus (4).
+
+Controles negativos, medidos:
+
+  - "pausa sempre" (tirar a guarda de orçamento E o `break` do laço) → o teste
+    do "dentro do orçamento" e o de ordem ficam vermelhos;
+  - "nunca pausa" (esvaziar o laço) → o do Pro→Plus fica vermelho.
+
+Tirar SÓ o `if usada <= budget: continue` de cima não vale como controle: o
+`break` no topo do laço faz o mesmo trabalho, então a injeção é no-op e os
+quatro testes passam. Foi a primeira tentativa aqui, e ela não media nada.
+"""
+import pytest
+
+from core.services import agents_energy_sweep as sweep
+from core.services import plan_service
+from core.services.plan_limits import agent_energy_cost
+from db import activate_agent, list_agents
+
+# 1+1+2+2+2+3+3 = 14 → exatamente o orçamento do Pro
+TODOS = ("reporter", "carteiro", "xerife", "barao", "faria_limer", "detetive", "cofre")
+
+
+def _liga_todos(user_id: int) -> None:
+    for kind in TODOS:
+        activate_agent(user_id, kind)          # sem energy_budget: sem gate na ativação
+    assert sum(agent_energy_cost(k) for k in TODOS) == 14
+
+
+def _ativos(user_id: int) -> set[str]:
+    return {a["kind"] for a in list_agents(user_id) if a["status"] == "active"}
+
+
+@pytest.fixture
+def so_este_usuario(user_id, monkeypatch):
+    """v2 ON + lister escopado ao usuário de teste.
+
+    O `PLANS_V2_ENABLED=1` não é decoração: o `tests/conftest.py:21` põe `0` na
+    suíte inteira, então sem isto a varredura sai no primeiro `if` e TODO teste
+    daqui passaria por vazio — inclusive os que afirmam que ela pausou algo.
+    A varredura real percorre a tabela toda e o DB de teste é compartilhado.
+    """
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    from db import list_users_with_active_agents as real
+    monkeypatch.setattr(
+        sweep, "list_users_with_active_agents",
+        lambda: [r for r in real() if int(r["user_id"]) == user_id],
+    )
+    monkeypatch.setattr(plan_service, "agents_beta_tester", lambda u, email=None: False)
+    return user_id
+
+
+def test_flag_off_tick_inerte(so_este_usuario, monkeypatch):
+    """O freio de emergência desliga a varredura."""
+    _liga_todos(so_este_usuario)
+    monkeypatch.setattr(plan_service, "agents_energy_budget", lambda u: 0)
+    monkeypatch.setenv("PLANS_V2_ENABLED", "0")
+
+    res = sweep.enforce_agents_energy_budget()
+
+    assert res["disabled"] is True
+    assert len(_ativos(so_este_usuario)) == 7
+
+
+def test_pro_cai_para_plus_e_sobram_os_mais_antigos(so_este_usuario, monkeypatch):
+    _liga_todos(so_este_usuario)
+    monkeypatch.setattr(plan_service, "agents_energy_budget", lambda u: 4)
+
+    res = sweep.enforce_agents_energy_budget()
+
+    restantes = _ativos(so_este_usuario)
+    usada = sum(agent_energy_cost(k) for k in restantes)
+    assert usada <= 4, f"ficou acima do orçamento: {usada} com {sorted(restantes)}"
+    assert res["paused"] == 7 - len(restantes)
+    # Cai o mais RECENTE: os primeiros ativados são os que sobram.
+    assert restantes == {"reporter", "carteiro", "xerife"}, (
+        "deviam sobrar os três primeiros ativados (1+1+2 = 4)"
+    )
+
+
+def test_dentro_do_orcamento_nao_desliga_nada(so_este_usuario, monkeypatch):
+    """Positivo: sem ele, pausar sempre passaria no grupo."""
+    _liga_todos(so_este_usuario)
+    monkeypatch.setattr(plan_service, "agents_energy_budget", lambda u: 14)
+
+    res = sweep.enforce_agents_energy_budget()
+
+    assert res["paused"] == 0
+    assert len(_ativos(so_este_usuario)) == 7
+
+
+def test_tester_do_beta_fica_intocado(user_id, monkeypatch):
+    """O `agent_kind_allowed` já isenta o tester nos runners. Sem a mesma saída
+    aqui, a varredura desligaria justamente quem está testando o beta."""
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    from db import list_users_with_active_agents as real
+    monkeypatch.setattr(
+        sweep, "list_users_with_active_agents",
+        lambda: [r for r in real() if int(r["user_id"]) == user_id],
+    )
+    _liga_todos(user_id)
+    monkeypatch.setattr(plan_service, "agents_beta_tester", lambda u, email=None: True)
+    monkeypatch.setattr(plan_service, "agents_energy_budget", lambda u: 0)
+
+    res = sweep.enforce_agents_energy_budget()
+
+    assert res["paused"] == 0
+    assert len(_ativos(user_id)) == 7

--- a/tests/test_of_trial_expiry.py
+++ b/tests/test_of_trial_expiry.py
@@ -95,7 +95,7 @@ class TestSweep:
         _, connection, deleted = sweep_env
         monkeypatch.setenv("PLANS_V2_ENABLED", "0")  # freio: default agora é LIGADO
 
-        res = ofte.pause_expired_trial_connections()
+        res = ofte.enforce_of_bank_limits()
 
         assert res["disabled"] is True
         assert res["paused"] == 0
@@ -108,7 +108,7 @@ class TestSweep:
         # user_id do fixture não tem auth_accounts nem trial → get_plan_tier real = 'free'
         assert plan_service.get_plan_tier(uid) == "free"
 
-        res = ofte.pause_expired_trial_connections()
+        res = ofte.enforce_of_bank_limits()
 
         assert res["paused"] == 1
         assert deleted == [connection["provider_item_id"]]
@@ -122,7 +122,7 @@ class TestSweep:
         _, connection, deleted = sweep_env
         monkeypatch.setattr(plan_service, "get_plan_tier", lambda uid: "plus")
 
-        res = ofte.pause_expired_trial_connections()
+        res = ofte.enforce_of_bank_limits()
 
         assert res["paused"] == 0
         assert deleted == []
@@ -132,7 +132,7 @@ class TestSweep:
         uid, connection, deleted = sweep_env
         monkeypatch.setattr(plan_service, "_ACCESS_ALLOWLIST", {uid})
 
-        res = ofte.pause_expired_trial_connections()
+        res = ofte.enforce_of_bank_limits()
 
         assert res["checked_users"] == 0
         assert res["paused"] == 0
@@ -146,7 +146,7 @@ class TestSweep:
             raise RuntimeError("pluggy fora do ar")
 
         monkeypatch.setattr(ofte, "delete_pluggy_item", _boom)
-        res = ofte.pause_expired_trial_connections()
+        res = ofte.enforce_of_bank_limits()
         assert res["paused"] == 0
         assert res["errors"] == 1
         # nunca marca PAUSED com o item ainda vivo na Pluggy (slot pago vazaria)
@@ -154,7 +154,7 @@ class TestSweep:
 
         # próximo tick, Pluggy voltou → pausa
         monkeypatch.setattr(ofte, "delete_pluggy_item", lambda item_id, key=None: deleted.append(item_id) or True)
-        res = ofte.pause_expired_trial_connections()
+        res = ofte.enforce_of_bank_limits()
         assert res["paused"] == 1
         assert _connection_status(connection["id"]) == "PAUSED"
 
@@ -199,3 +199,59 @@ class TestPausedState:
         # deletar o item na Pluggy dispara item/deleted — não pode reabrir o estado
         assert update_pluggy_open_finance_item_status(connection["provider_item_id"], "DELETED") == 0
         assert _connection_status(connection["id"]) == "PAUSED"
+
+
+class TestTetoPorPlano:
+    """Queda ENTRE planos pagos: o teto passou a valer para as conexões que já
+    existem, não só para a próxima.
+
+    Antes, `of_banks_max` só barrava conexão nova (`_enforce_bank_limit`, no
+    `/pluggy-item`). Quem tinha 5 bancos no Pro e descia para o Essencial
+    (teto 1) seguia com os 5 sincronizando e ocupando slot pago na Pluggy.
+
+    Controle negativo (medido): trocando o `[int(limit):]` por `[0:]` — pausar
+    sempre tudo — o teste do teto respeitado fica vermelho; voltando o filtro
+    para `tier == "free"`, os dois primeiros ficam vermelhos e os 9 antigos
+    seguem verdes.
+    """
+
+    def _cinco(self, user_id):
+        # Sufixos a partir de "b": o "a" é o do fixture, e repeti-lo faz UPSERT
+        # na mesma linha em vez de criar conexão nova — a primeira versão deste
+        # teste media 5 conexões achando que media 6.
+        return [_make_pluggy_connection(user_id, suffix=s) for s in "bcdef"]
+
+    def test_cai_do_pro_para_o_essencial_e_sobra_o_mais_antigo(self, sweep_env, monkeypatch):
+        uid, primeira, deleted = sweep_env
+        extras = self._cinco(uid)                      # 1 do fixture + 5 = 6
+        monkeypatch.setattr(plan_service, "get_user_limits", lambda u: {"of_banks_max": 1})
+
+        res = ofte.enforce_of_bank_limits()
+
+        assert res["paused"] == 5, "tinha que sobrar exatamente o teto (1)"
+        # A mais ANTIGA é a do fixture (menor id) — ela sobrevive.
+        assert _connection_status(primeira["id"]) != "PAUSED", "pausou a conexão mais antiga"
+        for c in extras:
+            assert _connection_status(c["id"]) == "PAUSED"
+        assert set(deleted) == {c["provider_item_id"] for c in extras}, (
+            "o item da Pluggy tem que ser apagado junto — senão o slot pago vaza"
+        )
+
+    def test_dentro_do_teto_nao_pausa_nada(self, sweep_env, monkeypatch):
+        """Positivo: sem ele, pausar tudo sempre passaria no grupo."""
+        uid, _, deleted = sweep_env
+        self._cinco(uid)
+        monkeypatch.setattr(plan_service, "get_user_limits", lambda u: {"of_banks_max": 6})
+
+        res = ofte.enforce_of_bank_limits()
+
+        assert res["paused"] == 0
+        assert deleted == []
+
+    def test_teto_none_e_ilimitado(self, sweep_env, monkeypatch):
+        uid, _, deleted = sweep_env
+        self._cinco(uid)
+        monkeypatch.setattr(plan_service, "get_user_limits", lambda u: {"of_banks_max": None})
+
+        assert ofte.enforce_of_bank_limits()["paused"] == 0
+        assert deleted == []


### PR DESCRIPTION
Parte 2 da #77, com a decisão que faltava: *"usuários que descem de plano devem se adequar aos limites do plano em que desceram"*.

Levantamento antes de escrever: **nenhum teto deste código agia retroativamente**. `check_can_create_pocket`, `check_can_create_card`, `_enforce_bank_limit` e o gate de energia dos agentes só barram **criar mais**. A regra é nova para o sistema inteiro, não só para os dois casos da issue.

Dos limites de `PlanLimits`, só **quatro** podem ficar estourados depois de uma queda — os outros (`history_days`, as flags de áudio/OFX/boletos, os contadores mensais) já barram no uso e não acumulam nada.

## Open Finance

A varredura que existia só tratava trial vencido (`tier == "free"`). Agora trata toda queda — e o caso antigo virou o caso `of_banks_max == 0`:

```python
excedentes = sorted(conns, key=lambda c: int(c["id"]))[int(limit):]
```

Com teto 0, `[0:]` devolve a lista toda. **Não é um ramo novo, é o mesmo ramo generalizado** — os 9 testes que já existiam passam sem uma expectativa alterada.

O buraco fechado: quem tinha 5 bancos no Pro e descia para o Essencial (teto 1) seguia com os 5 sincronizando, ocupando slot pago na Pluggy.

## Agentes — e uma correção do que eu te relatei antes

**Eu disse que "qualquer queda" deixava os agentes rodando. Estava errado.** A queda para um tier **sem** energia (Grátis e Essencial, orçamento 0) **já era tratada**: os runners filtram por `agent_kind_allowed` (`core/services/piggy_agents.py:180` e mais 7 lugares), que é exatamente `agents_energy_budget(uid) > 0`.

O buraco era só de **pago para pago**, e na escada de hoje existe um caso só: **Pro (14, cabem os 7) → Plus (4)**.

Varredura nova (`core/services/agents_energy_sweep.py`), no mesmo tick da de OF. **Pausa, não apaga**: `pause_agent` deixa a linha e o histórico de disparos, então voltar ao plano maior é um clique — mesma decisão de produto da conexão de OF pausada.

O tester do beta fica **de fora**, como o `agent_kind_allowed` já faz nos runners. Sem essa saída, a varredura desligaria justamente os agentes de quem está testando o beta.

## Cai o mais recente, nos dois

Ordena por `id` crescente e desliga do fim para o começo. O banco principal costuma ser o primeiro conectado, e o que veio depois foi o que o plano maior habilitou. Determinístico e explicável ao usuário.

## ⚠️ Caixinhas e cartões ficaram de fora — e é achado, não esquecimento

Você pediu que alcançasse também caixinhas e cartões. **O código não deixa**, e as duas razões são diferentes:

**Caixinha:** `db/pockets.py:698` — `delete_pocket` **recusa** apagar caixinha com saldo:

```python
if Decimal(str(p["balance"])) != Decimal("0"):
    raise ValueError("POCKET_NOT_ZERO")
```

O invariante do repositório é que o dinheiro sai antes. Uma rotina automática não consegue usar esse caminho, e as caixinhas acima do teto são justamente as que têm dinheiro. As saídas seriam: (a) só apagar as vazias — inútil na prática; (b) devolver o saldo à conta principal e então apagar — **isso é criar movimentação financeira automática**, exatamente o tipo de coisa que já barrou um PR antes neste repositório; (c) não apagar.

**Cartão:** `db/cards.py:266` — `delete_card` apaga sem condição, e por cascade leva `credit_bills` e `credit_transactions` junto, **incluindo fatura em aberto**. Apagar um cartão acima do teto apaga uma dívida que o usuário tem e o histórico de como ela nasceu.

Não implementei nenhum dos dois porque a operação é irreversível sobre dado financeiro e o parâmetro que falta é seu: **o que acontece com o saldo da caixinha, e o que acontece com a fatura em aberto do cartão?** Enquanto isso não tiver resposta, qualquer coisa que eu escrevesse ali seria eu inventando destino para o dinheiro de alguém.

Vale considerar também a terceira opção que ofereci e que segue disponível para esses dois: **não apagar, e sim marcar a conta como acima do teto e deixar o usuário escolher o que sai**. Para OF e agentes o automático é seguro porque é reversível; para caixinha e cartão não é.

## O que foi medido

Suíte: **1463 passam**, 0 falhas.

**Três controles negativos**, cada um derrubando o seu grupo:

| injeção | vermelhos |
|---|---|
| agentes "pausa sempre" (tirar a guarda **e** o `break`) | o positivo (`dentro_do_orcamento`) e o de ordem |
| agentes "nunca pausa" (esvaziar o laço) | o do Pro→Plus |
| OF de volta ao filtro `tier == "free"` | os **2** novos de OF; os **9** antigos seguem verdes |

**Positivos**, verdes em todas as versões: `test_dentro_do_teto_nao_pausa_nada` (OF), `test_teto_none_e_ilimitado` (OF) e `test_dentro_do_orcamento_nao_desliga_nada` (agentes). Sem eles, "pausar tudo sempre" passaria nos dois grupos.

Dois erros meus de medição no caminho, corrigidos e **registrados nos comentários dos testes** para não se repetirem:

1. o helper reusava o sufixo `"a"` do fixture, o que faz **UPSERT** em vez de conexão nova — o teste media 5 conexões achando que media 6;
2. a primeira injeção de controle nos agentes era **no-op**: eu tirei a guarda de orçamento de cima, mas o `break` no topo do laço fazia o mesmo trabalho, e os quatro testes passavam.

## Não medido

O tick real do agendador (`_open_finance_trial_expiry`, no monólito) não é exercitado por teste — as duas varreduras são chamadas diretas nos testes. O que ficou coberto é a decisão de quem cai; o que não ficou é a amarração no laço `while True` do startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
