### PR TITLE
fix(pb-nav): cronômetro só lê o localStorage com o motor ligado

### DIFF
--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -160,7 +160,16 @@
   // animação inteira até .finished). Com ?pbdebug=1 o resultado aparece na
   // PRÓPRIA tela — o aparelho é o único lugar onde isso se mede, e nem sempre
   // há Mac com o Web Inspector do lado.
-  const debug = (() => {
+  //
+  // `enabled &&` na frente, e isso não é otimização: este arquivo carrega em
+  // TODA página do domínio, e o gate acima promete que ele não encosta no
+  // localStorage quando o motor está desligado — é o que o
+  // `tests/frontend/pb_nav_gate.test.mjs` afirma, para que religar a leitura da
+  // chave legada `pbSpa` não passe batido. Sem o curto-circuito, o
+  // cronômetro lia `pbDebug` em toda visita ao site público e derrubava essa
+  // asserção. O flag só significa alguma coisa quando há troca de página para
+  // medir, e troca só existe com o motor ligado.
+  const debug = enabled && (() => {
     if (qs.get("pbdebug") === "0") { try { localStorage.removeItem("pbDebug"); } catch (_) {} }
     if (qs.get("pbdebug") === "1") { try { localStorage.setItem("pbDebug", "1"); } catch (_) {} }
     try { return localStorage.getItem("pbDebug") === "1"; } catch (_) { return false; }


### PR DESCRIPTION
**A `main` está vermelha.** O job `frontend` falha em `tests/frontend/pb_nav_gate.test.mjs`, e não é de nenhum PR aberto — reproduzi em `origin/main` puro:

```
✖ localStorage.pbSpa legado não liga em lugar nenhum e é apagado
  inApp=false: o gate não pode ler o localStorage
  + [ 'pbDebug' ]
  - []
```

## Causa

O `pb-nav.js` carrega em **toda** página do domínio, e o gate promete que ele não encosta no `localStorage` quando o motor de SPA está desligado. A asserção larga (`localReads == []`) existe de propósito, e o próprio teste diz por quê:

> O destravamento vem do gate, não do `removeItem`: ele não LÊ o localStorage. Sem esta asserção, religar a leitura da chave legada (ainda que hoje inócua, porque o `removeItem` roda antes) passaria batido.

O cronômetro por fase que o [#122](https://github.com/JapaLcK/Bot_Financeiro/pull/122) trouxe lê `pbDebug` no **topo do módulo** (`frontend/pb-nav.js:163`), **fora** do gate — que decide na linha 87. Resultado: passou a ler o localStorage em toda visita ao site público.

## Conserto

`enabled &&` na frente da IIFE. O flag só significa alguma coisa quando há troca de página para medir, e troca só existe com o motor ligado.

**Consequência aceita:** `?pbdebug=1` numa página sem SPA deixa de persistir a chave. Ali não havia nada para cronometrar — o stopwatch mede rede/scripts/mutate/vt de uma troca, que não acontece fora do motor.

**A alternativa era afrouxar o teste** para olhar só leituras de `pbSpa`. Não fiz: a asserção larga é justamente o que protege a promessa do arquivo inteiro, e trocar código por teste mais fraco é o caminho errado quando o código tem conserto de uma linha. Se a intenção do #122 era mesmo poder ligar o debug de fora do app, é o teste que deve mudar — e aí a mudança precisa ser deliberada, com a promessa reescrita.

## Medido

`npm run test:frontend`: **42 passam**.

**Controle negativo:** tirando o `enabled &&`, o teste do gate volta a falhar (5 passam, 1 falha) — a mesma falha que está na `main` agora.

## Por que passou batido

O CI do #122 (`e4b19b2`) foi **cancelado** pelo `cancel-in-progress` do workflow quando o merge seguinte chegou — os dois merges saíram com ~1 minuto de diferença. O vermelho só apareceu no run do #123 (`26a111d`), já depois de os dois estarem na `main`.

```
26a111d failure    20:48:35   ← #123
e4b19b2 cancelled  20:48:16   ← #122, o que introduziu o defeito
0db01b3 cancelled  20:47:14   ← #140
b0e4656 success    20:28:45
```

Vale como aviso separado: com `cancel-in-progress`, merges em rajada deixam commits na `main` **sem CI nenhum**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)