### PR TITLE
pb-nav: leitura do pbDebug vira preguiçosa e a suíte de frontend volta ao verde

### DIFF
--- a/frontend/pb-nav.js
+++ b/frontend/pb-nav.js
@@ -160,11 +160,20 @@
   // animação inteira até .finished). Com ?pbdebug=1 o resultado aparece na
   // PRÓPRIA tela — o aparelho é o único lugar onde isso se mede, e nem sempre
   // há Mac com o Web Inspector do lado.
-  const debug = (() => {
+  // PREGUIÇOSO de propósito. Como IIFE no escopo do módulo, isto lia o
+  // localStorage em TODA página que carrega o pb-nav — inclusive fora do modo
+  // app e com o motor desligado —, quebrando a garantia que o gate tem desde
+  // que existe: ele não toca storage antes de decidir. O cronômetro só é usado
+  // dentro de uma troca de página, ou seja, depois de o gate ter passado; ler
+  // ali não custa nada e não vaza para quem nunca liga o SPA.
+  let _debug = null;
+  function debugOn() {
+    if (_debug !== null) return _debug;
     if (qs.get("pbdebug") === "0") { try { localStorage.removeItem("pbDebug"); } catch (_) {} }
     if (qs.get("pbdebug") === "1") { try { localStorage.setItem("pbDebug", "1"); } catch (_) {} }
-    try { return localStorage.getItem("pbDebug") === "1"; } catch (_) { return false; }
-  })();
+    try { _debug = localStorage.getItem("pbDebug") === "1"; } catch (_) { _debug = false; }
+    return _debug;
+  }
 
   function stopwatch(key) {
     const t0 = performance.now();
@@ -180,7 +189,7 @@
         const total = Math.round(performance.now() - t0);
         const line = "[pb-nav] " + key + " " + via + " " + total + "ms (" + parts.join(", ") + ")";
         console.log(line);
-        if (debug) showDebug(line);
+        if (debugOn()) showDebug(line);
       },
     };
   }


### PR DESCRIPTION
Fecha #155.

## O que está quebrado

`tests/frontend/pb_nav_gate.test.mjs` está **vermelho na `main` hoje**. Reproduzido em cópia limpa (`git archive origin/main`), sem branch nenhum aplicado:

```
main pura: 42 tests, 41 pass, 1 fail
✖ localStorage.pbSpa legado não liga em lugar nenhum e é apagado
   AssertionError: inApp=false: o gate não pode ler o localStorage
   + [ 'pbDebug' ]   - []
```

Apareceu no CI do #143, que **não toca** `pb-nav.js`.

## A causa

O #122 (`e4b19b2`, cronômetro por fase) adicionou em `frontend/pb-nav.js:163`:

```js
const debug = (() => {
  ...
  return localStorage.getItem("pbDebug") === "1";
})();
```

Como IIFE no escopo do módulo, isso roda na **avaliação do arquivo** — em toda página que carrega o `pb-nav`, fora do modo app e com o motor desligado.

Isso viola uma garantia que existe desde o `c9e4adb` e está escrita no próprio teste:

> O destravamento vem do gate, não do `removeItem`: ele não LÊ o `localStorage`. Sem esta asserção, religar a leitura da chave legada (ainda que hoje inócua) passaria batido.

Alguém escreveu a guarda para impedir exatamente que o gate voltasse a ler storage. O PR seguinte reintroduziu a leitura — outra chave, outro motivo, mesmo contrato quebrado. O teste fez o trabalho dele.

## O conserto

`debugOn()` preguiçoso com cache, no lugar do IIFE. O cronômetro só é usado dentro de uma troca de página (`stopwatch.done`), ou seja **depois** de o gate ter passado — ler ali não vaza para quem nunca liga o SPA. O motivo está comentado no código, para ninguém "simplificar" de volta.

```
sem o conserto: 42 tests, 41 pass, 1 fail
com o conserto: 42 tests, 42 pass, 0 fail
```

## Impacto em produção

Baixo. É outra chave (`pbDebug`, não `pbSpa`), está em `try/catch`, e o gate **desligava** corretamente — os outros 5 casos do arquivo sempre passaram, inclusive "sem flag nenhuma o motor fica desligado". O que estava quebrado era a garantia de não tocar storage, não o comportamento.

Alto como sinal: com a suíte de frontend vermelha na `main`, ninguém consegue distinguir regressão nova de ruído — e combinado com a #78 o CI deixa de ser leitura confiável.

## Não verificado

Suíte Python não rodada: o diff é um `.js` que nenhum teste Python carrega. Nada exercitado em produção nem no app iOS — `pb-nav` só é reproduzível de verdade no WKWebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)