### PR TITLE
Trocar o plano da conta pelo painel de usuários do /admin

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1214,6 +1214,85 @@ async def fetch_admin_user_detail(user_id: int, admin_user: str = "admin") -> di
     }
 
 
+# Valores aceitos na coluna auth_accounts.plan, na ordem da escada. São os
+# MESMOS que o webhook da Stripe grava (_stored_plan_for_price): 'pro' é o
+# alias LEGADO do tier Plus (R$ 19,90) e 'pro_max' é o tier Pro. Gravar 'plus'
+# daria o mesmo tier no plan_service, mas furaria as queries que ainda casam o
+# literal 'pro' (engagement_scheduler) — por isso ele não é oferecido aqui.
+ADMIN_PLAN_VALUES: tuple[str, ...] = ("free", "essencial", "pro", "pro_max")
+ADMIN_PLAN_MONTHS_MAX = 120
+
+
+def set_account_plan(
+    plan: str,
+    months: int = 12,
+    *,
+    user_id: int | None = None,
+    email: str | None = None,
+) -> dict | None:
+    """Grava plano + validade de UMA conta. Síncrono: chame por asyncio.to_thread.
+
+    Fonte única do que "mudar de plano pelo admin" significa — o /admin/grant-pro
+    e o botão do painel de usuários passam os dois por aqui. Descer para 'free'
+    zera a validade; qualquer plano pago põe now() + months.
+
+    NÃO fala com a Stripe: se a conta tem assinatura viva, o próximo webhook
+    dela volta a mandar no par (plan, plan_expires_at). É grant/ajuste manual.
+
+    Devolve a linha atualizada, ou None se a conta não existe. Entrada inválida
+    levanta ValueError.
+    """
+    from db.connection import get_conn
+
+    plan = (plan or "").strip().lower()
+    if plan not in ADMIN_PLAN_VALUES:
+        raise ValueError("plano inválido (use " + ", ".join(ADMIN_PLAN_VALUES) + ").")
+    if (user_id is None) == (email is None):
+        raise ValueError("informe user_id OU email.")
+    if plan == "free":
+        months = 1                       # ignorado pelo CASE; só tipa o parâmetro
+    elif not 1 <= int(months) <= ADMIN_PLAN_MONTHS_MAX:
+        raise ValueError(f"months deve estar entre 1 e {ADMIN_PLAN_MONTHS_MAX}.")
+
+    if user_id is not None:
+        where, target = "user_id = %(target)s", int(user_id)
+    else:
+        where, target = "lower(email) = lower(%(target)s)", (email or "").strip()
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                update auth_accounts
+                   set plan = %(plan)s,
+                       plan_expires_at = case
+                           when %(plan)s::text = 'free' then null
+                           else now() + (%(months)s || ' months')::interval
+                       end,
+                       -- Plano pago sobre ex-assinante: status terminal
+                       -- (canceled/unpaid) viraria 'Cancelado' no painel de
+                       -- usuários mesmo com o plano vigente. Status em curso
+                       -- (active/trialing/past_due) fica intacto: a relação
+                       -- Stripe segue viva e os webhooks continuam donos dele.
+                       -- Descer para 'free' não mexe: 'canceled' num
+                       -- ex-assinante é a descrição correta.
+                       last_payment_status = case
+                           when %(plan)s::text <> 'free'
+                                and lower(coalesce(last_payment_status, ''))
+                                    in ('canceled', 'incomplete_expired', 'unpaid')
+                           then 'inactive'
+                           else last_payment_status
+                       end
+                 where {where}
+                returning user_id, email, plan, plan_expires_at, last_payment_status
+                """,
+                {"plan": plan, "months": int(months), "target": target},
+            )
+            row = cur.fetchone()
+        conn.commit()
+        return dict(row) if row else None
+
+
 async def log_admin_startup_warnings() -> None:
     # Coleta todos os avisos primeiro, depois faz UM único insert em batch.
     # Antes eram N chamadas sequenciais a log_system_event(), cada uma abrindo
@@ -1382,41 +1461,14 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
     ):
         """Concede plano Pro a uma conta (por e-mail) por N meses. Uso: conta
         demo do review da Apple / grants manuais.
-        Ex.: /admin/grant-pro?email=teste@teste.com"""
-        import asyncio
+        Ex.: /admin/grant-pro?email=teste@teste.com
 
-        from db.connection import get_conn
-
-        def _grant():
-            with get_conn() as conn:
-                with conn.cursor() as cur:
-                    cur.execute(
-                        """
-                        update auth_accounts
-                           set plan = 'pro',
-                               plan_expires_at = now() + (%s || ' months')::interval,
-                               -- Grant sobre ex-assinante: status terminal
-                               -- (canceled/unpaid) viraria 'Cancelado' no
-                               -- painel de usuários mesmo com o grant vigente.
-                               -- Status em curso (active/trialing/past_due)
-                               -- fica intacto: a relação Stripe segue viva e
-                               -- os webhooks continuam donos dele.
-                               last_payment_status = case
-                                   when lower(coalesce(last_payment_status, ''))
-                                        in ('canceled', 'incomplete_expired', 'unpaid')
-                                   then 'inactive'
-                                   else last_payment_status
-                               end
-                         where lower(email) = lower(%s)
-                        returning user_id, email, plan, plan_expires_at
-                        """,
-                        (int(months), email.strip()),
-                    )
-                    row = cur.fetchone()
-                conn.commit()
-                return row
-
-        row = await asyncio.to_thread(_grant)
+        A escrita é a mesma do painel de usuários (set_account_plan) — 'pro' é
+        o alias legado do tier Plus."""
+        try:
+            row = await asyncio.to_thread(set_account_plan, "pro", months, email=email)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc), "email": email}
         if not row:
             return {"ok": False, "error": "conta não encontrada", "email": email}
         return {
@@ -1514,6 +1566,59 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
         if data is None:
             raise HTTPException(status_code=404, detail="Conta não encontrada.")
         return JSONResponse(content=_json_safe(data))
+
+    @app.post("/admin/api/users/{user_id}/plan")
+    async def admin_api_user_set_plan(
+        user_id: int, request: Request, username: str = Depends(_get_current_admin)
+    ):
+        """Body: {"plan": "free"|"essencial"|"pro"|"pro_max", "months": 12}.
+
+        Upgrade/downgrade manual pelo painel de usuários. Mexe só no banco: a
+        assinatura na Stripe continua onde estava e o próximo webhook dela
+        volta a mandar no plano — por isso o painel avisa quando a conta tem
+        stripe_customer_id. Os gates que leem get_plan_tier passam a valer na
+        hora; o que já existe acima do teto do plano novo (bancos de Open
+        Finance, agentes) cai na varredura de downgrade, que roda a cada 6h.
+        """
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Corpo da requisição inválido.")
+        if not isinstance(payload, dict):
+            raise HTTPException(status_code=400, detail="Corpo da requisição inválido.")
+        months = payload.get("months")
+        try:
+            months = 12 if months is None else int(months)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=422, detail="months inválido.")
+        try:
+            row = await asyncio.to_thread(
+                set_account_plan, str(payload.get("plan") or ""), months, user_id=user_id
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        if not row:
+            raise HTTPException(status_code=404, detail="Conta não encontrada.")
+        await log_system_event(
+            "info",
+            "admin_plan_changed",
+            f"Plano da conta {user_id} → {row['plan']} (admin {username}).",
+            source="admin",
+            user_id=int(user_id),
+            details={
+                "plan": row["plan"],
+                "months": None if row["plan"] == "free" else months,
+                "expires_at": _json_safe(row["plan_expires_at"]),
+                "admin": username,
+            },
+        )
+        return JSONResponse(content=_json_safe({
+            "ok": True,
+            "user_id": row["user_id"],
+            "plan": row["plan"],
+            "plan_expires_at": row["plan_expires_at"],
+            "last_payment_status": row["last_payment_status"],
+        }))
 
     @app.delete("/admin/api/events/{event_id}")
     async def admin_delete_event(event_id: int, username: str = Depends(_get_current_admin)):

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -185,6 +185,11 @@ e gestão do programa de afiliados (comissões, payouts, PIX). As páginas
 `admin-login.html` e `admin-dashboard.html` **não carregam app-mode nem o shim de área
 segura**, de propósito.
 
+O drill-down de uma conta troca o plano à mão (`POST /admin/api/users/{id}/plan`
+→ `set_account_plan`, a mesma escrita do `/admin/grant-pro`): grava
+`plan`/`plan_expires_at` no banco e **não fala com a Stripe** — assinatura viva
+continua lá e o próximo webhook dela sobrescreve.
+
 ### Tarefas de fundo
 
 Sobem no startup do app quando `RUN_BACKGROUND_TASKS != "0"`: rendimento de

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -268,6 +268,12 @@ button:disabled { opacity: .6; cursor: wait; }
 }
 .detail-event .t { color: var(--soft); font-size: 11px; white-space: nowrap; }
 
+/* Editor de plano do drill-down. Os controles herdam o estilo global de
+   `button, select`; no celular a media query de tela pequena já os deixa 100%. */
+.plan-editor { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 16px; }
+.plan-hint { flex: 1 1 240px; min-width: 0; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.plan-hint.warn { color: #fcd34d; }
+
 /* ── Error list ──────────────────────────────────────────────────────── */
 .error-list  { display: grid; gap: 8px; }
 .error-item  {
@@ -1827,6 +1833,11 @@ function planLabel(p) {
   const k = String(p || 'free').trim().toLowerCase() || 'free';
   return PLAN_LABELS[k] || k;
 }
+// Valores GRAVÁVEIS na coluna plan, na ordem da escada — espelho do
+// ADMIN_PLAN_VALUES de core/admin_dashboard.py, comparado por
+// tests/test_admin_users_panel.py. 'plus' fica de fora de propósito: dá o
+// mesmo tier que 'pro', mas não é o que o webhook da Stripe grava.
+const PLAN_WRITE_VALUES = ['free', 'essencial', 'pro', 'pro_max'];
 // Origem do cadastro (auth_accounts.signup_source). null = conta anterior à coluna.
 const SOURCE_LABELS = { web: 'Web', app: 'App iOS', google: 'Google', google_app: 'Google (app)' };
 function sourceLabel(s) {
@@ -2077,6 +2088,11 @@ function renderUserDetail(data) {
     p.insight_email_opt_out && 'insights',
     p.whatsapp_updates_opt_out && 'updates WA',
   ].filter(Boolean).join(', ') || 'nenhum';
+  // Plano pré-selecionado no editor. 'plus' (valor antigo em algumas contas)
+  // cai no 'pro', que é o mesmo tier e é o valor que gravamos.
+  const stored = String(p.plan || 'free').trim().toLowerCase();
+  const planNow = stored === 'plus' ? 'pro'
+    : (PLAN_WRITE_VALUES.includes(stored) ? stored : 'free');
 
   $id('user-detail').innerHTML = `
     <div class="detail-head" style="display:flex;align-items:center;gap:10px;margin:4px 0 14px">
@@ -2102,6 +2118,23 @@ function renderUserDetail(data) {
       ${item('WhatsApp', (p.has_whatsapp_identity || p.phone_status === 'confirmed') ? 'conectado' : (p.phone_status || 'não conectado'))}
       ${item('IA no mês', fInt(p.ai_messages_this_month))}
       ${item('Opt-outs', optOuts)}
+    </div>
+
+    <div class="detail-section-title">Alterar plano</div>
+    <div class="plan-editor">
+      <select id="plan-new" aria-label="Novo plano"
+              onchange="$id('plan-months').disabled = this.value === 'free'">
+        ${PLAN_WRITE_VALUES.map(v => `
+          <option value="${v}" ${v === planNow ? 'selected' : ''}>${esc(planLabel(v))}</option>`).join('')}
+      </select>
+      <select id="plan-months" aria-label="Validade do plano" ${planNow === 'free' ? 'disabled' : ''}>
+        ${[1, 3, 6, 12, 24, 60].map(m => `
+          <option value="${m}" ${m === 12 ? 'selected' : ''}>${m} ${m === 1 ? 'mês' : 'meses'}</option>`).join('')}
+      </select>
+      <button class="btn-primary" id="plan-apply" onclick="applyPlanChange(${Number(p.user_id)})">Aplicar</button>
+      <span class="plan-hint ${p.stripe_customer_id ? 'warn' : ''}">${p.stripe_customer_id
+        ? 'Conta com cliente na Stripe: isto muda só o banco — a assinatura continua lá e o próximo webhook dela sobrescreve o plano. Cancele/troque no Stripe também.'
+        : 'Vale na hora para os limites do plano. Bancos de Open Finance e agentes acima do teto novo caem na varredura de downgrade (a cada 6h).'}</span>
     </div>
 
     <div class="detail-section-title">Uso (contagens — sem conteúdo financeiro)</div>
@@ -2130,6 +2163,40 @@ function renderUserDetail(data) {
         <span class="t" title="${fDate(lg.created_at)}">${fRelTime(lg.created_at)}</span>
       </div>`).join('') : '<div class="empty">Sem logins registrados.</div>'}
   `;
+}
+
+/* Upgrade/downgrade manual. Só o banco: a assinatura na Stripe segue de pé (é
+   o que o aviso do editor diz), então isto serve a grant/suporte, não a
+   cancelamento de cobrança. */
+async function applyPlanChange(userId) {
+  const plan = $id('plan-new').value;
+  const months = Number($id('plan-months').value) || 12;
+  const validade = plan === 'free'
+    ? 'sem validade'
+    : `por ${months} ${months === 1 ? 'mês' : 'meses'}`;
+  if (!confirm(`Mudar a conta ${userId} para ${planLabel(plan)} (${validade})?\n\n`
+    + 'A assinatura na Stripe NÃO é alterada por aqui.')) return;
+
+  const btn = $id('plan-apply');
+  btn.disabled = true;
+  try {
+    const res = await fetch(`/admin/api/users/${userId}/plan`, {
+      method: 'POST',
+      headers: { ...authH(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan, months }),
+    });
+    if (res.status === 401) { window.location.href = '/admin/login'; return; }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) { alert(data.detail || 'Erro ao alterar o plano.'); btn.disabled = false; return; }
+    // Redesenha o drill-down (plano/status novos) e a lista atrás dele, que
+    // mostra plano e expiração na linha da conta.
+    await openUserDetail(userId);
+    loadUsers();
+  } catch (e) {
+    console.error('plan-change:', e);
+    alert('Falha de rede ao alterar o plano.');
+    btn.disabled = false;
+  }
 }
 
 /* Listeners do modal */

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -563,3 +563,122 @@ def test_user_detail_404_for_unknown_account():
     client = _admin_client()
     response = client.get("/admin/api/users/999999999999")
     assert response.status_code == 404
+
+
+# ── Mudança de plano pelo painel (POST /admin/api/users/{id}/plan) ─────────
+
+def _set_plan(client: TestClient, uid: int, **body):
+    return client.post(
+        f"/admin/api/users/{uid}/plan",
+        headers={dashboard.CSRF_HEADER_NAME: "test-admin-csrf"},
+        json=body,
+    )
+
+
+def _stored_plan(uid: int) -> tuple[str, object, str]:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select plan, plan_expires_at, last_payment_status "
+                "from auth_accounts where user_id = %s",
+                (uid,),
+            )
+            row = cur.fetchone()
+    return row["plan"], row["plan_expires_at"], row["last_payment_status"]
+
+
+def test_set_plan_requires_admin_auth(panel_accounts):
+    _tag, uids = panel_accounts
+    client = TestClient(dashboard.app, base_url="https://testserver")
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, "test-admin-csrf")
+    assert _set_plan(client, uids["free"], plan="pro_max").status_code == 401
+    assert _stored_plan(uids["free"])[0] == "free"
+
+
+def test_set_plan_sobe_e_desce(panel_accounts):
+    """Upgrade põe validade no futuro; downgrade para Grátis zera a validade —
+    senão a conta continuaria com data de expiração de um plano que ela não
+    tem mais."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+    uid = uids["free"]
+
+    up = _set_plan(client, uid, plan="pro_max", months=3)
+    assert up.status_code == 200, up.text
+    assert up.json()["plan"] == "pro_max"
+    plan, expires, _pay = _stored_plan(uid)
+    assert plan == "pro_max"
+    assert expires is not None
+    assert timedelta(days=80) < (expires - NOW) < timedelta(days=100)
+    assert client.get(f"/admin/api/users/{uid}").json()["profile"]["plan"] == "pro_max"
+
+    down = _set_plan(client, uid, plan="free")
+    assert down.status_code == 200, down.text
+    plan, expires, _pay = _stored_plan(uid)
+    assert plan == "free"
+    assert expires is None
+    assert client.get(f"/admin/api/users/{uid}").json()["profile"]["account_status"] == "free"
+
+
+def test_set_plan_pago_limpa_status_terminal_mas_downgrade_nao(panel_accounts):
+    """Mesma regra do /admin/grant-pro (os dois passam por set_account_plan):
+    plano pago sobre ex-assinante limpa o 'canceled' — senão o painel mostraria
+    'Cancelado' com plano vigente. Descer para Grátis não mexe: 'canceled' num
+    ex-assinante é a descrição correta."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+    uid = uids["canceled"]                      # plan free + last_payment_status canceled
+
+    assert _set_plan(client, uid, plan="essencial", months=1).status_code == 200
+    assert _stored_plan(uid)[2] == "inactive"
+    assert client.get(f"/admin/api/users/{uid}").json()["profile"]["account_status"] == "granted"
+
+    # Assinante em curso não perde o status: o webhook continua dono dele.
+    uid_pagante = uids["paying"]
+    assert _set_plan(client, uid_pagante, plan="pro_max", months=1).status_code == 200
+    assert _stored_plan(uid_pagante)[2] == "active"
+
+    # Descer para Grátis não escreve na coluna: quem estava em trial continua
+    # 'trialing' (o webhook é quem fecha esse ciclo).
+    uid_trial = uids["trial"]
+    assert _set_plan(client, uid_trial, plan="free").status_code == 200
+    assert _stored_plan(uid_trial) == ("free", None, "trialing")
+
+
+@pytest.mark.parametrize("body", [
+    {"plan": "plus"},          # tier certo, valor que o webhook NÃO grava
+    {"plan": "pro-max"},
+    {"plan": ""},
+    {"plan": "pro", "months": 0},
+    {"plan": "pro", "months": 999},
+])
+def test_set_plan_rejeita_entrada_invalida(panel_accounts, body):
+    """A conta não pode ficar com um valor de plan que o resto do código não
+    reconhece — 'plus' é o caso traiçoeiro: dá o mesmo tier, mas some das
+    queries que casam o literal 'pro'."""
+    _tag, uids = panel_accounts
+    client = _admin_client()
+    uid = uids["free"]
+    assert _set_plan(client, uid, **body).status_code == 422
+    assert _stored_plan(uid)[0] == "free"
+
+
+def test_set_plan_404_para_conta_inexistente():
+    client = _admin_client()
+    assert _set_plan(client, 999999999999, plan="pro", months=1).status_code == 404
+
+
+def test_planos_gravaveis_do_html_espelham_o_backend():
+    """O <select> do painel é HTML estático — não importa a lista do Python.
+    Se as duas divergirem, o admin escolhe um plano que a API recusa (ou deixa
+    de ver um que existe)."""
+    import pathlib
+    import re
+
+    html = (pathlib.Path(dashboard.__file__).parent / "admin-dashboard.html").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"const PLAN_WRITE_VALUES = \[([^\]]*)\]", html)
+    assert match, "PLAN_WRITE_VALUES sumiu de frontend/admin-dashboard.html"
+    do_html = tuple(re.findall(r"'([a-z_]+)'", match.group(1)))
+    assert do_html == admin_dashboard.ADMIN_PLAN_VALUES


### PR DESCRIPTION
## O que muda

O drill-down de uma conta no modal **Usuários & assinaturas** do `/admin` mostrava o plano e não deixava mexer nele. Subir ou descer alguém exigia o `/admin/grant-pro` (só `pro`, só por e-mail) ou SQL na mão. Agora tem um seletor de plano com upgrade e downgrade no próprio painel.

### Backend — `core/admin_dashboard.py`

- **`set_account_plan()`** vira a fonte única do que "mudar de plano pelo admin" significa: grava `plan` + `plan_expires_at` (descer para Grátis zera a validade) e limpa `last_payment_status` terminal quando o plano novo é pago. O **`/admin/grant-pro` passa a chamá-la** em vez de manter a segunda cópia do mesmo `UPDATE` — era a mesma regra de `last_payment_status` em dois lugares, exatamente o que o §0.1 do `CLAUDE.md` alerta.
- **`POST /admin/api/users/{user_id}/plan`**, body `{plan, months}`: auth de admin + CSRF pelo middleware global, `422` para entrada inválida, `404` para conta inexistente, e um `system_event_logs` (`admin_plan_changed`) registrando qual admin fez.

Valores graváveis: `free` / `essencial` / `pro` (= Plus, alias legado) / `pro_max` (= Pro) — os **mesmos** que o webhook do Stripe grava (`_stored_plan_for_price`). `plus` é recusado de propósito: dá o mesmo tier no `plan_service`, mas sumiria da query `where plan = 'pro'` do `engagement_scheduler`.

### Frontend — `frontend/admin-dashboard.html`

Seção "Alterar plano" no drill-down: `<select>` de plano (pré-selecionado no atual, com `plus` legado caindo em `pro`), `<select>` de validade (1–60 meses, desabilitado quando Grátis), botão com confirmação. Conta com `stripe_customer_id` ganha aviso de que isto **não** mexe na assinatura. Aplicar recarrega o drill-down e a lista atrás dele.

## Escopo, explícito

- **Só banco.** Cancelar cobrança continua sendo no Stripe — o painel avisa em vez de fingir que resolve. Assinatura viva significa que o próximo webhook sobrescreve o plano.
- **Downgrade retroativo** segue o caminho do #153: os limites do plano novo valem na hora nos gates que leem `get_plan_tier`; o que já existe acima do teto (bancos de Open Finance, agentes) cai na varredura de downgrade, que roda a cada 6h. Mesmo comportamento de um downgrade vindo do Stripe.

## Testes

6 testes novos em `tests/test_admin_users_panel.py`:

| teste | o que prova |
|---|---|
| `test_set_plan_requires_admin_auth` | 401 sem sessão de admin, e a conta não muda |
| `test_set_plan_sobe_e_desce` | **positivo**: upgrade põe validade no futuro; downgrade para Grátis zera |
| `test_set_plan_pago_limpa_status_terminal_mas_downgrade_nao` | plano pago sobre ex-assinante vira "Cortesia"; assinante em curso mantém `active`; descer não escreve na coluna (trial continua `trialing`) |
| `test_set_plan_rejeita_entrada_invalida` (×5) | **negativo**: `plus`, `pro-max`, `""`, `months=0`, `months=999` → 422 e plano intacto |
| `test_set_plan_404_para_conta_inexistente` | 404 |
| `test_planos_gravaveis_do_html_espelham_o_backend` | o `<select>` do HTML estático × `ADMIN_PLAN_VALUES` do Python — a duplicação inevitável do §0.7 |

## ⚠️ Não verificado

**Não rodei a suíte.** O worktree é Windows e não tem Python (só o stub do WindowsApps) nem Postgres — não houve baseline nem execução. Os testes acima foram escritos, não vistos passar nem falhar; o CI é o primeiro sinal deles. A UI também não foi exercitada em navegador: `admin-dashboard.html` é servido com `no-store` e sem `StaticFiles`, então só depois do deploy.

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
