### PR TITLE
Uma chave só de categoria: a barra do donut e quem a lê

### DIFF
--- a/core/budget_alerts.py
+++ b/core/budget_alerts.py
@@ -22,11 +22,14 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Iterable
 
-from db.connection import get_conn, cat_norm_sql, CAT_CANON_ORDER
+from db.connection import get_conn, cat_key_sql, CAT_CANON_ORDER
 from utils_text import fmt_brl
 
-# Comparacao de categoria case- E acento-insensivel (fonte unica: db/connection.py).
-_CAT_EQ = f"{cat_norm_sql('categoria')} = {cat_norm_sql('%s')}"
+# Casamento de categoria pela `cat_key_sql` (fonte unica: db/connection.py) — a
+# mesma chave do donut, do total e da lista. Sem ela o orcamento chamado
+# "sem categoria" nunca dispararia alerta, por mais que a barra do dashboard
+# passasse de 100%.
+_CAT_EQ = f"{cat_key_sql('categoria')} = {cat_key_sql('%s')}"
 
 
 THRESHOLDS = (80, 100, 120)

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -10,7 +10,7 @@ from utils_text import (
     fmt_brl, is_internal_category, canonicalize_category_label, normalize_text,
     merchant_key, RECURRING_SUGGESTION_BLOCKLIST, CATEGORY_LABELS,
 )
-from utils_date import extract_date_from_text, today_tz, parse_period_from_text, month_range_today
+from utils_date import day_tz, extract_date_from_text, today_tz, parse_period_from_text, month_range_today
 from core.services.category_service import infer_category, learn_from_inference
 from parsers import (
     parse_receita_despesa_natural,
@@ -608,7 +608,11 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
         # formata data de forma amigável
         if criado is not None:
             try:
-                d = criado.date() if hasattr(criado, "date") else __import__("datetime").datetime.fromisoformat(str(criado)).date()
+                # `day_tz` (utils_date), não `.date()`: o cru devolve o dia no fuso da
+                # SESSÃO do Postgres (UTC no Railway), e um gasto das 21:30 em São
+                # Paulo saía aqui como o dia SEGUINTE — enquanto "liste <categoria>"
+                # (`list_launches_by_category`, mesma fonte) dizia o dia certo.
+                d = day_tz(criado) if hasattr(criado, "date") else __import__("datetime").datetime.fromisoformat(str(criado)).date()
                 if d == today:
                     data_str = "hoje"
                 elif d == today - timedelta(days=1):

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from psycopg.types.json import Json, Jsonb
 
 import db_support as _db_support
-from utils_date import _tz
+from utils_date import _tz, day_tz
 
 from .connection import get_conn, cat_norm_sql
 from .users import ensure_user, ensure_user_tx
@@ -699,7 +699,13 @@ def list_launches_by_category(
             "valor": float(r["valor"] or 0),
             "categoria": r["categoria"],
             "descricao": r["descricao"],
-            "data": r["dt"].date() if hasattr(r["dt"], "date") else r["dt"],
+            # `day_tz` (utils_date), não `.date()`: o cru devolve o dia no fuso da
+            # SESSÃO do Postgres (UTC no Railway), e um gasto das 21:30 em São Paulo
+            # sairia aqui como o dia SEGUINTE — o MESMO lançamento com dia diferente
+            # em "liste <categoria>" e em "meus últimos lançamentos" (`list_launches`,
+            # core/handlers/launches.py, que já usa `day_tz`). A perna do crédito é
+            # naive (`purchased_at::timestamp`) e passa direto.
+            "data": day_tz(r["dt"]),
             "fonte": r["fonte"],
             "user_seq": r["user_seq"],
         }

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -10,7 +10,7 @@ from psycopg.types.json import Json, Jsonb
 import db_support as _db_support
 from utils_date import _tz, day_tz
 
-from .connection import get_conn, cat_norm_sql
+from .connection import get_conn, cat_norm_sql, cat_key_sql
 from .users import ensure_user, ensure_user_tx
 
 
@@ -587,7 +587,12 @@ def list_launches_by_category(
       `by_bill_month` que `get_largest_expenses` expõe nunca foi chamado com
       False aqui, e uma janela alternativa que ninguém pede é só mais um SQL pra
       manter em sincronia.
-    - Match de categoria case- e acento-insensível (mesmo `cat_norm_sql`).
+    - Match de categoria pela `cat_key_sql` — case- e acento-insensível E com o
+      vazio colapsado em 'sem categoria', a MESMA expressão que o donut do
+      dashboard agrupa. Contra a coluna crua, `norm(NULL)` é NULL e nunca casa
+      com nada: a barra "sem categoria" dizia R$ 100,00 e esta lista abria
+      vazia (medido). Chega em produção pela importação de cartão do Open
+      Finance, que grava `credit_transactions.categoria` NULO.
     - Tipos internos de gerenciamento (criar_caixinha & cia) ficam de fora;
       `is_internal_movement` NÃO é filtrado de propósito: senão "liste os
       lançamentos em investimento_aporte" voltaria vazio. Consequência: numa
@@ -606,9 +611,9 @@ def list_launches_by_category(
     """
     ensure_user(user_id)
 
-    _cat = cat_norm_sql("categoria")
-    _cat_ct = cat_norm_sql("ct.categoria")
-    _arg = cat_norm_sql("%s")
+    _cat = cat_key_sql("categoria")
+    _cat_ct = cat_key_sql("ct.categoria")
+    _arg = cat_key_sql("%s")
 
     params: list = [user_id, categoria]
     launch_filters = ""

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -10,7 +10,7 @@ from psycopg.types.json import Json, Jsonb
 import db_support as _db_support
 from utils_date import _tz, day_tz
 
-from .connection import get_conn, cat_key_sql
+from .connection import get_conn, cat_key_sql, TIPO_DESPESA_SQL
 from .users import ensure_user, ensure_user_tx
 
 
@@ -435,7 +435,8 @@ def get_largest_expenses(
     retorna os lançamentos/compras de maior valor, um por um.
 
     Fontes:
-      - launches.tipo='despesa' AND is_internal_movement=false (por criado_em)
+      - launches: `TIPO_DESPESA_SQL` (a moderna e a legada 'saida', mesma
+        forma do total e da lista) AND is_internal_movement=false (por criado_em)
       - credit_transactions onde is_refund=false
 
     `by_bill_month`:
@@ -503,7 +504,7 @@ def get_largest_expenses(
                            'launches' as fonte
                     from launches
                     where user_id = %s
-                      and tipo = 'despesa'
+                      and {TIPO_DESPESA_SQL}
                       and is_internal_movement = false
                       {cat_filter}
                       and criado_em >= %s and criado_em < %s

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -10,7 +10,7 @@ from psycopg.types.json import Json, Jsonb
 import db_support as _db_support
 from utils_date import _tz, day_tz
 
-from .connection import get_conn, cat_norm_sql, cat_key_sql
+from .connection import get_conn, cat_key_sql
 from .users import ensure_user, ensure_user_tx
 
 
@@ -459,11 +459,16 @@ def get_largest_expenses(
     end_excl = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
     end_date_excl = end_date + timedelta(days=1)  # janela meio-aberta em period_end
 
+    # `cat_key_sql` e não `cat_norm_sql`: mesma chave da lista e do total da
+    # categoria (`list_launches_by_category`; `sum_spent_in_category_period`,
+    # db/budgets.py). Os "5 maiores" saem ao lado daquele total na resposta do
+    # bot — com a chave crua, a categoria SEM nome trazia total e lista com
+    # valor e nenhum "maior gasto".
     cat_filter = (
-        f"and {cat_norm_sql('categoria')} = {cat_norm_sql('%s')}" if categoria else ""
+        f"and {cat_key_sql('categoria')} = {cat_key_sql('%s')}" if categoria else ""
     )
     cat_filter_ct = (
-        f"and {cat_norm_sql('ct.categoria')} = {cat_norm_sql('%s')}" if categoria else ""
+        f"and {cat_key_sql('ct.categoria')} = {cat_key_sql('%s')}" if categoria else ""
     )
 
     if by_bill_month:

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -21,13 +21,19 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_norm_sql, CAT_META_SQL
+# `cat_norm_sql` continua aqui de propósito: o GROUP BY do `get_top_categories`
+# e o join com `cat_meta` (linhas ~388/399) casam contra o CATÁLOGO
+# (`user_categories.name`, normalizado por `CAT_META_SQL` com a mesma
+# expressão). Trocar só um lado quebraria o join; e o rótulo daquele grupo é
+# a grafia crua do lançamento, não a chave — mudar isso é outro assunto.
+from .connection import get_conn, cat_norm_sql, cat_key_sql, CAT_META_SQL
 
-# Comparação de categoria case- E acento-insensível (fonte única: db/connection.py).
-_CAT_EQ = "{} = {}".format(cat_norm_sql("COALESCE(categoria, '')"), cat_norm_sql("%s"))
-_CAT_CT_EQ = "{} = {}".format(
-    cat_norm_sql("COALESCE(ct.categoria, '')"), cat_norm_sql("%s")
-)
+# Casamento de categoria pela `cat_key_sql` (fonte única, db/connection.py). Isto
+# aqui já colapsava o vazio por conta própria, mas sob o rótulo `''` — então a
+# pergunta "sem categoria" (o nome que o donut mostra) não casava. A chave
+# compartilhada mantém o `''` casando e passa a aceitar o rótulo também.
+_CAT_EQ = f"{cat_key_sql('categoria')} = {cat_key_sql('%s')}"
+_CAT_CT_EQ = f"{cat_key_sql('ct.categoria')} = {cat_key_sql('%s')}"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -22,13 +22,20 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_norm_sql, cat_key_sql, CAT_META_SQL, CAT_CANON_ORDER
+from .connection import get_conn, cat_key_sql, CAT_META_SQL, CAT_CANON_ORDER
 from .users import ensure_user
 
 
-# Comparação de categoria case- E acento-insensível (fonte única: db/connection.py).
-_CAT_EQ    = f"{cat_norm_sql('categoria')} = {cat_norm_sql('%s')}"
-_CAT_CT_EQ = f"{cat_norm_sql('ct.categoria')} = {cat_norm_sql('%s')}"
+# Casamento de categoria: `cat_key_sql` (fonte única, db/connection.py) — case-,
+# acento-insensível E com o vazio colapsado em 'sem categoria'. Para categoria
+# escrita é idêntico ao `cat_norm_sql`; só o vazio muda, e ele precisa mudar: o
+# donut rotula a linha sem categoria como "sem categoria" e anexa o orçamento de
+# mesmo nome, então um leitor que casasse a coluna crua dizia "0 gasto" no mesmo
+# mês em que o donut mostrava a barra em 20% do orçamento (medido). Vale também
+# para `category_budgets.categoria`, onde as duas expressões dão o mesmo valor —
+# usar uma só evita a próxima divergência.
+_CAT_EQ    = f"{cat_key_sql('categoria')} = {cat_key_sql('%s')}"
+_CAT_CT_EQ = f"{cat_key_sql('ct.categoria')} = {cat_key_sql('%s')}"
 
 # Mesma lista que `core/budget_alerts.py` filtra como interna.
 _INTERNAL_CATEGORIES = {
@@ -334,26 +341,24 @@ def get_budgets_status_for_month(
                   where user_id=%s
                 ),
                 spent_launches as (
-                  select {cat_norm_sql('categoria')} as cat, sum(valor)::numeric as total
+                  select {cat_key_sql('categoria')} as cat, sum(valor)::numeric as total
                   from launches
                   where user_id=%s
                     and tipo in ('despesa', 'saida')
                     and is_internal_movement = false
                     and date_part('year',  criado_em) = %s
                     and date_part('month', criado_em) = %s
-                    and categoria is not null
-                  group by {cat_norm_sql('categoria')}
+                  group by {cat_key_sql('categoria')}
                 ),
                 spent_cards as (
-                  select {cat_norm_sql('ct.categoria')} as cat, sum(ct.valor)::numeric as total
+                  select {cat_key_sql('ct.categoria')} as cat, sum(ct.valor)::numeric as total
                   from credit_transactions ct
                   join credit_bills b on b.id = ct.bill_id
                   where ct.user_id=%s
                     and ct.is_refund = false
                     and date_part('year',  b.period_end) = %s
                     and date_part('month', b.period_end) = %s
-                    and ct.categoria is not null
-                  group by {cat_norm_sql('ct.categoria')}
+                  group by {cat_key_sql('ct.categoria')}
                 ),
                 spent_all as (
                   select cat, sum(total) as total from (
@@ -367,14 +372,14 @@ def get_budgets_status_for_month(
                 )
                 select
                   b.categoria,
-                  {cat_norm_sql('b.categoria')} as cat_key,
+                  {cat_key_sql('b.categoria')} as cat_key,
                   b.budget::float as budget,
                   coalesce(sa.total, 0)::float as spent,
                   uc.emoji,
                   uc.color
                 from budgets b
-                left join spent_all sa on sa.cat = {cat_norm_sql('b.categoria')}
-                left join cat_meta uc on uc.cat = {cat_norm_sql('b.categoria')}
+                left join spent_all sa on sa.cat = {cat_key_sql('b.categoria')}
+                left join cat_meta uc on uc.cat = {cat_key_sql('b.categoria')}
                 order by lower(b.categoria)
                 """,
                 (

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -22,7 +22,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_norm_sql, CAT_META_SQL, CAT_CANON_ORDER
+from .connection import get_conn, cat_norm_sql, cat_key_sql, CAT_META_SQL, CAT_CANON_ORDER
 from .users import ensure_user
 
 
@@ -234,15 +234,22 @@ def sum_spent_in_category_period(
       - cartão: is_refund=false, atribuído ao período pelo MÊS DA FATURA
         (credit_bills.period_end). Assim um gasto parcelado conta uma parcela
         por mês, e não os R$ totais na data da compra.
-    Comparação de categoria case- e acento-insensível.
+    Comparação de categoria pela `cat_key_sql`: case-, acento-insensível E com o
+    vazio colapsado em 'sem categoria', a MESMA chave da lista
+    (`list_launches_by_category`) e do donut. Tem que ser a mesma porque o
+    `_total_despesa` do bot (core/handlers/launches.py) subtrai um do outro e
+    chama a diferença de movimentação interna: com `cat_norm_sql` cru aqui, uma
+    despesa SEM categoria dava total 0 contra lista R$ 120,00, e o bot respondia
+    "não conta como gasto — é movimentação interna" sobre um gasto de verdade.
+    Para categoria escrita as duas expressões são idênticas; só o vazio muda.
     """
     ensure_user(user_id)
     start_dt = datetime.combine(start_date, datetime.min.time())
     end_excl = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
     end_date_excl = end_date + timedelta(days=1)  # janela meio-aberta em period_end
-    _cat = cat_norm_sql("categoria")
-    _cat_ct = cat_norm_sql("ct.categoria")
-    _arg = cat_norm_sql("%s")
+    _cat = cat_key_sql("categoria")
+    _cat_ct = cat_key_sql("ct.categoria")
+    _arg = cat_key_sql("%s")
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/db/budgets.py
+++ b/db/budgets.py
@@ -22,7 +22,9 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
-from .connection import get_conn, cat_key_sql, CAT_META_SQL, CAT_CANON_ORDER
+from .connection import (
+    get_conn, cat_key_sql, CAT_META_SQL, CAT_CANON_ORDER, TIPO_DESPESA_SQL,
+)
 from .users import ensure_user
 
 
@@ -237,7 +239,9 @@ def sum_spent_in_category_period(
 
     Usado pela resposta "quanto gastei na categoria X" do bot — espelha a
     atribuição do DASHBOARD pra os números baterem:
-      - launches: tipo='despesa', is_internal_movement=false, por criado_em
+      - launches: `TIPO_DESPESA_SQL` (a moderna e a legada 'saida' — mesma
+        forma da lista, senão a diferença entre os dois vira "movimentação
+        interna" no `_total_despesa`), is_internal_movement=false, por criado_em
       - cartão: is_refund=false, atribuído ao período pelo MÊS DA FATURA
         (credit_bills.period_end). Assim um gasto parcelado conta uma parcela
         por mês, e não os R$ totais na data da compra.
@@ -265,7 +269,7 @@ def sum_spent_in_category_period(
                   coalesce((
                     select sum(valor) from launches
                     where user_id=%s
-                      and tipo = 'despesa'
+                      and {TIPO_DESPESA_SQL}
                       and {_cat} = {_arg}
                       and is_internal_movement = false
                       and criado_em >= %s

--- a/db/connection.py
+++ b/db/connection.py
@@ -137,6 +137,40 @@ def cat_norm_sql(expr: str) -> str:
     return f"translate(lower({expr}), '{_CAT_ACCENTS_FROM}', '{_CAT_ACCENTS_TO}')"
 
 
+# Rótulo de quem está SEM categoria. NULL e '' são a mesma coisa pro usuário —
+# `db/analytics.py` já colapsa os dois assim.
+CAT_VAZIA_LABEL = "sem categoria"
+
+
+def cat_key_sql(expr: str) -> str:
+    """Chave de AGRUPAMENTO e de CASAMENTO de categoria: `cat_norm_sql` com o
+    vazio colapsado em `CAT_VAZIA_LABEL`.
+
+    Existe porque as duas pontas tinham que ser a MESMA expressão e não eram: o
+    donut do dashboard agrupava por `COALESCE(categoria,'sem categoria')` e a
+    lista de lançamentos casava contra a coluna CRUA. Resultado: a barra "sem
+    categoria" dizia R$ 100 e a lista abria vazia — `norm(NULL)` não é
+    'sem categoria'. Chega em produção pela importação de cartão do Open Finance
+    sem categoria do provedor (`db/open_finance.py` → `add_imported_credit_purchase`,
+    que grava `credit_transactions.categoria` NULO).
+    """
+    return cat_norm_sql(f"coalesce(nullif({expr}, ''), '{CAT_VAZIA_LABEL}')")
+
+
+# `has_time`: dá pra confiar na HORA do lançamento ou só na data?
+# Fonte única — a Visão Geral (query 4 do dashboard) e a lista de lançamentos de
+# uma categoria (`list_launches_by_category`) precisam responder igual, senão o
+# mesmo gasto aparece "10/03, 00:30" numa tela e "09/03" na outra (o `::date` de
+# um timestamptz sai no fuso da SESSÃO do Postgres, não em America/Sao_Paulo).
+LAUNCH_HAS_TIME_SQL = """
+        CASE
+          WHEN source = 'ofx' THEN false
+          WHEN source = 'open_finance'
+            THEN COALESCE((efeitos->>'time_known')::boolean, false)
+          ELSE true
+        END"""
+
+
 # Catálogo deduplicado por nome normalizado, pronto pra virar CTE de join.
 # `user_categories` é única só no par EXATO (user_id, name), então 'cafe' e
 # 'café' coexistem: um join por valor normalizado contra a tabela crua devolve

--- a/db/connection.py
+++ b/db/connection.py
@@ -157,6 +157,28 @@ def cat_key_sql(expr: str) -> str:
     return cat_norm_sql(f"coalesce(nullif({expr}, ''), '{CAT_VAZIA_LABEL}')")
 
 
+# ── `tipo` de `launches`: a forma legada conta junto ──────────────────────────
+# Nenhum escritor de hoje grava 'saida'/'entrada' (ver o comentário de
+# `_TIPO_ALIASES`, db/accounts.py), mas muito read path ainda trata esses valores
+# como tipo. Fonte ÚNICA em SQL das duas formas — `tests/test_tipo_aliases.py`
+# compara esta tabela com o `_TIPO_ALIASES` do Python, que é a mesma regra do
+# outro lado (§0.7: duplicação inevitável exige teste que compare as duas).
+#
+# Por que importa: as barras de categoria do dashboard contam
+# `tipo IN ('despesa','saida')` e o "Gastos do mês" lia só `despesa`. Com uma
+# linha legada na base, a soma das barras e o gráfico diário passavam do total
+# exibido, e o "sobrou este mês" saía maior do que é.
+TIPO_DESPESA_SQL = "tipo IN ('despesa', 'saida')"
+TIPO_RECEITA_SQL = "tipo IN ('receita', 'entrada')"
+
+# Colapsa a forma legada na moderna. Para quem AGRUPA por tipo (o "Gastos do
+# mês", a evolução por mês); quem só FILTRA usa os dois de cima.
+TIPO_CANON_SQL = (
+    f"CASE WHEN {TIPO_DESPESA_SQL} THEN 'despesa' "
+    f"WHEN {TIPO_RECEITA_SQL} THEN 'receita' ELSE tipo END"
+)
+
+
 # `has_time`: dá pra confiar na HORA do lançamento ou só na data?
 # Fonte única — a Visão Geral (query 4 do dashboard) e a lista de lançamentos de
 # uma categoria (`list_launches_by_category`) precisam responder igual, senão o

--- a/db/connection.py
+++ b/db/connection.py
@@ -160,7 +160,7 @@ def cat_key_sql(expr: str) -> str:
 # ── `tipo` de `launches`: a forma legada conta junto ──────────────────────────
 # Nenhum escritor de hoje grava 'saida'/'entrada' (ver o comentário de
 # `_TIPO_ALIASES`, db/accounts.py), mas muito read path ainda trata esses valores
-# como tipo. Fonte ÚNICA em SQL das duas formas — `tests/test_tipo_aliases.py`
+# como tipo. Fonte ÚNICA em SQL das duas formas — `tests/test_tipo_legado_no_dashboard.py`
 # compara esta tabela com o `_TIPO_ALIASES` do Python, que é a mesma regra do
 # outro lado (§0.7: duplicação inevitável exige teste que compare as duas).
 #
@@ -180,10 +180,11 @@ TIPO_CANON_SQL = (
 
 
 # `has_time`: dá pra confiar na HORA do lançamento ou só na data?
-# Fonte única — a Visão Geral (query 4 do dashboard) e a lista de lançamentos de
-# uma categoria (`list_launches_by_category`) precisam responder igual, senão o
-# mesmo gasto aparece "10/03, 00:30" numa tela e "09/03" na outra (o `::date` de
-# um timestamptz sai no fuso da SESSÃO do Postgres, não em America/Sao_Paulo).
+# Quem decide se o front escreve "10/03, 00:30" ou só "10/03" — as duas telas que
+# leem `has_time` (`dashboard.js` e `home.html`) saem daqui. A lista do bot
+# (`list_launches_by_category`) NÃO usa esta expressão: ela nunca imprime hora, e
+# o dia dela vem do `day_tz` em Python (utils_date), não de um `::date` em SQL —
+# que sairia no fuso da SESSÃO do Postgres, não em America/Sao_Paulo.
 LAUNCH_HAS_TIME_SQL = """
         CASE
           WHEN source = 'ofx' THEN false

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -74,7 +74,6 @@ from db.connection import (
     TIPO_DESPESA_SQL,
     TIPO_RECEITA_SQL,
     cat_key_sql,
-    cat_norm_sql,
 )
 from db.open_finance import BANK_ACCOUNTS_SQL
 from db import (
@@ -691,7 +690,7 @@ async def get_financial_data(
         # DESC vem por último e ganha o dict. Trocar para ASC inverte o
         # desempate: a tela passa a mostrar um limite e o bot a responder outro.
         _q(
-            f"SELECT categoria, budget, {cat_norm_sql('categoria')} AS cat_key "
+            f"SELECT categoria, budget, {cat_key_sql('categoria')} AS cat_key "
             "FROM category_budgets WHERE user_id = %s ORDER BY categoria DESC",
             (user_id,),
         ),

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -67,7 +67,7 @@ from core.sessions import (
     revoke_session,
     touch_session,
 )
-from db.connection import cat_norm_sql
+from db.connection import CAT_VAZIA_LABEL, LAUNCH_HAS_TIME_SQL, cat_key_sql, cat_norm_sql
 from db.open_finance import BANK_ACCOUNTS_SQL
 from db import (
     accrue_all_pockets,
@@ -291,8 +291,10 @@ async def list_users() -> list:
             return await cur.fetchall()
 
 # Chave de agrupamento do donut de categorias: case- E acento-insensível, pra
-# "cafe da manha" e "café da manhã" virarem UMA fatia (fonte: db/connection.py).
-_CAT_KEY_DONUT = cat_norm_sql("COALESCE(categoria, 'sem categoria')")
+# "cafe da manha" e "café da manhã" virarem UMA fatia. É a MESMA expressão que
+# `list_launches_by_category` usa pra casar — clicar numa barra tem que abrir
+# exatamente as linhas que ela somou (fonte: db/connection.py::cat_key_sql).
+_CAT_KEY_DONUT = cat_key_sql("categoria")
 
 
 def _month_range(year: int, month: int):
@@ -505,12 +507,7 @@ async def get_financial_data(
                        NULL::int AS installment_no,
                        NULL::date AS bill_period_end,
                        posted_at,
-                       CASE
-                         WHEN source = 'ofx' THEN false
-                         WHEN source = 'open_finance'
-                           THEN COALESCE((efeitos->>'time_known')::boolean, false)
-                         ELSE true
-                       END AS has_time
+                       {LAUNCH_HAS_TIME_SQL} AS has_time
                 FROM launches
                 WHERE user_id = %s
                   AND criado_em >= %s AND criado_em < %s
@@ -556,7 +553,7 @@ async def get_financial_data(
         # `bill.period_end`, igual query 5).
         _q(
             f"""
-            SELECT (array_agg(COALESCE(categoria, 'sem categoria')
+            SELECT (array_agg(COALESCE(NULLIF(categoria, ''), '{CAT_VAZIA_LABEL}')
                               ORDER BY dt DESC))[1] AS categoria,
                    {_CAT_KEY_DONUT} AS cat_key,
                    SUM(valor) AS total,
@@ -565,7 +562,14 @@ async def get_financial_data(
                 SELECT categoria, valor, 1 AS cnt, criado_em AS dt
                 FROM launches
                 WHERE user_id = %s
-                  AND tipo = 'despesa'
+                  -- Plural: a linha LEGADA `tipo='saida'` é despesa e entrava
+                  -- na LISTA da categoria (`_TIPO_ALIASES`, db/accounts.py) sem
+                  -- entrar nesta barra. Uma 'saida' de R$ 100 + uma 'despesa' de
+                  -- R$ 5 davam donut R$ 5 × lista R$ 105 na mesma categoria e
+                  -- mês. Nenhum escritor de hoje grava 'saida' (db/accounts.py:540),
+                  -- então em base nova isto não muda número nenhum; em base com
+                  -- linha antiga, o donut passa a mostrar o valor completo.
+                  AND tipo IN ('despesa', 'saida')
                   AND is_internal_movement = false
                   AND criado_em >= %s AND criado_em < %s
                 UNION ALL

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -67,7 +67,15 @@ from core.sessions import (
     revoke_session,
     touch_session,
 )
-from db.connection import CAT_VAZIA_LABEL, LAUNCH_HAS_TIME_SQL, cat_key_sql, cat_norm_sql
+from db.connection import (
+    CAT_VAZIA_LABEL,
+    LAUNCH_HAS_TIME_SQL,
+    TIPO_CANON_SQL,
+    TIPO_DESPESA_SQL,
+    TIPO_RECEITA_SQL,
+    cat_key_sql,
+    cat_norm_sql,
+)
 from db.open_finance import BANK_ACCOUNTS_SQL
 from db import (
     accrue_all_pockets,
@@ -527,8 +535,13 @@ async def get_financial_data(
         # em vez de tudo no mês da compra. Pagamento da fatura é launch interna,
         # então não dobra.
         _q(
-            """
-            SELECT tipo, SUM(valor) AS total FROM (
+            f"""
+            -- `TIPO_CANON_SQL`: a linha legada 'saida' é despesa e 'entrada' é
+            -- receita. As barras de categoria (query 6) e o gráfico diário
+            -- (query 9) já contam as duas formas; se este total lesse só
+            -- 'despesa', a soma das barras PASSARIA do "Gastos do mês" e o
+            -- "sobrou este mês" sairia maior do que é.
+            SELECT {TIPO_CANON_SQL} AS tipo, SUM(valor) AS total FROM (
                 SELECT tipo, valor
                 FROM launches
                 WHERE user_id = %s
@@ -542,7 +555,7 @@ async def get_financial_data(
                   AND ct.is_refund = false
                   AND b.period_end >= %s AND b.period_end < %s
             ) merged
-            GROUP BY tipo
+            GROUP BY 1
             """,
             (
                 user_id, query_start, month_end,
@@ -591,7 +604,7 @@ async def get_financial_data(
         ),
         # 7) Allocations (aportes do mês)
         _q(
-            """
+            f"""
             SELECT
                 CASE
                     WHEN tipo IN ('deposito_caixinha', 'saque_caixinha') THEN 'pockets'
@@ -608,7 +621,7 @@ async def get_financial_data(
               AND (
                 tipo IN ('aporte_investimento', 'deposito_caixinha',
                          'saque_caixinha', 'resgate_investimento')
-                OR (tipo = 'despesa' AND LOWER(REPLACE(COALESCE(categoria, ''), ' ', '_')) IN (
+                OR ({TIPO_DESPESA_SQL} AND LOWER(REPLACE(COALESCE(categoria, ''), ' ', '_')) IN (
                     'investimentos', 'investimento_aporte', 'criptomoedas'
                 ))
               )
@@ -919,15 +932,20 @@ async def get_monthly_history(
         async with conn.cursor() as cur:
             await cur.execute(
                 f"""
+                -- `TIPO_CANON_SQL` pelo mesmo motivo do "Gastos do mês"
+                -- (query 5 de `get_financial_data`): a barra do mês corrente
+                -- desta evolução tem que bater com aquele número, e com
+                -- `tipo IN ('receita','despesa')` a linha legada 'saida' ficava
+                -- de fora só aqui.
                 SELECT TO_CHAR(DATE_TRUNC('month', criado_em), 'YYYY-MM') AS mes,
-                       tipo, SUM(valor) AS total
+                       {TIPO_CANON_SQL} AS tipo, SUM(valor) AS total
                 FROM launches
                 WHERE user_id = %s
                   AND criado_em >= DATE_TRUNC('month', NOW()) - INTERVAL '{n_months - 1} months'
                   {limit_clause}
-                  AND tipo IN ('receita', 'despesa')
+                  AND ({TIPO_RECEITA_SQL} OR {TIPO_DESPESA_SQL})
                   AND is_internal_movement = false
-                GROUP BY mes, tipo
+                GROUP BY mes, 2
                 ORDER BY mes
                 """,
                 params,

--- a/tests/test_categoria_vazia_donut_e_lista.py
+++ b/tests/test_categoria_vazia_donut_e_lista.py
@@ -25,8 +25,9 @@ import asyncio
 from datetime import datetime, time
 
 import db
+from core.handlers import launches as h
 from db.connection import CAT_VAZIA_LABEL
-from utils_date import today_tz
+from utils_date import month_range_today, today_tz
 import frontend.finance_bot_websocket_custom as dashboard
 
 
@@ -73,3 +74,38 @@ def test_categoria_normal_continua_casando(pro_user_id):
 
     rows, resumo = db.list_launches_by_category(pro_user_id, CAT_VAZIA_LABEL)
     assert len(rows) == 1 and resumo["despesa"] == 100.0, (rows, resumo)
+
+
+def test_o_total_da_categoria_nao_chama_gasto_de_movimentacao_interna(pro_user_id):
+    """O total e a lista têm que descrever as MESMAS linhas.
+
+    `_total_despesa` (core/handlers/launches.py) subtrai
+    `sum_spent_in_category_period` do resumo da lista e atribui a diferença a
+    movimentação interna. Com a chave crua só de um lado, a despesa sem
+    categoria dava total 0 × lista R$ 120,00, e o bot respondia — medido, com a
+    lista já consertada e o total ainda não:
+
+        🔁 R$ 120,00 movimentados em **sem categoria** neste mês.
+        Não conta como gasto — é movimentação interna.
+
+    sobre um gasto de verdade. Pior que a lista vazia de antes: número certo com
+    explicação errada. Controle NEGATIVO: volte as três `cat_key_sql` de
+    `sum_spent_in_category_period` (db/budgets.py) para `cat_norm_sql` — este
+    teste fica vermelho.
+    """
+    _grava_sem_categoria(pro_user_id, 120, None)
+    start, end = month_range_today()
+
+    total = db.sum_spent_in_category_period(pro_user_id, CAT_VAZIA_LABEL, start, end)
+    _, resumo = db.list_launches_by_category(
+        pro_user_id, CAT_VAZIA_LABEL, start, end, tipo="despesa", limit=1,
+    )
+    assert total == resumo["despesa"] == 120.0, (total, resumo)
+
+    # os "5 maiores" saem ao lado desse total na mesma resposta
+    maiores = db.get_largest_expenses(pro_user_id, start, end, categoria=CAT_VAZIA_LABEL)
+    assert len(maiores) == 1 and maiores[0]["valor"] == 120.0, maiores
+
+    resposta = h._total_despesa(pro_user_id, CAT_VAZIA_LABEL, start, end, "neste mês")
+    assert "movimenta" not in resposta.lower(), resposta
+    assert "120,00" in resposta, resposta

--- a/tests/test_categoria_vazia_donut_e_lista.py
+++ b/tests/test_categoria_vazia_donut_e_lista.py
@@ -31,14 +31,15 @@ from utils_date import month_range_today, today_tz
 import frontend.finance_bot_websocket_custom as dashboard
 
 
-def _grava_sem_categoria(user_id, valor, categoria):
+def _grava_sem_categoria(user_id, valor, categoria, interna=False):
     """`add_launch_and_update_balance` sempre grava alguma categoria; a linha sem
     categoria entra por SQL, que é como o importador do Open Finance a cria."""
     with db.get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "insert into launches (user_id, tipo, valor, categoria, nota, "
-            "criado_em, is_internal_movement) values (%s,'despesa',%s,%s,%s,%s,false)",
-            (user_id, valor, categoria, "importado", datetime.combine(today_tz(), time(10, 0))),
+            "criado_em, is_internal_movement) values (%s,'despesa',%s,%s,%s,%s,%s)",
+            (user_id, valor, categoria, "importado",
+             datetime.combine(today_tz(), time(10, 0)), interna),
         )
         conn.commit()
 
@@ -109,3 +110,55 @@ def test_o_total_da_categoria_nao_chama_gasto_de_movimentacao_interna(pro_user_i
     resposta = h._total_despesa(pro_user_id, CAT_VAZIA_LABEL, start, end, "neste mês")
     assert "movimenta" not in resposta.lower(), resposta
     assert "120,00" in resposta, resposta
+
+
+def test_spend_query_soma_gasto_real_e_deixa_interna_de_fora(pro_user_id):
+    """A pergunta como o usuário digita, com as duas linhas que precisam se
+    separar: uma despesa REAL sem categoria e uma movimentação INTERNA sem
+    categoria, no mesmo mês e na mesma categoria.
+
+    O gasto real tem que entrar no "você gastou"; a interna tem que ficar fora
+    dele e ser anunciada à parte. Antes da chave compartilhada o total dava 0 e
+    as DUAS viravam "movimentação interna" — os R$ 120,00 reais junto.
+
+    Controle NEGATIVO: `_CAT_EQ`/`_CAT_CT_EQ` ou as três `cat_key_sql` de
+    `sum_spent_in_category_period` (db/budgets.py) de volta para `cat_norm_sql`
+    → este teste fica vermelho.
+    """
+    _grava_sem_categoria(pro_user_id, 120, None)
+    _grava_sem_categoria(pro_user_id, 80, None, interna=True)
+
+    resposta = h.spend_query(pro_user_id, "quanto gastei em sem categoria")
+
+    # (2) a despesa real conta como GASTO
+    assert "R$ 120,00" in resposta, resposta
+    # (3) a interna fica FORA do gasto, e aparece separada
+    assert "R$ 80,00" in resposta and "movimenta" in resposta.lower(), resposta
+    # e o total do gasto não é a soma das duas
+    assert "R$ 200,00" not in resposta, resposta
+
+    start, end = month_range_today()
+    assert db.sum_spent_in_category_period(pro_user_id, CAT_VAZIA_LABEL, start, end) == 120.0
+
+
+def test_orcamento_sem_categoria_ve_o_mesmo_gasto_do_donut(pro_user_id):
+    """Um orçamento PODE se chamar "sem categoria" — `upsert_budget` aceita.
+
+    Medido antes do conserto: o donut mostrava `budget 500,00 / 20%` sobre
+    R$ 100,00, e `sum_spent_in_category_this_month('sem categoria')` devolvia
+    `0.0` no mesmo mês. Duas telas, o mesmo orçamento, consumo diferente.
+
+    Controle NEGATIVO: `_CAT_EQ`/`_CAT_CT_EQ` (db/budgets.py) de volta para
+    `cat_norm_sql` → o assert do `this_month` fica vermelho.
+    """
+    db.upsert_budget(pro_user_id, CAT_VAZIA_LABEL, 500)
+    _grava_sem_categoria(pro_user_id, 100, "")
+
+    barras = _donut(pro_user_id)
+    assert barras == {CAT_VAZIA_LABEL: 100.0}, barras
+
+    assert db.sum_spent_in_category_this_month(pro_user_id, CAT_VAZIA_LABEL) == 100.0
+
+    status = db.get_budgets_status_for_month(pro_user_id)
+    linha = [c for c in status["budgets"] if c["categoria"] == CAT_VAZIA_LABEL]
+    assert linha and linha[0]["spent"] == 100.0, status

--- a/tests/test_categoria_vazia_donut_e_lista.py
+++ b/tests/test_categoria_vazia_donut_e_lista.py
@@ -31,14 +31,14 @@ from utils_date import month_range_today, today_tz
 import frontend.finance_bot_websocket_custom as dashboard
 
 
-def _grava_sem_categoria(user_id, valor, categoria, interna=False):
+def _grava(user_id, valor, categoria, tipo="despesa", interna=False):
     """`add_launch_and_update_balance` sempre grava alguma categoria; a linha sem
     categoria entra por SQL, que é como o importador do Open Finance a cria."""
     with db.get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "insert into launches (user_id, tipo, valor, categoria, nota, "
-            "criado_em, is_internal_movement) values (%s,'despesa',%s,%s,%s,%s,%s)",
-            (user_id, valor, categoria, "importado",
+            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, tipo, valor, categoria, "importado",
              datetime.combine(today_tz(), time(10, 0)), interna),
         )
         conn.commit()
@@ -51,8 +51,8 @@ def _donut(user_id):
 
 
 def test_lista_encontra_o_que_o_donut_mostra(pro_user_id):
-    _grava_sem_categoria(pro_user_id, 100, None)   # NULL: o que o Open Finance grava
-    _grava_sem_categoria(pro_user_id, 20, "")      # '' — o mesmo pro usuário
+    _grava(pro_user_id, 100, None)   # NULL: o que o Open Finance grava
+    _grava(pro_user_id, 20, "")      # '' — o mesmo pro usuário
 
     assert _donut(pro_user_id) == {CAT_VAZIA_LABEL: 120.0}, _donut(pro_user_id)
 
@@ -68,7 +68,7 @@ def test_categoria_normal_continua_casando(pro_user_id):
         pro_user_id, "despesa", 50, "compra", None, categoria="Alimentação",
         criado_em=datetime.combine(today_tz(), time(11, 0)),
     )
-    _grava_sem_categoria(pro_user_id, 100, None)
+    _grava(pro_user_id, 100, None)
 
     rows, resumo = db.list_launches_by_category(pro_user_id, "alimentacao")
     assert len(rows) == 1 and resumo["despesa"] == 50.0, (rows, resumo)
@@ -94,7 +94,7 @@ def test_o_total_da_categoria_nao_chama_gasto_de_movimentacao_interna(pro_user_i
     `sum_spent_in_category_period` (db/budgets.py) para `cat_norm_sql` — este
     teste fica vermelho.
     """
-    _grava_sem_categoria(pro_user_id, 120, None)
+    _grava(pro_user_id, 120, None)
     start, end = month_range_today()
 
     total = db.sum_spent_in_category_period(pro_user_id, CAT_VAZIA_LABEL, start, end)
@@ -125,8 +125,8 @@ def test_spend_query_soma_gasto_real_e_deixa_interna_de_fora(pro_user_id):
     `sum_spent_in_category_period` (db/budgets.py) de volta para `cat_norm_sql`
     → este teste fica vermelho.
     """
-    _grava_sem_categoria(pro_user_id, 120, None)
-    _grava_sem_categoria(pro_user_id, 80, None, interna=True)
+    _grava(pro_user_id, 120, None)
+    _grava(pro_user_id, 80, None, interna=True)
 
     resposta = h.spend_query(pro_user_id, "quanto gastei em sem categoria")
 
@@ -152,7 +152,7 @@ def test_orcamento_sem_categoria_ve_o_mesmo_gasto_do_donut(pro_user_id):
     `cat_norm_sql` → o assert do `this_month` fica vermelho.
     """
     db.upsert_budget(pro_user_id, CAT_VAZIA_LABEL, 500)
-    _grava_sem_categoria(pro_user_id, 100, "")
+    _grava(pro_user_id, 100, "")
 
     barras = _donut(pro_user_id)
     assert barras == {CAT_VAZIA_LABEL: 100.0}, barras
@@ -162,3 +162,61 @@ def test_orcamento_sem_categoria_ve_o_mesmo_gasto_do_donut(pro_user_id):
     status = db.get_budgets_status_for_month(pro_user_id)
     linha = [c for c in status["budgets"] if c["categoria"] == CAT_VAZIA_LABEL]
     assert linha and linha[0]["spent"] == 100.0, status
+
+
+# ── a forma legada do `tipo` nos leitores de categoria ─────────────────────
+
+def test_linha_legada_saida_conta_como_gasto_nas_duas_categorias(pro_user_id):
+    """`sum_spent_in_category_period` e `get_largest_expenses` fixavam
+    `tipo = 'despesa'` enquanto a lista da mesma categoria conta
+    `('despesa','saida')` (`_TIPO_ALIASES`). A diferença entre os dois é o que o
+    `_total_despesa` chama de movimentação interna — então uma despesa legada
+    saía como "não conta como gasto" e sumia dos "Maiores gastos".
+
+    Vale nas DUAS categorias, e são caminhos diferentes: a escrita passa pelo
+    `cat_filter`/`_CAT_EQ` com um nome, e a vazia só é alcançável desde que a
+    chave compartilhada entrou. Zero linhas legadas na produção às 27/08/2026
+    21:50 UTC — isto fecha a classe, não apaga um incêndio.
+
+    Controle NEGATIVO: `{TIPO_DESPESA_SQL}` de volta para `tipo = 'despesa'` em
+    db/budgets.py (`sum_spent_in_category_period`) ou em db/accounts.py
+    (`get_largest_expenses`) — este teste fica vermelho.
+    """
+    _grava(pro_user_id, 100, "mercado", tipo="saida")
+    _grava(pro_user_id, 70, None, tipo="saida")
+    start, end = month_range_today()
+
+    for categoria, esperado in (("mercado", 100.0), (CAT_VAZIA_LABEL, 70.0)):
+        total = db.sum_spent_in_category_period(pro_user_id, categoria, start, end)
+        _, resumo = db.list_launches_by_category(
+            pro_user_id, categoria, start, end, tipo="despesa", limit=1,
+        )
+        assert total == resumo["despesa"] == esperado, (categoria, total, resumo)
+
+        maiores = db.get_largest_expenses(pro_user_id, start, end, categoria=categoria)
+        assert [m["valor"] for m in maiores] == [esperado], (categoria, maiores)
+
+        resposta = h._total_despesa(pro_user_id, categoria, start, end, "neste mês")
+        assert "movimenta" not in resposta.lower(), (categoria, resposta)
+
+
+def test_despesa_moderna_responde_exatamente_o_mesmo(pro_user_id):
+    """Controle POSITIVO do alias legado — a base de 100% da produção hoje.
+
+    Sem linha legada nenhuma, os três leitores têm que devolver o que sempre
+    devolveram; um alias que mudasse o número da despesa moderna seria pior que
+    o descasamento que ele conserta.
+    """
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 45, "compra", None, categoria="mercado",
+        criado_em=datetime.combine(today_tz(), time(12, 0)),
+    )
+    _grava(pro_user_id, 30, None)                     # moderna, sem categoria
+    _grava(pro_user_id, 25, "mercado", interna=True)  # interna: fora do gasto
+    start, end = month_range_today()
+
+    assert db.sum_spent_in_category_period(pro_user_id, "mercado", start, end) == 45.0
+    assert db.sum_spent_in_category_period(pro_user_id, CAT_VAZIA_LABEL, start, end) == 30.0
+    assert [m["valor"] for m in
+            db.get_largest_expenses(pro_user_id, start, end, categoria="mercado")] == [45.0]
+    assert db.sum_spent_in_category_this_month(pro_user_id, "mercado") == 45.0

--- a/tests/test_categoria_vazia_donut_e_lista.py
+++ b/tests/test_categoria_vazia_donut_e_lista.py
@@ -1,0 +1,75 @@
+"""A barra "sem categoria" do donut e a lista daquela categoria têm que casar.
+
+O donut do dashboard agrupa por `cat_key_sql` (db/connection.py), que colapsa
+NULL e '' no rótulo `sem categoria`. A lista de uma categoria
+(`list_launches_by_category`, db/accounts.py) casava contra a coluna CRUA via
+`cat_norm_sql`, e `translate(lower(NULL))` é NULL — que não é igual a nada, nem a
+si mesmo. Medido antes do conserto: donut `[('sem categoria', 100.0)]`, lista
+`rows=0` tanto para 'sem categoria' quanto para 'outros'.
+
+Isso chega em produção pela importação de cartão do Open Finance
+(`add_imported_credit_purchase`, db/open_finance.py), que grava
+`credit_transactions.categoria` NULO quando o provedor não manda categoria.
+
+Controle NEGATIVO: troque as três `cat_key_sql` de volta por `cat_norm_sql` em
+`list_launches_by_category` — os DOIS testes ficam vermelhos (0 linhas contra
+R$ 120,00 e R$ 100,00 nas barras). Medido.
+Controle POSITIVO: o primeiro assert de `test_categoria_normal_continua_casando`
+(categoria escrita, com acento e caixa trocados → 1 linha, R$ 50,00) é o caminho
+de sempre; ele passa com o conserto e passaria sem ele. Está aqui porque a
+mudança RESTRINGE o casamento, e uma chave que só achasse o vazio — ou que
+varresse a linha sem categoria para dentro de 'alimentação' — seria pior que o
+bug original.
+"""
+import asyncio
+from datetime import datetime, time
+
+import db
+from db.connection import CAT_VAZIA_LABEL
+from utils_date import today_tz
+import frontend.finance_bot_websocket_custom as dashboard
+
+
+def _grava_sem_categoria(user_id, valor, categoria):
+    """`add_launch_and_update_balance` sempre grava alguma categoria; a linha sem
+    categoria entra por SQL, que é como o importador do Open Finance a cria."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "insert into launches (user_id, tipo, valor, categoria, nota, "
+            "criado_em, is_internal_movement) values (%s,'despesa',%s,%s,%s,%s,false)",
+            (user_id, valor, categoria, "importado", datetime.combine(today_tz(), time(10, 0))),
+        )
+        conn.commit()
+
+
+def _donut(user_id):
+    hoje = today_tz()
+    d = asyncio.run(dashboard.get_financial_data(user_id, year=hoje.year, month=hoje.month))
+    return {c["categoria"]: c["total"] for c in d["expense_categories"]}
+
+
+def test_lista_encontra_o_que_o_donut_mostra(pro_user_id):
+    _grava_sem_categoria(pro_user_id, 100, None)   # NULL: o que o Open Finance grava
+    _grava_sem_categoria(pro_user_id, 20, "")      # '' — o mesmo pro usuário
+
+    assert _donut(pro_user_id) == {CAT_VAZIA_LABEL: 120.0}, _donut(pro_user_id)
+
+    rows, resumo = db.list_launches_by_category(pro_user_id, CAT_VAZIA_LABEL)
+    assert len(rows) == 2, rows
+    assert resumo["despesa"] == 120.0, resumo
+
+
+def test_categoria_normal_continua_casando(pro_user_id):
+    """Controle POSITIVO: a chave nova ainda é case- e acento-insensível, e não
+    varre a linha sem categoria para dentro de uma categoria escrita."""
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 50, "compra", None, categoria="Alimentação",
+        criado_em=datetime.combine(today_tz(), time(11, 0)),
+    )
+    _grava_sem_categoria(pro_user_id, 100, None)
+
+    rows, resumo = db.list_launches_by_category(pro_user_id, "alimentacao")
+    assert len(rows) == 1 and resumo["despesa"] == 50.0, (rows, resumo)
+
+    rows, resumo = db.list_launches_by_category(pro_user_id, CAT_VAZIA_LABEL)
+    assert len(rows) == 1 and resumo["despesa"] == 100.0, (rows, resumo)

--- a/tests/test_dia_das_listagens_no_fuso.py
+++ b/tests/test_dia_das_listagens_no_fuso.py
@@ -1,0 +1,43 @@
+"""O dia impresso de um lançamento é o de São Paulo nas DUAS listagens.
+
+`criado_em` é `timestamptz`: o `datetime` que o psycopg devolve vem no fuso da
+SESSÃO do Postgres — UTC no Railway, `America/New_York` no banco de teste local
+—, nunca no fuso do app. `.date()` cru dava o dia daquele fuso, então um gasto
+das 23:30 em São Paulo saía como o dia SEGUINTE para "liste mercado", enquanto
+"meus últimos lançamentos" (já convertido com `day_tz`, PR #158) dizia o dia
+certo: o MESMO lançamento com duas datas.
+
+Controle NEGATIVO: troque `day_tz(r["dt"])` de volta por `r["dt"].date()` em
+db/accounts.py (`list_launches_by_category`) — o primeiro assert fica vermelho.
+Controle POSITIVO: o segundo assert é o caminho que o PR já consertou; ele prova
+que a conversão continua de pé lá, e é a metade que o negativo NÃO derruba.
+
+Os dois horários existem porque o teste tem que discriminar nos dois bancos:
+00:30 em São Paulo já é o dia anterior em New York (−1h) e 23:30 já é o dia
+seguinte em UTC (+3h). Com um só, o teste passaria de graça em um dos dois.
+"""
+from datetime import datetime, time, timedelta
+
+import db
+from core.handlers import launches as h
+from utils_date import _tz, today_tz
+
+
+def _grava(uid, dia, hora, minuto, nota):
+    db.add_launch_and_update_balance(
+        uid, "despesa", 10, nota, None, categoria="mercado",
+        criado_em=datetime.combine(dia, time(hora, minuto), tzinfo=_tz()),
+    )
+
+
+def test_o_dia_e_o_de_sao_paulo_nas_duas_listagens(pro_user_id):
+    dia = today_tz() - timedelta(days=10)   # nem "hoje" nem "ontem": sai como data
+    _grava(pro_user_id, dia, 0, 30, "madrugada")
+    _grava(pro_user_id, dia, 23, 30, "noite")
+
+    rows, _ = db.list_launches_by_category(pro_user_id, "mercado")
+    assert len(rows) == 2, rows
+    assert {r["data"] for r in rows} == {dia}, [r["data"] for r in rows]
+
+    texto = h.list_launches(pro_user_id, limit=10)
+    assert texto.count(dia.strftime("%d/%m")) == 2, texto

--- a/tests/test_tipo_legado_no_dashboard.py
+++ b/tests/test_tipo_legado_no_dashboard.py
@@ -1,0 +1,143 @@
+"""Uma linha legada `tipo='saida'` não pode fazer as barras passarem do total.
+
+`launches.tipo` tem duas formas para a mesma coisa: a moderna ('despesa',
+'receita') e a legada ('saida', 'entrada'). Nenhum escritor de hoje grava a
+legada (o comentário de `_TIPO_ALIASES`, db/accounts.py), mas muito read path
+ainda a trata como tipo — e os números do MÊS no dashboard vinham de queries que
+discordavam entre si:
+
+| número na tela        | de onde vem                       | lia          |
+|-----------------------|-----------------------------------|--------------|
+| barras de categoria   | query 6 de `get_financial_data`   | as duas      |
+| gráfico de gastos/dia | query 9                           | as duas      |
+| "Gastos do mês"       | query 5 → `monthly_expense`       | só a moderna |
+| "sobrou este mês"     | `monthly_income - expense - apt`  | só a moderna |
+| evolução por mês      | `get_monthly_history`             | só a moderna |
+
+Com uma linha legada na base, a soma das barras e o gráfico diário PASSAVAM do
+"Gastos do mês", e o "sobrou" saía maior do que é — dinheiro a mais na cara do
+usuário, sem erro nenhum.
+
+Medido na produção (Railway, 27/08/2026 08:46 UTC): ZERO linhas
+'saida'/'entrada' em `launches`, então nenhum número de usuário muda hoje. O
+conserto é da convenção, não de um incêndio.
+
+Controle NEGATIVO: volte a query 5 para `SELECT tipo, ... GROUP BY tipo` em
+frontend/finance_bot_websocket_custom.py — `test_barras_nao_passam_do_total_do_mes`
+fica vermelho (barras 150 × total 50).
+Controle POSITIVO: `test_base_sem_linha_legada_nao_muda_nenhum_numero` prova que
+uma base normal (que é 100% da produção hoje) responde exatamente o mesmo.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, time
+
+import db
+from db.accounts import _TIPO_ALIASES
+from db.connection import TIPO_CANON_SQL, TIPO_DESPESA_SQL, TIPO_RECEITA_SQL
+from utils_date import today_tz
+import frontend.finance_bot_websocket_custom as dashboard
+
+
+def _hoje_as(hora: int):
+    return datetime.combine(today_tz(), time(hora, 0))
+
+
+def _grava_tipo_legado(user_id, tipo, valor, categoria):
+    """`add_launch_and_update_balance` não grava a forma legada (nem deve): a
+    linha antiga entra por SQL, que é como ela existe numa base de verdade."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "insert into launches (user_id, tipo, valor, categoria, nota, "
+            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,false)",
+            (user_id, tipo, valor, categoria, "legado", _hoje_as(9)),
+        )
+        conn.commit()
+
+
+def _dados(user_id):
+    hoje = today_tz()
+    return asyncio.run(
+        dashboard.get_financial_data(user_id, year=hoje.year, month=hoje.month)
+    )
+
+
+# ── a fonte única das duas formas ──────────────────────────────────────────
+
+def test_o_sql_e_o_python_falam_dos_mesmos_aliases():
+    """§0.7: a regra existe em Python (`_TIPO_ALIASES`, para a lista de uma
+    categoria) e em SQL (`db/connection.py`, para o dashboard). Enquanto forem
+    duas, um teste compara — senão só uma é corrigida no dia em que mudar."""
+    for tipo in _TIPO_ALIASES["despesa"]:
+        assert f"'{tipo}'" in TIPO_DESPESA_SQL, (tipo, TIPO_DESPESA_SQL)
+    for tipo in _TIPO_ALIASES["receita"]:
+        assert f"'{tipo}'" in TIPO_RECEITA_SQL, (tipo, TIPO_RECEITA_SQL)
+    # e o CASE que colapsa a legada na moderna usa exatamente esses dois
+    assert TIPO_DESPESA_SQL in TIPO_CANON_SQL and TIPO_RECEITA_SQL in TIPO_CANON_SQL
+
+
+# ── os números do mês têm que concordar ────────────────────────────────────
+
+def test_barras_nao_passam_do_total_do_mes(pro_user_id):
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 50, "compra", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    _grava_tipo_legado(pro_user_id, "saida", 100, "mercado")
+
+    d = _dados(pro_user_id)
+    barras = sum(c["total"] for c in d["expense_categories"])
+    diario = sum(x["total"] for x in d["daily_expenses"])
+
+    assert d["monthly_expense"] == 150.0, d["monthly_expense"]
+    assert barras == d["monthly_expense"], (barras, d["monthly_expense"])
+    assert diario == d["monthly_expense"], (diario, d["monthly_expense"])
+
+
+def test_receita_legada_entra_no_total_e_no_sobrou(pro_user_id):
+    """`entrada` é o espelho de `saida`: fora do total, o "sobrou este mês"
+    (receitas − gastos − aportes, calculado no front a partir destes números)
+    aparece MENOR do que é."""
+    _grava_tipo_legado(pro_user_id, "entrada", 300, "salario")
+    db.add_launch_and_update_balance(
+        pro_user_id, "receita", 200, "freela", None,
+        categoria="rendimentos", criado_em=_hoje_as(11),
+    )
+    d = _dados(pro_user_id)
+    assert d["monthly_income"] == 500.0, d["monthly_income"]
+
+
+def test_evolucao_por_mes_bate_com_o_gasto_do_mes(pro_user_id):
+    """A barra do mês corrente da evolução e o "Gastos do mês" são o mesmo
+    número em duas telas — não podem discordar por causa do tipo."""
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 50, "compra", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    _grava_tipo_legado(pro_user_id, "saida", 100, "mercado")
+
+    d = _dados(pro_user_id)
+    hist = asyncio.run(dashboard.get_monthly_history(pro_user_id, n_months=1))
+    mes = today_tz().strftime("%Y-%m")
+    linha = [h for h in hist if h["month"] == mes]
+    assert linha, hist
+    assert linha[0]["expense"] == d["monthly_expense"] == 150.0, (linha, d["monthly_expense"])
+
+
+def test_base_sem_linha_legada_nao_muda_nenhum_numero(pro_user_id):
+    """Controle POSITIVO — é a base da produção inteira hoje (zero linhas
+    legadas, medido em 27/08/2026): os mesmos números de sempre."""
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 50, "compra", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    db.add_launch_and_update_balance(
+        pro_user_id, "receita", 80, "freela", None,
+        categoria="rendimentos", criado_em=_hoje_as(11),
+    )
+    d = _dados(pro_user_id)
+    assert d["monthly_expense"] == 50.0, d["monthly_expense"]
+    assert d["monthly_income"] == 80.0, d["monthly_income"]
+    assert sum(c["total"] for c in d["expense_categories"]) == 50.0, d["expense_categories"]
+    assert sum(x["total"] for x in d["daily_expenses"]) == 50.0, d["daily_expenses"]

--- a/tests/test_tipo_legado_no_dashboard.py
+++ b/tests/test_tipo_legado_no_dashboard.py
@@ -18,8 +18,9 @@ Com uma linha legada na base, a soma das barras e o gráfico diário PASSAVAM do
 "Gastos do mês", e o "sobrou" saía maior do que é — dinheiro a mais na cara do
 usuário, sem erro nenhum.
 
-Medido na produção (Railway, 27/08/2026 08:46 UTC): ZERO linhas
-'saida'/'entrada' em `launches`, então nenhum número de usuário muda hoje. O
+Reconferido na produção (Railway) em 27/08/2026 21:50 UTC, sobre o head final
+deste PR: `count(*) filter (where tipo='saida')` = 0 e o mesmo para 'entrada' em
+`launches` — ZERO linhas legadas, então nenhum número de usuário muda hoje. O
 conserto é da convenção, não de um incêndio.
 
 Controle NEGATIVO: volte a query 5 para `SELECT tipo, ... GROUP BY tipo` em
@@ -127,7 +128,8 @@ def test_evolucao_por_mes_bate_com_o_gasto_do_mes(pro_user_id):
 
 def test_base_sem_linha_legada_nao_muda_nenhum_numero(pro_user_id):
     """Controle POSITIVO — é a base da produção inteira hoje (zero linhas
-    legadas, medido em 27/08/2026): os mesmos números de sempre."""
+    legadas; mesma medição do topo do arquivo, 27/08/2026 21:50 UTC): os mesmos
+    números de sempre."""
     db.add_launch_and_update_balance(
         pro_user_id, "despesa", 50, "compra", None,
         categoria="mercado", criado_em=_hoje_as(10),

--- a/utils_date.py
+++ b/utils_date.py
@@ -20,6 +20,25 @@ def today_tz() -> date:
     return now_tz().date()
 
 
+def day_tz(dt):
+    """Dia de PAREDE de um instante, no fuso do app.
+
+    `dt.date()` cru devolve o dia no fuso da SESSÃO do Postgres — UTC no
+    Railway. Um gasto de 26/08 21:30 em São Paulo saía como 27/08 por esse
+    caminho, enquanto o dashboard, que formata o instante no navegador, dizia
+    26/08. Fonte única das DUAS listagens que imprimem o dia de um
+    `criado_em` (`list_launches_by_category`, db/accounts.py; `list_launches`,
+    core/handlers/launches.py): com uma cópia em cada lado, "liste lazer" e
+    "meus últimos lançamentos" divergiam em um dia para o mesmo lançamento.
+
+    Naive (a perna do crédito, `purchased_at::timestamp`) já é dia de parede:
+    passa direto. Sem `.date()` (str, None) volta como veio — quem chama trata.
+    """
+    if dt is None or not hasattr(dt, "date"):
+        return dt
+    return (dt.astimezone(_tz()) if dt.tzinfo else dt).date()
+
+
 # ---------------- feriados nacionais (BR) ----------------
 
 def _easter_sunday(year: int) -> date:


### PR DESCRIPTION
## O que muda

O donut de categorias agrupava por `COALESCE(categoria,'sem categoria')` e quem casa categoria comparava a coluna **crua**. `norm(NULL)` não é `'sem categoria'`, então a barra "sem categoria" somava R$ 100 e quem abrisse por aquele nome não achava nada.

`cat_key_sql` (`db/connection.py`) passa a ser a expressão única das duas pontas. Junto vêm `LAUNCH_HAS_TIME_SQL` (o `CASE` que estava inline na query 4, extraído **textualmente idêntico**) e `day_tz` (`utils_date.py`), o dia de parede no fuso do app.

## Alcance — medido, não estimado

Este é o único dos três PRs que muda o que **todo usuário** vê. Medido `main` × branch com o mesmo dado (`NULL`, `''`, `outros`, `Outros`, `mercado`):

| | main | branch |
|---|---|---|
| barras | `('', 20)` `('mercado',50)` `('outros',70)` `('sem categoria',10)` | `('mercado',50)` `('outros',70)` `('sem categoria',30)` |
| **soma das barras** | **150,0** | **150,0** |
| `monthly_expense` | **150,0** | **150,0** |

Única mudança: a barra de rótulo **vazio**, que na `main` renderizava sem nome, fundiu em "sem categoria". Nenhuma outra barra mudou de valor e a soma continua batendo com o total do mês.

## A query 6 passa a contar `tipo IN ('despesa','saida')`

A linha legada `'saida'` é despesa e já contava em `_TIPO_ALIASES` (`db/accounts.py`) sem contar nesta barra — uma `'saida'` de R$ 100 mais uma `'despesa'` de R$ 5 davam donut R$ 5 × lista R$ 105.

**Consultado na produção (Railway) em 27/08/2026 21:50 UTC, já sobre o head final: zero linhas `'saida'`/`'entrada'` em `launches`** (`count(*) filter` deu `saida = 0`, `entrada = 0`). Não muda número de nenhum usuário hoje; é o alinhamento do único read path do donut que estava na forma singular (os outros — `db/analytics.py:368`, `db/budgets.py:200,333`, `core/admin_dashboard.py`, `core/budget_alerts.py:132` — já usam o plural).

## `day_tz`

`criado.date()` cru devolve o dia no fuso da **sessão** do Postgres — UTC no Railway. Um gasto das 21:30 em São Paulo saía como o dia seguinte. As **duas** listagens do bot entram aqui junto com a função, senão elas divergem entre si: `list_launches` (`core/handlers/launches.py`) e `list_launches_by_category` (`db/accounts.py`).

## Testes

`4934 passed, 1 xfailed, 0 failed` neste branch sozinho, medido no head `dd7b9d0`.

Três regressões de **donut × lista** viajam neste PR, cada uma com controle negativo medido (desligue o conserto e ela fica vermelha) e controle positivo:

| teste | o que prova | controle negativo |
|---|---|---|
| `tests/test_dia_das_listagens_no_fuso.py::test_o_dia_e_o_de_sao_paulo_nas_duas_listagens` | o mesmo lançamento sai com o mesmo dia nas duas listagens do bot | `day_tz(r["dt"])` → `r["dt"].date()` em `list_launches_by_category`: vermelho, o lançamento das 00:30 volta com o dia anterior |
| `tests/test_categoria_vazia_donut_e_lista.py::test_lista_encontra_o_que_o_donut_mostra` | a barra "sem categoria" (NULL e `''`) abre uma lista com as linhas que ela somou | as três `cat_key_sql` → `cat_norm_sql`: vermelho, 0 linhas contra R$ 120,00 na barra |
| `tests/test_categoria_vazia_donut_e_lista.py::test_categoria_normal_continua_casando` | controle **positivo**: a chave nova continua case- e acento-insensível (`Alimentação` gravado, `alimentacao` pedido) e não varre a linha sem categoria para dentro de uma categoria escrita | — |

Os dois horários do primeiro teste (00:30 e 23:30 em São Paulo) existem porque ele precisa discriminar nos dois bancos: 00:30 já é o dia anterior no `America/New_York` do Postgres de teste local, e 23:30 já é o dia seguinte no UTC do Railway. Com um horário só, ele passaria de graça em um dos dois.

Os controles restantes da chave de categoria continuam no PR empilhado da feature — eles dependem da listagem que nasce lá, e foi verificado que seguem presentes.

## Não verificado

Nada foi visto no aparelho — o app carrega o site ao vivo, então mudança de frontend só aparece depois do deploy. Este PR é backend, mas o donut é o que a tela desenha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
