### PR TITLE
Mensagem de erro legível quando `detail` não é string

### DIFF
--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -6237,10 +6237,28 @@ function iofRate(days) {
 async function readApiError(resp) {
   try {
     const data = await resp.json();
-    return data.detail || JSON.stringify(data);
-  } catch (_) {
-    return await resp.text();
-  }
+    // `detail` chega em três formas nesta API e só duas são texto pra usuário:
+    //   • STRING — o caso comum;
+    //   • OBJETO com `message`/`code` — plan_limit (:5059), same_plan (:4114),
+    //     no_change (:4198); ignorá-lo trocava "Você atingiu o limite de 50
+    //     lançamentos" por "erro 403";
+    //   • LISTA — o 422 do FastAPI, diagnóstico de programador ({loc, msg,
+    //     type}), e objeto sem message/code: caem no genérico, senão vira
+    //     `{"detail":…}` cru ou "[object Object]" na tela.
+    const d = data && data.detail;
+    if (typeof d === "string" && d.trim()) return d;
+    if (d && typeof d === "object" && !Array.isArray(d)) {
+      const m = d.message || d.code;
+      if (typeof m === "string" && m.trim()) return m;
+    }
+  } catch (_) { /* corpo não-JSON (HTML de proxy, vazio): cai no genérico */ }
+  /* A cópia irmã em settings.html:1773 NÃO está alinhada com esta, e o
+     alinhamento não é deste PR: lá o teste é `typeof detail === "object"`, que é
+     TRUE para array, então o 422 do FastAPI (detail = lista de {loc,msg,type})
+     cai em `detail.message || detail.code || raw` e sai JSON cru na tela. Aqui o
+     `!Array.isArray` fecha esse buraco. Consertar settings.html toca 10 fluxos
+     que nada têm a ver com categorias — PR separado. */
+  return `Não foi possível concluir agora (erro ${resp.status}).`;
 }
 
 async function refreshDashboardAfterInvestment(msg) {


### PR DESCRIPTION
> **Empilhado** sobre #158. Base = `feat/chave-categoria-donut`.

## O problema

`readApiError` fazia `data.detail || JSON.stringify(data)`. Quando `detail` é **objeto** — o que acontece de verdade nesta API — o retorno era o próprio objeto, e o `new Error(obj)` dos 11 chamadores virava **`[object Object]`** na tela. Sem `detail`, saía o JSON cru.

## O que muda

As três formas passam a ser tratadas pelo que valem:

- **string** — o caso comum, devolvida como está;
- **objeto com `message`/`code`** — aproveitado. É o que o backend manda em `plan_limit` (`:5059`), `same_plan` (`:4114`) e `no_change` (`:4198`); ignorá-lo trocava *"Você atingiu o limite de 50 lançamentos"* por um número de status;
- **lista** (o 422 do FastAPI, que é diagnóstico de programador: `{loc, msg, type}`) e objeto sem texto legível — caem na mensagem genérica com o status.

O `catch` (corpo não-JSON: HTML de proxy num 502, corpo vazio num 504) também passa a cair no genérico, em vez de devolver o HTML inteiro para dentro de um `alert`.

## Por que antes da feature, e não depois

O PR da feature (empilhado sobre este) chama `readApiError` no caminho do **402 do gate de plano**, que vem com `detail` objeto. Se a feature entrasse primeiro, o usuário Grátis clicando numa categoria leria `[object Object]` até este PR merjar. Por isso a ordem da pilha é 1 → este → feature, e não a numeração original.

## `settings.html` continua desalinhada — de propósito

A cópia irmã em `frontend/settings.html:1773` testa `typeof detail === "object"`, que é **true para array**, então o 422 ainda sai cru naquela tela. Alinhá-la toca 10 fluxos que nada têm a ver com este helper — fica registrado em comentário e vale PR próprio.

## Testes

Sem teste próprio neste branch: a bateria que cobre este helper (incluindo o galho `catch`, que antes tinha zero cobertura) está em `tests/frontend/dashboard_category_escape.test.mjs`, que viaja no PR da feature por causa das fixtures compartilhadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)