### PR TITLE
Open Finance Onda 1: conexão morta para de dizer "Tudo em dia!"

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -211,6 +211,36 @@ PLUGGY_INCLUDE_SANDBOX=0
 PLUGGY_WEBHOOK_URL=
 PLUGGY_WEBHOOK_SECRET=
 
+# Ajuste fino do Open Finance. Todas têm default no código — as linhas abaixo
+# mostram o valor em vigor; descomente só para mudar.
+#
+# KILL SWITCH do job de saúde. Ele VEM LIGADO (é a única coisa do Open Finance
+# que roda mesmo com OF_REFRESH_ENABLED desligado, o default de produção): só faz
+# GET /items (não consome cota de coleta) e é o que tira do "Atualizado" a
+# conexão cujo item sumiu da Pluggy. Para desligar: 0/false/no/off.
+# OF_HEALTH_CHECK_ENABLED=1
+# Só remede conexão com saúde mais velha que isto (12h).
+# OF_HEALTH_MAX_AGE_SEC=43200
+# Disjuntor do job de saúde: se NINGUÉM respondeu e mais que esta % da amostra
+# deu 404, a passada aborta sem gravar (credencial errada marcaria a base toda
+# como "conexão perdida"). 100 desliga o disjuntor.
+# OF_HEALTH_MISSING_ABORT_PCT=50
+# Amostra mínima para o disjuntor acima valer.
+# OF_HEALTH_MIN_SAMPLE=5
+# Refresh proativo (só com OF_REFRESH_ENABLED=1): intervalo mínimo por item, 6h,
+# persistido em next_refresh_at — reiniciar o processo não o encurta.
+# OF_REFRESH_MIN_INTERVAL_SEC=21600
+# Jitter (%) aplicado ao intervalo acima, pra os items não baterem na Pluggy no
+# mesmo segundo.
+# OF_REFRESH_JITTER_PCT=10
+# Botão "Atualizar" / pull-to-refresh: janela em que um item não leva PATCH novo
+# (protege a cota de COLETA; ler o que a Pluggy já tem continua acontecendo).
+# OF_MANUAL_REFRESH_COOLDOWN_SEC=120
+# Lock por item do sync: quanto esperar pelo lock antes de desistir (15s).
+# OF_SYNC_LOCK_WAIT_MS=15000
+# Teto de conexões simultâneas segurando lock de sync.
+# OF_SYNC_LOCK_MAX_CONN=8
+
 # ── Google OAuth (Login com Google) ──────────────────────────────────────────
 # Como obter:
 # 1. Acesse https://console.cloud.google.com/apis/credentials

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -702,10 +702,22 @@ async def _fetch_admin_overview_inner(days: int = 30, admin_user: str = "admin")
     summary["login_success_rate_30d"] = round((login_success_30d / attempts_30d) * 100, 1) if attempts_30d else 0.0
     summary["login_success_rate_7d"] = round((login_success_7d / attempts_7d) * 100, 1) if attempts_7d else 0.0
 
+    # Open Finance: saúde das conexões (contadores agregados, sem PII). Fail-soft —
+    # o painel inteiro não pode cair porque uma contagem de OF falhou.
+    try:
+        from db.open_finance_state import of_health_counters
+        open_finance = await asyncio.to_thread(of_health_counters)
+    except Exception as exc:  # noqa: BLE001
+        # Chave PRÓPRIA: `erro` já é a CONTAGEM de conexões em erro. As duas
+        # semânticas na mesma chave faziam a falha virar tile verde no painel
+        # (fInt("relation não existe") = NaN, NaN > 0 = false).
+        open_finance = {"error": str(exc)[:200]}
+
     return {
         "generated_at": now,
         "window_days": days,
         "summary": summary,
+        "open_finance": open_finance,
         "ops_summary": {
             **ops_summary,
             **whatsapp_activity,

--- a/core/services/pluggy.py
+++ b/core/services/pluggy.py
@@ -8,13 +8,25 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 
+from core.services.pluggy_health import safe_code
+
 
 class PluggyConfigError(RuntimeError):
     pass
 
 
 class PluggyApiError(RuntimeError):
-    pass
+    """Erro HTTP da Pluggy. `status_code` existe para distinguir 404 (item some
+    de verdade) de 429/5xx (tenta de novo) sem ninguém fazer regex na mensagem.
+
+    NÃO carrega o corpo da resposta: ele traz PII do titular (ver
+    `_raise_for_pluggy_response`). `code` é o código curto da Pluggy, validado."""
+
+    def __init__(self, message: str, *, status_code: int | None = None,
+                 code: str | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
 
 
 def _pluggy_base_url() -> str:
@@ -38,13 +50,25 @@ def _client_credentials() -> tuple[str, str]:
 
 
 def _raise_for_pluggy_response(resp: httpx.Response, context: str) -> None:
+    """Levanta SEM o corpo da resposta. O corpo de erro da Pluggy carrega nome,
+    CPF e número de conta do titular — medido — e `str(exc)` desta exceção vira
+    `details` de `log_system_event`, PERSISTIDO em `system_event_logs` e lido
+    pelo painel admin, além de sair no `print` do refresh. Sobra o que serve para
+    depurar e não identifica ninguém: o HTTP status e, quando parece código, o
+    `code` da Pluggy (`safe_code` é a mesma regra usada nos warnings do health).
+    """
     if resp.is_success:
         return
     try:
-        detail: Any = resp.json()
+        body: Any = resp.json()
     except ValueError:
-        detail = resp.text
-    raise PluggyApiError(f"{context}: Pluggy retornou HTTP {resp.status_code}: {detail}")
+        body = None
+    code = safe_code(body.get("code")) if isinstance(body, dict) else ""
+    raise PluggyApiError(
+        f"{context}: Pluggy retornou HTTP {resp.status_code}" + (f" (code={code})" if code else ""),
+        status_code=resp.status_code,
+        code=code or None,
+    )
 
 
 def create_pluggy_api_key() -> str:

--- a/core/services/pluggy_health.py
+++ b/core/services/pluggy_health.py
@@ -1,0 +1,359 @@
+"""Saúde do item Pluggy — funções PURAS (sem banco, sem rede).
+
+Três responsabilidades, e só elas:
+
+  • `derive_item_health(item)` traduz o `GET /items/{id}` (feito pelo servidor)
+    num dicionário estável que vai pra coluna `open_finance_connections.health`;
+  • `resolve_connection_state(...)` é o ÚNICO ponto que decide `status` E
+    `status_reason` — os dois JUNTOS, a partir de uma observação;
+  • `connection_ui_state(row)` é a ÚNICA função que decide em qual dos 9 estados
+    (`_LABELS`) uma conexão está, e com que texto. Consumidores: snapshot da aba OF, resposta
+    do /refresh, painel admin e o job de saúde.
+
+Ter uma fonte só evita o que existia antes: um rótulo derivado do `status` no
+`settings.html`, outro no backend, e nenhum dos dois sabendo de produto atrasado.
+
+## A MÁQUINA DE ESTADOS, POR ESCRITO (não remende linha por linha)
+
+Três rodadas de revisão bateram no mesmo lugar pelo mesmo motivo: cada caminho
+(sync, job de saúde, reconexão, webhook) remendava `status` OU `status_reason`,
+e sempre esquecia o outro. Resultado medido: `item_missing` limpo com o
+`status='ERROR'` ficando ("Erro temporário" para sempre) e `no_accounts` que
+nunca saía. Os dois campos são UM estado só — logo, uma decisão só.
+
+O par é sempre `(status, status_reason)`. `status=None` significa "não mexe" e
+hoje NENHUMA linha o usa: espelho vazio com item vivo é ACTIVE + motivo, porque
+"não mexe" não tira um ERROR que já está lá — e sem sync periódico (o default)
+nada mais tiraria, o que fazia de ERROR um estado terminal. PAUSED/DELETED
+continuam protegidos pelo `where` do `mark_sync_result`. `status_reason=""`
+APAGA o motivo — nunca se devolve None aqui, senão o motivo velho sobrevive à
+observação nova, que é exatamente o bug.
+
+| # | evento (observação)                                   | status  | reason      |
+|---|-------------------------------------------------------|---------|-------------|
+| A | `GET /items/{id}` → 404 (sync ou job de saúde)        | ERROR   | item_missing|
+| B | item vivo, mas exige o usuário (LOGIN_ERROR, OUTDATED,| ERROR   | ""          |
+|   | WAITING_USER_INPUT, INVALID_CREDENTIALS)              |         |             |
+| C | item vivo em ERROR                                    | ERROR   | ""          |
+| D | sync: leitura remota incompleta (ex.: 429 em          | ACTIVE  | read_failed |
+|   | `/investments`) E espelho vazio                       |         |             |
+| E | sync: leitura COMPLETA e espelho vazio                | ACTIVE  | no_accounts |
+| F | item vivo com espelho cheio (sync ok ou só medido)    | ACTIVE  | ""          |
+| H | job de saúde: item vivo, espelho vazio                | ACTIVE  | mantém D/E, |
+|   | (não leu `/accounts`, então não INVENTA motivo)       |         | senão ""    |
+| G | reconexão pelo widget (`save_pluggy_open_finance_item`)| remoto | "" + health |
+|   |                                                       |         | zerado      |
+
+B e C devolvem motivo vazio de propósito: quem conta a história ali é o
+`health`, e o motivo velho (`item_missing` de ontem) só atrapalharia.
+
+E ≠ D: "li e veio vazio" não é "não consegui ler". Só o primeiro autoriza
+`no_accounts` — foi confundir os dois que fez um 429 em `/investments` descartar
+contas já lidas.
+
+H é o que tira o caráter pegajoso de `no_accounts`: `has_data` é OBSERVAÇÃO (o
+job pergunta ao espelho em `list_connections_for_health_check`, não à memória),
+então o motivo cai sozinho no instante em que existir dado — e o job nunca cria
+um motivo sobre uma leitura que ele não fez.
+
+G é o único evento que zera o `health`: consentimento novo torna a medição velha
+sem sentido (com ela, um `item_status: MISSING` de antes ainda pintava a tela).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any
+
+from utils_date import _tz
+
+# Produto (nosso nome) → chave do `statusDetail` da Pluggy.
+_PRODUCT_KEYS = {
+    "BANK": "accounts",
+    "CREDIT": "creditCards",
+    "INVESTMENTS": "investments",
+    "TRANSACTIONS": "transactions",
+}
+
+_PRODUCT_PT = {
+    "BANK": "Conta",
+    "CREDIT": "Cartão",
+    "INVESTMENTS": "Investimentos",
+    "TRANSACTIONS": "Transações",
+}
+
+# Status do item que significam "a Pluggy ainda está buscando".
+_UPDATING = {"UPDATING", "CREATED", "WAITING_USER_ACTION"}
+# Status que só o usuário resolve (reautorizar / responder MFA no banco).
+_NEEDS_USER = {"LOGIN_ERROR", "WAITING_USER_INPUT", "INVALID_CREDENTIALS", "OUTDATED"}
+
+_LABELS = {
+    "updated": "Atualizado",
+    "partial": "Parcial",
+    "updating": "Atualizando…",
+    "error_recoverable": "Erro temporário",
+    "needs_user_action": "Ação necessária",
+    "item_missing": "Conexão perdida",
+    "paused": "Pausado",
+    "removed": "Removido",
+    "no_accounts": "Sem dados",
+}
+
+_FIXED_DETAIL = {
+    "error_recoverable": "Tentaremos de novo automaticamente",
+    "needs_user_action": "Reautorize o banco",
+    "item_missing": "Refaça a conexão com o banco",
+    "paused": "Reative seu plano para voltar a sincronizar",
+    "no_accounts": "O banco não devolveu contas nem investimentos",
+}
+
+# `status_reason` que NÃO impede o estado verde. Qualquer outro motivo — inclusive
+# um que este arquivo não conhece — derruba o "Atualizado" (ver `out`).
+_REASONS_OK = ("", "ok")
+
+# Código aceitável da Pluggy. A mensagem dela cita nome, conta e documento do
+# titular; um `code` de verdade é curto e quase sem dígito ("004", "CC_001",
+# "INV_005", "MFA_TIMEOUT"). O teto de DÍGITOS é o que separa código de PII:
+# CPF ("123.456.789-01") e conta ("0001-12345-6") têm 11 dígitos cada e passavam
+# pelo formato — medido. `_` estava faltando na classe, então "CC_001", que é
+# código REAL de produção, era rejeitado.
+_CODE_FORMAT = re.compile(r"[A-Za-z0-9._-]{1,20}")
+_CODE_MAX_DIGITS = 6
+
+
+def safe_code(value: Any) -> str:
+    """O `code` da Pluggy, ou "" se ele não PARECER um código.
+
+    Fronteira de confiança: usado pelos warnings do health E pela mensagem de
+    erro da API (`core/services/pluggy.py`), que vira log persistido e painel
+    admin. Uma regra só para os dois — duas seriam duas chances de errar.
+    """
+    text = str(value if value is not None else "").strip()
+    if not _CODE_FORMAT.fullmatch(text):
+        return ""
+    return text if sum(c.isdigit() for c in text) <= _CODE_MAX_DIGITS else ""
+
+
+def _warning_codes(detail: dict) -> list[str]:
+    """Só o CÓDIGO do warning entra no health — e só se ele PARECER um código.
+
+    A mensagem da Pluggy cita nome, conta e documento do titular, e o health é
+    lido pelo painel admin, pelo log e pelo snapshot que desce pro navegador.
+    Cortar em 64 caracteres NÃO impede vazamento: quando `warnings` vem como
+    lista de STRINGS (a Pluggy manda os dois formatos), `code` virava os
+    primeiros 64 caracteres da mensagem — medido, com CPF dentro.
+
+    Só dict com `code` no formato de código passa. Qualquer outra coisa vira um
+    sentinela fixo: o painel continua sabendo que houve warning, sem carregar
+    texto livre junto.
+
+    `warnings` também pode não ser lista: medido, `{"warnings": 7}` estourava
+    `TypeError` aqui e MATAVA o sync inteiro (o chamador não tem try) — um campo
+    inesperado da Pluggy não pode custar a sincronização.
+    """
+    warnings = detail.get("warnings")
+    if not isinstance(warnings, list):
+        return []
+    out: list[str] = []
+    for w in warnings:
+        code = safe_code(w.get("code")) if isinstance(w, dict) else ""
+        out.append(code or "invalid_warning")
+    return out
+
+
+def _iso(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def derive_item_health(item: dict, *, now: datetime | None = None) -> dict:
+    """Saúde por produto a partir do item cru da Pluggy.
+
+    `stale_products` é a lista de produtos que a Pluggy NÃO conseguiu atualizar
+    nesta execução — é o que separa "atualizado" de "atualizei o que deu".
+    """
+    item = item if isinstance(item, dict) else {}
+    status_detail = item.get("statusDetail") or {}
+    products: dict[str, dict] = {}
+    stale: list[str] = []
+
+    for name, key in _PRODUCT_KEYS.items():
+        detail = status_detail.get(key)
+        if not isinstance(detail, dict):
+            continue
+        updated = bool(detail.get("isUpdated"))
+        products[name] = {
+            "updated": updated,
+            "last_updated_at": _iso(detail.get("lastUpdatedAt")),
+            "warnings": _warning_codes(detail),
+        }
+        if not updated:
+            stale.append(name)
+
+    return {
+        "observed_at": (now or datetime.now(_tz())).isoformat(),
+        "item_status": (str(item.get("status") or "").upper() or None),
+        "execution_status": (str(item.get("executionStatus") or "").upper() or None),
+        "products": products,
+        "stale_products": stale,
+    }
+
+
+# Motivo de quem leu pela metade. Não está em `_LABELS` de propósito: o `out()`
+# do `connection_ui_state` manda motivo desconhecido para `error_recoverable`
+# ("Erro temporário / Tentaremos de novo automaticamente"), que é a verdade.
+READ_FAILED = "read_failed"
+
+
+# Motivos que só o espelho vazio explica — os únicos que uma observação SEM
+# leitura do provedor (o job de saúde) pode manter de pé.
+_MOTIVOS_DE_ESPELHO_VAZIO = ("no_accounts", READ_FAILED)
+
+
+def resolve_connection_state(
+    *,
+    health: dict | None = None,
+    missing: bool = False,
+    has_data: bool = True,
+    leitura_completa: bool | None = None,
+    reason_atual: str = "",
+) -> tuple[str | None, str]:
+    """`(status, status_reason)` de UMA observação — a tabela do topo do módulo.
+
+    Único ponto do sistema que decide os dois campos, e sempre os dois juntos.
+    Chamado pelo sync, pelo job de saúde e pelo 404; a reconexão (linha G) é SQL
+    e mora em `save_pluggy_open_finance_item`.
+
+    `has_data`         — o espelho AGORA (contas ou investimentos), não o histórico.
+    `leitura_completa` — `True` lemos contas E investimentos; `False` a leitura
+                         caiu no meio (429 em `/investments`); `None` esta
+                         observação NÃO leu o provedor (job de saúde: só
+                         `GET /items`). Com `None` o motivo de espelho vazio não
+                         é INVENTADO — só mantido se já estava lá.
+    `reason_atual`     — o motivo gravado hoje, para a decisão de manter/limpar.
+    """
+    if missing:
+        return "ERROR", "item_missing"
+
+    item_status = str((health or {}).get("item_status") or "").upper()
+    if item_status in _NEEDS_USER or item_status == "ERROR":
+        return "ERROR", ""
+
+    # LIMITAÇÃO CONHECIDA (Onda 1, não corrigida de propósito): um `item_status`
+    # de erro que não esteja em `_NEEDS_USER` nem seja "ERROR" cai adiante como
+    # item saudável. Não é regressão: com `has_data=True` o resolvedor SEMPRE
+    # tratou status desconhecido como saudável; esta onda só estendeu isso ao
+    # `has_data=False` para destravar o ERROR terminal. Não ampliamos a lista
+    # porque a taxonomia da Pluggy não é observável daqui — nenhum status desse
+    # tipo aparece no repositório e ninguém tem acesso ao provedor para
+    # confirmá-lo. Adivinhar a lista é pior que a lacuna. Vira item de Onda 2
+    # SÓ com evidência real de um status externo assim.
+
+    if has_data:
+        return "ACTIVE", ""
+
+    # Espelho vazio NÃO é erro do ITEM — ele respondeu, e respondeu saudável
+    # (qualquer outra coisa já saiu acima). O `status` é a saúde do item; quem
+    # explica o espelho vazio é o `status_reason`.
+    # Devolver None aqui ("não mexe") deixava um ERROR anterior grudado: com
+    # `OF_REFRESH_ENABLED` off (o default) não há PATCH → não há webhook → não há
+    # sync completo, e ERROR virava TERMINAL na prática — medido, 404 no tick 0 e
+    # item vivo nos 5 seguintes continuava "Erro temporário".
+    if leitura_completa is None:
+        motivo = str(reason_atual or "").lower()
+        return "ACTIVE", (motivo if motivo in _MOTIVOS_DE_ESPELHO_VAZIO else "")
+    return "ACTIVE", ("no_accounts" if leitura_completa else READ_FAILED)
+
+
+def _dm(iso_text: str | None) -> str | None:
+    """'2026-08-12T…' → '12/08'. Devolve None se não der pra ler."""
+    if not iso_text:
+        return None
+    try:
+        return f"{iso_text[8:10]}/{iso_text[5:7]}" if iso_text[4] == "-" and iso_text[7] == "-" else None
+    except IndexError:
+        return None
+
+
+def _stale_detail(health: dict) -> str:
+    stale = [p for p in (health.get("stale_products") or []) if p in _PRODUCT_PT]
+    if not stale:
+        return "Parte dos dados ainda não veio"
+    nomes = [_PRODUCT_PT[p] for p in stale]
+    products = health.get("products") or {}
+    datas = sorted(
+        d for d in (_dm((products.get(p) or {}).get("last_updated_at")) for p in stale) if d
+    )
+    texto = " e ".join(nomes) + (" desatualizados" if len(nomes) > 1 else " desatualizado")
+    return f"{texto} desde {datas[0]}" if datas else texto
+
+
+def connection_ui_state(connection_row: dict) -> dict:
+    """Estado + textos de UMA conexão. Única fonte dos estados de `_LABELS`.
+
+    Lê `status`, `status_reason`, `health` e `last_sync_at` da linha de
+    `open_finance_connections`. `health` NULL significa "saúde ainda não medida"
+    — NÃO "nunca sincronizou": linha legada tem last_sync_at e nenhum health.
+    """
+    row = connection_row if isinstance(connection_row, dict) else {}
+    status = str(row.get("status") or "").upper()
+    reason = str(row.get("status_reason") or "").lower()
+    health = row.get("health") if isinstance(row.get("health"), dict) else None
+    stale = list((health or {}).get("stale_products") or [])
+
+    def out(state: str, detail: str | None = None) -> dict:
+        # DEFAULT SEGURO: estado desconhecido nunca é verde. Um `status_reason`
+        # pendente que este arquivo não conhece (gravado por um caminho novo)
+        # não pode virar "Atualizado" — foi exatamente assim que `no_accounts`
+        # (item vivo que não espelhou nada) chegou à tela como "Tudo em dia!".
+        if state == "updated" and reason not in _REASONS_OK:
+            state = reason if reason in _LABELS else "error_recoverable"
+            detail = _FIXED_DETAIL.get(state)
+        return {
+            "state": state,
+            "label": _LABELS[state],
+            "detail": detail if detail is not None else _FIXED_DETAIL.get(state),
+            "stale_products": stale,
+        }
+
+    if status == "DELETED":
+        return out("removed")
+    if status == "PAUSED":
+        return out("paused")
+    if reason == "item_missing":
+        return out("item_missing")
+
+    if health:
+        item_status = str(health.get("item_status") or "").upper()
+        if item_status in _NEEDS_USER:
+            return out("needs_user_action")
+        if item_status in _UPDATING:
+            return out("updating")
+        # ERROR vem ANTES de "parcial": item em erro COM produto atrasado é erro,
+        # e rotulá-lo de "Parcial" ("atualizei o que deu") subestima o estado.
+        if status == "ERROR" or item_status == "ERROR":
+            # ...mas `status` local em ERROR com o ITEM vivo e o motivo dizendo
+            # por que o espelho está vazio: quem explica é o motivo. O override
+            # do `out()` só rodava no ramo verde, então ERROR/no_accounts nunca
+            # mostrava "Sem dados" — o estado desta onda ficava invisível.
+            # Item em ERROR de verdade continua "Erro temporário": motivo velho
+            # não subestima erro, e este ramo nunca vira verde.
+            return out("no_accounts" if reason == "no_accounts" and item_status != "ERROR"
+                       else "error_recoverable")
+        if stale or str(health.get("execution_status") or "").upper() == "PARTIAL_SUCCESS":
+            return out("partial", _stale_detail(health))
+        return out("updated")
+
+    # Sem health medido: cai no status local (comportamento de hoje).
+    if status in _UPDATING:
+        return out("updating")
+    if status in _NEEDS_USER:
+        return out("needs_user_action")
+    if status == "ERROR":
+        # Mesma classe do ramo com health: o motivo explica melhor que "Erro
+        # temporário" (linha legada gravada antes desta onda também cai aqui).
+        return out("no_accounts" if reason == "no_accounts" else "error_recoverable")
+    if row.get("last_sync_at") is None:
+        return out("updating", "Ainda não sincronizou")
+    return out("updated")

--- a/core/services/pluggy_sync.py
+++ b/core/services/pluggy_sync.py
@@ -594,8 +594,16 @@ def _sync_item_contido(connection: dict) -> dict:
             # Tira o item do verde na tela: `status=None` é "não mexe" (a chamada
             # falhou, não observamos a saúde do item — só que a tentativa não deu
             # certo), e o motivo pendente faz `connection_ui_state` recusar
-            # "Atualizado" pelo default seguro dele. O motivo cai sozinho no
-            # próximo sync/job de saúde que conseguir ler.
+            # "Atualizado" pelo default seguro dele.
+            #
+            # LIMITE MEDIDO: quem limpa `read_failed` é só um sync que consiga
+            # ler as contas. O job de saúde NÃO lê contas (só `GET /items`), e o
+            # early return `if has_data:` de `resolve_connection_state` devolve
+            # ("ACTIVE","") antes do ramo que preservaria o motivo — então um
+            # banco que 429 de forma persistente volta ao verde em até
+            # OF_HEALTH_MAX_AGE_SEC (12h) com o espelho velho. A pílula não olha
+            # a idade de `last_sync_at`; "Atualizado" quer dizer "o item está
+            # saudável na Pluggy", não "nosso espelho está fresco". Onda 2.
             mark_sync_result(connection["id"], ok=False, status=None,
                              status_reason=READ_FAILED)
         except Exception as exc2:  # banco fora do ar não pode derrubar o lote também

--- a/core/services/pluggy_sync.py
+++ b/core/services/pluggy_sync.py
@@ -8,6 +8,7 @@ O trabalho aqui é bloqueante (httpx + DB); chame via asyncio.to_thread a partir
 
 from __future__ import annotations
 
+import os
 import time
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
@@ -18,6 +19,7 @@ from dateutil import parser as _dateutil_parser
 from utils_date import _tz
 
 from core.services.pluggy import (
+    PluggyApiError,
     create_pluggy_api_key,
     get_pluggy_item,
     list_pluggy_accounts,
@@ -25,17 +27,49 @@ from core.services.pluggy import (
     list_pluggy_transactions,
     update_pluggy_item,
 )
+from core.services.pluggy_health import (
+    READ_FAILED,
+    # "ainda buscando no banco": esperamos sair disto antes de sincronizar, senão
+    # lemos o snapshot velho. Vem do `pluggy_health` porque lá é a fonte do
+    # significado dos status de item — aqui era o MESMO conjunto declarado de novo.
+    _UPDATING as ITEM_UPDATING,
+    connection_ui_state,
+    derive_item_health,
+    resolve_connection_state,
+)
 from db import (
+    claim_items_for_refresh,
+    claim_manual_refresh,
+    get_connections_by_item_id,
     get_open_finance_connection_by_item_id,
     get_open_finance_snapshot,
     import_open_finance_credit,
     import_open_finance_launches,
-    list_pluggy_item_ids,
+    list_connections_for_health_check,
+    mark_sync_attempt,
+    mark_sync_result,
+    pluggy_item_lock,
     save_open_finance_investments,
     sync_open_finance_caixinhas,
     save_open_finance_sync,
     sync_imported_open_finance_updates,
 )
+
+
+def _HEALTH_MISSING() -> dict:
+    """Health de item que sumiu — os dois caminhos que gravam 404 usam este."""
+    return {"observed_at": datetime.now(_tz()).isoformat(), "item_status": "MISSING",
+            "execution_status": None, "products": {}, "stale_products": []}
+
+
+def item_missing(exc: Exception) -> bool:
+    """404 no `GET /items/{id}` = o item não existe mais na Pluggy.
+
+    É a ÚNICA resposta que prova isso: o `GET /accounts?itemId=<deletado>` volta
+    200 com `results: []` (medido em produção), indistinguível de um item vivo
+    sem contas se ninguém perguntar pelo item.
+    """
+    return isinstance(exc, PluggyApiError) and exc.status_code == 404
 
 
 def _to_decimal(value: Any, default: str = "0") -> Decimal:
@@ -152,16 +186,63 @@ def is_caixinha(investment: dict) -> bool:
 
 
 def sync_pluggy_item(provider_item_id: str) -> dict:
-    """Sincroniza um item Pluggy: contas + transações → tabelas OF. Idempotente."""
+    """Sincroniza um item Pluggy: contas + transações → tabelas OF. Idempotente.
+
+    Máquina de estados (explícita, porque remendá-la um caso por vez foi como o
+    bug original nasceu): aborta APENAS em PAUSED e DELETED. ERROR **não** é
+    terminal — é recuperável, e é por aqui que ERROR volta a ACTIVE: item
+    consultado → saudável → sync executado → concluído.
+
+    Este é o ÚNICO lugar do sistema que carimba ACTIVE/last_sync_at.
+    """
     connection = get_open_finance_connection_by_item_id(provider_item_id)
     if not connection:
         return {"ok": False, "reason": "connection_not_found", "item_id": provider_item_id}
 
+    status_local = str(connection.get("status") or "").upper()
     # Trial venceu sem virar assinatura: dados importados ficam, mas o sync PARA
     # (o item nem existe mais na Pluggy). Barra webhook atrasado/replay.
-    if str(connection.get("status") or "").upper() == "PAUSED":
+    if status_local == "PAUSED":
         return {"ok": False, "reason": "connection_paused", "item_id": provider_item_id}
+    # Desconectado: terminal do mesmo jeito. Sem isto, um webhook atrasado
+    # (item/updated chega depois do item/deleted) ressuscitava a conexão.
+    if status_local == "DELETED":
+        return {"ok": False, "reason": "connection_deleted", "item_id": provider_item_id}
 
+    # PERGUNTA PELO ITEM ANTES DE DAR POR BOM. O `/accounts?itemId=<deletado>`
+    # devolve 200 com results:[] — só o `GET /items/{id}` devolve 404. Sem esta
+    # consulta, item apagado no banco virava "sincronizado agora, 0 contas".
+    api_key = create_pluggy_api_key()
+    try:
+        item = get_pluggy_item(provider_item_id, api_key)
+    except Exception as exc:
+        if not item_missing(exc):
+            raise
+        # NÃO apaga espelho, NÃO apaga item local nem remoto, NÃO reconecta:
+        # a decisão de refazer a conexão é do usuário. Aqui só se conta a verdade.
+        status, reason = resolve_connection_state(missing=True)
+        mark_sync_result(connection["id"], ok=False, status=status, status_reason=reason,
+                         health=_HEALTH_MISSING())
+        return {"ok": False, "reason": "item_missing", "item_id": provider_item_id,
+                "connection_id": connection["id"], "user_id": connection["user_id"]}
+
+    health = derive_item_health(item)
+    return _sync_pluggy_item_confirmado(provider_item_id, connection, api_key, health)
+
+
+def _sync_pluggy_item_confirmado(provider_item_id: str, connection: dict, api_key: str,
+                                 health: dict) -> dict:
+    """O sync em si, com o item já confirmado vivo.
+
+    Duas fases, e a fronteira entre elas é o lock:
+      1. LEITURA remota (contas, transações, investimentos) — sem lock nenhum.
+         É read-only contra a Pluggy, e a paginação leva até 60 requisições por
+         conta; segurar um lock de sessão aqui retinha uma conexão de banco por
+         minutos (ver `pluggy_item_lock`).
+      2. ESCRITA — dentro do lock por item. É ela que dava os 10
+         `deadlock detected` medidos em produção, quando `item/updated` e
+         `transactions/created` chegavam com 0–17s de intervalo.
+    """
     # Ponto comum de TODOS os caminhos que mexem na carteira — inclusive o webhook
     # de produção, que chama esta função direto (frontend/routes/open_finance.py),
     # sem passar por sync_pluggy_user. Segurar aqui cobre as leituras remotas
@@ -177,49 +258,106 @@ def sync_pluggy_item(provider_item_id: str) -> dict:
     heartbeat = lambda: _hold_aggregate_emails(connection["user_id"], "sync_item")
     heartbeat()
 
-    api_key = create_pluggy_api_key()
-
     accounts: list[dict] = []
-    for raw_account in list_pluggy_accounts(provider_item_id, api_key):
-        heartbeat()
-        account = normalize_pluggy_account(raw_account)
-        if not account["provider_account_id"]:
-            continue
-        raw_txs = list_pluggy_transactions(account["provider_account_id"], api_key,
-                                           on_page=heartbeat)
-        account["transactions"] = [
-            tx for tx in (normalize_pluggy_transaction(t) for t in raw_txs) if tx["provider_transaction_id"]
-        ]
-        accounts.append(account)
-
-    result = save_open_finance_sync(connection["id"], accounts)
-
-    # #10: investimentos (inclui Caixinha/CDB) — espelho em open_finance_investments.
-    investments = [normalize_pluggy_investment(i) for i in list_pluggy_investments(provider_item_id, api_key)]
-    inv_result = save_open_finance_investments(connection["id"], investments)
-
-    # Caixinhas do OF viram caixinhas do Pig automaticamente (auto-create + dedup) e o
-    # saldo do banco é espelhado nas vinculadas — mas SÓ pra planos pagos (Essencial+).
-    # No Grátis (pós-trial) o OF nem sincroniza (conexão PAUSED barra acima); este gate é
-    # a segunda trava: se o usuário caiu de plano, as caixinhas congelam (não atualizam).
-    # Renda variável (ações/FIIs) é lida à parte no snapshot, também gated. Fail-soft.
-    caixinha_result = {"caixinhas_created": 0, "caixinhas_linked": 0, "caixinhas_mirrored": 0}
     try:
-        from core.services.plan_service import require_min_tier
-        if require_min_tier(connection["user_id"], "essencial"):
-            caixinha_result = sync_open_finance_caixinhas(connection["id"], connection["user_id"])
-    except Exception as exc:
-        print(f"[pluggy_sync] caixinha auto-import: {exc}")
+        for raw_account in list_pluggy_accounts(provider_item_id, api_key):
+            heartbeat()
+            account = normalize_pluggy_account(raw_account)
+            if not account["provider_account_id"]:
+                continue
+            raw_txs = list_pluggy_transactions(account["provider_account_id"], api_key,
+                                               on_page=heartbeat)
+            account["transactions"] = [
+                tx for tx in (normalize_pluggy_transaction(t) for t in raw_txs) if tx["provider_transaction_id"]
+            ]
+            accounts.append(account)
+    except Exception:
+        # Falhou lendo conta/transação: foi TENTATIVA, e o carimbo de tentativa
+        # mora depois do lock, lá embaixo — sem isto a falha não deixava rastro
+        # nenhum na linha. Não vira resultado: o motivo continua desconhecido e
+        # quem decide retentar é o chamador (`_retryable`).
+        mark_sync_attempt(connection["id"], origin="sync")
+        raise
 
-    # Fase 1: conta BANK → launches (analytics, sem mover saldo); cartão → faturas (opção a).
-    imported = import_open_finance_launches(connection["user_id"], connection["id"])
-    imported_credit = import_open_finance_credit(connection["user_id"], connection["id"])
-    # Propaga correções da Pluggy (transactions/updated) pros já importados (não deixa stale).
-    updated = sync_imported_open_finance_updates(connection["user_id"], connection["id"])
+    # #10: investimentos (inclui Caixinha/CDB). A leitura fica AQUI, junto do
+    # resto do remoto: corretora (XP/Rico/BTG/Warren) devolve `/accounts` vazio
+    # porque a carteira vive em `/investments`, e o early-return de `no_accounts`
+    # ficava ANTES desta chamada — a conexão nunca espelhava nada e last_sync_at
+    # congelava para sempre. `PLUGGY_PRODUCTS` inclui INVESTMENTS de propósito.
+    #
+    # FAIL-SOFT, e isto não é zelo: subir a leitura para antes de qualquer
+    # escrita fez um 429 em `/investments` DESCARTAR as contas e transações já
+    # lidas — medido, 1 conta + 1 transação viraram 0 e 0, e `/investments` com
+    # rate limit é o caso de produção que originou esta onda. O que não pode
+    # é confundir "li e veio vazio" com "não consegui ler": só o primeiro
+    # autoriza `no_accounts`.
+    investments: list[dict] = []
+    investments_ok = True
+    try:
+        investments = [normalize_pluggy_investment(i)
+                       for i in list_pluggy_investments(provider_item_id, api_key)]
+    except Exception as exc:
+        investments_ok = False
+        print(f"[pluggy_sync] investimentos indisponíveis item={provider_item_id} "
+              f"erro={type(exc).__name__}", flush=True)
+    heartbeat()
+
+    # ── FASE 2: escrita, serializada por item ────────────────────────────────
+    with pluggy_item_lock(provider_item_id) as locked:
+        if not locked:
+            return {"ok": False, "reason": "sync_in_progress", "item_id": provider_item_id,
+                    "connection_id": connection["id"], "user_id": connection["user_id"]}
+        # Tentativa carimbada DEPOIS do lock: quem não conseguiu escrever não
+        # tentou sincronizar, e antes o perdedor da corrida já mexia na linha.
+        mark_sync_attempt(connection["id"], origin="sync")
+
+        # Item vivo que não espelhou NADA — nem conta nem investimento — não é
+        # sucesso. Só que a decisão vem depois da leitura de investimentos: item
+        # de corretora é exatamente isto, zero contas e a carteira toda em
+        # `/investments`. `health` é carimbado (é a saúde medida agora, e ela
+        # vale); o que não pode é ACTIVE/last_sync_at.
+        if not accounts and not investments:
+            status, reason = resolve_connection_state(
+                health=health, has_data=False, leitura_completa=investments_ok)
+            mark_sync_result(connection["id"], ok=False, status=status,
+                             status_reason=reason, health=health)
+            return {"ok": False, "reason": reason, "item_id": provider_item_id,
+                    "connection_id": connection["id"], "user_id": connection["user_id"],
+                    "accounts_synced": 0, "transactions_synced": 0}
+
+        result = save_open_finance_sync(connection["id"], accounts)
+        inv_result = save_open_finance_investments(connection["id"], investments)
+
+        # Caixinhas do OF viram caixinhas do Pig automaticamente (auto-create + dedup) e o
+        # saldo do banco é espelhado nas vinculadas — mas SÓ pra planos pagos (Essencial+).
+        # No Grátis (pós-trial) o OF nem sincroniza (conexão PAUSED barra acima); este gate é
+        # a segunda trava: se o usuário caiu de plano, as caixinhas congelam (não atualizam).
+        # Renda variável (ações/FIIs) é lida à parte no snapshot, também gated. Fail-soft.
+        caixinha_result = {"caixinhas_created": 0, "caixinhas_linked": 0, "caixinhas_mirrored": 0}
+        try:
+            from core.services.plan_service import require_min_tier
+            if require_min_tier(connection["user_id"], "essencial"):
+                caixinha_result = sync_open_finance_caixinhas(connection["id"], connection["user_id"])
+        except Exception as exc:
+            print(f"[pluggy_sync] caixinha auto-import: {exc}")
+
+        # Fase 1: conta BANK → launches (analytics, sem mover saldo); cartão → faturas (opção a).
+        imported = import_open_finance_launches(connection["user_id"], connection["id"])
+        imported_credit = import_open_finance_credit(connection["user_id"], connection["id"])
+        # Propaga correções da Pluggy (transactions/updated) pros já importados (não deixa stale).
+        updated = sync_imported_open_finance_updates(connection["user_id"], connection["id"])
+
+        # Concluído: ESTE é o único carimbo de sucesso do sistema. Dentro do
+        # lock de propósito — ele afirma que as escritas acima valeram.
+        status, reason = resolve_connection_state(health=health, has_data=True,
+                                                  leitura_completa=investments_ok)
+        mark_sync_result(connection["id"], ok=True, status=status, status_reason=reason,
+                         health=health, at=datetime.now(_tz()))
 
     # Agentes do Piggy — gatilho pós-sync: Xerife roda só sobre o delta deste
     # usuário. IMPORTANTE: depois da reconciliação/import acima (merge-silencioso
     # primeiro, senão duplicata manual+OF viraria falso positivo). Fail-soft.
+    # FORA do lock: não mexe no espelho do item e pode demorar.
     if imported.get("inserted") or (imported_credit or {}).get("inserted"):
         try:
             from core.services.piggy_agents import run_agents_for_user
@@ -232,6 +370,10 @@ def sync_pluggy_item(provider_item_id: str) -> dict:
         "item_id": provider_item_id,
         "connection_id": connection["id"],
         "user_id": connection["user_id"],
+        # Sucesso PARCIAL continua sendo sucesso de sync (o que veio, veio), mas
+        # quem lê o resultado precisa saber o que ficou pra trás.
+        "stale_products": list(health.get("stale_products") or []),
+        "investments_ok": investments_ok,
         **result,
         **inv_result,
         **caixinha_result,
@@ -241,9 +383,29 @@ def sync_pluggy_item(provider_item_id: str) -> dict:
     }
 
 
-def refresh_all_pluggy_items(user_id: int | None = None) -> dict:
-    """Dispara update na Pluggy pra cada item ativo (Pluggy re-busca do banco e manda
-    webhook → sync). Usado pelo tick de refresh periódico. Falhas por item são engolidas.
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def request_pluggy_refresh(*, origin: str, user_id: int | None = None, limit: int = 200) -> dict:
+    """Dispara o PATCH /items dos itens ELEGÍVEIS (a Pluggy re-busca do banco e
+    manda webhook → sync). Usado pelo tick periódico e pelo refresh manual.
+
+    Três coisas mudaram em relação ao `refresh_all_pluggy_items` que existia aqui:
+
+    1. `origin="startup"` não dispara NADA. O tick antigo rodava um refresh no boot
+       e o Railway sobe container novo a cada deploy — medido: 15 rodadas em 48h,
+       10 delas nos 5 minutos seguintes a um deploy. Cota da Pluggy queimada por
+       deploy, não por necessidade.
+    2. Quem escolhe os itens é `claim_items_for_refresh`, um `UPDATE ... RETURNING`
+       atômico: duas instâncias no mesmo tick não pegam o mesmo item, e o cooldown
+       fica PERSISTIDO em `next_refresh_at` (sobrevive a restart, que era como o
+       intervalo de 6h virava "a cada deploy").
+    3. Falha de PATCH deixou de ser engolida (`except Exception: pass`) — vira
+       evento com item e motivo.
 
     LIMITAÇÃO CONHECIDA (decisão de 2026-08-15): este caminho é fire-and-forget —
     dispara o PATCH e retorna; o webhook chega depois e aciona sync_pluggy_item (que
@@ -257,31 +419,124 @@ def refresh_all_pluggy_items(user_id: int | None = None) -> dict:
         momento do envio), não com um snapshot parcial errado como no bug original;
         e o feed se autocorrige quando o webhook processa.
     Fechar 100% exigiria um worker renovando o lease enquanto o item está UPDATING
-    (processo/estado novo), custo desproporcional pro cenário. Reavaliar se surgir
-    evidência de webhook lento recorrente."""
-    items = list_pluggy_item_ids(user_id)
+    (processo/estado novo), custo desproporcional pro cenário."""
+    if origin == "startup":
+        print("[pluggy_sync] of_refresh_skipped_startup", flush=True)
+        return {"triggered": 0, "total": 0, "origin": origin, "skipped": "startup",
+                "failures": []}
+
+    claimed = claim_items_for_refresh(
+        cooldown_sec=_env_int("OF_REFRESH_MIN_INTERVAL_SEC", 6 * 60 * 60),
+        jitter_pct=float(_env_int("OF_REFRESH_JITTER_PCT", 10)),
+        origin=origin,
+        limit=limit,
+        user_id=user_id,
+    )
     triggered = 0
+    failures: list[dict] = []
     segurados: set[int] = set()
-    for item_id in items:
+    for row in claimed:
+        item_id = row.get("provider_item_id")
+        if not item_id:
+            continue
         try:
             # Segura o e-mail dos agregados ANTES do PATCH: daqui até o webhook
             # trazer os dados novos, o evento maduro seguiria reivindicável com o
             # valor velho — e o emailed_at recusaria a correção depois.
-            if user_id is not None:
-                if user_id not in segurados:
-                    _hold_aggregate_emails(user_id, "refresh_all")
-                    segurados.add(user_id)
-            else:
-                conn = get_open_finance_connection_by_item_id(item_id)
-                dono = (conn or {}).get("user_id")
-                if dono is not None and dono not in segurados:
-                    _hold_aggregate_emails(dono, "refresh_all")
-                    segurados.add(dono)
+            dono = row.get("user_id")
+            if dono is not None and dono not in segurados:
+                _hold_aggregate_emails(dono, "refresh_all")
+                segurados.add(dono)
             update_pluggy_item(item_id)
             triggered += 1
-        except Exception:
-            pass
-    return {"triggered": triggered, "total": len(items)}
+        except Exception as exc:
+            motivo = "item_missing" if item_missing(exc) else type(exc).__name__
+            failures.append({"item_id": item_id, "reason": motivo, "error": str(exc)[:200]})
+            print(f"[pluggy_sync] pluggy_refresh_patch_failed item={item_id} motivo={motivo}",
+                  flush=True)
+    return {"triggered": triggered, "total": len(claimed), "origin": origin,
+            "failures": failures,
+            "claimed": [{"item_id": r.get("provider_item_id"), "user_id": r.get("user_id")}
+                        for r in claimed]}
+
+
+def run_of_health_check(*, limit: int = 200) -> dict:
+    """Mede a saúde das conexões ativas com um `GET /items/{id}` por item.
+
+    Só GET: não consome cota de COLETA da Pluggy (o PATCH é que consome), então
+    pode rodar mesmo com o refresh desligado. É o que faz uma conexão cujo item
+    sumiu sair de ACTIVE — sem webhook e sem refresh, nada mais executaria o
+    caminho novo e ela ficaria "Atualizado" para sempre.
+
+    DISJUNTOR: este job escreve `status='ERROR'` em conexão de usuário e roda
+    ligado por padrão. Se a credencial apontar para o client errado, o
+    `GET /items/{id}` devolve 404 para TODOS e uma passada marcaria a base
+    inteira como `item_missing` — mandando todo mundo refazer a conexão.
+
+    A CONDIÇÃO DE SAÍDA é `checked > 0`, e é ela que faz o disjuntor convergir.
+    UM item que respondeu prova que a credencial está boa; se os outros deram
+    404 com a mesma chave, eles sumiram de verdade. Sem essa condição o
+    disjuntor travava PARA SEMPRE — medido: 10 conexões, 6 mortas, tick 1 marca
+    0 de 6 e as 4 sadias saem do lote (health fresco); do tick 2 em diante a
+    amostra É só a dos mortos, 100% > 50%, e as 6 nunca saíam de "Atualizado" —
+    exatamente o que este job existe para evitar quando `OF_REFRESH_ENABLED`
+    está off (o default).
+
+    Só quando NINGUÉM respondeu (`checked == 0`) o percentual manda: acima de
+    `OF_HEALTH_MISSING_ABORT_PCT` numa amostra de pelo menos
+    `OF_HEALTH_MIN_SAMPLE` items, a passada aborta sem gravar os ausentes e
+    loga. 100% desliga o disjuntor.
+    """
+    if (os.getenv("OF_HEALTH_CHECK_ENABLED") or "1").strip().lower() in ("0", "false", "no", "off"):
+        return {"checked": 0, "missing": 0, "skipped": "disabled"}
+
+    rows = list_connections_for_health_check(
+        older_than_sec=_env_int("OF_HEALTH_MAX_AGE_SEC", 12 * 60 * 60),
+        limit=limit,
+    )
+    if not rows:
+        return {"checked": 0, "missing": 0}
+
+    api_key = create_pluggy_api_key()
+    checked = 0
+    ausentes: list[dict] = []
+    for row in rows:
+        try:
+            item = get_pluggy_item(row["provider_item_id"], api_key)
+        except Exception as exc:
+            if not item_missing(exc):
+                print(f"[pluggy_sync] health check falhou item={row['provider_item_id']}: {exc}")
+                continue
+            ausentes.append(row)   # só grava depois, se o disjuntor não abrir
+            continue
+        # ok=None: saúde medida NÃO é sucesso de sync — não pode carimbar last_sync_at.
+        # `status` E `status_reason` saem JUNTOS do resolvedor: limpar só o motivo
+        # deixava o `status='ERROR'` que este mesmo job escreveu, e a tela trocava
+        # "Refaça a conexão" por "Erro temporário" — para sempre (medido). Igual
+        # para `no_accounts`: quem responde se ele ainda vale é o espelho
+        # (`has_data`, lido na mesma query), não a memória da última passada.
+        health = derive_item_health(item)
+        status, reason = resolve_connection_state(
+            health=health, has_data=bool(row.get("has_data")),
+            reason_atual=str(row.get("status_reason") or ""))
+        mark_sync_result(row["id"], ok=None, status=status, status_reason=reason,
+                         health=health)
+        checked += 1
+
+    limite = _env_int("OF_HEALTH_MISSING_ABORT_PCT", 50) / 100.0
+    minimo = _env_int("OF_HEALTH_MIN_SAMPLE", 5)
+    if (ausentes and checked == 0 and len(rows) >= minimo
+            and len(ausentes) / len(rows) > limite):
+        print(f"[pluggy_sync] of_health_circuit_open ausentes={len(ausentes)}/{len(rows)} "
+              f"limite={limite:.0%} — nada gravado", flush=True)
+        return {"checked": checked, "missing": 0, "aborted": "too_many_missing",
+                "missing_seen": len(ausentes), "sample": len(rows)}
+
+    status, reason = resolve_connection_state(missing=True)
+    for row in ausentes:
+        mark_sync_result(row["id"], ok=False, status=status, status_reason=reason,
+                         health=_HEALTH_MISSING())
+    return {"checked": checked, "missing": len(ausentes)}
 
 
 def _hold_aggregate_emails(user_id: int, origem: str) -> None:
@@ -316,18 +571,52 @@ def _hold_aggregate_emails(user_id: int, origem: str) -> None:
         print(f"[pluggy_sync] hold agregados ({origem}): {exc}")
 
 
+def _sync_item_contido(connection: dict) -> dict:
+    """`sync_pluggy_item` de UM item que NUNCA derruba o lote.
+
+    `sync_pluggy_item` re-levanta o que não é 404 de propósito (é o que faz o
+    webhook retentar um 429 — `_retryable`, em `frontend/routes/open_finance.py`).
+    No LOTE isso é o oposto do que se quer: um único banco com a cota estourada
+    subia a exceção até `refresh_and_sync_pluggy_user` e virava 502 na rota —
+    sem relatório por item, sem `of_manual_refresh` no log, e os bancos
+    saudáveis do mesmo usuário nunca sincronizavam. Falha de um item é
+    resultado DAQUELE item.
+
+    Mesma escolha já feita para a leitura de `/investments` (READ_FAILED, ver
+    `_sync_pluggy_item_confirmado`): leitura que falhou não é dado ausente.
+    """
+    item_id = connection["provider_item_id"]
+    try:
+        return sync_pluggy_item(item_id)
+    except Exception as exc:
+        print(f"[pluggy_sync] item {item_id} falhou no lote: {type(exc).__name__}: {exc}")
+        try:
+            # Tira o item do verde na tela: `status=None` é "não mexe" (a chamada
+            # falhou, não observamos a saúde do item — só que a tentativa não deu
+            # certo), e o motivo pendente faz `connection_ui_state` recusar
+            # "Atualizado" pelo default seguro dele. O motivo cai sozinho no
+            # próximo sync/job de saúde que conseguir ler.
+            mark_sync_result(connection["id"], ok=False, status=None,
+                             status_reason=READ_FAILED)
+        except Exception as exc2:  # banco fora do ar não pode derrubar o lote também
+            print(f"[pluggy_sync] mark_sync_result falhou ({item_id}): {exc2}")
+        return {"ok": False, "reason": READ_FAILED, "item_id": item_id,
+                "connection_id": connection.get("id"), "error": type(exc).__name__}
+
+
 def sync_pluggy_user(user_id: int) -> dict:
     """Sincroniza todos os itens Pluggy de um usuário (útil pra sync manual/testes)."""
     snapshot = get_open_finance_snapshot(user_id)
-    items = [
-        c["provider_item_id"]
+    conns = [
+        c
         for c in snapshot.get("connections", [])
         if (c.get("provider") == "pluggy" and c.get("provider_item_id"))
     ]
+    items = [c["provider_item_id"] for c in conns]
     if items:
         _hold_aggregate_emails(user_id, "sync_user")
 
-    results = [sync_pluggy_item(item_id) for item_id in items]
+    results = [_sync_item_contido(c) for c in conns]
 
     # Agentes whole-portfolio: rodam UMA vez, depois de TODOS os itens sincronizarem,
     # pra não gravar um retrato parcial que o dedupe por período congelaria. Ficam
@@ -356,11 +645,6 @@ def sync_pluggy_user(user_id: int) -> dict:
     }
 
 
-# Status de item Pluggy que significam "ainda buscando no banco" — enquanto o item
-# está nesses estados, os dados novos ainda não chegaram, então esperamos antes de sync.
-_PLUGGY_ITEM_UPDATING = {"UPDATING", "CREATED", "WAITING_USER_ACTION"}
-
-
 def refresh_and_sync_pluggy_user(
     user_id: int,
     *,
@@ -369,8 +653,7 @@ def refresh_and_sync_pluggy_user(
 ) -> dict:
     """Refresh sob demanda: pede pra Pluggy re-buscar do banco (PATCH /items),
     espera a atualização concluir e então sincroniza. É o que o botão "Atualizar"
-    do Open Finance chama — puxa transação nova, marca a conexão ACTIVE e limpa
-    o status "Pendente".
+    do Open Finance chama.
 
     Por que não é só sincronizar: sem webhook (ambiente de dev), o PATCH é
     ASSÍNCRONO na Pluggy — ela re-busca do banco e só depois os dados novos ficam
@@ -378,36 +661,64 @@ def refresh_and_sync_pluggy_user(
     transação que acabou de acontecer não estaria lá). Por isso esperamos o item
     sair de UPDATING (com teto de `wait_seconds`) antes de sincronizar.
 
-    Em produção o webhook `transactions/updated` já dispara o sync sozinho; este
-    fluxo é o fallback manual e cobre o dev.
+    A RESPOSTA É POR ITEM E POR PRODUTO. Antes, o 404 do PATCH e o do
+    `get_pluggy_item` eram engolidos (`except Exception: pass`), a função devolvia
+    `ok: True, still_updating: 0` e a tela dizia "Tudo em dia!" para uma conexão
+    morta. Agora cada item volta com estado, motivo e produtos, e o `ok` do topo é
+    a conjunção: só é verdadeiro se TODOS os itens estiverem em `_ESTADOS_OK`.
 
-    `wait_seconds` fica curto de propósito (teto abaixo do timeout do proxy) — se a
-    Pluggy demorar mais, sincronizamos o que já tem e devolvemos still_updating>0 pro
-    front pedir pra tocar "Atualizar" de novo. Configurável via OF_REFRESH_WAIT_SEC.
+    QUEM LEVA PATCH é decidido por `claim_manual_refresh`, não por "todo item do
+    snapshot": conexão PAUSED/DELETED fica de fora (o item nem existe mais na
+    Pluggy) e item refrescado há menos de `OF_MANUAL_REFRESH_COOLDOWN_SEC` volta
+    como `rate_limited`. Isto passou a ser obrigatório quando o pull-to-refresh
+    do app foi ligado neste caminho: antes o gesto só relia o snapshot, agora
+    cada puxão pediria coleta nova em todos os bancos do usuário.
     """
-    import os
-
     if wait_seconds is None:
-        try:
-            wait_seconds = int(os.getenv("OF_REFRESH_WAIT_SEC", "18"))
-        except ValueError:
-            wait_seconds = 18
+        wait_seconds = _env_int("OF_REFRESH_WAIT_SEC", 18)
     if poll_interval is None:
         try:
             poll_interval = float(os.getenv("OF_REFRESH_POLL_SEC", "2.5"))
-        except ValueError:
+        except (TypeError, ValueError):
             poll_interval = 2.5
 
+    t0 = time.monotonic()
     snapshot = get_open_finance_snapshot(user_id)
-    items = [
-        c["provider_item_id"]
-        for c in snapshot.get("connections", [])
+    conns = [
+        c for c in snapshot.get("connections", [])
         if (c.get("provider") == "pluggy" and c.get("provider_item_id"))
     ]
+    items = [c["provider_item_id"] for c in conns]
+    institutions = {c["provider_item_id"]: c.get("institution_name") for c in conns}
+
     if not items:
         # Sem banco Pluggy (ex.: só conexão mock): nada a refrescar, só sincroniza.
         result = sync_pluggy_user(user_id)
-        return {"ok": True, "refreshed": 0, "waited": False, "still_updating": 0, **result}
+        return {**result, "ok": True, "refreshed": 0, "waited": False, "still_updating": 0,
+                "items": [], "duration_ms": int((time.monotonic() - t0) * 1000)}
+
+    # Reivindica ANTES de falar com a Pluggy: o UPDATE condicional é o que
+    # serializa a rajada (5 puxões seguidos = 1 PATCH) e o que exclui os status
+    # terminais. Quem não foi reivindicado não leva PATCH nem espera.
+    liberados = claim_manual_refresh(
+        user_id, items,
+        cooldown_sec=_env_int("OF_MANUAL_REFRESH_COOLDOWN_SEC", 120),
+    )
+    rate_limited = {i for i in items if i not in set(liberados)}
+
+    if not liberados:
+        # Dentro do cooldown: zero PATCH e zero espera — mas SINCRONIZA. O que o
+        # cooldown protege é a cota de COLETA da Pluggy (só o PATCH a consome);
+        # reler o que ela já tem é GET. Antes isto era early-return puro, e
+        # bastava o tick periódico passar para o botão do usuário virar um
+        # "já está tudo em dia" sem ter olhado nada.
+        result = sync_pluggy_user(user_id)
+        parado = _refresh_items_report(items, institutions, {},
+                                       _reasons_do_sync(result), set(),
+                                       rate_limited=rate_limited)
+        return {**result, "ok": _todos_ok(parado), "refreshed": 0, "waited": False,
+                "still_updating": 0, "items": parado,
+                "duration_ms": int((time.monotonic() - t0) * 1000)}
 
     # Segura o e-mail dos agregados ANTES do PATCH: a espera do passo 2 leva até
     # wait_seconds (18s por padrão) e o touch de sync_pluggy_user só acontece
@@ -416,14 +727,19 @@ def refresh_and_sync_pluggy_user(
 
     api_key = create_pluggy_api_key()
 
-    # 1. Dispara o refresh na Pluggy pra cada item (falha por item não trava o resto).
+    # 1. Dispara o refresh na Pluggy pra cada item. Falha por item não trava o
+    #    resto, mas PARA DE SER INVISÍVEL: vira motivo na resposta.
     triggered = 0
-    for item_id in items:
+    patch_ok: dict[str, bool] = {}
+    reasons: dict[str, str] = {}
+    for item_id in liberados:
         try:
             update_pluggy_item(item_id, api_key)
+            patch_ok[item_id] = True
             triggered += 1
-        except Exception:
-            pass
+        except Exception as exc:
+            patch_ok[item_id] = False
+            reasons[item_id] = "item_missing" if item_missing(exc) else "refresh_failed"
 
     # 2. Espera os itens saírem de UPDATING (Pluggy terminou de re-buscar do banco).
     #    time.sleep aqui é ok: a rota chama isto via asyncio.to_thread (fora do loop).
@@ -431,26 +747,107 @@ def refresh_and_sync_pluggy_user(
     #    e pode passar do _SYNC_QUIET_MIN — sem renovar, o hold expiraria durante a
     #    própria espera e o e-mail poderia sair antes do sync final.
     deadline = time.monotonic() + max(0, wait_seconds)
-    pending = set(items)
+    pending = set(liberados)
     while pending and time.monotonic() < deadline:
         _hold_aggregate_emails(user_id, "refresh_user")
         time.sleep(poll_interval)
         for item_id in list(pending):
             try:
                 item = get_pluggy_item(item_id, api_key)
-            except Exception:
+            except Exception as exc:
                 pending.discard(item_id)  # erro de leitura não trava o fluxo
+                reasons.setdefault(item_id, "item_missing" if item_missing(exc) else "read_failed")
                 continue
             status = str(item.get("status") or "").upper()
-            if status not in _PLUGGY_ITEM_UPDATING:
+            if status not in ITEM_UPDATING:
                 pending.discard(item_id)
 
-    # 3. Sincroniza (idempotente): puxa contas/transações novas e marca ACTIVE.
+    # 3. Sincroniza (idempotente): puxa contas/transações novas e carimba o resultado.
     result = sync_pluggy_user(user_id)
+    reasons.update(_reasons_do_sync(result))
+
+    items_out = _refresh_items_report(items, institutions, patch_ok, reasons, pending,
+                                      rate_limited=rate_limited)
+    # `**result` PRIMEIRO: ele traz um `ok` próprio (o de sync_pluggy_user, que é
+    # sempre True) e sobrescreveria o veredito por item se viesse depois.
     return {
-        "ok": True,
+        **result,
+        "ok": _todos_ok(items_out),
         "refreshed": triggered,
         "waited": True,
         "still_updating": len(pending),
-        **result,
+        "items": items_out,
+        "duration_ms": int((time.monotonic() - t0) * 1000),
     }
+
+
+# Estados que autorizam dizer "tudo em dia". LISTA DE PERMISSÃO, nunca de
+# exclusão: um estado novo que este arquivo não conhece precisa nascer FALSO.
+# `rate_limited` entra porque significa "acabou de ser atualizado", não "falhou".
+_ESTADOS_OK = ("updated", "rate_limited")
+
+
+def _todos_ok(items_out: list[dict]) -> bool:
+    return all(i["state"] in _ESTADOS_OK for i in items_out)
+
+
+def _reasons_do_sync(result: dict) -> dict[str, str]:
+    """Motivo por item dos syncs que não deram certo (os dois caminhos usam)."""
+    return {str(r.get("item_id")): str(r.get("reason"))
+            for r in (result.get("results") or [])
+            if not r.get("ok") and r.get("reason")}
+
+
+# Estado SOBREPOSTO aqui → (rótulo, detalhe). O rótulo vem do banco via
+# `connection_ui_state`; quando este relatório troca o `state`, o rótulo tem que
+# ir junto — senão sai `state="partial"` com `label="Atualizado"`, que é
+# armadilha para quem consumir isto depois. Só vale para o estado que ESTE
+# arquivo sobrepõe: um "partial" vindo do `connection_ui_state` mantém o detalhe
+# dele ("Cartão desatualizado desde 12/08"), que diz muito mais.
+_OVERRIDE_LABEL = {
+    "partial": ("Parcial", "Parte dos dados ainda não veio"),
+    "rate_limited": ("Atualizado", "Atualizado há pouco"),
+}
+
+
+# Produto → como ele aparece na resposta quando está atrasado.
+def _product_state(info: dict) -> str:
+    if info.get("updated"):
+        return "updated"
+    last = str(info.get("last_updated_at") or "")[:10]
+    return f"stale_since_{last}" if last else "stale"
+
+
+def _refresh_items_report(items, institutions, patch_ok, reasons, pending,
+                          *, rate_limited=()) -> list[dict]:
+    """Estado por item DEPOIS do sync, lido do banco — que é onde o `mark_sync_result`
+    acabou de gravar status, motivo e saúde. `connection_ui_state` é quem decide o
+    estado; aqui só se junta com o resultado do PATCH e da espera."""
+    out = []
+    for item_id in items:
+        rows = get_connections_by_item_id(item_id)
+        row = rows[0] if len(rows) == 1 else {}
+        ui = connection_ui_state(row)
+        health = row.get("health") if isinstance(row.get("health"), dict) else {}
+        state, label, detail = ui["state"], ui["label"], ui["detail"]
+        if not patch_ok.get(item_id, True) and state == "updated":
+            # PATCH falhou mas o espelho estava íntegro: não é "tudo em dia".
+            state, (label, detail) = "partial", _OVERRIDE_LABEL["partial"]
+        elif item_id in rate_limited and state == "updated":
+            # Dentro do cooldown do manual: não pedimos coleta nova, e o que está
+            # no banco é recente. Só sobrepõe o estado quando ele era verde — um
+            # item perdido/pausado continua reportando o que ele é.
+            state, (label, detail) = "rate_limited", _OVERRIDE_LABEL["rate_limited"]
+        out.append({
+            "item_id": item_id,
+            "institution": institutions.get(item_id),
+            "state": state,
+            "label": label,
+            "detail": detail,
+            "products": {k: _product_state(v) for k, v in (health.get("products") or {}).items()},
+            "reason": ("rate_limited" if state == "rate_limited"
+                       else (reasons.get(item_id) or row.get("status_reason"))),
+            "patch_ok": bool(patch_ok.get(item_id, False)),
+            "still_updating": item_id in pending,
+        })
+    return out

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -250,6 +250,21 @@ from .open_finance import (
     update_pluggy_open_finance_item_status,
 )
 
+# ── Open Finance: estado da conexão (tentativa × sucesso, saúde, claim, lock) ──
+from .open_finance_state import (
+    AmbiguousItemError,
+    claim_items_for_refresh,
+    claim_manual_refresh,
+    get_connections_by_item_id,
+    list_connections_for_health_check,
+    mark_sync_attempt,
+    mark_sync_result,
+    of_health_counters,
+    pluggy_item_lock,
+    register_item,
+    token_hash,
+)
+
 # ── Renda variável (ações/FIIs via Open Finance) ──────────────────────────────
 from .rv import (
     list_rv_positions,
@@ -514,6 +529,10 @@ __all__ = [
     "sync_imported_open_finance_updates", "get_consolidated_balance", "list_bank_accounts", "pending_bank_outflows", "assert_bank_covers",
     "disconnect_open_finance_connection", "save_pluggy_open_finance_item", "user_synced_within",
     "update_pluggy_open_finance_item_status",
+    "AmbiguousItemError", "claim_items_for_refresh", "claim_manual_refresh",
+    "get_connections_by_item_id",
+    "list_connections_for_health_check", "mark_sync_attempt", "mark_sync_result",
+    "of_health_counters", "pluggy_item_lock", "register_item", "token_hash",
     "list_pluggy_connections_for_trial_sweep", "pause_open_finance_connection",
     # reports
     "set_daily_report_enabled", "set_daily_report_hour", "get_daily_report_prefs",

--- a/db/cards.py
+++ b/db/cards.py
@@ -694,18 +694,43 @@ def add_imported_credit_purchase(
 
     with get_conn() as conn:
         with conn.cursor() as cur:
+            # O SELECT acima é o caminho rápido; o ON CONFLICT é a rede da CORRIDA.
+            # Dois webhooks da Pluggy (`item/updated` e `transactions/created`, 0–17s
+            # de intervalo) sincronizavam o mesmo item em paralelo e os dois passavam
+            # pelo SELECT antes de qualquer INSERT — 1 `duplicate key` em
+            # `uq_credit_tx_source_external` medido em produção.
+            #
+            # DO NOTHING, nunca DO UPDATE: atualizar `valor` aqui mudaria a compra sem
+            # ajustar `credit_bills.total` nem migrar de fatura — corromperia a fatura
+            # em silêncio. Correção legítima vinda da Pluggy tem caminho próprio
+            # (`sync_imported_open_finance_updates`), que ajusta o total pela diferença
+            # e migra de ciclo. `where external_id is not null` reproduz o predicado do
+            # índice PARCIAL (db/schema.py) — sem ele o Postgres não infere o índice.
             cur.execute(
                 """
                 insert into credit_transactions
                     (bill_id, user_id, card_id, tipo, valor, categoria, nota, purchased_at, is_refund,
                      source, external_id, installment_no, installments_total, group_id)
                 values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                on conflict (user_id, source, external_id) where external_id is not null
+                do nothing
                 returning id
                 """,
                 (bill_id, user_id, card_id, tipo, valor, categoria, None, purchased_at, is_refund,
                  source, external_id, installment_no, installments_total, group_id),
             )
-            tx_id = cur.fetchone()["id"]
+            row = cur.fetchone()
+            if row is None:
+                # A outra transação ganhou: devolve a linha dela e NÃO soma a fatura
+                # de novo (era exatamente assim que o total dobrava).
+                cur.execute(
+                    "select id from credit_transactions where user_id=%s and source=%s and external_id=%s",
+                    (user_id, source, external_id),
+                )
+                existing = cur.fetchone()
+                conn.commit()
+                return (existing["id"] if existing else None), False
+            tx_id = row["id"]
             cur.execute(
                 "update credit_bills set total = total + %s where id=%s and user_id=%s",
                 (valor, bill_id, user_id),  # valor já assinado: compra sobe, estorno desce

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -243,14 +243,21 @@ def get_open_finance_snapshot(user_id: int, limit: int = 8) -> dict:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                select id, provider, provider_item_id, status, institution_name, last_sync_at
+                select id, provider, provider_item_id, status, institution_name, last_sync_at,
+                       last_attempt_at, status_reason, health
                 from open_finance_connections
                 where user_id=%s
                 order by updated_at desc, id desc
                 """,
                 (user_id,),
             )
-            connections = cur.fetchall()
+            connections = [dict(r) for r in (cur.fetchall() or [])]
+            # `ui` é o estado exibível — decidido por `connection_ui_state`, a única
+            # função que o decide. O front deixou de derivar rótulo do `status`:
+            # ele não sabe de produto atrasado nem de item que sumiu.
+            from core.services.pluggy_health import connection_ui_state
+            for c in connections:
+                c["ui"] = connection_ui_state(c)
 
             cur.execute(
                 """
@@ -446,16 +453,30 @@ def save_pluggy_open_finance_item(user_id: int, item: dict) -> dict:
                 """
                 insert into open_finance_connections (
                     user_id, provider, provider_item_id, status, institution_id,
-                    institution_name, consent_url, consent_expires_at, last_sync_at, raw, updated_at
+                    institution_name, consent_url, consent_expires_at, raw, updated_at
                 )
-                values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                values (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
                 on conflict (user_id, provider, provider_item_id)
                 do update set status = excluded.status,
                               institution_id = excluded.institution_id,
                               institution_name = excluded.institution_name,
-                              last_sync_at = excluded.last_sync_at,
                               raw = excluded.raw,
-                              updated_at = excluded.updated_at
+                              updated_at = excluded.updated_at,
+                              -- Linha G da tabela de estados
+                              -- (core/services/pluggy_health.py): reconectar
+                              -- ZERA motivo e saúde. Sem isto a tela dizia
+                              -- "Conexão perdida / Refaça a conexão" logo depois
+                              -- de o usuário ter refeito — e um health velho com
+                              -- item_status MISSING ainda pintava a tela.
+                              status_reason = null,
+                              health = null
+                -- NÃO carimba last_sync_at: conectar não é sincronizar. Carimbar
+                -- aqui fazia a conexão nascer "Atualizado agora" antes de qualquer
+                -- sync e ligava `user_synced_within`, que segura o e-mail dos
+                -- agentes achando que uma carteira estava se mexendo. Quem carimba
+                -- sucesso é `mark_sync_result`, no fim de um sync real.
+                -- `status` continua sendo escrito: é ele que tira a conexão de
+                -- DELETED quando o usuário reconecta pelo widget.
                 returning id, provider, provider_item_id, status, institution_name, last_sync_at
                 """,
                 (
@@ -467,7 +488,6 @@ def save_pluggy_open_finance_item(user_id: int, item: dict) -> dict:
                     str(institution_name),
                     None,
                     None,
-                    now,
                     Jsonb(item),
                     now,
                 ),
@@ -489,12 +509,38 @@ def update_pluggy_open_finance_item_status(provider_item_id: str, status: str, r
                 """
                 update open_finance_connections
                 set status=%s,
+                    -- O par (status, status_reason) é UM estado só. Este caminho
+                    -- (webhook) não passa pelo `resolve_connection_state` porque
+                    -- ele não observa o item — só repete o que a Pluggy disse —,
+                    -- mas grava o MESMO par que o resolvedor daria: linhas B/C da
+                    -- tabela (item em erro) são ERROR + motivo VAZIO, porque quem
+                    -- conta a história ali é o status/health, não o motivo de
+                    -- ontem. Sem isto, `item/error` sobre ACTIVE/no_accounts
+                    -- produzia ERROR/no_accounts — par incoerente (medido).
+                    -- EXCEÇÃO, `item_missing`: WEBHOOK NÃO É EVIDÊNCIA DE ITEM VIVO.
+                    -- Apagá-lo REBAIXA a mensagem — um `item/error` entregue com
+                    -- atraso (replay) sobre o par que o job de saúde acabou de
+                    -- gravar virava ERROR/None → "Erro temporário / Tentaremos de
+                    -- novo automaticamente" (medido), e o usuário parava de ser
+                    -- mandado refazer a conexão. Aceitar isso seria aceitar até
+                    -- ~12h (OF_HEALTH_MAX_AGE_SEC) mostrando estado saudável numa
+                    -- conexão que exige ação — a mentira que esta onda existe para
+                    -- matar. Quem PODE limpar `item_missing` é só quem OBSERVA o
+                    -- item: o job de saúde (GET /items) e o sync bem-sucedido, os
+                    -- dois pelo `resolve_connection_state`. E o par continua
+                    -- coerente: ERROR/item_missing é exatamente a linha A da tabela,
+                    -- o mesmo par que o job de saúde grava.
+                    status_reason=case
+                        when lower(coalesce(status_reason,'')) = 'item_missing' then status_reason
+                        else null end,
                     raw=coalesce(%s, raw),
                     updated_at=now()
                 where provider='pluggy' and provider_item_id=%s
-                  -- PAUSED é estado local terminal (trial venceu): deletar o item na
-                  -- Pluggy dispara webhook item/deleted, que não pode sobrescrevê-lo.
-                  and upper(coalesce(status,'')) <> 'PAUSED'
+                  -- PAUSED e DELETED são estados locais TERMINAIS: PAUSED = trial
+                  -- vencido (o item nem existe mais na Pluggy), DELETED = conexão
+                  -- removida. Webhook atrasado (item/updated depois do item/deleted)
+                  -- não pode ressuscitar nenhum dos dois.
+                  and upper(coalesce(status,'')) not in ('PAUSED', 'DELETED')
                 """,
                 (status, Jsonb(raw) if raw is not None else None, item_id),
             )
@@ -804,23 +850,20 @@ def sync_open_finance_caixinhas(connection_id: int, user_id: int) -> dict:
 
 
 def get_open_finance_connection_by_item_id(provider_item_id: str, provider: str = "pluggy") -> dict | None:
-    """Localiza a conexão pelo item da Pluggy (o webhook só traz o item, não o user)."""
-    item_id = (provider_item_id or "").strip()
-    if not item_id:
-        return None
+    """A conexão daquele item da Pluggy (o webhook só traz o item, não o user).
 
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                select id, user_id, provider, provider_item_id, status, institution_name
-                from open_finance_connections
-                where provider=%s and provider_item_id=%s
-                limit 1
-                """,
-                (provider, item_id),
-            )
-            return cur.fetchone()
+    Levanta `AmbiguousItemError` quando o item aparece em mais de uma conexão. O
+    `limit 1` sem `order by` que existia aqui escolhia um dono ao acaso — e a
+    tabela permite (user_id, provider, provider_item_id), ou seja, dois usuários
+    PODEM ter o mesmo item. Sincronizar a carteira do usuário sorteado é pior que
+    falhar alto.
+    """
+    from .open_finance_state import AmbiguousItemError, get_connections_by_item_id
+
+    rows = get_connections_by_item_id(provider_item_id, provider)
+    if len(rows) > 1:
+        raise AmbiguousItemError((provider_item_id or "").strip(), rows)
+    return rows[0] if rows else None
 
 
 def delete_open_finance_transactions(
@@ -946,16 +989,12 @@ def save_open_finance_sync(connection_id: int, accounts: list[dict]) -> dict:
                     )
                     transaction_count += 1
 
-            # Fix (b): sync com sucesso (contas puxadas) já marca a conexão ATIVA —
-            # não depende do webhook item/updated pra sair de "Pendente".
-            cur.execute(
-                """
-                update open_finance_connections
-                set status='ACTIVE', last_sync_at=%s, updated_at=%s
-                where id=%s
-                """,
-                (now, now, connection_id),
-            )
+            # NÃO carimba status/last_sync_at aqui. Esta função é o ESPELHO e só
+            # isso: ela roda igual com 0 contas (item deletado devolve
+            # `/accounts` = 200 + results:[]) e carimbar ACTIVE aqui era o que
+            # ressuscitava conexão morta — DELETED/ERROR viravam ACTIVE com
+            # "sincronizado agora". Quem afirma sucesso é `mark_sync_result`, no
+            # sync, DEPOIS de o `GET /items/{id}` confirmar que o item existe.
         conn.commit()
 
     return {"accounts_synced": account_count, "transactions_synced": transaction_count}
@@ -1739,7 +1778,7 @@ def detect_open_finance_bill_increase(user_id: int, months: int = 4) -> list:
 # conexão atual e portanto não podem compor o saldo corrente.
 # Só contas em BRL: o saldo manual é em reais e não há conversão de câmbio —
 # somar USD 100 como R$ 100 mentiria o total.
-_BANK_ACCOUNTS_SQL = """
+BANK_ACCOUNTS_SQL = """
     select * from (
         select distinct on (a.provider_account_id)
             a.id, a.name, a.balance, c.institution_name,
@@ -1757,12 +1796,12 @@ _BANK_ACCOUNTS_SQL = """
 def list_bank_accounts(user_id: int) -> list[dict]:
     """Contas BANK conectadas e ativas, com saldo e rótulo para exibição.
 
-    Mesmo recorte do `get_consolidated_balance` — as duas leem `_BANK_ACCOUNTS_SQL`.
+    Mesmo recorte do `get_consolidated_balance` — as duas leem `BANK_ACCOUNTS_SQL`.
     """
     ensure_user(user_id)
     with get_conn() as conn:
         with conn.cursor() as cur:
-            cur.execute(_BANK_ACCOUNTS_SQL + " order by balance desc nulls last, id", (user_id,))
+            cur.execute(BANK_ACCOUNTS_SQL + " order by balance desc nulls last, id", (user_id,))
             rows = [dict(r) for r in (cur.fetchall() or [])]
 
     for r in rows:
@@ -1884,7 +1923,7 @@ def get_consolidated_balance(user_id: int) -> dict:
             manual = row["b"] if row else Decimal("0")
 
             cur.execute(
-                f"select coalesce(sum(balance), 0) as b, count(*) as n from ({_BANK_ACCOUNTS_SQL}) s",
+                f"select coalesce(sum(balance), 0) as b, count(*) as n from ({BANK_ACCOUNTS_SQL}) s",
                 (user_id,),
             )
             of_row = cur.fetchone()

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -1,0 +1,497 @@
+"""Estado da conexão Open Finance: tentativa, resultado, cooldown e posse do item.
+
+Existe porque `save_open_finance_sync` carimbava `status='ACTIVE', last_sync_at=now()`
+INCONDICIONALMENTE, no fim de todo caminho — inclusive quando a Pluggy tinha devolvido
+`{"results": []}` para um item já deletado (o `/accounts` responde 200 com lista vazia;
+só o `GET /items/{id}` devolve 404). Resultado medido em produção: conexão morta
+aparecendo como "Atualizado agora" e `DELETED`/`ERROR` ressuscitando para `ACTIVE`.
+
+A separação é toda a ideia:
+  • `last_attempt_at` = tentamos;
+  • `last_sync_at`    = deu certo (não há `last_success_at`: seria a segunda versão
+    da mesma verdade — §0.7);
+  • `health`          = o que o `GET /items/{id}` disse, produto a produto;
+  • `next_refresh_at` = cooldown E alvo do claim atômico entre instâncias.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+from contextlib import contextmanager
+from datetime import datetime
+from functools import lru_cache
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from utils_date import _tz
+
+from .connection import get_conn
+
+# Estados locais terminais: nenhum resultado de sync pode sobrescrevê-los.
+# PAUSED = trial venceu (o item nem existe mais na Pluggy); DELETED = removido.
+# CUIDADO: interpolado como tupla Python nos `f"""..."""` abaixo — reduzir a lista
+# a UM elemento emitiria `('PAUSED',)` e quebraria o SQL. Ao mexer, vire lista SQL.
+_TERMINAL = ("PAUSED", "DELETED")
+
+
+class AmbiguousItemError(RuntimeError):
+    """O mesmo provider_item_id aparece em mais de uma conexão (usuários diferentes).
+
+    Antes disto, `get_open_finance_connection_by_item_id` fazia `limit 1` SEM
+    `order by`: o webhook do item escolhia um dono ao acaso e sincronizava a
+    carteira do usuário errado. Levantar é o único desfecho seguro.
+    """
+
+    def __init__(self, item_id: str, connections: list[dict]):
+        super().__init__(f"item {item_id} está ligado a {len(connections)} conexões")
+        self.item_id = item_id
+        self.connections = connections
+
+
+def get_connections_by_item_id(item_id: str, provider: str = "pluggy") -> list[dict]:
+    """TODAS as conexões daquele item — sem `limit`, para que a ambiguidade apareça."""
+    item = (item_id or "").strip()
+    if not item:
+        return []
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select id, user_id, provider, provider_item_id, status, institution_name,
+                       last_sync_at, last_attempt_at, status_reason, health,
+                       next_refresh_at, last_refresh_origin
+                from open_finance_connections
+                where provider=%s and provider_item_id=%s
+                order by id
+                """,
+                (provider, item),
+            )
+            return [dict(r) for r in (cur.fetchall() or [])]
+
+
+def mark_sync_attempt(connection_id: int, *, origin: str = "sync") -> int:
+    """Carimba a TENTATIVA. Nunca toca em last_sync_at."""
+    now = datetime.now(_tz())
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                update open_finance_connections
+                   set last_attempt_at=%s, last_refresh_origin=coalesce(%s, last_refresh_origin),
+                       updated_at=%s
+                 where id=%s
+                   and upper(coalesce(status,'')) not in {_TERMINAL}
+                """,
+                (now, origin, now, connection_id),
+            )
+            updated = cur.rowcount
+        conn.commit()
+    return updated
+
+
+def mark_sync_result(
+    connection_id: int,
+    *,
+    ok: bool | None,
+    status: str | None = None,
+    status_reason: str | None = None,
+    health: dict | None = None,
+    at: datetime | None = None,
+) -> int:
+    """Resultado de um sync (ou do job de saúde, com ok=None).
+
+    `ok=True`  → carimba last_sync_at (sucesso) e o status pedido.
+    `ok=False` → carimba só a tentativa e o motivo; last_sync_at fica onde estava.
+    `ok=None`  → job de saúde: grava `health` sem afirmar sucesso nem falha.
+
+    `status_reason`: None mantém o motivo atual, `""` APAGA. Apagar precisava
+    existir — com `coalesce` puro, um `item_missing` gravado por um 404
+    transitório só saía num sync completo, e o sync periódico é dormente por
+    padrão (`OF_REFRESH_ENABLED`): a tela mandava refazer a conexão para sempre.
+    """
+    now = at or datetime.now(_tz())
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                update open_finance_connections
+                   set status = coalesce(%s, status),
+                       status_reason = case when %s = '' then null
+                                            else coalesce(%s, status_reason) end,
+                       health = coalesce(%s, health),
+                       last_attempt_at = case when %s then last_attempt_at else %s end,
+                       last_sync_at = case when %s then %s else last_sync_at end,
+                       updated_at = %s
+                 where id=%s
+                   and upper(coalesce(status,'')) not in {_TERMINAL}
+                """,
+                (
+                    (str(status).upper() if status else None),
+                    status_reason, status_reason,
+                    (Jsonb(health) if health is not None else None),
+                    ok is None, now,          # job de saúde não é tentativa de sync
+                    bool(ok), now,            # só sucesso avança last_sync_at
+                    now,
+                    connection_id,
+                ),
+            )
+            updated = cur.rowcount
+        conn.commit()
+    return updated
+
+
+def claim_items_for_refresh(
+    *,
+    cooldown_sec: int,
+    jitter_pct: float,
+    origin: str,
+    limit: int,
+    user_id: int | None = None,
+) -> list[dict]:
+    """Reivindica os items elegíveis e JÁ agenda o próximo — num UPDATE ... RETURNING.
+
+    Atômico entre instâncias: duas réplicas do Railway (o deploy sobe a nova antes
+    de derrubar a velha) rodando o mesmo tick não pegam o mesmo item, porque quem
+    perde a linha já a vê com `next_refresh_at` no futuro. O jitter espalha os
+    items para não baterem todos na Pluggy no mesmo segundo.
+
+    NÃO escreve `last_refresh_requested_at`: aquela coluna é o relógio do
+    cooldown MANUAL (`claim_manual_refresh`), e só ele a lê. Uma coluna com dois
+    relógios (§0.7) fazia o tick periódico queimar o botão do usuário — medido:
+    logo depois de um tick, o refresh manual voltava vazio por 120s. O relógio
+    deste caminho é `next_refresh_at`, que já está sendo escrito acima.
+    """
+    # Jitter serve para ESPALHAR, não para viajar no tempo: com 400% (medido),
+    # 14 de 40 agendamentos caíam no PASSADO e o cooldown persistido — a razão de
+    # existir da coluna — deixava de valer. Teto de 100% → fator em [0.5, 1.5].
+    jitter = min(max(float(jitter_pct or 0), 0.0), 100.0) / 100.0
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                update open_finance_connections
+                   set next_refresh_at = now()
+                        + make_interval(secs => %s) * (1 + (random()-0.5)*%s),
+                       last_refresh_origin = %s
+                 where id in (
+                       select id from open_finance_connections
+                        where provider='pluggy'
+                          and upper(coalesce(status,'')) not in {_TERMINAL}
+                          and (next_refresh_at is null or next_refresh_at <= now())
+                          and (%s::bigint is null or user_id = %s)
+                        order by next_refresh_at nulls first, id
+                        limit %s
+                        for update skip locked
+                 )
+                returning id, user_id, provider_item_id
+                """,
+                (cooldown_sec, jitter, origin, user_id, user_id, limit),
+            )
+            rows = [dict(r) for r in (cur.fetchall() or [])]
+        conn.commit()
+    return rows
+
+
+def claim_manual_refresh(user_id: int, item_ids: list[str], *, cooldown_sec: int) -> list[str]:
+    """Quais items deste usuário PODEM levar um PATCH agora. Reivindica e devolve.
+
+    Duas coisas que o caminho manual não tinha e viraram incidente quando o
+    pull-to-refresh passou a chamá-lo (antes ele só relia o snapshot):
+
+      • **rajada**: 5 puxões seguidos viravam 5 PATCH por banco — medido. O
+        `where` condicional é o que serializa: quem chega dentro do cooldown não
+        atualiza linha nenhuma e volta de mãos vazias, mesmo em paralelo.
+      • **status terminal**: PAUSED (trial vencido) e DELETED levavam PATCH
+        também, gastando cota num item que nem existe mais na Pluggy.
+
+    O cooldown é CURTO de propósito (`OF_MANUAL_REFRESH_COOLDOWN_SEC`, 120s): o
+    manual tem que poder furar o tick de 6h — ele só não pode martelar. Por isso
+    ele mora em `last_refresh_requested_at`, e não em `next_refresh_at`, que é o
+    relógio do tick periódico.
+    """
+    ids = [str(i) for i in (item_ids or []) if i]
+    if not ids:
+        return []
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                update open_finance_connections
+                   set last_refresh_requested_at = now(), last_refresh_origin = 'manual'
+                 where user_id = %s and provider = 'pluggy'
+                   and provider_item_id = any(%s)
+                   and upper(coalesce(status,'')) not in {_TERMINAL}
+                   and (last_refresh_requested_at is null
+                        or last_refresh_requested_at <= now() - make_interval(secs => %s))
+                returning provider_item_id
+                """,
+                (user_id, ids, cooldown_sec),
+            )
+            claimed = [r["provider_item_id"] for r in (cur.fetchall() or [])]
+        conn.commit()
+    return claimed
+
+
+def list_connections_for_health_check(*, older_than_sec: int, limit: int) -> list[dict]:
+    """Conexões ativas cuja saúde nunca foi medida ou está velha demais.
+
+    É o que faz uma conexão morta sair de ACTIVE mesmo com o refresh desligado e
+    sem webhook nenhum: um `GET /items/{id}` não consome cota de coleta.
+
+    `has_data` vem junto porque o job de saúde precisa decidir `no_accounts` por
+    OBSERVAÇÃO e não por memória (ver a tabela em `core/services/pluggy_health.py`):
+    sem ele, um `no_accounts` de uma passada ruim ficava pegajoso para sempre.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                select c.id, c.user_id, c.provider_item_id, c.status, c.status_reason,
+                       c.health,
+                       (exists (select 1 from open_finance_accounts a
+                                 where a.connection_id = c.id)
+                        or exists (select 1 from open_finance_investments i
+                                    where i.connection_id = c.id)) as has_data
+                  from open_finance_connections c
+                 where provider='pluggy'
+                   and upper(coalesce(status,'')) not in {_TERMINAL}
+                   and provider_item_id is not null
+                   and (
+                       health is null
+                       or coalesce((health->>'observed_at')::timestamptz, to_timestamp(0))
+                          < now() - make_interval(secs => %s)
+                   )
+                 order by id
+                 limit %s
+                """,
+                (older_than_sec, limit),
+            )
+            return [dict(r) for r in (cur.fetchall() or [])]
+
+
+def register_item(
+    user_id: int | None,
+    *,
+    provider_item_id: str | None = None,
+    token_hash: str | None = None,
+    origin: str,
+    status: str | None = None,
+    last_event: str | None = None,
+    provider: str = "pluggy",
+) -> int:
+    """Registra que um item (ou um connect token) existiu.
+
+    O `GET /items` da Pluggy devolve 401, então o universo remoto NÃO é
+    enumerável: sem este rastro não há como descobrir um item órfão. Guarda
+    HASH do token, nunca o token — ele autoriza abrir a conexão.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into open_finance_item_registry
+                    (user_id, provider, provider_item_id, connect_token_hash,
+                     origin, status, last_event)
+                values (%s,%s,%s,%s,%s,%s,%s)
+                returning id
+                """,
+                (user_id, provider, provider_item_id, token_hash, origin, status, last_event),
+            )
+            new_id = cur.fetchone()["id"]
+        conn.commit()
+    return new_id
+
+
+def token_hash(access_token: str) -> str:
+    """sha256 do connect token — o BRUTO nunca vai para o banco."""
+    return hashlib.sha256((access_token or "").encode("utf-8")).hexdigest()
+
+
+def of_health_counters() -> dict[str, Any]:
+    """Contadores da aba Open Finance do painel admin (uma query, sem PII)."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select
+                  count(*) filter (where upper(coalesce(status,'')) in ('ACTIVE','UPDATED')) as ativas,
+                  count(*) filter (where upper(coalesce(status,'')) = 'ERROR') as erro,
+                  count(*) filter (where coalesce(jsonb_array_length(health->'stale_products'),0) > 0)
+                      as parciais,
+                  count(*) filter (where status_reason = 'item_missing') as item_missing,
+                  count(*) filter (where status_reason = 'no_accounts') as sem_contas,
+                  count(*) as total,
+                  max(extract(epoch from (now() - last_sync_at)))
+                      filter (where upper(coalesce(status,'')) not in ('PAUSED','DELETED'))
+                      as maior_atraso_sec
+                from open_finance_connections
+                where provider='pluggy'
+                """
+            )
+            row = dict(cur.fetchone() or {})
+
+            # Produto mais atrasado: lido do health, que é onde a Pluggy diz
+            # quem ficou pra trás (o status da conexão não sabe disso).
+            cur.execute(
+                """
+                select p as produto, count(*) as n
+                  from open_finance_connections,
+                       lateral jsonb_array_elements_text(coalesce(health->'stale_products','[]'::jsonb)) p
+                 where provider='pluggy'
+                   and upper(coalesce(status,'')) not in ('PAUSED','DELETED')
+                 group by p order by n desc
+                """
+            )
+            row["stale_por_produto"] = {r["produto"]: int(r["n"]) for r in (cur.fetchall() or [])}
+
+            # Items vistos (registry) que não têm conexão local nenhuma.
+            cur.execute(
+                """
+                select count(distinct r.provider_item_id) as n
+                  from open_finance_item_registry r
+                 where r.provider_item_id is not null
+                   and not exists (
+                       select 1 from open_finance_connections c
+                        where c.provider = r.provider
+                          and c.provider_item_id = r.provider_item_id
+                   )
+                """
+            )
+            row["items_sem_conexao"] = int((cur.fetchone() or {}).get("n") or 0)
+
+            # Deadlocks/retries recentes (24h) — o log de sistema é a fonte.
+            # `system_event_logs` é criada PREGUIÇOSAMENTE (core/admin_dashboard.py):
+            # num banco onde nenhum evento foi gravado ainda ela não existe, e o
+            # erro derrubaria a caixa inteira de OF do painel. `to_regclass`
+            # pergunta sem estourar — dentro de um except a transação já estaria
+            # abortada e as leituras acima iriam junto.
+            cur.execute("select to_regclass('public.system_event_logs') as t")
+            if not (cur.fetchone() or {}).get("t"):
+                row["eventos_24h"] = {}
+                return _finaliza(row)
+            cur.execute(
+                """
+                select event_type, count(*) as n
+                  from system_event_logs
+                 where source='open_finance' and created_at > now() - interval '24 hours'
+                   and event_type in ('pluggy_sync_retry','pluggy_sync_failed',
+                                      'of_item_missing','of_item_owner_conflict')
+                 group by event_type
+                """
+            )
+            row["eventos_24h"] = {r["event_type"]: int(r["n"]) for r in (cur.fetchall() or [])}
+
+    return _finaliza(row)
+
+
+def _finaliza(row: dict) -> dict:
+    row["maior_atraso_sec"] = int(row["maior_atraso_sec"] or 0)
+    return row
+
+
+def _lock_key(item_id: str) -> str:
+    return f"of_sync:{item_id}"
+
+
+def _lock_wait_ms() -> int:
+    """Teto de espera pelo lock, em ms. NUNCA 0.
+
+    `lock_timeout='0ms'` no Postgres significa *desligado* — espera infinita —,
+    o oposto do que "0" sugere. Medido: `400ms` desistia em 0,48s; `0` seguia
+    bloqueado depois de 3s, com a thread segurando a conexão dedicada. O piso é
+    1ms, que é "não espere" de verdade.
+    """
+    try:
+        return max(1, int(os.getenv("OF_SYNC_LOCK_WAIT_MS", "15000")))
+    except (TypeError, ValueError):
+        return 15000
+
+
+@lru_cache(maxsize=1)
+def _lock_slots() -> threading.Semaphore:
+    """Teto de conexões DEDICADAS simultâneas (fora do pool).
+
+    Medido: 30 syncs concorrentes abriam 30 backends extras. Quando o
+    `psycopg.connect` estoura, o erro não é retentável e a cota da Pluggy já foi
+    gasta na leitura — troca um `PoolTimeout` local por falha de cluster. Quem
+    não pega vaga volta `False` e o chamador reporta `sync_in_progress`, que é o
+    mesmo desfecho de perder o lock.
+
+    ponytail: teto POR PROCESSO. Com N réplicas o teto real é N×. Se isso
+    apertar, o próximo degrau é contar as conexões no banco, não aqui.
+    """
+    try:
+        teto = int(os.getenv("OF_SYNC_LOCK_MAX_CONN", "8"))
+    except (TypeError, ValueError):
+        teto = 8
+    return threading.Semaphore(max(1, teto))
+
+
+@contextmanager
+def pluggy_item_lock(item_id: str):
+    """Serializa a FASE DE ESCRITA de um item da Pluggy. Devolve True se adquiriu.
+
+    Duas decisões, e as duas custaram caro na versão anterior:
+
+    1. **A janela é só a escrita.** O lock era pego antes das leituras remotas e
+       segurado durante `list_pluggy_transactions` — até 60 requisições paginadas
+       POR CONTA, minutos. A leitura remota é read-only contra a Pluggy e não
+       precisa de lock nenhum; quem dava os 10 `deadlock detected` medidos em
+       produção eram os upserts. O chamador (`pluggy_sync`) entra aqui só depois
+       de ter tudo em memória.
+    2. **Conexão DEDICADA, fora do pool.** Um advisory lock de SESSÃO retém a
+       conexão enquanto dura, e reter conexão do pool aqui é auto-deadlock: o
+       próprio sync precisa do pool para escrever. Medido: com
+       `DB_POOL_MAX_SYNC=2` e 2 locks abertos, um `select 1` trivial estourava
+       `PoolTimeout` em 30s — em produção `max_size=8`, ou seja, 8 syncs
+       travariam o processo inteiro (dashboard e WhatsApp junto).
+
+    Bloqueante com teto (`OF_SYNC_LOCK_WAIT_MS`, 15s): como a janela agora é
+    curta, esperar a vez é melhor que desistir — quem chega segundo escreve
+    depois, e todas as escritas são idempotentes. Estourou o teto, devolve False
+    e o chamador reporta `sync_in_progress`.
+
+    ponytail: a chave é por ITEM. Se aparecer deadlock entre items DO MESMO
+    usuário (import de cartão + launches disputam as mesmas linhas de
+    credit_bills), a correção é subir a chave para `of_sync_user:<user_id>` —
+    mesma estrutura, uma linha de mudança, ao custo de serializar os bancos de
+    um usuário.
+    """
+    item = (item_id or "").strip()
+    if not item:
+        yield False
+        return
+
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL não está definido.")
+
+    espera = _lock_wait_ms() / 1000.0
+    # Vaga ANTES de abrir o socket: o teto só vale se ninguém conectar sem passar
+    # por aqui. Mesmo teto de tempo do lock — quem espera demais desiste igual.
+    if not _lock_slots().acquire(timeout=espera):
+        yield False
+        return
+
+    try:
+        conn = psycopg.connect(url, autocommit=True)
+    except Exception:
+        _lock_slots().release()
+        raise
+    try:
+        conn.execute("select set_config('lock_timeout', %s, false)", (f"{_lock_wait_ms()}ms",))
+        try:
+            conn.execute("select pg_advisory_lock(hashtext(%s))", (_lock_key(item),))
+            got = True
+        except (psycopg.errors.LockNotAvailable, psycopg.errors.QueryCanceled):
+            got = False
+        yield got
+    finally:
+        # Fechar a conexão libera o advisory lock de sessão — não há unlock a
+        # esquecer, e um processo morto no meio não deixa o item travado.
+        conn.close()
+        _lock_slots().release()

--- a/db/schema.py
+++ b/db/schema.py
@@ -426,6 +426,71 @@ def init_db():
         create index if not exists idx_open_finance_transactions_account_date
           on open_finance_transactions(account_id, transaction_date desc)
         """,
+        # Onda 1 (contenção OF): tentativa ≠ sucesso, e saúde medida no servidor.
+        # `last_sync_at` passa a significar SUCESSO (o sync deixou de carimbá-lo
+        # incondicionalmente), então não existe last_success_at — seria a segunda
+        # versão da mesma verdade.
+        """
+        alter table open_finance_connections add column if not exists last_attempt_at timestamptz
+        """,
+        """
+        alter table open_finance_connections add column if not exists status_reason text
+        """,
+        """
+        alter table open_finance_connections add column if not exists health jsonb
+        """,
+        """
+        alter table open_finance_connections add column if not exists next_refresh_at timestamptz
+        """,
+        """
+        alter table open_finance_connections add column if not exists last_refresh_requested_at timestamptz
+        """,
+        """
+        alter table open_finance_connections add column if not exists last_refresh_origin text
+        """,
+        """
+        create index if not exists idx_of_conn_refresh_due
+          on open_finance_connections(next_refresh_at)
+          where provider='pluggy'
+        """,
+        # Um item da Pluggy pertence a UM usuário. A unicidade de hoje é por
+        # (user_id, provider, provider_item_id), o que permite o mesmo item em
+        # duas contas. O índice fecha isso — mas NÃO pode derrubar o boot: se já
+        # houver duplicata em produção, a criação falha e o init_db inteiro
+        # (~200 statements) morreria junto. Warning e segue.
+        """
+        do $$ begin
+          create unique index if not exists uq_of_conn_provider_item
+            on open_finance_connections(provider, provider_item_id);
+        exception when others then
+          raise warning 'uq_of_conn_provider_item nao criado: %', sqlerrm;
+        end $$
+        """,
+        # Rastro de todo item que passou por aqui — inclusive os que nunca viraram
+        # conexão (token emitido e abandonado, webhook de item desconhecido). Sem
+        # isto não há como saber que um item existe na Pluggy: o GET /items (lista)
+        # devolve 401, então o universo remoto não é enumerável.
+        """
+        create table if not exists open_finance_item_registry (
+          id bigserial primary key,
+          -- NULL de propósito: webhook de item DESCONHECIDO (nenhuma conexão
+          -- local) é exatamente o caso que precisa ser registrado, e nele não
+          -- há dono a atribuir. `not null` tornaria esse registro impossível.
+          user_id bigint references users(id) on delete cascade,
+          provider text not null default 'pluggy',
+          provider_item_id text,
+          connect_token_hash text,
+          origin text not null,
+          status text,
+          last_event text,
+          created_at timestamptz not null default now(),
+          updated_at timestamptz not null default now()
+        )
+        """,
+        """
+        create index if not exists idx_of_item_registry_item
+          on open_finance_item_registry(provider, provider_item_id)
+        """,
         # report diário (preferências do usuário)
         """
         create table if not exists daily_report_prefs (

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -143,7 +143,10 @@ Via **Pluggy**. Endpoints em `frontend/routes/open_finance.py`
 (`/open-finance/{user_id}` e `connect-token`, `connectors`, `sync`, `refresh`,
 `pluggy-item`, `caixinhas`, `caixinhas/bind`, `mock-connect`) mais o webhook
 `/open-finance/pluggy/webhook`. Serviços em `core/services/pluggy*.py` e
-`open_finance*.py`; tabelas `open_finance_connections/accounts/transactions/investments`.
+`open_finance*.py`; tabelas `open_finance_connections/accounts/transactions/investments` mais
+`open_finance_item_registry` — o rastro de todo item que passou por aqui, inclusive o
+que nunca virou conexão (token emitido e abandonado, webhook de item desconhecido); o
+`GET /items` da Pluggy devolve 401, então sem ela o universo remoto não é enumerável.
 
 Boa parte do comportamento é regida por flags `OF_*` (beta por e-mail/user_id, limite
 de bancos no free, refresh proativo). Antes de mexer, leia as flags — o
@@ -193,9 +196,19 @@ continua lá e o próximo webhook dela sobrescreve.
 ### Tarefas de fundo
 
 Sobem no startup do app quando `RUN_BACKGROUND_TASKS != "0"`: rendimento de
-investimento, refresh e expiração de Open Finance, cobrança de recorrentes,
-agendadores de engajamento e de IA proativa, retenção de eventos de login. Em teste e
-no `dashboard_dev.py` ficam desligadas.
+investimento, Open Finance (abaixo), cobrança de recorrentes, agendadores de
+engajamento e de IA proativa, retenção de eventos de login. Em teste e no
+`dashboard_dev.py` ficam desligadas.
+
+O Open Finance tem **três** trabalhos, não dois: expiração de trial
+(`_open_finance_trial_expiry`), refresh proativo e **job de saúde** — os dois últimos no
+mesmo tick de `_open_finance_refresh`. O refresh proativo depende de
+`OF_REFRESH_ENABLED` (off por padrão em produção); o job de saúde roda MESMO com ele
+desligado e ESCREVE `status`/`status_reason`/`health` na conexão do usuário. É de
+propósito: ele só faz `GET /items` (não consome cota de coleta) e é o que tira do
+"Atualizado" a conexão cujo item sumiu da Pluggy — sem refresh e sem webhook, nada mais
+faria essa verificação. Kill switch: `OF_HEALTH_CHECK_ENABLED=0` (default `1`).
+(Há ainda `_open_finance_proactive`, que retorna na hora sem `OF_PROACTIVE_ENABLED`.)
 
 ---
 

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -875,6 +875,17 @@ button, select, .user-chip, .error-item, .card-clickable, .health-item.clickable
     </div>
   </section>
 
+  <!-- ── Open Finance ────────────────────────────────────────────────── -->
+  <section class="grid-2" style="margin-bottom:16px">
+    <div class="card" style="grid-column:1/-1">
+      <div class="section-title">
+        <h2><i class="ph ph-bank" aria-hidden="true"></i> Open Finance</h2>
+        <span class="meta">Saúde das conexões Pluggy</span>
+      </div>
+      <div class="health-grid" id="of-health-grid"></div>
+    </div>
+  </section>
+
   <!-- ── Eventos operacionais ────────────────────────────────────────── -->
   <section class="grid-2" style="margin-bottom:16px">
     <div class="card">
@@ -1468,6 +1479,53 @@ function renderOpsHealthGrid(ops) {
 }
 
 
+/* ── Open Finance ────────────────────────────────────────────────── */
+/* Contadores vêm de `of_health_counters()` (db/open_finance_state.py) — a
+   mesma fonte que o job de saúde alimenta. Sem PII: só contagens. */
+function renderOpenFinanceGrid(of) {
+  of = of || {};
+  // `of.error` é a FALHA de leitura (fail-soft do backend); `of.erro` é a
+  // contagem de conexões em erro. Falha tem que aparecer como falha — antes as
+  // duas dividiam a chave e o painel ficava verde com todos os números zerados.
+  if (of.error) {
+    $id('of-health-grid').innerHTML =
+      `<div class="health-item danger"><div class="health-item-val red">falhou</div>` +
+      `<div class="health-item-label">Contadores de OF indisponíveis</div>` +
+      `<div class="health-item-hint">${esc(of.error)}</div></div>`;
+    return;
+  }
+  const stale = of.stale_por_produto || {};
+  const ev = of.eventos_24h || {};
+  const atrasoH = Math.floor((of.maior_atraso_sec || 0) / 3600);
+  const items = [
+    { label: "Conexões",            val: fInt(of.total),        color: 'blue' },
+    { label: "Saudáveis",           val: fInt(of.ativas),       color: 'green' },
+    { label: "Em erro",             val: fInt(of.erro),         color: of.erro > 0 ? 'red' : 'green', cls: of.erro > 0 ? 'danger' : '' },
+    { label: "Parciais",            val: fInt(of.parciais),     color: of.parciais > 0 ? 'yellow' : 'green', cls: of.parciais > 0 ? 'warning' : '',
+      hint: "Algum produto não atualizou" },
+    { label: "Items ausentes",      val: fInt(of.item_missing), color: of.item_missing > 0 ? 'red' : 'green', cls: of.item_missing > 0 ? 'danger' : '',
+      hint: "GET /items devolveu 404" },
+    { label: "Sem contas",          val: fInt(of.sem_contas),   color: of.sem_contas > 0 ? 'yellow' : 'green', cls: of.sem_contas > 0 ? 'warning' : '' },
+    { label: "Items sem conexão",   val: fInt(of.items_sem_conexao), color: of.items_sem_conexao > 0 ? 'yellow' : 'green', cls: of.items_sem_conexao > 0 ? 'warning' : '',
+      hint: "Vistos no registry, sem conexão local" },
+    { label: "Maior atraso",        val: atrasoH ? `${atrasoH}h` : '—', color: atrasoH > 48 ? 'red' : (atrasoH > 24 ? 'yellow' : 'green'), cls: atrasoH > 48 ? 'danger' : '' },
+    { label: "Conta atrasada",      val: fInt(stale.BANK || 0),        color: (stale.BANK||0) > 0 ? 'yellow' : 'green' },
+    { label: "Cartão atrasado",     val: fInt(stale.CREDIT || 0),      color: (stale.CREDIT||0) > 0 ? 'yellow' : 'green' },
+    { label: "Investim. atrasados", val: fInt(stale.INVESTMENTS || 0), color: (stale.INVESTMENTS||0) > 0 ? 'yellow' : 'green' },
+    { label: "Retries 24h",         val: fInt(ev.pluggy_sync_retry || 0), color: (ev.pluggy_sync_retry||0) > 0 ? 'yellow' : 'green',
+      hint: "Deadlock/serialização" },
+    { label: "Syncs falhos 24h",    val: fInt(ev.pluggy_sync_failed || 0), color: (ev.pluggy_sync_failed||0) > 0 ? 'red' : 'green', cls: (ev.pluggy_sync_failed||0) > 0 ? 'danger' : '' },
+    { label: "Conflito de dono 24h",val: fInt(ev.of_item_owner_conflict || 0), color: (ev.of_item_owner_conflict||0) > 0 ? 'red' : 'green', cls: (ev.of_item_owner_conflict||0) > 0 ? 'danger' : '' },
+  ];
+  $id('of-health-grid').innerHTML = items.map(it => `
+    <div class="health-item ${it.cls||''}">
+      <div class="health-item-val ${it.color||''}">${it.val}</div>
+      <div class="health-item-label">${it.label}</div>
+      ${it.hint ? `<div class="health-item-hint">${it.hint}</div>` : ''}
+    </div>
+  `).join('');
+}
+
 /* ── Summary cards ───────────────────────────────────────────────── */
 function renderSummary(s) {
   const cards = [
@@ -1736,6 +1794,7 @@ async function loadOverview(force=false) {
   renderErrorList(data.recent_errors);
   renderHealthGrid(data.summary, data.recent_errors, data.ops_summary);
   renderOpsHealthGrid(data.ops_summary);
+  renderOpenFinanceGrid(data.open_finance);
   renderOpsList(data.recent_ops);
   renderEmails(data.email_stats || {}, data.recent_emails || []);
   renderSignups(data.recent_signups);

--- a/frontend/app-mode.css
+++ b/frontend/app-mode.css
@@ -633,6 +633,13 @@ html.pb-app .upgrade-toast {
 html.pb-app.pb-root-settings .topbar { display: none !important; }
 html.pb-app body.pb-page-settings { padding-top: env(safe-area-inset-top); }
 
+/* Botão "Atualizar" do Open Finance: no app o gesto de puxar a tela já faz
+   isso (o pull-to-refresh chama o mesmo /refresh), então o botão é um segundo
+   controle para a mesma ação. Some SÓ onde o gesto existe — `html.pb-app` é
+   app iOS ou PWA instalada; no mobile web o botão continua sendo a única
+   maneira de atualizar. Sem sniffer de user-agent e sem media query nova. */
+html.pb-app body.pb-page-settings #of-refresh-btn { display: none !important; }
+
 /* ─── Settings vira "Minha conta" (estilo app) ─────────────────────────── */
 /* Paleta movida pra html.pb-app.pb-root-settings (1º paint); aqui só estrutural. */
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -7109,6 +7109,9 @@ function sendRefreshSilent() {
   _doRefresh({ silent: true });
 }
 
+// Agrupa a rajada de `open_finance_synced` (ver ws.onmessage) num refresh só.
+let _ofSyncDebounce;
+
 function _doRefresh({ silent }) {
   if (ws && ws.readyState === WebSocket.OPEN) {
     const msg = {
@@ -7195,6 +7198,13 @@ function connect() {
 
       stopSpin();
       setLaunchesLoading(false);
+    } else if (msg.type === "open_finance_synced") {
+      // O backend já mandava este evento e NENHUM arquivo do front o tratava —
+      // o banco sincronizava e o dashboard só mostrava depois de um F5. O
+      // debounce agrupa a rajada de webhooks da Pluggy (item/updated e
+      // transactions/created chegam com segundos de diferença) num pedido só.
+      clearTimeout(_ofSyncDebounce);
+      _ofSyncDebounce = setTimeout(sendRefreshSilent, 1500);
     }
   };
   ws.onclose = () => { setStatus("disconnected"); setTimeout(connect, 3000); };

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -68,6 +68,7 @@ from core.sessions import (
     touch_session,
 )
 from db.connection import cat_norm_sql
+from db.open_finance import BANK_ACCOUNTS_SQL
 from db import (
     accrue_all_pockets,
     accrue_all_investments,
@@ -691,16 +692,11 @@ async def get_financial_data(
     # sem dedup, o saldo (e a contagem) somaria em dobro. Pega a conexão mais recente.
     # Só contas em BRL: não há conversão de câmbio — somar USD 100 como R$ 100 mente o total.
     # PAUSED/DELETED continuam no banco só como histórico e ficam fora do saldo atual.
+    # Mesma definição de `db.open_finance.BANK_ACCOUNTS_SQL` que o saldo
+    # consolidado e a escolha de origem usam — era uma CÓPIA à mão aqui, e duas
+    # versões do mesmo recorte divergem no dia em que só uma é corrigida.
     of_bank_rows = await _q(
-        "SELECT COALESCE(SUM(b), 0) AS b, COUNT(*) AS n FROM ("
-        "  SELECT DISTINCT ON (a.provider_account_id) "
-        "    a.balance AS b, UPPER(COALESCE(c.status, '')) AS connection_status "
-        "  FROM open_finance_accounts a "
-        "  JOIN open_finance_connections c ON c.id = a.connection_id "
-        "  WHERE c.user_id = %s AND UPPER(a.type) = 'BANK' "
-        "    AND UPPER(COALESCE(a.currency, 'BRL')) = 'BRL' "
-        "  ORDER BY a.provider_account_id, c.id DESC"
-        ") uniq WHERE connection_status NOT IN ('PAUSED', 'DELETED')",
+        f"SELECT COALESCE(SUM(balance), 0) AS b, COUNT(*) AS n FROM ({BANK_ACCOUNTS_SQL}) s",
         (user_id,),
     )
     of_bank_balance = float(of_bank_rows[0]["b"]) if of_bank_rows else 0.0
@@ -1458,6 +1454,52 @@ manager = ConnectionManager()
 
 # ─── App startup ──────────────────────────────────────────────────────────────
 
+async def _open_finance_refresh():
+    # Tick periódico do Open Finance. DORME PRIMEIRO, de propósito: a versão
+    # anterior refrescava no boot, e o Railway sobe container novo a cada
+    # deploy — medido, 15 rodadas em 48h, 10 delas nos 5 min seguintes a um
+    # deploy. O cooldown real vive em `next_refresh_at` (persistido), então
+    # reiniciar o processo não adianta nada pra quem quer forçar refresh.
+    #
+    # O JOB DE SAÚDE roda mesmo com OF_REFRESH_ENABLED desligado: ele só faz
+    # GET /items (não consome cota de coleta) e é o que tira do "Atualizado"
+    # a conexão cujo item sumiu — sem ele, com refresh off e sem webhook,
+    # nada mais executaria essa verificação.
+    interval = int(os.getenv("OF_REFRESH_INTERVAL_SEC", str(6 * 60 * 60)))
+    refresh_ligado = (os.getenv("OF_REFRESH_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on")
+    from core.services.pluggy_sync import request_pluggy_refresh, run_of_health_check
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            saude = await asyncio.to_thread(run_of_health_check)
+            print(f"[open_finance_health] {saude}", flush=True)
+            if refresh_ligado:
+                res = await asyncio.to_thread(request_pluggy_refresh, origin="periodic")
+                print(f"[open_finance_refresh] {res}", flush=True)
+                # Os eventos ficam AQUI porque `request_pluggy_refresh` roda numa
+                # thread (log_system_event é async). Ela devolve o que reivindicou
+                # e o que falhou; nada mais é engolido.
+                from core.admin_dashboard import log_system_event  # noqa: PLC0415
+                if res.get("claimed"):
+                    await log_system_event(
+                        "info", "of_refresh_claimed",
+                        f"Refresh periódico reivindicou {len(res['claimed'])} item(ns)",
+                        source="open_finance",
+                        details={"origin": res.get("origin"), "items": res["claimed"],
+                                 "triggered": res.get("triggered")},
+                    )
+                for falha in res.get("failures") or []:
+                    await log_system_event(
+                        "warning", "pluggy_refresh_patch_failed",
+                        f"PATCH de refresh falhou: {falha.get('item_id')}",
+                        source="open_finance", details=falha,
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            print(f"[open_finance_refresh] erro: {exc}", file=sys.stderr)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     _t0 = _startup_time.monotonic()
@@ -1668,24 +1710,6 @@ async def lifespan(app: FastAPI):
                 raise
             except Exception as exc:
                 print(f"[account_deletion] erro: {exc}", file=sys.stderr)
-
-    async def _open_finance_refresh():
-        # Refresh periódico dos bancos conectados (P1 #5). Dormant por padrão: só roda
-        # com OF_REFRESH_ENABLED ligado (evita martelar a Pluggy no trial).
-        if (os.getenv("OF_REFRESH_ENABLED") or "").strip().lower() not in ("1", "true", "yes", "on"):
-            return
-        interval = int(os.getenv("OF_REFRESH_INTERVAL_SEC", str(6 * 60 * 60)))
-        from core.services.pluggy_sync import refresh_all_pluggy_items
-        while True:
-            try:
-                res = await asyncio.to_thread(refresh_all_pluggy_items)
-                print(f"[open_finance_refresh] {res}", flush=True)
-                await asyncio.sleep(interval)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                print(f"[open_finance_refresh] erro: {exc}", file=sys.stderr)
-                await asyncio.sleep(interval)
 
     async def _open_finance_trial_expiry():
         # Pausa conexões OF de trial vencido que não virou assinatura (libera o slot

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -13,6 +13,8 @@ import hashlib
 import hmac
 import json
 import os
+import random
+import time
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -25,6 +27,7 @@ from core.services.pluggy import (
     create_pluggy_api_key,
     create_pluggy_connect_token,
     delete_pluggy_item,
+    get_pluggy_item,
     list_pluggy_connectors,
 )
 from core.services.plan_service import is_pro
@@ -38,10 +41,13 @@ from db import (
     create_mock_open_finance_connection,
     delete_open_finance_transactions,
     disconnect_open_finance_connection,
+    get_connections_by_item_id,
     get_open_finance_connection_by_item_id,
     get_open_finance_snapshot,
     list_pluggy_item_ids,
+    register_item,
     save_pluggy_open_finance_item,
+    token_hash,
     update_pluggy_open_finance_item_status,
 )
 from frontend.routes import shared
@@ -62,12 +68,63 @@ PLUGGY_SYNC_EVENTS = {
 }
 
 
-async def _run_pluggy_sync_bg(item_id: str) -> None:
-    """Roda o sync fora do request (fire-and-forget), logando falhas."""
+# Um sync em voo por item + UM bit de "chegou evento enquanto rodava". A Pluggy
+# manda `item/updated` e `transactions/created` com 0–17s de intervalo, e cada
+# evento virava uma task: 10 `deadlock detected` medidos em produção. O dirty é
+# BOOLEANO por item de propósito — fila de eventos aqui só adiaria o mesmo sync
+# N vezes, e o sync é idempotente: uma re-execução cobre qualquer número de
+# eventos que chegaram durante a anterior.
+_INFLIGHT: dict[str, asyncio.Task] = {}
+_DIRTY: set[str] = set()
+
+# Só erro TRANSITÓRIO é retentado. Erro de programação ou de validação repetido
+# 3x é o mesmo erro 3x — e ainda esconde o defeito no log.
+_SYNC_MAX_ATTEMPTS = 3
+
+# HTTP da Pluggy que some sozinho: cota estourada e erro do lado dela. 404 fica
+# de fora de propósito (é `item_missing`, tratado no sync), 4xx de credencial
+# também — repetir não conserta chave errada.
+_HTTP_TRANSITORIO = {429, 500, 502, 503, 504}
+
+
+def _retryable(exc: BaseException) -> bool:
+    if isinstance(exc, PluggyApiError) and exc.status_code in _HTTP_TRANSITORIO:
+        return True
     try:
-        result = await asyncio.to_thread(sync_pluggy_item, item_id)
+        from psycopg import errors as pg_errors
+        return isinstance(exc, (pg_errors.DeadlockDetected, pg_errors.SerializationFailure))
+    except Exception:  # psycopg ausente/alterado: não retenta
+        return False
+
+
+async def _run_pluggy_sync_bg(item_id: str) -> None:
+    """Roda o sync fora do request (fire-and-forget), logando o resultado REAL.
+
+    Antes isto logava `pluggy_sync_done` em nível info mesmo com `ok:false` —
+    397 sucessos e 41 falhas na mesma prateleira, e ninguém procurando por elas.
+    """
+    result: dict | None = None
+    try:
+        for tentativa in range(1, _SYNC_MAX_ATTEMPTS + 1):
+            try:
+                result = await asyncio.to_thread(sync_pluggy_item, item_id)
+                break
+            except Exception as exc:
+                if not _retryable(exc) or tentativa == _SYNC_MAX_ATTEMPTS:
+                    raise
+                espera = 0.5 * (2 ** (tentativa - 1)) * (0.75 + random.random() / 2)
+                await log_system_event(
+                    "warning", "pluggy_sync_retry",
+                    f"Sync Pluggy vai repetir ({tentativa}/{_SYNC_MAX_ATTEMPTS}): {item_id}",
+                    source="open_finance",
+                    details={"item_id": item_id, "attempt": tentativa,
+                             "error": type(exc).__name__, "sleep_sec": round(espera, 3)},
+                )
+                await asyncio.sleep(espera)
+
+        result = result if isinstance(result, dict) else {}
         # Atualização ao vivo (PWA): avisa o cliente conectado pra recarregar saldo/timeline.
-        uid = result.get("user_id") if isinstance(result, dict) else None
+        uid = result.get("user_id")
         if uid:
             try:
                 from frontend.finance_bot_websocket_custom import manager
@@ -76,12 +133,31 @@ async def _run_pluggy_sync_bg(item_id: str) -> None:
                 )
             except Exception:
                 pass
+
+        ok = bool(result.get("ok"))
+        reason = str(result.get("reason") or "")
+        # Sync que deu certo mas deixou produto pra trás não pode ficar mudo: é
+        # daqui que sai "atualizei o que deu" na tela e a contagem do painel.
+        if ok and result.get("stale_products"):
+            await log_system_event(
+                "warning", "of_product_stale",
+                f"Sync concluído com produto atrasado: {item_id}",
+                source="open_finance",
+                details={"item_id": item_id, "stale_products": result["stale_products"]},
+            )
+        if ok:
+            nivel, evento = "info", "pluggy_sync_done"
+        elif reason in ("item_missing", "owner_conflict"):
+            nivel, evento = "error", "of_item_missing"
+        else:
+            nivel, evento = "warning", "pluggy_sync_done"
         await log_system_event(
-            "info",
-            "pluggy_sync_done",
-            f"Sync Pluggy concluído: {item_id}",
+            nivel,
+            evento,
+            f"Sync Pluggy {'concluído' if ok else 'sem sucesso'}: {item_id}"
+            + (f" ({reason})" if reason else ""),
             source="open_finance",
-            details=result,
+            details={**result, "reason": reason or None},
         )
     except Exception as exc:  # noqa: BLE001 — background, não pode derrubar nada
         await log_system_event(
@@ -89,13 +165,27 @@ async def _run_pluggy_sync_bg(item_id: str) -> None:
             "pluggy_sync_failed",
             f"Sync Pluggy falhou: {item_id}: {exc}",
             source="open_finance",
-            details={"item_id": item_id, "error": str(exc)},
+            details={"item_id": item_id, "error": str(exc)[:200]},
         )
 
 
+def _on_sync_done(item_id: str) -> None:
+    """Fim de um sync: solta o slot e, se chegou evento no meio, roda UMA vez mais."""
+    _INFLIGHT.pop(item_id, None)
+    if item_id in _DIRTY:
+        _DIRTY.discard(item_id)
+        _schedule_pluggy_sync(item_id)
+
+
 def _schedule_pluggy_sync(item_id: str) -> None:
-    if item_id:
-        asyncio.create_task(_run_pluggy_sync_bg(item_id), name=f"pluggy_sync_{item_id}")
+    if not item_id:
+        return
+    if item_id in _INFLIGHT:
+        _DIRTY.add(item_id)   # coalesce: uma re-execução no fim, não uma task por evento
+        return
+    task = asyncio.create_task(_run_pluggy_sync_bg(item_id), name=f"pluggy_sync_{item_id}")
+    _INFLIGHT[item_id] = task
+    task.add_done_callback(lambda _t: _on_sync_done(item_id))
 
 
 def _bank_limit_enabled() -> bool:
@@ -348,6 +438,21 @@ async def open_finance_connect_token_route(request: Request, user_id: int):
     except PluggyApiError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
+    # Registra que ESTE usuário pediu um token. O `GET /items` da Pluggy devolve
+    # 401, então sem este rastro um item criado e nunca reportado ao /pluggy-item
+    # é invisível para nós. Guarda o HASH: o token bruto abre a conexão e NUNCA
+    # pode ir para o banco.
+    try:
+        await asyncio.to_thread(
+            register_item, user_id,
+            token_hash=token_hash(token_data["accessToken"]), origin="connect_token",
+        )
+    except Exception as exc:  # noqa: BLE001 — rastro nunca derruba a emissão do token
+        await log_system_event(
+            "warning", "of_item_registry_failed", "Falha ao registrar connect token",
+            source="open_finance", details={"error": str(exc)[:200]},
+        )
+
     return {
         "ok": True,
         "accessToken": token_data["accessToken"],
@@ -358,14 +463,71 @@ async def open_finance_connect_token_route(request: Request, user_id: int):
 
 @router.post("/open-finance/{user_id}/pluggy-item")
 async def open_finance_pluggy_item_route(request: Request, user_id: int, payload: OpenFinancePluggyItemPayload):
-    shared.authorize_dashboard_access(request, user_id)
+    """Registra o item que o widget da Pluggy acabou de criar.
+
+    O dict `item` vem DO NAVEGADOR: nome do banco, status e id são todos escolhidos
+    pelo cliente. A única coisa aproveitada dele é o `id`, e só para perguntar à
+    Pluggy quem é o dono — o que grava é a resposta REMOTA. Duas checagens:
+
+      • `clientUserId` do item (que nós mesmos setamos ao emitir o connect token)
+        precisa bater com o usuário logado. É ESTA que discrimina: sem ela, o id
+        de um item de outra pessoa vira uma conexão nesta conta;
+      • se o item já pertence a outra conta aqui dentro, 409 e nada é gravado.
+
+    Comparar `session_uid` com o `{user_id}` da URL seria redundante e não é o
+    conserto: `shared.authorize_dashboard_access` já levanta 403 quando os dois
+    diferem (frontend/routes/shared.py), então aqui eles são iguais por
+    construção. `session_uid` é usado abaixo por clareza de origem, não por
+    segurança adicional.
+    """
+    session_uid = shared.authorize_dashboard_access(request, user_id)
     item = payload.item if isinstance(payload.item, dict) else {}
-    new_item_id = item.get("id") or item.get("itemId")
-    await _enforce_bank_limit(user_id, str(new_item_id) if new_item_id else None)
+    new_item_id = str(item.get("id") or item.get("itemId") or "").strip()
+    if not new_item_id:
+        raise HTTPException(status_code=400, detail="Item Pluggy sem id.")
+
     try:
-        connection = await asyncio.to_thread(save_pluggy_open_finance_item, user_id, payload.item)
+        remote = await asyncio.to_thread(get_pluggy_item, new_item_id)
+    except PluggyConfigError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except PluggyApiError as exc:
+        if getattr(exc, "status_code", None) == 404:
+            raise HTTPException(status_code=404, detail="Item não existe na Pluggy.") from exc
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    dono_remoto = remote.get("clientUserId")
+    if str(dono_remoto or "") != str(session_uid):
+        await log_system_event(
+            "error", "of_item_owner_conflict",
+            "Item Pluggy não pertence ao usuário da sessão",
+            source="open_finance",
+            details={"item_id": new_item_id, "origin": "pluggy_item_route"},
+        )
+        raise HTTPException(status_code=403, detail="Este item não pertence a esta conta.")
+
+    outros = [c for c in await asyncio.to_thread(get_connections_by_item_id, new_item_id)
+              if int(c["user_id"]) != int(session_uid)]
+    if outros:
+        await log_system_event(
+            "error", "of_item_owner_conflict",
+            "Item Pluggy já vinculado a outra conta",
+            source="open_finance",
+            details={"item_id": new_item_id, "connections": len(outros)},
+        )
+        raise HTTPException(status_code=409, detail="Este item já está vinculado a outra conta.")
+
+    await _enforce_bank_limit(session_uid, new_item_id)
+    try:
+        # Grava o REMOTO: status e instituição vêm da Pluggy, não do navegador.
+        connection = await asyncio.to_thread(save_pluggy_open_finance_item, session_uid, remote)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    await asyncio.to_thread(
+        register_item, session_uid,
+        provider_item_id=new_item_id, origin="pluggy_item",
+        status=str(remote.get("status") or "") or None,
+    )
 
     await asyncio.to_thread(
         record_audit_event,
@@ -398,22 +560,57 @@ async def open_finance_sync_route(request: Request, user_id: int):
 
 
 @router.post("/open-finance/{user_id}/refresh")
-async def open_finance_refresh_route(request: Request, user_id: int):
-    """Refresh manual (botão "Atualizar"): pede pra Pluggy re-buscar do banco
-    (PATCH /items), espera concluir e sincroniza — puxa transação nova, marca a
-    conexão ACTIVE e limpa "Pendente". Difere do /sync, que só relê o que a Pluggy
-    já tem sem forçar uma nova busca no banco.
+async def open_finance_refresh_route(request: Request, user_id: int, wait: int | None = None):
+    """Refresh manual (botão "Atualizar" e pull-to-refresh do app): pede pra Pluggy
+    re-buscar do banco (PATCH /items), espera concluir e sincroniza. Difere do
+    /sync, que só relê o que a Pluggy já tem sem forçar nova busca no banco.
+
+    `?wait=` (teto 18s) existe porque o pull-to-refresh do app tem watchdog de 12s:
+    com a espera padrão o gesto virava âmbar mesmo quando tudo dava certo.
     """
     shared.authorize_dashboard_access(request, user_id)
+    espera = max(0, min(int(wait), 18)) if wait is not None else None
+    t0 = time.monotonic()
     try:
-        result = await asyncio.to_thread(refresh_and_sync_pluggy_user, user_id)
+        result = await asyncio.to_thread(refresh_and_sync_pluggy_user, user_id, wait_seconds=espera)
     except PluggyConfigError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except PluggyApiError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
+    # Clique registrado com o usuário ANONIMIZADO (hash), sem token, credencial
+    # ou valor — só quem, quando, quanto demorou e como terminou.
+    itens = result.get("items") or []
+    await log_system_event(
+        "info" if result.get("ok") else "warning",
+        "of_manual_refresh",
+        f"Refresh manual de Open Finance ({'ok' if result.get('ok') else 'com pendências'})",
+        source="open_finance",
+        details={
+            "user_hash": hashlib.sha256(str(user_id).encode()).hexdigest()[:16],
+            "ok": bool(result.get("ok")),
+            "duration_ms": int((time.monotonic() - t0) * 1000),
+            "items": [{"item_id": i.get("item_id"), "state": i.get("state"),
+                       "reason": i.get("reason")} for i in itens],
+        },
+    )
+
     snapshot = await asyncio.to_thread(get_open_finance_snapshot, user_id)
+    # `ok` aqui é só "a requisição foi atendida" — NÃO é o veredito do refresh.
+    # Quem diz se deu certo é `sync.ok` (conjunção por item) e `sync.items[]`, que
+    # é o que o settings.html lê. Ler `data.ok` reintroduz o toast verde em cima
+    # de um item perdido.
     return json.loads(shared.jdump({"ok": True, "sync": result, **snapshot}))
+
+
+def _ip_prefix(request: Request) -> str:
+    """IP do chamador truncado (/24 em v4, /48 em v6) — o suficiente pra ver um
+    padrão de abuso, insuficiente pra identificar alguém."""
+    ip = (request.client.host if request.client else "") or ""
+    if ":" in ip:
+        return ":".join(ip.split(":")[:3]) + "::/48"
+    partes = ip.split(".")
+    return ".".join(partes[:3]) + ".0/24" if len(partes) == 4 else "desconhecido"
 
 
 def _verify_pluggy_webhook_signature(raw_body: bytes, signature_header: str, secret: str) -> bool:
@@ -480,6 +677,16 @@ async def open_finance_pluggy_webhook(request: Request):
 
     raw_body = await request.body()
     if not _authorize_pluggy_webhook(request, raw_body, secret):
+        # 401 mudo era um buraco de observabilidade: um webhook mal configurado
+        # (ou uma tentativa de fora) não deixava rastro nenhum. O evento NÃO leva
+        # secret, headers, corpo, nomes, contas, CPF, e-mail nem valores — só um
+        # IP truncado e o horário.
+        await log_system_event(
+            "warning", "pluggy_webhook_unauthorized",
+            "Webhook Pluggy recusado (credencial inválida)",
+            source="open_finance",
+            details={"ip_prefix": _ip_prefix(request), "has_token_param": bool(request.query_params.get("token"))},
+        )
         raise HTTPException(status_code=401, detail="Não autorizado.")
 
     try:
@@ -489,9 +696,11 @@ async def open_finance_pluggy_webhook(request: Request):
 
     event_name = str(event.get("event") or event.get("type") or "")
     item_id = str(event.get("itemId") or event.get("item_id") or event.get("item", {}).get("id") or "")
+    # `item/updated` NÃO escreve mais ACTIVE: quem afirma que sincronizou é o sync,
+    # depois de consultar o item e puxar as contas. O webhook só diz o que a Pluggy
+    # disse.
     status_by_event = {
         "item/created": "UPDATING",
-        "item/updated": "ACTIVE",
         "item/error": "ERROR",
         "item/deleted": "DELETED",
     }
@@ -499,15 +708,40 @@ async def open_finance_pluggy_webhook(request: Request):
     if item_id and status:
         await asyncio.to_thread(update_pluggy_open_finance_item_status, item_id, status, event)
 
+    # Antes de qualquer sync, resolve a POSSE do item. O `limit 1` sem `order by`
+    # que existia aqui sorteava um dono quando o item aparecia em duas contas.
+    conexoes = await asyncio.to_thread(get_connections_by_item_id, item_id) if item_id else []
+
     # transactions/deleted: a Pluggy manda os ids removidos — apaga direto, senão ficam
     # órfãos (um re-sync não os removeria, pois não voltam no list_transactions).
     if item_id and event_name == "transactions/deleted":
         deleted_ids = event.get("transactionIds") or event.get("transactionsIds") or []
         if isinstance(deleted_ids, list) and deleted_ids:
             await asyncio.to_thread(delete_open_finance_transactions, item_id, deleted_ids)
-    # Demais eventos com dado novo: dispara o sync pesado fora do request.
     elif item_id and event_name in PLUGGY_SYNC_EVENTS:
-        _schedule_pluggy_sync(item_id)
+        if len(conexoes) == 1:
+            _schedule_pluggy_sync(item_id)
+        elif not conexoes:
+            # Item que não conhecemos: registra (o GET /items lista devolve 401,
+            # então este é o único jeito de saber que ele existe) e NÃO sincroniza.
+            await log_system_event(
+                "warning", "of_webhook_item_unknown",
+                "Webhook de item sem conexão local",
+                source="open_finance", details={"item_id": item_id, "event": event_name},
+            )
+            await asyncio.to_thread(
+                register_item, None, provider_item_id=item_id,
+                origin="webhook", last_event=event_name,
+            )
+        else:
+            # Dois donos possíveis: sincronizar um deles é sincronizar a carteira
+            # do usuário errado. Recusa.
+            await log_system_event(
+                "error", "of_item_owner_conflict",
+                "Item Pluggy ligado a mais de uma conexão — sync recusado",
+                source="open_finance",
+                details={"item_id": item_id, "connections": len(conexoes), "event": event_name},
+            )
 
     await log_system_event(
         "info" if event_name != "item/error" else "warning",
@@ -557,7 +791,7 @@ async def open_finance_disconnect_route(request: Request, user_id: int):
             await log_system_event(
                 "warning", "pluggy_disconnect_auth_failed",
                 f"Sem apiKey pra deletar items no disconnect do user {user_id}: {exc}",
-                source="open_finance", details={"user_id": user_id, "error": str(exc)},
+                source="open_finance", details={"user_id": user_id, "error": str(exc)[:200]},
             )
         if api_key:
             for item_id in pluggy_item_ids:
@@ -568,7 +802,7 @@ async def open_finance_disconnect_route(request: Request, user_id: int):
                         "warning", "pluggy_item_delete_failed",
                         f"Falha ao deletar item {item_id} na Pluggy no disconnect: {exc}",
                         source="open_finance",
-                        details={"item_id": item_id, "error": str(exc)},
+                        details={"item_id": item_id, "error": str(exc)[:200]},
                     )
 
     deleted = await asyncio.to_thread(disconnect_open_finance_connection, user_id)

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -2783,16 +2783,18 @@ function bInitials(name) {
   if (n.includes("bradesco")) return "BR";
   return (name||"?").slice(0,2).toUpperCase();
 }
-// Status da conexão Open Finance → pill. Três estados:
-//  • Conectado    — sincronizando normal (ACTIVE/UPDATED)
-//  • Pendente     — a Pluggy ainda está verificando/buscando (UPDATING/CREATED/WAITING_USER_ACTION)
-//  • Não conectado — parado, precisa reconectar (PAUSED/LOGIN_ERROR/ERROR/OUTDATED/WAITING_USER_INPUT/desconhecido)
-function connStatusPill(status) {
-  const st = String(status || "").toUpperCase();
-  if (st === "ACTIVE" || st === "ATIVO" || st === "UPDATED") return { pc: "active",  pl: "Conectado" };
-  if (st === "UPDATING" || st === "CREATED" || st === "WAITING_USER_ACTION") return { pc: "pending", pl: "Pendente" };
-  return { pc: "error", pl: "Não conectado" };
-}
+// A pílula vem PRONTA do backend (`connection_ui_state`, core/services/pluggy_health.py):
+// é a única função que decide os estados, e ela enxerga o que o status local não
+// enxerga — produto atrasado e item que sumiu da Pluggy. Aqui só se traduz o estado
+// para a classe CSS que já existe (active/pending/error).
+// Estado que não estiver nesta tabela cai no default do `renderConnections`
+// ("pending"), NUNCA em verde.
+const OF_PILL_CLASS = {
+  updated: "active", partial: "pending", updating: "pending",
+  error_recoverable: "error", needs_user_action: "error",
+  item_missing: "error", paused: "error", removed: "error",
+  no_accounts: "pending",
+};
 
 /* ── Render ──────────────────────────────────── */
 function renderConnections(list) {
@@ -2809,14 +2811,19 @@ function renderConnections(list) {
   el.innerHTML = list.map(c => {
     const cls = bClass(c.institution_name);
     const ini = bInitials(c.institution_name);
-    const { pc, pl } = connStatusPill(c.status);
+    const ui = c.ui || {};
+    const pc = OF_PILL_CLASS[ui.state] || "pending";
+    const pl = ui.label || "Pendente";
+    // UMA linha de detalhe, e só quando há atraso/problema a explicar.
+    const detalhe = ui.detail ? `<div class="conn-meta">${esc(ui.detail)}</div>` : "";
     return `<div class="connection-row">
       <div class="conn-logo ${cls}">${esc(ini)}</div>
       <div class="conn-info">
         <div class="conn-name">${esc(c.institution_name)}</div>
         <div class="conn-meta">Última sync: ${esc(fmtDate(c.last_sync_at))}</div>
+        ${detalhe}
       </div>
-      <span class="pill ${pc}">${pl}</span>
+      <span class="pill ${pc}">${esc(pl)}</span>
     </div>`;
   }).join("");
 }
@@ -3032,42 +3039,109 @@ async function bindCaixinha(ofInvestmentId, newPocketVal, currentPocketId) {
   loadCaixinhas();
 }
 
-/* ── Refresh (botão "Atualizar") ─────────────────
+/* ── Refresh (botão "Atualizar" e pull-to-refresh) ─────────────────
    Diferente do loadData (que só relê o snapshot): pede pra Pluggy re-buscar do
-   banco (PATCH /items), espera concluir e sincroniza — puxa transação nova, marca
-   a conexão ATIVA e limpa "Pendente". */
-async function refreshOpenFinance() {
-  if (!USER_ID) { showToast("Sessão inválida. Faça login novamente", "error"); return; }
-  const btn = document.getElementById("of-refresh-btn");
+   banco (PATCH /items), espera concluir e sincroniza.
+
+   `propagate` (vindo do PTR): a falha REJEITA a promise, o que faz o indicador
+   do gesto virar âmbar em vez de fingir sucesso — e o toast/disable do botão
+   ficam de fora, porque nesse caminho o botão nem existe (some no modo app).
+   `wait`: teto de espera mandado na query — o watchdog do PTR é 12s, e o
+   default de 18s do servidor faria todo gesto bem-sucedido terminar em âmbar. */
+async function refreshOpenFinance(opts) {
+  const { propagate = false, wait = null } = opts || {};
+  if (!USER_ID) {
+    const erro = new Error("Sessão inválida. Faça login novamente");
+    if (propagate) throw erro;
+    showToast(erro.message, "error");
+    return;
+  }
+  const btn = propagate ? null : document.getElementById("of-refresh-btn");
   const orig = btn ? btn.textContent : "";
   if (btn) { btn.disabled = true; btn.textContent = "↻ Atualizando…"; }
-  showToast("Buscando novidades no seu banco… pode levar alguns segundos.", "ok");
+  if (!propagate) showToast("Buscando novidades no seu banco… pode levar alguns segundos.", "ok");
   try {
-    const resp = await fetch(`${API}/open-finance/${USER_ID}/refresh`, authOptions({
+    const qs = wait ? `?wait=${encodeURIComponent(wait)}` : "";
+    const resp = await fetch(`${API}/open-finance/${USER_ID}/refresh${qs}`, authOptions({
       method: "POST",
       headers: authHeaders({ "Content-Type": "application/json" }),
     }));
     if (!resp.ok) throw new Error(await readApiError(resp));
     const data = await resp.json();
-    const c = data.connections  || [];
-    const a = data.accounts     || [];
-    const t = data.transactions || [];
-    updateStats(c, a, t);
-    renderConnections(c);
-    renderAccounts(a);
-    renderTransactions(t);
-    if (c.length > 0) setStep(3);
-    const sync = data.sync || {};
-    if (Number(sync.still_updating) > 0) {
-      showToast("O banco ainda está atualizando. Se faltar algo, toque em Atualizar de novo.", "error");
+    const veredito = refreshVerdict(data.sync || {});
+    if (propagate) {
+      // Repinta pela porta canônica: `loadData` é quem bumpa `_dataGen`, é dono
+      // do fan-out (caixinhas) e tem a guarda de geração. Pintar aqui direto
+      // deixaria o painel de caixinhas parado no gesto e devolveria a classe de
+      // bug que a guarda existe pra impedir — resposta velha por cima de nova.
+      await loadData({ propagate: true });
     } else {
-      showToast("Tudo em dia!", "ok");
+      const c = data.connections  || [];
+      const a = data.accounts     || [];
+      const t = data.transactions || [];
+      updateStats(c, a, t);
+      renderConnections(c);
+      renderAccounts(a);
+      renderTransactions(t);
+      if (c.length > 0) setStep(3);
+      showToast(veredito.msg, veredito.tone);
     }
+    // Já repintado: agora sim o indicador do gesto pode virar âmbar.
+    if (propagate && veredito.tone === "error") throw new Error(veredito.msg);
   } catch (err) {
+    if (propagate) throw err;
     showToast(err.message || "Erro ao atualizar", "error");
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = orig || "↻ Atualizar"; }
   }
+}
+
+/* O veredito deixou de ser `still_updating > 0`: esse número era 0 mesmo quando
+   o item tinha sumido da Pluggy, e a tela dizia "Tudo em dia!" para uma conexão
+   morta. Agora lê `sync.items[]`, que traz estado por item.
+
+   REGRA DA TABELA: verde só para estado que está em OF_VERDICT_OK. Estado que
+   este arquivo não conhece — porque o backend ganhou um caso novo — cai no
+   genérico honesto, nunca em "Tudo em dia!". Era exatamente esse buraco que
+   fazia `no_accounts`, `paused` e `removed` virarem verde por baixo. */
+const OF_VERDICT_OK = ["updated", "rate_limited"];
+
+/* Ordem de GRAVIDADE: o primeiro estado desta lista que aparecer manda na
+   mensagem. Trocar a ordem muda o que o usuário vê quando tem dois bancos. */
+const OF_VERDICT = [
+  ["item_missing",      (i) => `A conexão ${ofBanco(i)} foi perdida. Refaça a conexão.`],
+  ["removed",           (i) => `A conexão ${ofBanco(i)} foi removida. Reconecte para voltar a sincronizar.`],
+  ["paused",            (i) => `A sincronização ${ofBanco(i)} está pausada. Reative seu plano para atualizar.`],
+  ["needs_user_action", (i) => `O ${ofNome(i)} precisa que você reautorize o acesso.`],
+  ["no_accounts",       (i) => `O ${ofNome(i)} não devolveu nenhuma conta ou investimento.`],
+  ["updating",          ()  => "O banco ainda está atualizando. Se faltar algo, toque em Atualizar de novo."],
+  ["partial",           (i) => i.detail
+      ? `Atualizei o que deu: ${i.detail.charAt(0).toLowerCase()}${i.detail.slice(1)}.`
+      : "Atualizei o que deu — parte dos dados não veio."],
+  ["error_recoverable", () => "Não consegui atualizar agora. Tente de novo em instantes."],
+];
+
+function ofBanco(i) { return i.institution ? `com o ${i.institution}` : "com o banco"; }
+function ofNome(i)  { return i.institution || "banco"; }
+
+function refreshVerdict(sync) {
+  const items = Array.isArray(sync.items) ? sync.items : [];
+  for (const [estado, msg] of OF_VERDICT) {
+    const achado = items.find((i) => i.state === estado);
+    if (achado) return { tone: "error", msg: msg(achado) };
+  }
+  if (Number(sync.still_updating) > 0)
+    return { tone: "error", msg: "O banco ainda está atualizando. Se faltar algo, toque em Atualizar de novo." };
+  // Default SEGURO: qualquer estado fora da lista de permissão, ou um `ok:false`
+  // sem item nenhum, não pode terminar em verde.
+  const desconhecido = items.find((i) => !OF_VERDICT_OK.includes(i.state));
+  if (desconhecido || (items.length === 0 && sync.ok === false))
+    return { tone: "error", msg: "Não consegui atualizar agora. Tente de novo em instantes." };
+  // Nada foi pedido ao banco porque acabamos de pedir: verde (os dados SÃO
+  // recentes), mas dizendo o que aconteceu em vez de fingir uma busca nova.
+  if (items.length && items.every((i) => i.state === "rate_limited"))
+    return { tone: "ok", msg: "Você acabou de atualizar — já está tudo em dia." };
+  return { tone: "ok", msg: "Tudo em dia!" };
 }
 
 /* ── Connect ─────────────────────────────────── */
@@ -3510,7 +3584,10 @@ window.PBRefresh = () => {
     return Promise.resolve(_notifSave).catch(function () {})
       .then(function () { return loadNotificationSettings({ propagate: true }); });
   if (view === "open-finance")
-    return loadData({ propagate: true });
+    // Puxar a tela ATUALIZA de verdade (PATCH na Pluggy + sync), não só relê o
+    // snapshot. wait=8 porque o watchdog do indicador é 12s (app-mode.js) e o
+    // default do servidor (18s) faria todo sucesso terminar em âmbar.
+    return refreshOpenFinance({ propagate: true, wait: 8 });
   return Promise.resolve();   // data / legal: nada dinâmico a atualizar
 };
 </script>

--- a/tests/frontend/of_refresh_ui.test.mjs
+++ b/tests/frontend/of_refresh_ui.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * Onda 1 do Open Finance, lado do navegador. Dois invariantes:
+ *
+ *  1. O botão "↻ Atualizar" do Open Finance some SÓ onde o gesto de puxar
+ *     existe (html.pb-app = app iOS ou PWA instalada). No mobile web ele
+ *     continua sendo a única forma de atualizar — some lá e o usuário fica sem
+ *     ação nenhuma.
+ *  2. O veredito do refresh só fica verde para estado que ele CONHECE como bom.
+ *     Estado desconhecido, pausado, removido ou sem dados nunca vira
+ *     "Tudo em dia!" — no gesto do celular isso é a diferença entre o indicador
+ *     verde e o âmbar com a mensagem certa.
+ *  3. O dashboard reage ao `open_finance_synced` que o backend JÁ mandava e
+ *     NENHUM arquivo do front tratava — e reage UMA vez por rajada: a Pluggy
+ *     manda item/updated e transactions/created com segundos de diferença.
+ *
+ * Cada teste discrimina: sem a regra do app-mode.css o 1º dá visível/visível;
+ * com o antigo `return {tone:"ok"}` de default o 2º volta "Tudo em dia!" nos
+ * cinco estados; sem a branch nova do ws.onmessage o 3º conta 0 `get_month`
+ * (e sem o debounce, conta 3).
+ *
+ * Rodar:  npm run test:frontend
+ *         (um arquivo só: node --test tests/frontend/of_refresh_ui.test.mjs)
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+// porta própria: 8899 é do fanout, 8901 do hiw_rail, 8903 dos modais — o
+// `node --test` roda os arquivos em PARALELO e duas suítes na mesma porta se matam.
+const PORT = Number(process.env.PB_OF_TEST_PORT || 8905);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const SAFARI = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1";
+const APP_UA = SAFARI + " PigBankApp/1.0";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const json = (body) => ({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+async function startServer() {
+  const proc = spawn("python3", ["-m", "http.server", String(PORT), "--bind", "127.0.0.1",
+                                 "--directory", FRONTEND], { stdio: "ignore" });
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    if (proc.exitCode !== null) throw new Error(`http.server morreu (porta ${PORT} ocupada?)`);
+    try { if ((await fetch(`${ORIGIN}/settings.html`)).ok) return proc; } catch { /* subindo */ }
+  }
+  proc.kill();
+  throw new Error(`http.server não subiu em ${ORIGIN}`);
+}
+
+async function waitFor(cond, what, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return;
+    await sleep(50);
+  }
+  throw new Error(`timeout esperando: ${what}`);
+}
+
+let server, browser;
+before(async () => { server = await startServer(); browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/** Página com as rotas de API neutralizadas (asset vai pro http.server). */
+async function newPage(contextOpts = {}) {
+  const ctx = await browser.newContext({ ...contextOpts });
+  const page = await ctx.newPage();
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin !== ORIGIN) return route.abort();     // CDN (pluggy, chart.js) fora
+    if (/\.[a-z0-9]+$/i.test(url.pathname)) return route.continue();
+    return route.fulfill(json({}));
+  });
+  await page.route("**/static/auth-refresh.js", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript",
+                    body: readFileSync(join(FRONTEND, "auth-refresh.js"), "utf8") }));
+  await page.route("**/auth/validate", (route) => route.fulfill(json({ user_id: 1 })));
+  await page.route("**/auth/me", (route) => route.fulfill(json({ app_access: true, plan_tier: "pro" })));
+  page.__ctx = ctx;
+  return page;
+}
+
+async function botaoVisivel(page) {
+  return page.evaluate(() => {
+    const b = document.getElementById("of-refresh-btn");
+    if (!b) return null;
+    return getComputedStyle(b).display !== "none";
+  });
+}
+
+test("botão Atualizar do OF: some no modo app, fica no mobile web", async () => {
+  // No app (UA PigBankApp) o app-mode.js liga html.pb-app + body.pb-page-settings,
+  // que é exatamente o que a regra do app-mode.css exige.
+  const noApp = await newPage({ userAgent: APP_UA, viewport: { width: 390, height: 844 },
+                                hasTouch: true, isMobile: true });
+  try {
+    await noApp.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => noApp.evaluate(() => document.documentElement.classList.contains("pb-app")),
+                  "html.pb-app no modo app");
+    assert.equal(await botaoVisivel(noApp), false, "no app o botão tem que sumir (o gesto substitui)");
+  } finally { await noApp.__ctx.close(); }
+
+  // Mesmo aparelho, navegador comum: o botão é a única forma de atualizar.
+  const noWeb = await newPage({ userAgent: SAFARI, viewport: { width: 390, height: 844 },
+                               hasTouch: true, isMobile: true });
+  try {
+    await noWeb.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await sleep(300);
+    assert.equal(await noWeb.evaluate(() => document.documentElement.classList.contains("pb-app")), false);
+    assert.equal(await botaoVisivel(noWeb), true, "no mobile web o botão CONTINUA");
+  } finally { await noWeb.__ctx.close(); }
+});
+
+/**
+ * O veredito é uma tabela de permissão: `OF_VERDICT_OK` decide quem pode ser
+ * verde. O teste discrimina — com o `default: return {tone:"ok"}` que existia
+ * antes, os quatro casos aqui voltavam "Tudo em dia!".
+ */
+test("veredito do refresh: só estado conhecido-bom fica verde", async () => {
+  const page = await newPage({ viewport: { width: 390, height: 844 } });
+  try {
+    await page.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => page.evaluate(() => typeof window.refreshVerdict === "function"),
+                  "refreshVerdict existir na página");
+
+    // NUNCA verde — inclusive o estado inventado, que é o ponto do teste: o
+    // backend pode ganhar um caso novo antes desta tela saber dele.
+    for (const state of ["no_accounts", "paused", "removed", "item_missing",
+                         "estado_que_ninguem_implementou_ainda"]) {
+      const v = await page.evaluate((s) =>
+        window.refreshVerdict({ ok: true, still_updating: 0, items: [{
+          item_id: "i1", institution: "Nubank", state: s, label: s, detail: null }] }), state);
+      assert.notEqual(v.tone, "ok", `${state} não pode ser verde (veio "${v.msg}")`);
+      assert.notEqual(v.msg, "Tudo em dia!", `${state} devolveu "Tudo em dia!"`);
+    }
+
+    // Um item bom + um desconhecido: o desconhecido manda.
+    const misto = await page.evaluate(() => window.refreshVerdict({ ok: true, items: [
+      { item_id: "a", state: "updated" }, { item_id: "b", state: "coisa_nova" }] }));
+    assert.notEqual(misto.tone, "ok", "um item desconhecido derruba o verde do outro");
+
+    // CONTROLE POSITIVO: o caminho legítimo continua verde — sem isto o teste
+    // passaria num código que recusa tudo.
+    for (const bons of [["updated"], ["updated", "rate_limited"], ["rate_limited"]]) {
+      const v = await page.evaluate((estados) => window.refreshVerdict({
+        ok: true, still_updating: 0,
+        items: estados.map((s, n) => ({ item_id: `i${n}`, state: s })) }), bons);
+      assert.equal(v.tone, "ok", `${bons.join("+")} tinha que ficar verde`);
+      assert.match(v.msg, /tudo em dia/i, v.msg);
+    }
+    // Só cooldown: verde, mas dizendo que não pediu coleta nova.
+    const cooldown = await page.evaluate(() => window.refreshVerdict({
+      ok: true, items: [{ item_id: "a", state: "rate_limited" }] }));
+    assert.equal(cooldown.tone, "ok");
+    assert.match(cooldown.msg, /acabou de atualizar/i, cooldown.msg);
+  } finally { await page.__ctx.close(); }
+});
+
+test("dashboard: rajada de open_finance_synced vira UM get_month", async () => {
+  const page = await newPage();
+  try {
+    // WebSocket falso: guarda o que a página manda e deixa a gente empurrar
+    // mensagens do servidor. Chart é stub porque o CDN está bloqueado aqui.
+    await page.addInitScript(() => {
+      window.__sent = [];
+      window.Chart = function () { return { destroy() {}, update() {}, data: {}, options: {} }; };
+      window.Chart.register = () => {};
+      class FakeWS {
+        constructor(url) {
+          this.url = url; this.readyState = 1; window.__ws = this;
+          setTimeout(() => this.onopen && this.onopen(), 0);
+        }
+        send(data) { window.__sent.push(JSON.parse(data)); }
+        close() {}
+      }
+      FakeWS.OPEN = 1;
+      window.WebSocket = FakeWS;
+    });
+
+    await page.goto(`${ORIGIN}/dashboard.html`);
+    await waitFor(() => page.evaluate(() => !!window.__ws), "o dashboard abrir o WebSocket");
+
+    const antes = await page.evaluate(() =>
+      window.__sent.filter((m) => m.type === "get_month").length);
+
+    // três eventos em 200ms, como a Pluggy manda
+    await page.evaluate(async () => {
+      const msg = JSON.stringify({ type: "open_finance_synced", item_id: "item-1" });
+      for (let i = 0; i < 3; i++) {
+        window.__ws.onmessage({ data: msg });
+        await new Promise((r) => setTimeout(r, 70));
+      }
+    });
+
+    await sleep(2500);   // debounce de 1,5s + folga
+    const depois = await page.evaluate(() =>
+      window.__sent.filter((m) => m.type === "get_month").length);
+
+    assert.equal(depois - antes, 1,
+      `esperava 1 get_month para a rajada (antes=${antes}, depois=${depois})`);
+  } finally { await page.__ctx.close(); }
+});

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -1,0 +1,371 @@
+"""G4 — concorrência real: threads de verdade, banco de verdade, caminho de verdade.
+
+Fatos medidos em produção: a Pluggy manda `item/updated` e `transactions/created`
+com 0–17s de intervalo, e cada evento criava uma task de sync sem lock nenhum —
+10 `deadlock detected` e 1 violação de `uq_credit_tx_source_external` (o import de
+cartão fazia SELECT-depois-INSERT, que é check-then-act).
+
+CONTROLE NEGATIVO do grupo (os dois primeiros MEDIDOS nesta rodada):
+  • desligar o `pluggy_item_lock` (fazer o contextmanager devolver True sem tomar
+    lock) → `test_dois_syncs_do_mesmo_item_serializam_a_escrita` vermelho, na
+    asserção de sobreposição das janelas de escrita;
+  • devolver o lock para ANTES das leituras remotas (como era) →
+    `test_lock_nao_e_segurado_durante_a_paginacao` vermelho;
+  • tirar o `on conflict ... do nothing` do `add_imported_credit_purchase`
+    → `test_duas_importacoes_do_mesmo_external_id...` vermelho (IntegrityError).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+import db
+import core.services.pluggy_sync as ps
+import frontend.routes.open_finance as of_routes
+from db.connection import get_conn
+
+ITEM = {
+    "id": "item-conc", "status": "UPDATED", "executionStatus": "SUCCESS",
+    "statusDetail": {"accounts": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00Z"}},
+}
+
+
+def _conexao(user_id: int, item_id: str = "item-conc") -> dict:
+    return db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": item_id, "status": "UPDATED", "connector": {"id": 612, "name": "Nubank"}},
+    )
+
+
+def _espelho(connection_id: int) -> tuple[int, int]:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("select count(*) as n from open_finance_accounts where connection_id=%s",
+                        (connection_id,))
+            contas = int(cur.fetchone()["n"])
+            cur.execute(
+                "select count(*) as n from open_finance_transactions t "
+                "join open_finance_accounts a on a.id=t.account_id where a.connection_id=%s",
+                (connection_id,))
+            txs = int(cur.fetchone()["n"])
+    return contas, txs
+
+
+# ── 21. dois syncs do mesmo item em paralelo ─────────────────────────────────
+# O lock deixou de cercar o sync inteiro e passa a cercar SÓ a fase de escrita:
+# segurar um advisory lock de SESSÃO durante `list_pluggy_transactions` (até 60
+# requisições paginadas por conta) retinha uma conexão do pool por minutos —
+# medido, com DB_POOL_MAX_SYNC=2 e 2 locks abertos um `select 1` estourava
+# PoolTimeout em 30s, e em produção max_size=8 travaria o processo inteiro.
+#
+# CONTROLE NEGATIVO deste par: fazer `pluggy_item_lock` devolver True sem tomar
+# lock nenhum → `test_dois_syncs...` vermelho (as janelas de escrita se
+# sobrepõem). Devolver o lock para o começo do sync (como era) →
+# `test_lock_nao_e_segurado_durante_a_paginacao` vermelho.
+
+def _prova_lock_livre(item_id: str) -> bool:
+    """De uma conexão de FORA: ninguém está segurando o lock deste item."""
+    import os
+    import psycopg
+    from db.open_finance_state import _lock_key
+    with psycopg.connect(os.environ["DATABASE_URL"], autocommit=True) as c:
+        got = c.execute("select pg_try_advisory_lock(hashtext(%s)) as g",
+                        (_lock_key(item_id),)).fetchone()[0]
+        if got:
+            c.execute("select pg_advisory_unlock(hashtext(%s))", (_lock_key(item_id),))
+        return bool(got)
+
+
+def test_dois_syncs_do_mesmo_item_serializam_a_escrita(user_id, monkeypatch):
+    conexao = _conexao(user_id)
+    janelas: list[tuple[float, float]] = []
+    real_save = db.save_open_finance_sync
+
+    def _save_lento(connection_id, accounts):
+        inicio = time.monotonic()
+        try:
+            return real_save(connection_id, accounts)
+        finally:
+            time.sleep(0.4)          # segura a fase de ESCRITA
+            janelas.append((inicio, time.monotonic()))
+
+    monkeypatch.setattr(ps, "save_open_finance_sync", _save_lento)
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: ITEM)
+    monkeypatch.setattr(ps, "list_pluggy_accounts", lambda i, k=None: [
+        {"id": "acc-conc", "name": "Conta", "type": "BANK", "currencyCode": "BRL",
+         "balance": "10.00"}])
+    monkeypatch.setattr(ps, "list_pluggy_transactions",
+                        lambda acc, k=None, **kw: [{"id": "tx-conc", "description": "M",
+                                                    "amount": "-1.00", "date": "2026-08-19"}])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: [])
+
+    barreira = threading.Barrier(2, timeout=10)
+    resultados: list[dict] = []
+    erros: list[BaseException] = []
+
+    def _roda():
+        try:
+            barreira.wait()
+            resultados.append(ps.sync_pluggy_item("item-conc"))
+        except BaseException as exc:   # noqa: BLE001 — o teste decide o que fazer
+            erros.append(exc)
+
+    threads = [threading.Thread(target=_roda) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert erros == [], f"nenhuma exceção era esperada: {erros}"
+    assert len(janelas) == 2, f"as duas escritas tinham que acontecer: {janelas}"
+    (a_ini, a_fim), (b_ini, b_fim) = sorted(janelas)
+    assert b_ini >= a_fim - 0.01, (
+        f"as escritas se sobrepuseram — o lock não serializou: {janelas}")
+    assert all(r.get("ok") for r in resultados), resultados
+    assert _espelho(conexao["id"]) == (1, 1), "espelho gravado uma vez só"
+    assert _prova_lock_livre("item-conc"), "o lock tem que ser solto no fim"
+
+
+def test_lock_nao_e_segurado_durante_a_paginacao(user_id, monkeypatch):
+    """A leitura remota é read-only contra a Pluggy e não pode reter nada.
+
+    Durante a paginação: (1) ninguém segura o advisory lock do item e (2) o pool
+    continua atendendo — que é o que estourava PoolTimeout.
+    """
+    _conexao(user_id, "item-pag")
+    medidas: list[tuple[bool, bool]] = []
+
+    def _txs(account_id, api_key=None, **kw):
+        pool_ok = False
+        try:
+            with get_conn() as c:
+                pool_ok = c.execute("select 1 as x").fetchone()["x"] == 1
+        except Exception:
+            pool_ok = False
+        medidas.append((_prova_lock_livre("item-pag"), pool_ok))
+        return []
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {**ITEM, "id": "item-pag"})
+    monkeypatch.setattr(ps, "list_pluggy_accounts", lambda i, k=None: [
+        {"id": "acc-pag", "name": "Conta", "type": "BANK", "currencyCode": "BRL",
+         "balance": "10.00"}])
+    monkeypatch.setattr(ps, "list_pluggy_transactions", _txs)
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: [])
+
+    ps.sync_pluggy_item("item-pag")
+
+    assert medidas, "a paginação tinha que ter sido exercitada"
+    for lock_livre, pool_ok in medidas:
+        assert lock_livre, "o lock estava tomado DURANTE a leitura remota"
+        assert pool_ok, "o pool não respondeu durante a leitura remota"
+
+
+# ── 22. evento durante o sync → UMA re-execução ──────────────────────────────
+
+def test_evento_durante_o_sync_gera_exatamente_uma_reexecucao(monkeypatch):
+    execucoes: list[str] = []
+    liberado = asyncio.Event()
+
+    async def _sync_lento(item_id):
+        execucoes.append(item_id)
+        if len(execucoes) == 1:
+            await liberado.wait()
+        return None
+
+    monkeypatch.setattr(of_routes, "_run_pluggy_sync_bg", _sync_lento)
+    of_routes._INFLIGHT.clear()
+    of_routes._DIRTY.clear()
+
+    async def _cenario():
+        of_routes._schedule_pluggy_sync("item-x")   # 1º evento: roda
+        await asyncio.sleep(0)
+        of_routes._schedule_pluggy_sync("item-x")   # chega durante o sync → dirty
+        of_routes._schedule_pluggy_sync("item-x")   # e mais um → continua 1 bit
+        liberado.set()
+        for _ in range(10):
+            await asyncio.sleep(0)
+        return list(execucoes)
+
+    feitas = asyncio.run(_cenario())
+
+    assert feitas == ["item-x", "item-x"], f"esperava 1 execução + 1 re-execução: {feitas}"
+    assert of_routes._INFLIGHT == {}
+    assert of_routes._DIRTY == set()
+
+
+# ── 23. duas importações do mesmo external_id ────────────────────────────────
+
+def test_duas_importacoes_do_mesmo_external_id_somam_a_fatura_uma_vez(user_id):
+    card_id = db.create_card(user_id, "Nubank", closing_day=10, due_day=17)
+    compra = date(2026, 8, 5)
+    barreira = threading.Barrier(2, timeout=10)
+    saidas: list[tuple] = []
+    erros: list[BaseException] = []
+
+    def _importa():
+        try:
+            barreira.wait()
+            saidas.append(db.add_imported_credit_purchase(
+                user_id, card_id, "-100.00", "mercado", compra, "ext-dup",
+            ))
+        except BaseException as exc:  # noqa: BLE001
+            erros.append(exc)
+
+    threads = [threading.Thread(target=_importa) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert erros == [], f"a corrida não pode estourar: {erros}"
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "select count(*) as n from credit_transactions "
+                "where user_id=%s and source='open_finance' and external_id='ext-dup'",
+                (user_id,))
+            assert int(cur.fetchone()["n"]) == 1, "duplicou a transação de cartão"
+            cur.execute(
+                "select total from credit_bills where user_id=%s and card_id=%s",
+                (user_id, card_id))
+            totais = [Decimal(str(r["total"])) for r in cur.fetchall()]
+    assert totais == [Decimal("100.00")], f"a fatura somou {totais} (deveria somar uma vez só)"
+
+
+# ── 24. retry só para erro de concorrência ───────────────────────────────────
+
+def test_retry_dispara_em_deadlock_e_nao_em_erro_de_programacao(monkeypatch):
+    eventos: list[tuple] = []
+
+    async def _log(level, event_type, message, **kw):
+        eventos.append((level, event_type))
+
+    async def _sleep_rapido(_s):
+        return None
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
+
+    tentativas = []
+
+    def _sempre_deadlock(item_id):
+        tentativas.append(item_id)
+        raise psycopg.errors.DeadlockDetected("deadlock detected")
+
+    monkeypatch.setattr(of_routes, "sync_pluggy_item", _sempre_deadlock)
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-dead"))
+
+    assert len(tentativas) == 3, f"máximo de 3 tentativas: {len(tentativas)}"
+    retries = [e for e in eventos if e[1] == "pluggy_sync_retry"]
+    assert len(retries) == 2, f"um log por RETENTATIVA (2 esperas para 3 tentativas): {eventos}"
+    assert ("error", "pluggy_sync_failed") in eventos
+
+    # erro de programação não é retentado — repetir 3x é o mesmo bug 3x
+    eventos.clear()
+    tentativas.clear()
+
+    def _erro_bobo(item_id):
+        tentativas.append(item_id)
+        raise ValueError("bug de verdade")
+
+    monkeypatch.setattr(of_routes, "sync_pluggy_item", _erro_bobo)
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-bug"))
+
+    assert len(tentativas) == 1
+    assert [e for e in eventos if e[1] == "pluggy_sync_retry"] == []
+
+
+# ── RODADA 3: o lock não pode esperar para sempre nem abrir conexão sem teto ──
+
+def test_lock_wait_zero_nao_significa_espera_infinita(user_id, monkeypatch):
+    """`lock_timeout='0ms'` no Postgres significa *desligado*, não *não espere*.
+    Medido antes: `400ms` desistia em 0,48s; `0` seguia bloqueado depois de 3s,
+    com a thread segurando a conexão dedicada."""
+    _conexao(user_id, "item-wait0")
+    monkeypatch.setenv("OF_SYNC_LOCK_WAIT_MS", "0")
+
+    resultado = {}
+
+    def _segundo():
+        t0 = time.monotonic()
+        with db.pluggy_item_lock("item-wait0") as got:
+            resultado["got"] = got
+            resultado["s"] = time.monotonic() - t0
+
+    with db.pluggy_item_lock("item-wait0") as primeiro:
+        assert primeiro is True
+        t = threading.Thread(target=_segundo)
+        t.start()
+        t.join(timeout=5)
+
+    assert not t.is_alive(), "esperou para sempre"
+    assert resultado["got"] is False
+    assert resultado["s"] < 2, f"desistiu em {resultado['s']:.2f}s"
+
+
+def test_teto_de_conexoes_dedicadas(user_id, monkeypatch):
+    """Medido antes: 30 syncs concorrentes = 30 backends extras fora do pool
+    (antes=1, DURANTE=31). Quem não pega vaga volta False — mesmo desfecho de
+    perder o lock, e o chamador já sabe reportar `sync_in_progress`."""
+    import db.open_finance_state as ofs
+
+    monkeypatch.setenv("OF_SYNC_LOCK_MAX_CONN", "2")
+    monkeypatch.setenv("OF_SYNC_LOCK_WAIT_MS", "200")
+    ofs._lock_slots.cache_clear()
+    try:
+        antes = _backends()
+        segurando = threading.Event()
+        soltar = threading.Event()
+        pegos: list[bool] = []
+
+        def _segura(item):
+            with db.pluggy_item_lock(item) as got:
+                pegos.append(got)
+                segurando.set()
+                soltar.wait(timeout=5)
+
+        ts = [threading.Thread(target=_segura, args=(f"item-teto-{n}",)) for n in range(5)]
+        for t in ts:
+            t.start()
+        segurando.wait(timeout=5)
+        time.sleep(0.6)          # tempo de todo mundo tentar e os excedentes desistirem
+        durante = _backends()
+        soltar.set()
+        for t in ts:
+            t.join(timeout=5)
+
+        assert durante - antes <= 2, f"teto furado: {durante - antes} conexões extras"
+        assert pegos.count(False) >= 3, f"quem não pegou vaga tem que voltar False: {pegos}"
+        assert pegos.count(True) >= 1, "CONTROLE POSITIVO: alguém tem que conseguir trabalhar"
+    finally:
+        ofs._lock_slots.cache_clear()
+
+
+def _backends() -> int:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("select count(*) as n from pg_stat_activity"
+                        " where datname = current_database()")
+            return int(cur.fetchone()["n"])
+
+
+def test_429_da_pluggy_e_retentado_pelo_webhook():
+    """`_retryable` devolvia False para todo `PluggyApiError`: um 429 no meio do
+    sync não era retentado, e a cota de leitura já tinha sido gasta. 404 fica de
+    fora de propósito — é `item_missing`, e repetir não ressuscita item."""
+    from core.services.pluggy import PluggyApiError
+
+    assert of_routes._retryable(PluggyApiError("rate", status_code=429)) is True
+    assert of_routes._retryable(PluggyApiError("gateway", status_code=502)) is True
+    assert of_routes._retryable(PluggyApiError("sumiu", status_code=404)) is False
+    assert of_routes._retryable(PluggyApiError("chave errada", status_code=401)) is False
+    assert of_routes._retryable(ValueError("bug")) is False

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -1,0 +1,542 @@
+"""G1 — o sync para de mentir que deu certo.
+
+Fato medido em produção que originou o grupo: `GET /accounts?itemId=<item deletado>`
+devolve **HTTP 200 com results:[]**; só `GET /items/{id}` devolve 404. Como
+`save_open_finance_sync` carimbava `status='ACTIVE', last_sync_at=now()`
+incondicionalmente, um item apagado no banco virava "Atualizado agora" — e um sync
+posterior ressuscitava `DELETED → ACTIVE` e `ERROR → ACTIVE`.
+
+CONTROLE NEGATIVO do grupo (MEDIDO): desligar o conserto — tirar o `get_pluggy_item`
+e o `mark_sync_result` de `sync_pluggy_item` e devolver o `update ... status='ACTIVE',
+last_sync_at=now()` incondicional a `save_open_finance_sync` — deixa 5 testes
+vermelhos (404 não carimba, 404 não apaga, sem contas, ERROR→ACTIVE, tentativa ≠
+sucesso). O de PAUSED segue verde: ele testa outra guarda.
+
+CONTROLE POSITIVO: o caso 5 prova que o caminho legítimo continua funcionando —
+`ERROR` volta a `ACTIVE` quando o item está saudável e o sync completa. Sem ele o
+grupo passaria num código que recusasse tudo.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+import db
+import core.services.pluggy_sync as ps
+from core.services.pluggy import PluggyApiError
+from db.connection import get_conn
+from utils_date import _tz
+
+# Relógio fixo: nenhuma asserção pode depender do dia em que a suíte roda.
+AGORA = datetime(2026, 8, 20, 12, 0, 0, tzinfo=_tz())
+ANTES = datetime(2026, 8, 12, 9, 30, 0, tzinfo=_tz())
+
+ITEM_SAUDAVEL = {
+    "id": "item-g1",
+    "status": "UPDATED",
+    "executionStatus": "SUCCESS",
+    "clientUserId": "1",
+    "statusDetail": {
+        "accounts": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00.000Z", "warnings": []},
+        "creditCards": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00.000Z", "warnings": []},
+    },
+}
+
+
+class _Relogio(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return AGORA
+
+
+@pytest.fixture()
+def relogio_fixo(monkeypatch):
+    monkeypatch.setattr(ps, "datetime", _Relogio)
+    monkeypatch.setattr("db.open_finance_state.datetime", _Relogio)
+
+
+def _conexao(user_id: int, item_id: str = "item-g1", status: str = "UPDATED") -> dict:
+    conn = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": item_id, "status": status, "connector": {"id": 612, "name": "Nubank"}},
+    )
+    _set_estado(conn["id"], status=status, last_sync_at=ANTES, last_attempt_at=ANTES)
+    return conn
+
+
+def _set_estado(connection_id: int, **campos) -> None:
+    sets = ", ".join(f"{k}=%s" for k in campos)
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                f"update open_finance_connections set {sets} where id=%s",
+                (*campos.values(), connection_id),
+            )
+        c.commit()
+
+
+def _linha(item_id: str = "item-g1") -> dict:
+    rows = db.get_connections_by_item_id(item_id)
+    assert len(rows) == 1
+    return rows[0]
+
+
+def _espelho(connection_id: int) -> tuple[int, int]:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "select count(*) as n from open_finance_accounts where connection_id=%s",
+                (connection_id,),
+            )
+            contas = int(cur.fetchone()["n"])
+            cur.execute(
+                """
+                select count(*) as n from open_finance_transactions t
+                join open_finance_accounts a on a.id = t.account_id
+                where a.connection_id=%s
+                """,
+                (connection_id,),
+            )
+            txs = int(cur.fetchone()["n"])
+    return contas, txs
+
+
+def _mock_pluggy(monkeypatch, *, item, contas=(), txs=()):
+    """Mocka o mundo remoto. `item` pode ser um dict ou uma exceção a levantar."""
+    def _get_item(item_id, api_key=None):
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", _get_item)
+    monkeypatch.setattr(ps, "list_pluggy_accounts", lambda i, k=None: list(contas))
+    monkeypatch.setattr(ps, "list_pluggy_transactions",
+                        lambda acc, k=None, **kw: list(txs))
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: [])
+
+
+def _conta_pluggy(account_id="acc-g1"):
+    return {"id": account_id, "name": "Conta", "type": "BANK", "currencyCode": "BRL",
+            "balance": "1000.00"}
+
+
+def _tx_pluggy(tx_id="tx-g1"):
+    return {"id": tx_id, "description": "Mercado", "amount": "-50.00",
+            "date": "2026-08-19T10:00:00.000-03:00"}
+
+
+# ── 1. item 404 ───────────────────────────────────────────────────────────────
+
+def test_item_404_nao_carimba_sucesso(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    # espelho com dado dentro: um item que sumiu não pode apagar histórico
+    db.save_open_finance_sync(conexao["id"], [{
+        "provider_account_id": "acc-g1", "name": "Conta", "type": "BANK",
+        "currency": "BRL", "balance": 1000, "raw": {},
+        "transactions": [{"provider_transaction_id": "tx-g1", "description": "Mercado",
+                          "amount": -50, "transaction_date": ANTES.date(), "raw": {}}],
+    }])
+    _set_estado(conexao["id"], last_sync_at=ANTES)
+    antes = _espelho(conexao["id"])
+
+    _mock_pluggy(monkeypatch, item=PluggyApiError("nao existe", status_code=404))
+    res = ps.sync_pluggy_item("item-g1")
+
+    assert res["ok"] is False
+    assert res["reason"] == "item_missing"
+    linha = _linha()
+    assert linha["status"] == "ERROR"
+    assert linha["status_reason"] == "item_missing"
+    assert linha["last_sync_at"] == ANTES, "last_sync_at é SUCESSO — não pode andar numa falha"
+    assert _espelho(conexao["id"]) == antes, "espelho não pode ser tocado"
+
+
+def test_item_404_nao_apaga_nada_nem_remoto(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    chamadas = []
+    monkeypatch.setattr("core.services.pluggy.delete_pluggy_item",
+                        lambda *a, **kw: chamadas.append(a))
+    _mock_pluggy(monkeypatch, item=PluggyApiError("nao existe", status_code=404))
+
+    res = ps.sync_pluggy_item("item-g1")
+
+    assert res["reason"] == "item_missing"
+    assert chamadas == [], "conexão perdida NÃO deleta item na Pluggy"
+    assert len(db.get_connections_by_item_id("item-g1")) == 1, "a conexão local continua lá"
+    assert db.get_open_finance_snapshot(user_id)["connections"], "nada foi removido"
+
+
+# ── 3. item vivo, zero contas ────────────────────────────────────────────────
+
+def test_item_vivo_sem_contas_nao_e_sucesso(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    _mock_pluggy(monkeypatch, item=ITEM_SAUDAVEL, contas=[])
+
+    res = ps.sync_pluggy_item("item-g1")
+
+    assert res["ok"] is False
+    assert res["reason"] == "no_accounts"
+    linha = _linha()
+    assert linha["status_reason"] == "no_accounts"
+    assert linha["last_sync_at"] == ANTES
+
+
+# ── 4. DELETED não ressuscita ────────────────────────────────────────────────
+
+def test_webhook_item_updated_nao_ressuscita_deleted(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    _set_estado(conexao["id"], status="DELETED")
+
+    # o caminho do webhook: status_by_event não escreve mais ACTIVE…
+    assert db.update_pluggy_open_finance_item_status("item-g1", "ACTIVE") == 0
+    # …e o sync recusa antes de qualquer leitura remota (a rede está bloqueada
+    # na suíte: se ele tentasse, o teste estouraria alto).
+    res = ps.sync_pluggy_item("item-g1")
+
+    assert res == {"ok": False, "reason": "connection_deleted", "item_id": "item-g1"}
+    assert _linha()["status"] == "DELETED"
+
+
+# ── 5. CONTROLE POSITIVO: ERROR → ACTIVE ─────────────────────────────────────
+
+def test_error_volta_para_active_quando_item_esta_saudavel(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    _set_estado(conexao["id"], status="ERROR", status_reason="item_missing", last_sync_at=ANTES)
+    _mock_pluggy(monkeypatch, item=ITEM_SAUDAVEL,
+                 contas=[_conta_pluggy()], txs=[_tx_pluggy()])
+
+    res = ps.sync_pluggy_item("item-g1")
+
+    assert res["ok"] is True, res
+    linha = _linha()
+    assert linha["status"] == "ACTIVE"
+    # Sucesso APAGA o motivo (linha F da tabela em pluggy_health): "ok" era um
+    # segundo sentinela para a mesma coisa — o vazio já é o estado verde.
+    assert linha["status_reason"] is None
+    assert linha["last_sync_at"] == AGORA, "sucesso avança last_sync_at"
+    assert linha["health"]["item_status"] == "UPDATED"
+    assert _espelho(conexao["id"]) == (1, 1)
+
+
+# ── 6. PAUSED continua terminal ──────────────────────────────────────────────
+
+def test_paused_barra_o_sync(user_id, relogio_fixo):
+    conexao = _conexao(user_id)
+    _set_estado(conexao["id"], status="PAUSED")
+
+    assert ps.sync_pluggy_item("item-g1") == {
+        "ok": False, "reason": "connection_paused", "item_id": "item-g1",
+    }
+
+
+# ── 7. tentativa ≠ sucesso ───────────────────────────────────────────────────
+
+def test_falha_avanca_tentativa_e_nao_sucesso(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    _set_estado(conexao["id"], last_attempt_at=ANTES, last_sync_at=ANTES)
+    _mock_pluggy(monkeypatch, item=ITEM_SAUDAVEL, contas=[])
+
+    ps.sync_pluggy_item("item-g1")
+
+    linha = _linha()
+    assert linha["last_attempt_at"] == AGORA, "tentamos: last_attempt_at anda"
+    assert linha["last_sync_at"] == ANTES, "não deu certo: last_sync_at fica"
+
+
+# ── 8. quem tira de DELETED é a reconexão explícita ──────────────────────────
+
+def test_so_reconexao_explicita_sai_de_deleted(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id)
+    _set_estado(conexao["id"], status="DELETED")
+
+    # webhook e sync não tiram
+    db.update_pluggy_open_finance_item_status("item-g1", "ACTIVE")
+    ps.sync_pluggy_item("item-g1")
+    assert _linha()["status"] == "DELETED"
+
+    # o usuário reconecta pelo widget → upsert com o item remoto
+    db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": "item-g1", "status": "UPDATED", "connector": {"id": 612, "name": "Nubank"}},
+    )
+    assert _linha()["status"] == "UPDATED"
+
+
+# ── 9. item vivo SÓ com investimento (corretora) ─────────────────────────────
+# Defeito medido: o early-return de `no_accounts` acontecia ANTES de
+# `list_pluggy_investments`. Corretora (XP/Rico/BTG/Warren) devolve `/accounts`
+# vazio porque a carteira vive em `/investments` — a conexão nunca espelhava
+# nada e `last_sync_at` congelava para sempre.
+# CONTROLE NEGATIVO: mover o `if not accounts: ... return` para antes da leitura
+# de investimentos (como era) deixa este teste vermelho em três asserções.
+
+def test_item_so_com_investimento_espelha_e_e_sucesso(user_id, monkeypatch, relogio_fixo):
+    conexao = _conexao(user_id, "item-corretora")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-corretora"}, contas=[])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: [
+        {"id": "inv-1", "name": "CDB Nu", "type": "FIXED_INCOME", "subtype": "CDB",
+         "currencyCode": "BRL", "balance": "1500.00"},
+    ])
+
+    res = ps.sync_pluggy_item("item-corretora")
+
+    assert res["ok"] is True, res
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("select count(*) as n from open_finance_investments where connection_id=%s",
+                        (conexao["id"],))
+            assert int(cur.fetchone()["n"]) == 1, "o investimento tinha que ter sido espelhado"
+    linha = _linha("item-corretora")
+    assert linha["last_sync_at"] == AGORA, "item que espelhou investimento sincronizou"
+    assert linha["status_reason"] is None
+
+
+def test_item_sem_conta_e_sem_investimento_continua_no_accounts(user_id, monkeypatch, relogio_fixo):
+    """CONTROLE POSITIVO do conserto acima: quem não traz NADA continua não sendo
+    sucesso — o conserto não pode transformar todo item vazio em verde."""
+    _conexao(user_id, "item-vazio")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-vazio"}, contas=[])
+
+    res = ps.sync_pluggy_item("item-vazio")
+
+    assert res["ok"] is False and res["reason"] == "no_accounts"
+    assert _linha("item-vazio")["last_sync_at"] == ANTES
+
+
+# ── 10. `no_accounts` não pode virar "Atualizado" na tela ────────────────────
+
+def test_no_accounts_nunca_vira_estado_verde(user_id, monkeypatch, relogio_fixo):
+    _conexao(user_id, "item-semconta")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-semconta"}, contas=[])
+
+    ps.sync_pluggy_item("item-semconta")
+
+    conexoes = db.get_open_finance_snapshot(user_id)["connections"]
+    ui = [c["ui"] for c in conexoes if c["provider_item_id"] == "item-semconta"][0]
+    assert ui["state"] != "updated", "item que não espelhou nada não é 'Atualizado'"
+    assert ui["state"] == "no_accounts"
+    assert ui["label"] == "Sem dados"
+
+
+# ── 11. conectar ≠ sincronizar ──────────────────────────────────────────────
+# `save_pluggy_open_finance_item` carimbava last_sync_at=now(): a conexão nascia
+# "Atualizado agora" e `user_synced_within` devolvia True sem sync nenhum.
+# CONTROLE NEGATIVO: repor `last_sync_at = excluded.last_sync_at` no upsert deixa
+# as duas primeiras asserções vermelhas.
+
+def test_conectar_nao_carimba_sucesso(user_id):
+    conexao = db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-novo", "status": "UPDATING",
+                  "connector": {"id": 612, "name": "Nubank"}})
+
+    assert conexao["last_sync_at"] is None, "conectar não é sincronizar"
+    assert db.user_synced_within(user_id, 60) is False, \
+        "sem sync, nada pode segurar o e-mail dos agentes"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "updating", "recém-conectado é 'Atualizando…', não 'Atualizado'"
+
+
+def test_reconexao_saindo_de_deleted_continua_funcionando(user_id, monkeypatch, relogio_fixo):
+    """CONTROLE POSITIVO do teste acima: o upsert PODE (e deve) continuar mexendo
+    no status — é ele que tira a conexão de DELETED quando o usuário reconecta.
+    E um sync posterior é que carimba o sucesso."""
+    conexao = _conexao(user_id, "item-volta")
+    _set_estado(conexao["id"], status="DELETED", last_sync_at=None)
+
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-volta", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    assert _linha("item-volta")["status"] == "UPDATED"
+
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-volta"},
+                 contas=[_conta_pluggy("acc-volta")], txs=[_tx_pluggy("tx-volta")])
+    assert ps.sync_pluggy_item("item-volta")["ok"] is True
+    assert _linha("item-volta")["last_sync_at"] == AGORA
+
+
+# ── 12. RODADA 3: a máquina de estados, evento por evento ───────────────────
+# A tabela vive no topo de `core/services/pluggy_health.py`. Estes testes são a
+# tabela executável — cada um é uma linha dela.
+#
+# CONTROLE NEGATIVO DO GRUPO (medido, ver relatório): trocar o
+# `resolve_connection_state(...)` do sucesso por `status="ACTIVE",
+# status_reason="ok"` fixo e o do 404-que-voltou por `status_reason=volta`
+# (a versão da rodada 2) deixa 3 destes vermelhos.
+
+def test_429_em_investimentos_nao_descarta_as_contas_ja_lidas(user_id, monkeypatch, relogio_fixo):
+    """REGRESSÃO medida contra o HEAD: a leitura de `/investments` subiu para
+    antes de qualquer escrita, então um 429 nela jogava fora contas e transações
+    já lidas (até 60 requisições paginadas por conta). Fail-soft: o espelho das
+    contas não pode custar isso."""
+    conexao = _conexao(user_id)
+    _mock_pluggy(monkeypatch, item=ITEM_SAUDAVEL,
+                 contas=[_conta_pluggy()], txs=[_tx_pluggy()])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("rate limit", status_code=429)))
+
+    res = ps.sync_pluggy_item("item-g1")
+
+    assert _espelho(conexao["id"]) == (1, 1), "contas e transações lidas TÊM que ser gravadas"
+    assert res["ok"] is True
+    assert res["investments_ok"] is False, "o sync tem que dizer que leu pela metade"
+    assert _linha()["last_sync_at"] == AGORA
+
+
+def test_leitura_incompleta_com_zero_contas_nao_vira_no_accounts(user_id, monkeypatch, relogio_fixo):
+    """'não consegui ler' ≠ 'li e veio vazio' (linhas D × E da tabela). Sem esta
+    distinção, um 429 em `/investments` acusaria o banco de não ter dado nenhum —
+    e `no_accounts` manda a tela dizer "O banco não devolveu contas"."""
+    _conexao(user_id, "item-429")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-429"}, contas=[])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("rate limit", status_code=429)))
+
+    res = ps.sync_pluggy_item("item-429")
+
+    assert res["reason"] == "read_failed"
+    linha = _linha("item-429")
+    assert linha["status_reason"] == "read_failed"
+    assert linha["last_sync_at"] == ANTES, "leitura pela metade não é sucesso"
+    from core.services.pluggy_health import connection_ui_state
+    assert connection_ui_state(linha)["state"] == "error_recoverable"
+
+
+def test_falha_lendo_contas_registra_a_tentativa(user_id, monkeypatch, relogio_fixo):
+    """O carimbo de tentativa mora depois do lock; sem o `except` da fase de
+    leitura, uma falha remota não deixava rastro nenhum na linha."""
+    _conexao(user_id, "item-leitura")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-leitura"})
+    monkeypatch.setattr(ps, "list_pluggy_accounts", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("rate limit", status_code=429)))
+
+    with pytest.raises(PluggyApiError):
+        ps.sync_pluggy_item("item-leitura")
+
+    linha = _linha("item-leitura")
+    assert linha["last_attempt_at"] == AGORA, "falhar lendo É uma tentativa"
+    assert linha["last_sync_at"] == ANTES, "e não é sucesso"
+
+
+def test_reconectar_pelo_widget_limpa_motivo_e_saude(user_id, relogio_fixo):
+    """Linha G: depois de refazer a conexão, a tela não pode continuar dizendo
+    'Conexão perdida / Refaça a conexão' — nem herdar a saúde da conexão morta."""
+    conexao = _conexao(user_id, "item-refeito")
+    _set_estado(conexao["id"], status="ERROR", status_reason="item_missing")
+    db.mark_sync_result(conexao["id"], ok=False, status="ERROR",
+                        status_reason="item_missing",
+                        health={"observed_at": AGORA.isoformat(), "item_status": "MISSING",
+                                "execution_status": None, "products": {}, "stale_products": []})
+    assert _ui("item-refeito")["state"] == "item_missing"
+
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-refeito", "status": "UPDATING",
+                  "connector": {"id": 612, "name": "Nubank"}})
+
+    linha = _linha("item-refeito")
+    assert linha["status_reason"] is None
+    assert linha["health"] is None, "saúde do item morto não vale para o item novo"
+    assert _ui("item-refeito")["state"] == "updating"
+
+
+def _ui(item_id: str) -> dict:
+    from core.services.pluggy_health import connection_ui_state
+    return connection_ui_state(_linha(item_id))
+
+
+# ── 13. RODADA 4: o webhook grava o PAR, não só o `status` ──────────────────
+# `update_pluggy_open_finance_item_status` escrevia o `status` sozinho: medido,
+# `item/error` sobre ACTIVE/no_accounts produzia ERROR/no_accounts — par
+# incoerente que a UI ainda mascarava de "Erro temporário". Ele não passa pelo
+# `resolve_connection_state` (não observa o item, só repete a Pluggy), mas grava
+# o MESMO par que as linhas B/C dariam: ERROR + motivo vazio.
+# CONTROLE NEGATIVO (medido): tirar o `status_reason=null` do UPDATE deixa este
+# teste vermelho no par.
+
+def test_webhook_item_error_nao_deixa_par_incoerente(user_id, monkeypatch):
+    import json
+
+    from fastapi.testclient import TestClient
+
+    import frontend.finance_bot_websocket_custom as dashboard
+
+    conexao = _conexao(user_id, "item-webhook-erro")
+    db.mark_sync_result(conexao["id"], ok=False, status="ACTIVE",
+                        status_reason="no_accounts", at=None)
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", "test-webhook-secret")
+    monkeypatch.setattr("frontend.routes.open_finance._schedule_pluggy_sync", lambda i: None)
+
+    resp = TestClient(dashboard.app).post(
+        "/open-finance/pluggy/webhook?token=test-webhook-secret",
+        content=json.dumps({"event": "item/error", "itemId": "item-webhook-erro"}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    linha = _linha("item-webhook-erro")
+    assert (linha["status"], linha["status_reason"]) == ("ERROR", None), linha
+    assert _ui("item-webhook-erro")["state"] == "error_recoverable"
+
+
+def test_webhook_item_error_atrasado_nao_apaga_item_missing(user_id, monkeypatch):
+    """A exceção do par: `item/error` entregue com atraso (replay) NÃO pode rebaixar
+    "Conexão perdida / Refaça a conexão" para "Erro temporário / Tentaremos de novo".
+    CONTROLE NEGATIVO (medido): com `status_reason=null` cru no UPDATE, o par vira
+    ('ERROR', None) e a UI vira `error_recoverable` — as duas asserções vermelhas."""
+    import json
+
+    from fastapi.testclient import TestClient
+
+    import frontend.finance_bot_websocket_custom as dashboard
+
+    conexao = _conexao(user_id, "item-webhook-sumido")
+    db.mark_sync_result(conexao["id"], ok=False, status="ERROR",
+                        status_reason="item_missing", at=None)
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", "test-webhook-secret")
+    monkeypatch.setattr("frontend.routes.open_finance._schedule_pluggy_sync", lambda i: None)
+
+    resp = TestClient(dashboard.app).post(
+        "/open-finance/pluggy/webhook?token=test-webhook-secret",
+        content=json.dumps({"event": "item/error", "itemId": "item-webhook-sumido"}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    linha = _linha("item-webhook-sumido")
+    assert (linha["status"], linha["status_reason"]) == ("ERROR", "item_missing"), linha
+    assert _ui("item-webhook-sumido")["state"] == "item_missing"
+
+
+def test_webhook_item_deleted_continua_terminal(user_id, monkeypatch):
+    """CONTROLE POSITIVO: apagar o motivo junto não pode afrouxar o que já valia —
+    o webhook continua escrevendo o status que a Pluggy disse, e PAUSED/DELETED
+    continuam intocáveis."""
+    conexao = _conexao(user_id, "item-webhook-del")
+    assert db.update_pluggy_open_finance_item_status("item-webhook-del", "DELETED") == 1
+    assert _linha("item-webhook-del")["status"] == "DELETED"
+
+    _set_estado(conexao["id"], status_reason="item_missing")
+    assert db.update_pluggy_open_finance_item_status("item-webhook-del", "ERROR") == 0
+    linha = _linha("item-webhook-del")
+    assert (linha["status"], linha["status_reason"]) == ("DELETED", "item_missing")
+
+
+def test_sync_de_item_vazio_tira_o_error_e_diz_sem_dados(user_id, monkeypatch, relogio_fixo):
+    """A ponta a ponta do defeito: conexão presa em ERROR/item_missing, item vivo,
+    banco sem contas. O sync tem que tirar o ERROR e a tela dizer "Sem dados"."""
+    conexao = _conexao(user_id, "item-preso")
+    db.mark_sync_result(conexao["id"], ok=False, status="ERROR",
+                        status_reason="item_missing", at=None)
+    assert _ui("item-preso")["state"] == "item_missing"
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-preso"}, contas=[])
+
+    res = ps.sync_pluggy_item("item-preso")
+
+    linha = _linha("item-preso")
+    assert res["ok"] is False and res["reason"] == "no_accounts"
+    assert (linha["status"], linha["status_reason"]) == ("ACTIVE", "no_accounts"), linha
+    assert linha["last_sync_at"] == ANTES, "espelho vazio continua não sendo sucesso"
+    ui = _ui("item-preso")
+    assert (ui["state"], ui["label"]) == ("no_accounts", "Sem dados")

--- a/tests/test_of_health.py
+++ b/tests/test_of_health.py
@@ -1,0 +1,437 @@
+"""G2 — saúde do item e os estados de UI (funções puras, sem banco e sem rede).
+
+`derive_item_health` traduz o `GET /items/{id}`; `connection_ui_state` é a única
+função que decide em que estado uma conexão está. Antes, quem decidia era um
+`connStatusPill` no settings.html que só olhava o `status` — e por isso não sabia
+diferenciar "atualizado" de "atualizei o que deu" nem de "o item sumiu".
+
+CONTROLE NEGATIVO do grupo: fazer `derive_item_health` devolver `{}` fixo deixa
+9–13 vermelhos.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from core.services.pluggy_health import (
+    connection_ui_state,
+    derive_item_health,
+    resolve_connection_state,
+)
+from utils_date import _tz
+
+AGORA = datetime(2026, 8, 20, 12, 0, 0, tzinfo=_tz())
+
+ITEM_PARCIAL = {
+    "id": "item-x",
+    "status": "UPDATED",
+    "executionStatus": "PARTIAL_SUCCESS",
+    "statusDetail": {
+        "accounts": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00.000Z", "warnings": []},
+        "creditCards": {"isUpdated": False, "lastUpdatedAt": "2026-08-12T03:10:00.000Z",
+                        "warnings": [{"code": "004", "message": "Conta 1234-5 de JOÃO DA SILVA"}]},
+    },
+}
+
+
+def test_partial_com_cartao_atrasado_desde_12_08():
+    health = derive_item_health(ITEM_PARCIAL, now=AGORA)
+    assert health["execution_status"] == "PARTIAL_SUCCESS"
+    assert health["stale_products"] == ["CREDIT"]
+
+    ui = connection_ui_state({"status": "ACTIVE", "health": health, "last_sync_at": AGORA})
+    assert ui["state"] == "partial"
+    assert ui["label"] == "Parcial"
+    assert "Cartão" in ui["detail"]
+    assert "12/08" in ui["detail"], ui["detail"]
+    assert ui["stale_products"] == ["CREDIT"]
+
+
+def test_tudo_atualizado_vira_updated():
+    item = {
+        "status": "UPDATED", "executionStatus": "SUCCESS",
+        "statusDetail": {
+            "accounts": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00.000Z"},
+            "creditCards": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00.000Z"},
+            "investments": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00.000Z"},
+        },
+    }
+    health = derive_item_health(item, now=AGORA)
+    assert health["stale_products"] == []
+
+    ui = connection_ui_state({"status": "ACTIVE", "health": health, "last_sync_at": AGORA})
+    assert (ui["state"], ui["label"], ui["detail"]) == ("updated", "Atualizado", None)
+
+
+def test_updating_e_updating():
+    health = derive_item_health({"status": "UPDATING"}, now=AGORA)
+    ui = connection_ui_state({"status": "ACTIVE", "health": health, "last_sync_at": AGORA})
+    assert ui["state"] == "updating"
+    assert ui["label"] == "Atualizando…"
+
+
+def test_login_error_e_waiting_user_input_pedem_acao_do_usuario():
+    for status in ("LOGIN_ERROR", "WAITING_USER_INPUT"):
+        health = derive_item_health({"status": status}, now=AGORA)
+        ui = connection_ui_state({"status": "ACTIVE", "health": health, "last_sync_at": AGORA})
+        assert ui["state"] == "needs_user_action", status
+        assert ui["detail"] == "Reautorize o banco"
+
+
+def test_warning_chega_ao_health_sem_pii():
+    health = derive_item_health(ITEM_PARCIAL, now=AGORA)
+    warnings = health["products"]["CREDIT"]["warnings"]
+    assert warnings == ["004"], "só o código do warning entra no health"
+
+    texto = repr(health)
+    for vazamento in ("JOÃO", "SILVA", "1234-5", "Conta"):
+        assert vazamento not in texto, f"vazou '{vazamento}' no health: {texto}"
+
+
+def test_linha_legada_sem_health_nao_vira_nunca_sincronizou():
+    ui = connection_ui_state({"status": "ACTIVE", "health": None, "last_sync_at": AGORA})
+    assert ui["state"] == "updated"
+    assert "nunca" not in (ui["detail"] or "").lower()
+    assert "não sincronizou" not in (ui["detail"] or "").lower()
+
+
+def test_sem_health_e_sem_last_sync_e_que_e_nunca_sincronizou():
+    ui = connection_ui_state({"status": "ACTIVE", "health": None, "last_sync_at": None})
+    assert ui["state"] == "updating"
+    assert ui["detail"] == "Ainda não sincronizou"
+
+
+def test_item_missing_paused_e_removed_vem_do_status_local():
+    perdido = connection_ui_state({"status": "ERROR", "status_reason": "item_missing"})
+    assert (perdido["state"], perdido["label"]) == ("item_missing", "Conexão perdida")
+    assert perdido["detail"] == "Refaça a conexão com o banco"
+
+    pausado = connection_ui_state({"status": "PAUSED"})
+    assert (pausado["state"], pausado["label"]) == ("paused", "Pausado")
+
+    removido = connection_ui_state({"status": "DELETED"})
+    assert (removido["state"], removido["label"], removido["detail"]) == ("removed", "Removido", None)
+
+
+def test_erro_sem_motivo_e_recuperavel():
+    ui = connection_ui_state({"status": "ERROR", "health": None, "last_sync_at": AGORA})
+    assert ui["state"] == "error_recoverable"
+    assert ui["detail"] == "Tentaremos de novo automaticamente"
+
+
+# ── warning como lista de STRINGS: o corte em 64 chars não protegia nada ─────
+# Medido pelo Tester: `warnings: ["Conta 1234-5 de JOAO DA SILVA CPF ..."]` entrava
+# no health com 64 caracteres da mensagem — e o health desce no snapshot pro
+# navegador e sobe pro painel admin.
+# CONTROLE NEGATIVO: voltar `code = w.get("code") if isinstance(w, dict) else w`
+# deixa este teste vermelho.
+
+def test_warning_como_string_nao_vaza_texto_livre():
+    item = {
+        "status": "UPDATED",
+        "statusDetail": {"accounts": {
+            "isUpdated": False, "lastUpdatedAt": "2026-08-12T03:00:00Z",
+            "warnings": ["Conta 1234-5 de JOAO DA SILVA CPF 123.456.789-00 nao pode ser lida"],
+        }},
+    }
+    health = derive_item_health(item, now=AGORA)
+
+    assert health["products"]["BANK"]["warnings"] == ["invalid_warning"]
+    texto = repr(health)
+    for vazamento in ("JOAO", "SILVA", "123.456.789", "1234-5", "Conta"):
+        assert vazamento not in texto, f"vazou '{vazamento}': {texto}"
+
+
+def test_warning_dict_com_code_estranho_tambem_vira_sentinela():
+    """CONTROLE POSITIVO/limite: o formato legítimo passa (test_warning_chega_ao_health
+    _sem_pii cobre isso); texto livre dentro do `code` não."""
+    item = {"status": "UPDATED", "statusDetail": {"accounts": {
+        "isUpdated": True, "warnings": [
+            {"code": "MFA_TIMEOUT"},                       # legítimo
+            {"code": "titular JOAO DA SILVA sem acesso"},  # texto livre disfarçado
+            {"message": "sem code nenhum"},
+        ]}}}
+    codes = derive_item_health(item, now=AGORA)["products"]["BANK"]["warnings"]
+
+    assert codes == ["MFA_TIMEOUT", "invalid_warning", "invalid_warning"]
+    assert "JOAO" not in repr(codes)
+
+
+# ── ordem: ERROR ganha de "produto atrasado" ────────────────────────────────
+# CONTROLE NEGATIVO: pôr o teste de `stale` antes do de ERROR (como era) devolve
+# "partial" e este teste fica vermelho.
+
+def test_error_com_produto_atrasado_e_erro_nao_parcial():
+    health = derive_item_health({
+        "status": "ERROR", "executionStatus": "ERROR",
+        "statusDetail": {"creditCards": {"isUpdated": False,
+                                         "lastUpdatedAt": "2026-08-12T03:00:00Z"}},
+    }, now=AGORA)
+
+    ui = connection_ui_state({"status": "ERROR", "health": health, "last_sync_at": AGORA})
+    assert ui["state"] == "error_recoverable", "erro com produto atrasado é ERRO, não 'Parcial'"
+
+
+def test_partial_sem_erro_continua_partial():
+    """CONTROLE POSITIVO da ordem acima: sem ERROR, atraso continua sendo 'Parcial'."""
+    ui = connection_ui_state({"status": "ACTIVE", "health": derive_item_health(ITEM_PARCIAL, now=AGORA)})
+    assert ui["state"] == "partial"
+
+
+# ── a CLASSE: estado/motivo desconhecido nunca é verde ──────────────────────
+# `no_accounts` chegava à tela como "Atualizado" porque `connection_ui_state` não
+# conhecia o motivo e caía no ramo de sucesso. O conserto é a regra, não o caso.
+# CONTROLE NEGATIVO: tirar a guarda do `out()` deixa os três casos vermelhos.
+
+def test_motivo_pendente_desconhecido_nunca_e_updated():
+    saudavel = derive_item_health({"status": "UPDATED", "executionStatus": "SUCCESS",
+                                   "statusDetail": {"accounts": {"isUpdated": True}}}, now=AGORA)
+    for motivo, esperado in (("no_accounts", "no_accounts"),
+                             ("motivo_que_ninguem_escreveu_ainda", "error_recoverable"),
+                             ("quota_exceeded", "error_recoverable")):
+        ui = connection_ui_state({"status": "ACTIVE", "status_reason": motivo,
+                                  "health": saudavel, "last_sync_at": AGORA})
+        assert ui["state"] == esperado, motivo
+        assert ui["state"] != "updated"
+
+
+def test_motivo_ok_ou_vazio_continua_verde():
+    """CONTROLE POSITIVO: a guarda não pode recusar o caminho legítimo."""
+    saudavel = derive_item_health({"status": "UPDATED", "executionStatus": "SUCCESS",
+                                   "statusDetail": {"accounts": {"isUpdated": True}}}, now=AGORA)
+    for motivo in ("ok", "", None):
+        ui = connection_ui_state({"status": "ACTIVE", "status_reason": motivo,
+                                  "health": saudavel, "last_sync_at": AGORA})
+        assert ui["state"] == "updated", motivo
+
+
+# ── RODADA 4: espelho vazio NÃO pode deixar o ERROR grudado ─────────────────
+# Defeito medido: `resolve_connection_state` só corrigia o `status` no ramo
+# `has_data=True`; com o espelho vazio devolvia `None` ("não mexe"), e `None` não
+# tira um ERROR que já está lá. Com `OF_REFRESH_ENABLED` off (o default) não há
+# PATCH → webhook → sync completo, então ERROR virava TERMINAL na prática.
+# CONTROLE NEGATIVO (medido): trocar os dois `return "ACTIVE", ...` do ramo de
+# espelho vazio por `return None, ...` deixa os dois primeiros testes vermelhos.
+
+def test_espelho_vazio_com_item_vivo_sai_de_error():
+    """O par (status, reason) JUNTO: o status é a saúde do ITEM (boa), o motivo é
+    quem explica o espelho vazio."""
+    vivo = {"item_status": "UPDATED"}
+    # E: leu tudo e não veio nada.
+    assert resolve_connection_state(health=vivo, has_data=False, leitura_completa=True,
+                                    reason_atual="item_missing") == ("ACTIVE", "no_accounts")
+    # D: 429 no meio da leitura — "não consegui ler" ≠ "li e veio vazio".
+    assert resolve_connection_state(health=vivo, has_data=False, leitura_completa=False,
+                                    reason_atual="item_missing") == ("ACTIVE", "read_failed")
+
+
+def test_job_de_saude_com_espelho_vazio_tambem_sai_de_error():
+    """H: o job não leu `/accounts`, então não INVENTA motivo — mas o item está
+    vivo, e deixar o ERROR de ontem de pé era o bug. Motivo de espelho vazio
+    continua sendo carregado; um `item_missing` desmentido cai."""
+    vivo = {"item_status": "UPDATED"}
+    assert resolve_connection_state(health=vivo, has_data=False, leitura_completa=None,
+                                    reason_atual="item_missing") == ("ACTIVE", "")
+    assert resolve_connection_state(health=vivo, has_data=False, leitura_completa=None,
+                                    reason_atual="no_accounts") == ("ACTIVE", "no_accounts")
+
+
+@pytest.mark.parametrize("item_status", ["LOGIN_ERROR", "WAITING_USER_INPUT", "ERROR"])
+def test_item_doente_com_espelho_vazio_continua_em_erro(item_status):
+    """CONTROLE POSITIVO: o conserto não pode virar "nunca marca erro" — que é
+    pior que o bug. Item que exige o usuário (ou em erro) segue em ERROR."""
+    assert resolve_connection_state(health={"item_status": item_status}, has_data=False,
+                                    leitura_completa=True) == ("ERROR", "")
+    assert resolve_connection_state(missing=True) == ("ERROR", "item_missing")
+
+
+# ── RODADA 4: `no_accounts` mascarado de "Erro temporário" na UI ────────────
+# `connection_ui_state` testava `status == "ERROR"` ANTES do ramo `updated`, e o
+# override de motivo só rodava dentro do `out("updated")`: a linha
+# ERROR/no_accounts nunca mostrava "Sem dados", e o /refresh mandava
+# state="error_recoverable" (o OF_VERDICT do settings.html casa por STATE).
+# CONTROLE NEGATIVO (medido): voltar os dois ramos para `out("error_recoverable")`
+# fixo deixa `test_error_com_no_accounts_mostra_sem_dados` vermelho nos 2 casos.
+
+def _saudavel() -> dict:
+    return derive_item_health({"status": "UPDATED", "executionStatus": "SUCCESS",
+                               "statusDetail": {"accounts": {"isUpdated": True}}}, now=AGORA)
+
+
+def test_error_com_no_accounts_mostra_sem_dados():
+    com_health = connection_ui_state({"status": "ERROR", "status_reason": "no_accounts",
+                                      "health": _saudavel(), "last_sync_at": AGORA})
+    assert (com_health["state"], com_health["label"]) == ("no_accounts", "Sem dados")
+    # linha legada, sem saúde medida: mesma classe, mesmo desfecho.
+    sem_health = connection_ui_state({"status": "ERROR", "status_reason": "no_accounts",
+                                      "health": None, "last_sync_at": AGORA})
+    assert (sem_health["state"], sem_health["label"]) == ("no_accounts", "Sem dados")
+
+
+def test_erro_de_verdade_nao_e_rebaixado_a_sem_dados():
+    """CONTROLE POSITIVO da tabela de gravidade: motivo velho não subestima erro,
+    e este ramo NUNCA vira verde."""
+    doente = derive_item_health({"status": "ERROR", "statusDetail": {}}, now=AGORA)
+    ui = connection_ui_state({"status": "ERROR", "status_reason": "no_accounts",
+                              "health": doente, "last_sync_at": AGORA})
+    assert ui["state"] == "error_recoverable"
+    outro = connection_ui_state({"status": "ERROR", "status_reason": "read_failed",
+                                 "health": _saudavel(), "last_sync_at": AGORA})
+    assert outro["state"] == "error_recoverable"
+    for estado in ("no_accounts", "error_recoverable"):
+        assert estado != "updated"
+
+
+# ── painel admin: falha ≠ contagem ──────────────────────────────────────────
+# `of.erro` é a CONTAGEM de conexões em erro e o fail-soft devolvia `{"erro":
+# "<mensagem>"}` na MESMA chave — o grid fazia `fInt("relation não existe")` =
+# NaN, `NaN > 0` = false, e a caixa inteira ficava VERDE com tudo zerado.
+# CONTROLE NEGATIVO: voltar o fail-soft para `{"erro": str(exc)}` deixa o
+# segundo teste vermelho nas duas asserções.
+
+def test_painel_of_traz_a_contagem_e_nao_a_chave_de_falha(user_id):
+    import asyncio
+    import core.admin_dashboard as ad
+
+    # o painel inteiro depende das tabelas de admin, criadas preguiçosamente
+    asyncio.run(ad.ensure_admin_tables())
+    of = asyncio.run(ad._fetch_admin_overview_inner(days=1))["open_finance"]
+    assert isinstance(of["erro"], int), "`erro` é contagem de conexões, não texto"
+    assert "error" not in of, "sem falha, a chave de falha não existe"
+
+
+def test_falha_ao_ler_contadores_aparece_como_falha(user_id, monkeypatch):
+    import asyncio
+    import core.admin_dashboard as ad
+    import db.open_finance_state as ofs
+
+    def _explode():
+        raise RuntimeError('relation "open_finance_connections" does not exist')
+
+    asyncio.run(ad.ensure_admin_tables())
+    monkeypatch.setattr(ofs, "of_health_counters", _explode)
+    of = asyncio.run(ad._fetch_admin_overview_inner(days=1))["open_finance"]
+
+    assert "erro" not in of, "a falha não pode se disfarçar da contagem"
+    assert "does not exist" in of["error"]
+
+
+# ── RODADA 3: o que PARECE código, e o que é PII ────────────────────────────
+# `_warning_codes` e a mensagem de erro da API compartilham `safe_code`. A regra
+# é o teto de DÍGITOS: CPF e conta têm 11, código de verdade tem 3.
+# CONTROLE NEGATIVO: subir `_CODE_MAX_DIGITS` para 11 deixa
+# `test_code_com_cara_de_cpf_nao_passa` vermelho.
+
+def test_codigos_reais_da_pluggy_passam():
+    """CONTROLE POSITIVO: os três vistos em produção continuam entrando — apertar
+    a regra até recusar código legítimo é pior que o vazamento que ela evita.
+    (`CC_001` era recusado ANTES: faltava `_` na classe de caracteres.)"""
+    from core.services.pluggy_health import safe_code
+    for code in ("004", "CC_001", "INV_005", "MFA_TIMEOUT"):
+        assert safe_code(code) == code, code
+
+
+def test_code_com_cara_de_cpf_nao_passa():
+    from core.services.pluggy_health import safe_code
+    assert safe_code("123.456.789-01") == ""      # CPF
+    assert safe_code("0001-12345-6") == ""        # agência-conta-dígito
+    assert safe_code("Lucas Kuramoti") == ""      # nome (tem espaço)
+
+
+def test_warnings_escalar_nao_derruba_o_sync():
+    """Medido: `{"warnings": 7}` estourava `TypeError: 'int' object is not
+    iterable` dentro de `derive_item_health`, chamado sem `try` pelo sync."""
+    health = derive_item_health({"id": "x", "status": "UPDATED", "statusDetail": {
+        "accounts": {"isUpdated": True, "warnings": 7}}})
+    assert health["products"]["BANK"]["warnings"] == []
+
+
+def test_warning_em_formato_de_string_vira_sentinela():
+    health = derive_item_health({"id": "x", "status": "UPDATED", "statusDetail": {
+        "accounts": {"isUpdated": True,
+                     "warnings": ["Conta 0001-12345-6 de LUCAS KURAMOTI, CPF 123.456.789-01"]}}})
+    assert health["products"]["BANK"]["warnings"] == ["invalid_warning"]
+
+
+def test_erro_da_pluggy_nao_carrega_o_corpo_da_resposta():
+    """RAIZ do vazamento: `str(exc)` vira `details` de `log_system_event`,
+    PERSISTIDO em `system_event_logs` e lido pelo painel admin."""
+    import httpx
+    from core.services.pluggy import PluggyApiError, _raise_for_pluggy_response
+
+    corpo = {"code": 429, "message": "Too many requests",
+             "data": {"name": "Lucas Kuramoti", "documentNumber": "123.456.789-01",
+                      "accountNumber": "0001-12345-6"}}
+    resp = httpx.Response(429, json=corpo, request=httpx.Request("GET", "https://x/y"))
+
+    with pytest.raises(PluggyApiError) as exc:
+        _raise_for_pluggy_response(resp, "Falha ao consultar /investments na Pluggy")
+
+    texto = str(exc.value)
+    for pii in ("Kuramoti", "123.456.789-01", "0001-12345-6", "documentNumber"):
+        assert pii not in texto, f"PII na mensagem: {pii} — {texto}"
+    assert exc.value.status_code == 429, "o status continua acessível para decidir retry"
+    assert "429" in texto
+
+
+# ── PARIDADE Python × JS (§0.7) ──────────────────────────────────────────────
+# A tabela de estados existe duas vezes porque o settings.html não importa
+# Python. O CLAUDE.md manda: quando a duplicação é inevitável, um teste compara
+# as duas (precedente: tests/test_phosphor_subset.py). Sem isto, um estado novo
+# no backend degrada CALADO na tela — pílula "pending" e veredito genérico.
+
+import pathlib
+import re
+
+_HTML = (pathlib.Path(__file__).resolve().parent.parent
+         / "frontend" / "settings.html").read_text(encoding="utf-8")
+
+
+def _bloco(nome: str, abre: str, fecha: str) -> str:
+    m = re.search(rf"const {nome} = \{abre}(.*?)\{fecha};", _HTML, re.S)
+    assert m, f"{nome} sumiu/foi renomeado no settings.html — a paridade ficou cega"
+    return m.group(1)
+
+
+def _js_pill_states() -> set[str]:
+    return set(re.findall(r"(\w+)\s*:", _bloco("OF_PILL_CLASS", "{", "}")))
+
+
+def _js_verdict_ok() -> set[str]:
+    return set(re.findall(r'"(\w+)"', _bloco("OF_VERDICT_OK", "[", "]")))
+
+
+def _js_verdict_states() -> set[str]:
+    return set(re.findall(r'^\s*\["(\w+)"', _bloco("OF_VERDICT", "[", "]"), re.M))
+
+
+def test_estados_do_backend_e_do_settings_html_sao_os_mesmos():
+    from core.services.pluggy_health import _LABELS
+
+    py, js = set(_LABELS), _js_pill_states()
+    assert py == js, (
+        f"estado só no Python (vira pílula 'pending' calada): {sorted(py - js)}; "
+        f"estado só no JS (o backend nunca emite): {sorted(js - py)}")
+
+
+def test_conjunto_verde_e_o_mesmo_nos_dois_lados():
+    from core.services.pluggy_sync import _ESTADOS_OK
+
+    py, js = set(_ESTADOS_OK), _js_verdict_ok()
+    assert py == js, (
+        f"verde só no Python (o usuário vê erro no sucesso): {sorted(py - js)}; "
+        f"verde só no JS (toast verde em cima de falha): {sorted(js - py)}")
+
+
+def test_todo_estado_nao_verde_tem_mensagem_de_veredito():
+    """OF_VERDICT é a tabela de gravidade: estado sem linha lá cai no genérico."""
+    from core.services.pluggy_health import _LABELS
+    from core.services.pluggy_sync import _ESTADOS_OK
+
+    esperado = set(_LABELS) - set(_ESTADOS_OK)
+    js = _js_verdict_states()
+    assert esperado == js, (
+        f"estado sem mensagem em OF_VERDICT: {sorted(esperado - js)}; "
+        f"mensagem para estado que não existe no backend: {sorted(js - esperado)}")

--- a/tests/test_of_item_ownership.py
+++ b/tests/test_of_item_ownership.py
@@ -1,0 +1,206 @@
+"""G5 — de quem é o item.
+
+Fatos que originaram o grupo: `open_finance_connections` é única em
+(user_id, provider, provider_item_id) — ou seja, DOIS usuários podem ter o mesmo
+item —, `get_open_finance_connection_by_item_id` fazia `limit 1` SEM `order by`
+(sorteava o dono) e o `POST /pluggy-item` aceitava o dict `item` cru do navegador.
+
+CONTROLE NEGATIVO do grupo:
+  • remover a comparação `clientUserId == session_uid` do /pluggy-item
+    → `test_item_de_outro_client_user_id_e_recusado` vermelho;
+  • voltar o `limit 1` em `get_connections_by_item_id`
+    → `test_webhook_de_item_com_dois_donos_recusa_sync` vermelho.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MFA_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.open_finance as of_routes
+from db.connection import get_conn
+
+SEGREDO = "test-webhook-secret"
+
+
+@pytest.fixture()
+def eventos(monkeypatch):
+    """Captura os `log_system_event` da rota (a versão real grava no banco)."""
+    capturados: list[dict] = []
+
+    async def _log(level, event_type, message, **kw):
+        capturados.append({"level": level, "event": event_type, **kw})
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    return capturados
+
+
+@pytest.fixture()
+def sem_indice_unico():
+    """Deixa o item aparecer em duas conexões — o estado que o código precisa tratar.
+
+    O índice `uq_of_conn_provider_item` é criado dentro de um bloco que só emite
+    WARNING se falhar (db/schema.py): em produção, se já houver duplicata, ele NÃO
+    existe. Este teste reproduz exatamente esse banco.
+    """
+    with get_conn() as c:
+        c.execute("drop index if exists uq_of_conn_provider_item")
+        c.commit()
+    yield
+    with get_conn() as c:
+        try:
+            c.execute("create unique index if not exists uq_of_conn_provider_item "
+                      "on open_finance_connections(provider, provider_item_id)")
+            c.commit()
+        except Exception:
+            c.rollback()
+
+
+def _auth(client: TestClient, user_id: int, email: str = "of@t.com") -> dict:
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(user_id, email))
+    client.cookies.set(dashboard.DASHBOARD_COOKIE_NAME, dashboard.make_dashboard_token(user_id, hours=1))
+    token = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, token)
+    return {dashboard.CSRF_HEADER_NAME: token, "Content-Type": "application/json"}
+
+
+def _item_remoto(item_id: str, client_user_id) -> dict:
+    return {"id": item_id, "status": "UPDATED", "clientUserId": str(client_user_id),
+            "connector": {"id": 612, "name": "Nubank"}}
+
+
+# ── 25. clientUserId ≠ usuário da sessão ─────────────────────────────────────
+
+def test_item_de_outro_client_user_id_e_recusado(user_id, monkeypatch, eventos):
+    monkeypatch.setattr(of_routes, "get_pluggy_item",
+                        lambda item_id, api_key=None: _item_remoto(item_id, 999_999_999))
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id)
+
+    resp = client.post(f"/open-finance/{user_id}/pluggy-item",
+                       json={"item": {"id": "item-alheio"}}, headers=headers)
+
+    assert resp.status_code == 403, resp.text
+    assert db.get_connections_by_item_id("item-alheio") == [], "nada podia ter sido gravado"
+    assert any(e["event"] == "of_item_owner_conflict" for e in eventos), eventos
+
+
+def test_o_que_e_gravado_e_o_item_REMOTO_nao_o_do_navegador(user_id, monkeypatch, eventos):
+    monkeypatch.setattr(of_routes, "get_pluggy_item",
+                        lambda item_id, api_key=None: _item_remoto(item_id, user_id))
+    monkeypatch.setattr(of_routes, "_schedule_pluggy_sync", lambda item_id: None)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id)
+
+    # o navegador mente o nome do banco; o servidor usa o que a Pluggy respondeu
+    resp = client.post(
+        f"/open-finance/{user_id}/pluggy-item",
+        json={"item": {"id": "item-meu", "connector": {"id": 1, "name": "Banco Falso"}}},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    linha = db.get_connections_by_item_id("item-meu")[0]
+    assert linha["institution_name"] == "Nubank"
+    assert int(linha["user_id"]) == user_id
+
+
+# ── 26. item já vinculado a outra conta ──────────────────────────────────────
+
+def test_item_de_outra_conta_local_devolve_409(user_id, monkeypatch, eventos):
+    outro = user_id + 1
+    db.ensure_user(outro)
+    try:
+        db.save_pluggy_open_finance_item(
+            outro, {"id": "item-disputado", "status": "UPDATED",
+                    "connector": {"id": 612, "name": "Nubank"}})
+
+        # a Pluggy diz que o dono é o usuário da sessão, mas alguém já registrou aqui
+        monkeypatch.setattr(of_routes, "get_pluggy_item",
+                            lambda item_id, api_key=None: _item_remoto(item_id, user_id))
+        client = TestClient(dashboard.app)
+        headers = _auth(client, user_id)
+
+        resp = client.post(f"/open-finance/{user_id}/pluggy-item",
+                           json={"item": {"id": "item-disputado"}}, headers=headers)
+
+        assert resp.status_code == 409, resp.text
+        linhas = db.get_connections_by_item_id("item-disputado")
+        assert len(linhas) == 1 and int(linhas[0]["user_id"]) == outro, "o dono original ficou intacto"
+        assert any(e["event"] == "of_item_owner_conflict" and e["level"] == "error"
+                   for e in eventos), eventos
+    finally:
+        db.disconnect_open_finance_connection(outro)
+        with get_conn() as c:
+            c.execute("delete from users where id=%s", (outro,))
+            c.commit()
+
+
+# ── 27 e 28. webhook ─────────────────────────────────────────────────────────
+
+def _webhook(client: TestClient, evento: str, item_id: str):
+    return client.post(
+        f"/open-finance/pluggy/webhook?token={SEGREDO}",
+        content=json.dumps({"event": evento, "itemId": item_id}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def test_webhook_de_item_com_dois_donos_recusa_sync(user_id, monkeypatch, eventos, sem_indice_unico):
+    outro = user_id + 1
+    db.ensure_user(outro)
+    try:
+        for uid in (user_id, outro):
+            db.save_pluggy_open_finance_item(
+                uid, {"id": "item-2donos", "status": "UPDATED",
+                      "connector": {"id": 612, "name": "Nubank"}})
+        assert len(db.get_connections_by_item_id("item-2donos")) == 2
+
+        agendados = []
+        monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", SEGREDO)
+        monkeypatch.setattr(of_routes, "_schedule_pluggy_sync", lambda i: agendados.append(i))
+
+        resp = _webhook(TestClient(dashboard.app), "transactions/created", "item-2donos")
+
+        assert resp.status_code == 200, resp.text
+        assert agendados == [], "sincronizar um dos dois é sincronizar a carteira errada"
+        assert any(e["event"] == "of_item_owner_conflict" and e["level"] == "error"
+                   for e in eventos), eventos
+    finally:
+        for uid in (outro,):
+            db.disconnect_open_finance_connection(uid)
+            with get_conn() as c:
+                c.execute("delete from users where id=%s", (uid,))
+                c.commit()
+
+
+def test_webhook_de_item_desconhecido_registra_e_nao_sincroniza(monkeypatch, eventos):
+    agendados = []
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", SEGREDO)
+    monkeypatch.setattr(of_routes, "_schedule_pluggy_sync", lambda i: agendados.append(i))
+
+    resp = _webhook(TestClient(dashboard.app), "item/updated", "item-fantasma")
+
+    assert resp.status_code == 200, resp.text
+    assert agendados == []
+    assert any(e["event"] == "of_webhook_item_unknown" for e in eventos), eventos
+
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "select origin, user_id from open_finance_item_registry where provider_item_id=%s",
+                ("item-fantasma",))
+            linhas = cur.fetchall()
+            cur.execute("delete from open_finance_item_registry where provider_item_id=%s",
+                        ("item-fantasma",))
+        c.commit()
+    assert [l["origin"] for l in linhas] == ["webhook"]
+    assert linhas[0]["user_id"] is None, "item desconhecido não tem dono a atribuir"

--- a/tests/test_of_refresh_response.py
+++ b/tests/test_of_refresh_response.py
@@ -1,0 +1,296 @@
+"""G6 — o /refresh conta o que aconteceu com CADA banco.
+
+Fato medido: `refresh_and_sync_pluggy_user` engolia o 404 do PATCH e o do
+`get_pluggy_item`, devolvia `still_updating: 0`, e o settings.html mostrava
+"Tudo em dia!" para uma conexão que não existia mais na Pluggy. E o
+`pluggy_sync_done` era logado em nível `info` mesmo com `ok:false` (397 true ×
+41 false na mesma prateleira).
+
+CONTROLE NEGATIVO: restaurar o `ok: True` fixo no retorno de
+`refresh_and_sync_pluggy_user` (ou o log `info` incondicional em
+`_run_pluggy_sync_bg`) deixa este grupo vermelho.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MFA_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+import db
+import core.services.pluggy_sync as ps
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.open_finance as of_routes
+from core.services.pluggy import PluggyApiError
+
+ITEM_OK = {
+    "id": "item-vivo", "status": "UPDATED", "executionStatus": "SUCCESS",
+    "statusDetail": {"accounts": {"isUpdated": True, "lastUpdatedAt": "2026-08-20T11:00:00Z",
+                                  "warnings": []}},
+}
+
+
+def _auth(client: TestClient, user_id: int) -> dict:
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(user_id, "of@t.com"))
+    client.cookies.set(dashboard.DASHBOARD_COOKIE_NAME,
+                       dashboard.make_dashboard_token(user_id, hours=1))
+    token = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, token)
+    return {dashboard.CSRF_HEADER_NAME: token, "Content-Type": "application/json"}
+
+
+def _mundo_remoto(monkeypatch):
+    """Um item vivo (Nubank) e um item que sumiu da Pluggy (Inter)."""
+    def _get_item(item_id, api_key=None):
+        if item_id == "item-sumiu":
+            raise PluggyApiError("nao existe", status_code=404)
+        return ITEM_OK
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", _get_item)
+    monkeypatch.setattr(ps, "update_pluggy_item", lambda i, k=None: _get_item(i, k))
+    monkeypatch.setattr(ps, "list_pluggy_accounts", lambda i, k=None: [
+        {"id": f"acc-{i}", "name": "Conta", "type": "BANK", "currencyCode": "BRL",
+         "balance": "10.00"}])
+    monkeypatch.setattr(ps, "list_pluggy_transactions", lambda acc, k=None, **kw: [])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: [])
+    monkeypatch.setattr(ps, "_hold_aggregate_emails", lambda uid, origem: None)
+
+
+def test_refresh_com_item_sumido_nao_diz_que_esta_tudo_em_dia(user_id, monkeypatch):
+    db.save_pluggy_open_finance_item(user_id, {"id": "item-vivo", "status": "UPDATED",
+                                               "connector": {"id": 612, "name": "Nubank"}})
+    db.save_pluggy_open_finance_item(user_id, {"id": "item-sumiu", "status": "UPDATED",
+                                               "connector": {"id": 77, "name": "Inter"}})
+    _mundo_remoto(monkeypatch)
+
+    eventos: list[dict] = []
+
+    async def _log(level, event_type, message, **kw):
+        eventos.append({"level": level, "event": event_type, **kw})
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+
+    client = TestClient(dashboard.app)
+    resp = client.post(f"/open-finance/{user_id}/refresh?wait=0", headers=_auth(client, user_id))
+
+    assert resp.status_code == 200, resp.text
+    sync = resp.json()["sync"]
+    assert sync["ok"] is False, "um item perdido não pode virar 'tudo em dia'"
+
+    por_item = {i["item_id"]: i for i in sync["items"]}
+    assert por_item["item-sumiu"]["state"] == "item_missing"
+    assert por_item["item-sumiu"]["institution"] == "Inter"
+    assert por_item["item-sumiu"]["reason"] == "item_missing"
+    assert por_item["item-vivo"]["state"] == "updated"
+    assert por_item["item-vivo"]["products"] == {"BANK": "updated"}
+    assert isinstance(sync["duration_ms"], int)
+
+    # o clique fica registrado com o usuário ANONIMIZADO e sem segredo nenhum
+    clique = [e for e in eventos if e["event"] == "of_manual_refresh"]
+    assert len(clique) == 1, eventos
+    detalhes = clique[0]["details"]
+    assert clique[0]["level"] == "warning"
+    assert detalhes["ok"] is False
+    assert isinstance(detalhes["duration_ms"], int)
+    assert str(user_id) not in str(detalhes), "o id do usuário não pode aparecer em claro"
+    assert len(detalhes["user_hash"]) == 16
+    assert {i["item_id"] for i in detalhes["items"]} == {"item-vivo", "item-sumiu"}
+    texto = str(detalhes).lower()
+    for proibido in ("token", "apikey", "secret", "balance", "valor"):
+        assert proibido not in texto, f"'{proibido}' vazou no evento: {detalhes}"
+
+
+def test_sync_sem_sucesso_e_logado_como_warning_com_motivo(monkeypatch):
+    eventos: list[dict] = []
+
+    async def _log(level, event_type, message, **kw):
+        eventos.append({"level": level, "event": event_type, **kw})
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes, "sync_pluggy_item",
+                        lambda item_id: {"ok": False, "reason": "no_accounts",
+                                         "item_id": item_id})
+
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-x"))
+
+    assert len(eventos) == 1
+    assert eventos[0]["level"] == "warning", "ok:false não pode ser logado como info"
+    assert eventos[0]["details"]["reason"] == "no_accounts"
+
+
+def test_sync_com_item_perdido_e_logado_como_error(monkeypatch):
+    eventos: list[dict] = []
+
+    async def _log(level, event_type, message, **kw):
+        eventos.append({"level": level, "event": event_type, **kw})
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes, "sync_pluggy_item",
+                        lambda item_id: {"ok": False, "reason": "item_missing",
+                                         "item_id": item_id})
+
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-x"))
+
+    assert eventos[0]["level"] == "error"
+    assert eventos[0]["event"] == "of_item_missing"
+
+
+# ── RODADA 3: relatório coerente e refresh manual que ainda sincroniza ───────
+
+def test_label_acompanha_o_state_sobreposto(user_id, monkeypatch):
+    """`state` virava `partial`/`rate_limited` e `label` continuava "Atualizado".
+    Ninguém consome hoje — é armadilha para o próximo."""
+    _conexao_saudavel(user_id, "item-label")
+    monkeypatch.setattr(ps, "get_connections_by_item_id", db.get_connections_by_item_id)
+
+    out = ps._refresh_items_report(
+        ["item-label"], {"item-label": "Nubank"},
+        {"item-label": False}, {}, set(), rate_limited=set())
+    assert (out[0]["state"], out[0]["label"]) == ("partial", "Parcial"), out
+
+    out = ps._refresh_items_report(
+        ["item-label"], {"item-label": "Nubank"},
+        {}, {}, set(), rate_limited={"item-label"})
+    assert out[0]["state"] == "rate_limited"
+    assert out[0]["label"] == "Atualizado" and out[0]["detail"] == "Atualizado há pouco"
+
+
+def test_detalhe_do_parcial_de_verdade_nao_e_sobrescrito(user_id, monkeypatch):
+    """CONTROLE POSITIVO: `partial` vindo do `connection_ui_state` mantém o
+    detalhe dele ("Cartão desatualizado desde 12/08"), que diz muito mais."""
+    conexao = db.save_pluggy_open_finance_item(user_id, {
+        "id": "item-parcial-real", "status": "UPDATED",
+        "connector": {"id": 612, "name": "Nubank"}})
+    db.mark_sync_result(conexao["id"], ok=True, status="ACTIVE", status_reason="", health={
+        "observed_at": "2026-08-20T12:00:00-03:00", "item_status": "UPDATED",
+        "execution_status": "PARTIAL_SUCCESS", "stale_products": ["CREDIT"],
+        "products": {"CREDIT": {"updated": False, "last_updated_at": "2026-08-12T03:10:00Z",
+                                "warnings": []}}})
+    monkeypatch.setattr(ps, "get_connections_by_item_id", db.get_connections_by_item_id)
+
+    out = ps._refresh_items_report(["item-parcial-real"], {}, {}, {}, set())
+    assert out[0]["state"] == "partial"
+    assert out[0]["detail"] == "Cartão desatualizado desde 12/08", out[0]
+
+
+def test_manual_dentro_do_cooldown_ainda_sincroniza(user_id, monkeypatch):
+    """O cooldown do manual protege a cota de COLETA (o PATCH). Reler o que a
+    Pluggy já tem é GET — e era exatamente o que o usuário queria ao apertar o
+    botão. Antes: early-return sem PATCH E SEM SYNC, com "tudo em dia"."""
+    _conexao_saudavel(user_id, "item-cooldown")
+    _mundo_remoto(monkeypatch)
+    patches: list[str] = []
+    monkeypatch.setattr(ps, "update_pluggy_item", lambda i, k=None: patches.append(i))
+    monkeypatch.setattr(ps, "claim_manual_refresh", lambda *a, **kw: [])
+    syncs: list[int] = []
+    monkeypatch.setattr(ps, "sync_pluggy_user",
+                        lambda uid: syncs.append(uid) or {"ok": True, "results": []})
+
+    saida = ps.refresh_and_sync_pluggy_user(user_id, wait_seconds=0)
+
+    assert patches == [], "dentro do cooldown NÃO se pede coleta nova"
+    assert syncs == [user_id], "mas o que a Pluggy já tem tem que ser lido"
+    assert saida["refreshed"] == 0
+    assert [i["state"] for i in saida["items"]] == ["rate_limited"]
+
+
+def _conexao_saudavel(user_id: int, item_id: str) -> dict:
+    """Conexão que JÁ sincronizou com sucesso — sem isso o estado é "Atualizando…"
+    ("Ainda não sincronizou") e nada é sobreposto, que é o comportamento certo."""
+    conexao = db.save_pluggy_open_finance_item(user_id, {
+        "id": item_id, "status": "UPDATED", "connector": {"id": 612, "name": "Nubank"}})
+    db.mark_sync_result(conexao["id"], ok=True, status="ACTIVE", status_reason="", health={
+        "observed_at": "2026-08-20T12:00:00-03:00", "item_status": "UPDATED",
+        "execution_status": "SUCCESS", "products": {}, "stale_products": []})
+    return conexao
+
+
+# ── RODADA FINAL: um banco com 429 não pode derrubar o /refresh dos outros ────
+
+def test_um_item_com_429_nao_derruba_o_refresh_dos_demais(user_id, monkeypatch):
+    """Fato medido antes do conserto, por esta MESMA rota: `GET /items` devolvendo
+    429 num banco subia até a rota (o re-raise de `sync_pluggy_item` é o que faz o
+    webhook retentar) e virava `502 {"detail":"rate"}` — sem relatório por item,
+    sem `of_manual_refresh` no log, e o banco saudável do mesmo usuário com
+    `last_sync_at: None`.
+
+    CONTROLE NEGATIVO: trocar `_sync_item_contido` de volta por
+    `sync_pluggy_item` direto no lote (`sync_pluggy_user`) deixa este teste
+    vermelho já no `status_code == 200`.
+    """
+    db.save_pluggy_open_finance_item(user_id, {"id": "i-ok", "status": "UPDATED",
+                                               "connector": {"id": 612, "name": "Nubank"}})
+    # o item do 429 JÁ tinha sincronizado com sucesso — é essa conexão que dizia
+    # "Atualizado" enquanto a leitura de hoje falhava.
+    _conexao_saudavel(user_id, "i-429")
+    _mundo_remoto(monkeypatch)
+
+    def _get_item(item_id, api_key=None):
+        if item_id == "i-429":
+            raise PluggyApiError("rate", status_code=429)
+        return ITEM_OK
+
+    monkeypatch.setattr(ps, "get_pluggy_item", _get_item)
+    monkeypatch.setattr(ps, "update_pluggy_item", lambda i, k=None: None)
+
+    eventos: list[dict] = []
+
+    async def _log(level, event_type, message, **kw):
+        eventos.append({"level": level, "event": event_type, **kw})
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+
+    client = TestClient(dashboard.app)
+    resp = client.post(f"/open-finance/{user_id}/refresh?wait=0", headers=_auth(client, user_id))
+
+    assert resp.status_code == 200, resp.text
+    sync = resp.json()["sync"]
+    por_item = {i["item_id"]: i for i in sync["items"]}
+
+    # 1. o banco saudável sincronizou de verdade (o 429 do vizinho não o alcançou)
+    assert por_item["i-ok"]["state"] == "updated", por_item["i-ok"]
+    assert db.get_connections_by_item_id("i-ok")[0]["last_sync_at"] is not None
+
+    # 2. o que falhou volta como resultado DELE, com motivo próprio e sem verde
+    assert por_item["i-429"]["state"] == "error_recoverable", por_item["i-429"]
+    assert por_item["i-429"]["reason"] == "read_failed"
+    assert sync["ok"] is False, "um item que não deu para ler não é 'tudo em dia'"
+
+    # 3. a observabilidade do clique sai SEMPRE — inclusive quando um item falha
+    clique = [e for e in eventos if e["event"] == "of_manual_refresh"]
+    assert len(clique) == 1, eventos
+    assert clique[0]["level"] == "warning"
+    assert {i["item_id"] for i in clique[0]["details"]["items"]} == {"i-ok", "i-429"}
+
+
+def test_falha_de_um_item_nao_impede_o_sync_do_outro_no_lote(user_id, monkeypatch):
+    """CONTROLE POSITIVO do mesmo conserto no nível do lote: a contenção não pode
+    engolir o caminho legítimo — o item bom continua devolvendo `ok: True` com as
+    contas que leu, e só o item ruim vira `read_failed`."""
+    db.save_pluggy_open_finance_item(user_id, {"id": "i-ok", "status": "UPDATED",
+                                               "connector": {"id": 612, "name": "Nubank"}})
+    db.save_pluggy_open_finance_item(user_id, {"id": "i-boom", "status": "UPDATED",
+                                               "connector": {"id": 77, "name": "Inter"}})
+    _mundo_remoto(monkeypatch)
+
+    def _get_item(item_id, api_key=None):
+        if item_id == "i-boom":
+            raise RuntimeError("qualquer erro, não só HTTP")
+        return ITEM_OK
+
+    monkeypatch.setattr(ps, "get_pluggy_item", _get_item)
+
+    saida = ps.sync_pluggy_user(user_id)
+    por_item = {r["item_id"]: r for r in saida["results"]}
+
+    assert por_item["i-ok"]["ok"] is True
+    assert por_item["i-ok"]["accounts_synced"] == 1
+    assert por_item["i-boom"] == {"ok": False, "reason": "read_failed", "item_id": "i-boom",
+                                  "connection_id": por_item["i-boom"]["connection_id"],
+                                  "error": "RuntimeError"}

--- a/tests/test_of_refresh_schedule.py
+++ b/tests/test_of_refresh_schedule.py
@@ -1,0 +1,631 @@
+"""G3 — quando o refresh roda, e quantas vezes.
+
+Fatos medidos que originaram o grupo: o tick fazia `while True: refresh_all(); sleep()`,
+ou seja, refrescava NO BOOT — 15 rodadas em 48h, 10 delas nos 5 minutos seguintes a um
+deploy (o Railway sobe container novo a cada deploy). E o intervalo de 6h vivia só na
+memória do processo, então reiniciar zerava o cooldown.
+
+CONTROLE NEGATIVO do grupo (MEDIDO, as duas sabotagens juntas → 3 vermelhos):
+  • mover o `await asyncio.sleep(interval)` para DEPOIS do request em
+    `_open_finance_refresh` → `test_boot_nao_refresca` vermelho;
+  • trocar `claim_items_for_refresh` pela listagem sem reserva (o antigo
+    `list_pluggy_item_ids`) → `test_cooldown_persistido...` e
+    `test_origem_fica_gravada...` vermelhos.
+`test_claims_concorrentes...` exercita o `claim` direto (é a primitiva); ele fica
+verde nessas duas sabotagens porque não passa pelo chamador.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from datetime import datetime, timedelta
+
+import pytest
+
+import db
+import core.services.pluggy_sync as ps
+import frontend.finance_bot_websocket_custom as dashboard
+from db.connection import get_conn
+from utils_date import _tz
+
+
+def _conexao(user_id: int, item_id: str) -> dict:
+    return db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": item_id, "status": "UPDATED", "connector": {"id": 612, "name": "Nubank"}},
+    )
+
+
+def _linha(item_id: str) -> dict:
+    rows = db.get_connections_by_item_id(item_id)
+    assert len(rows) == 1
+    return rows[0]
+
+
+# ── 16. o boot não refresca ──────────────────────────────────────────────────
+
+def test_boot_nao_refresca(monkeypatch):
+    """Sobe a task do tick e avança o relógio ZERO: nada pode sair para a Pluggy."""
+    chamadas = []
+    monkeypatch.setenv("OF_REFRESH_ENABLED", "1")
+    monkeypatch.setattr(ps, "claim_items_for_refresh",
+                        lambda **kw: chamadas.append("claim") or [])
+    monkeypatch.setattr(ps, "run_of_health_check",
+                        lambda **kw: chamadas.append("health") or {})
+
+    dormidas = []
+
+    async def _sleep_falso(segundos):
+        dormidas.append(segundos)
+        raise asyncio.CancelledError   # corta o loop na PRIMEIRA espera
+
+    async def _corre():
+        monkeypatch.setattr(asyncio, "sleep", _sleep_falso)
+        with pytest.raises(asyncio.CancelledError):
+            await dashboard._open_finance_refresh()
+
+    asyncio.run(_corre())
+
+    assert dormidas == [6 * 60 * 60], "o tick tem que DORMIR antes de qualquer coisa"
+    assert chamadas == [], f"nada podia ter rodado no boot: {chamadas}"
+
+
+# ── 17. dois claims concorrentes: o item sai para UM só ──────────────────────
+
+def test_claims_concorrentes_entregam_o_item_uma_vez_so(user_id):
+    _conexao(user_id, "item-claim")
+    resultados: list[list] = []
+
+    def _claim():
+        resultados.append(db.claim_items_for_refresh(
+            cooldown_sec=3600, jitter_pct=0, origin="periodic", limit=10, user_id=user_id,
+        ))
+
+    import threading
+    t1, t2 = threading.Thread(target=_claim), threading.Thread(target=_claim)
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    ganhos = [r for lote in resultados for r in lote if r["provider_item_id"] == "item-claim"]
+    assert len(ganhos) == 1, f"o mesmo item foi reivindicado {len(ganhos)}x"
+
+
+# ── 18. cooldown persistido ──────────────────────────────────────────────────
+
+def test_cooldown_persistido_barra_o_segundo_tick(user_id, monkeypatch):
+    _conexao(user_id, "item-cd")
+    patches = []
+    monkeypatch.setattr(ps, "update_pluggy_item",
+                        lambda item, key=None: patches.append(item) or True)
+    monkeypatch.setattr(ps, "_hold_aggregate_emails", lambda uid, origem: None)
+    monkeypatch.setenv("OF_REFRESH_MIN_INTERVAL_SEC", "21600")
+    monkeypatch.setenv("OF_REFRESH_JITTER_PCT", "0")
+
+    ps.request_pluggy_refresh(origin="periodic", user_id=user_id)
+    assert patches == ["item-cd"]
+
+    # segundo tick, dentro do cooldown: zero PATCH
+    ps.request_pluggy_refresh(origin="periodic", user_id=user_id)
+    assert patches == ["item-cd"], "cooldown não segurou o segundo tick"
+
+    # vencido o cooldown (o relógio de verdade seria 6h; envelhecemos a linha)
+    _envelhece("item-cd")
+    ps.request_pluggy_refresh(origin="periodic", user_id=user_id)
+    assert patches == ["item-cd", "item-cd"]
+
+
+def _envelhece(item_id: str) -> None:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "update open_finance_connections set next_refresh_at = now() - interval '1 minute'"
+                " where provider_item_id=%s",
+                (item_id,),
+            )
+        c.commit()
+
+
+# ── 19. jitter dentro de ±10% ────────────────────────────────────────────────
+
+@pytest.mark.parametrize("semente", [1, 7, 99])
+def test_jitter_fica_dentro_de_dez_por_cento(user_id, semente, monkeypatch):
+    item = f"item-jit-{semente}"
+    _conexao(user_id, item)
+    random.seed(semente)   # o jitter é do Postgres; a semente fixa o resto do teste
+
+    antes = datetime.now(_tz())
+    db.claim_items_for_refresh(cooldown_sec=21600, jitter_pct=10, origin="periodic",
+                              limit=10, user_id=user_id)
+    alvo = _linha(item)["next_refresh_at"]
+
+    delta = (alvo - antes).total_seconds()
+    assert 21600 * 0.90 - 5 <= delta <= 21600 * 1.10 + 5, delta
+
+
+# ── 20. origem ───────────────────────────────────────────────────────────────
+
+def test_origin_startup_nao_dispara_nada(user_id, monkeypatch):
+    _conexao(user_id, "item-boot")
+    patches = []
+    monkeypatch.setattr(ps, "update_pluggy_item", lambda item, key=None: patches.append(item))
+    monkeypatch.setattr(ps, "claim_items_for_refresh",
+                        lambda **kw: pytest.fail("startup não pode nem reivindicar item"))
+
+    out = ps.request_pluggy_refresh(origin="startup")
+
+    assert out["triggered"] == 0
+    assert out["skipped"] == "startup"
+    assert patches == []
+
+
+def test_origem_fica_gravada_na_conexao(user_id, monkeypatch):
+    _conexao(user_id, "item-org")
+    monkeypatch.setattr(ps, "update_pluggy_item", lambda item, key=None: True)
+    monkeypatch.setattr(ps, "_hold_aggregate_emails", lambda uid, origem: None)
+
+    ps.request_pluggy_refresh(origin="periodic", user_id=user_id)
+    assert _linha("item-org")["last_refresh_origin"] == "periodic"
+
+    _envelhece("item-org")
+    ps.request_pluggy_refresh(origin="manual", user_id=user_id)
+    assert _linha("item-org")["last_refresh_origin"] == "manual"
+
+
+# ── job de saúde (é ele que tira do ACTIVE quem perdeu o item) ───────────────
+
+def test_job_de_saude_marca_item_missing_sem_carimbar_sucesso(user_id, monkeypatch):
+    """Com o refresh DESLIGADO e sem webhook, este job é a única coisa que
+    executa a verificação — é o que faz uma conexão morta sair de ACTIVE."""
+    from core.services.pluggy import PluggyApiError
+
+    conexao = _conexao(user_id, "item-saude")
+    _marca_sync(conexao["id"])
+    antes = _linha("item-saude")["last_sync_at"]
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item",
+                        lambda i, k=None: (_ for _ in ()).throw(PluggyApiError("sumiu", status_code=404)))
+
+    out = ps.run_of_health_check()
+
+    assert out["missing"] >= 1
+    linha = _linha("item-saude")
+    assert linha["status"] == "ERROR"
+    assert linha["status_reason"] == "item_missing"
+    assert linha["last_sync_at"] == antes, "medir saúde não é sincronizar"
+
+
+def test_job_de_saude_grava_health_sem_mexer_no_sucesso(user_id, monkeypatch):
+    conexao = _conexao(user_id, "item-saude2")
+    _marca_sync(conexao["id"])
+    antes = _linha("item-saude2")["last_sync_at"]
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "executionStatus": "PARTIAL_SUCCESS",
+        "statusDetail": {"creditCards": {"isUpdated": False,
+                                         "lastUpdatedAt": "2026-08-12T03:00:00Z"}},
+    })
+
+    ps.run_of_health_check()
+
+    linha = _linha("item-saude2")
+    assert linha["health"]["stale_products"] == ["CREDIT"]
+    # RODADA 4: item vivo passou a sair do resolvedor como ACTIVE mesmo com o
+    # espelho vazio (era `None`="não mexe", e "não mexe" nunca tirava um ERROR).
+    # O que o job continua não podendo mexer é o SUCESSO — a asserção abaixo.
+    assert linha["status"] == "ACTIVE", "item vivo é ACTIVE, não erro"
+    assert linha["last_sync_at"] == antes
+
+
+def _marca_sync(connection_id: int) -> None:
+    """Deixa a conexão com um sucesso anterior gravado (o que o job não pode mexer)."""
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "update open_finance_connections set last_sync_at = now() - interval '2 days',"
+                " health = null where id=%s",
+                (connection_id,),
+            )
+        c.commit()
+
+
+# ── refresh MANUAL: cooldown por item ────────────────────────────────────────
+# Antes, o pull-to-refresh do app chamava `loadData` (leitura de snapshot). Agora
+# ele chama o /refresh, e sem cooldown cada puxão viraria um PATCH por banco —
+# medido pelo Tester: 5 POSTs seguidos = 5 PATCH.
+# CONTROLE NEGATIVO: trocar `claim_manual_refresh(...)` por `liberados = items`
+# em `refresh_and_sync_pluggy_user` deixa os dois primeiros testes vermelhos.
+
+def _mundo_pluggy(monkeypatch, patches: list):
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "update_pluggy_item",
+                        lambda item, key=None: patches.append(item) or True)
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "executionStatus": "SUCCESS",
+        "statusDetail": {"accounts": {"isUpdated": True,
+                                      "lastUpdatedAt": "2026-08-20T11:00:00Z"}}})
+    monkeypatch.setattr(ps, "list_pluggy_accounts", lambda i, k=None: [
+        {"id": f"acc-{i}", "name": "Conta", "type": "BANK", "currencyCode": "BRL",
+         "balance": "10.00"}])
+    monkeypatch.setattr(ps, "list_pluggy_transactions", lambda acc, k=None, **kw: [])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: [])
+    monkeypatch.setattr(ps, "_hold_aggregate_emails", lambda uid, origem: None)
+
+
+def test_cinco_puxoes_seguidos_dao_um_patch_so(user_id, monkeypatch):
+    _conexao(user_id, "item-ptr")
+    patches: list[str] = []
+    _mundo_pluggy(monkeypatch, patches)
+
+    saidas = [ps.refresh_and_sync_pluggy_user(user_id, wait_seconds=0) for _ in range(5)]
+
+    assert patches == ["item-ptr"], f"a rajada virou {len(patches)} PATCH: {patches}"
+    assert saidas[0]["items"][0]["state"] == "updated"
+    estados = [s["items"][0]["state"] for s in saidas[1:]]
+    assert estados == ["rate_limited"] * 4, estados
+    assert all(s["refreshed"] == 0 for s in saidas[1:]), "puxão em cooldown não pede coleta"
+    # rate_limited NÃO é falha: os dados são de segundos atrás.
+    assert all(s["ok"] is True for s in saidas), [s["ok"] for s in saidas]
+
+
+def test_passado_o_cooldown_o_manual_volta_a_pedir(user_id, monkeypatch):
+    """CONTROLE POSITIVO: o cooldown é curto e o manual continua furando o tick
+    de 6h — o conserto não pode transformar o botão em enfeite."""
+    _conexao(user_id, "item-ptr2")
+    patches: list[str] = []
+    _mundo_pluggy(monkeypatch, patches)
+
+    ps.refresh_and_sync_pluggy_user(user_id, wait_seconds=0)
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("update open_finance_connections set last_refresh_requested_at ="
+                        " now() - interval '5 minutes' where provider_item_id='item-ptr2'")
+        c.commit()
+    saida = ps.refresh_and_sync_pluggy_user(user_id, wait_seconds=0)
+
+    assert patches == ["item-ptr2", "item-ptr2"]
+    assert saida["items"][0]["state"] == "updated"
+
+
+def test_conexao_pausada_ou_removida_nao_leva_patch(user_id, monkeypatch):
+    """PAUSED (trial vencido) e DELETED: o item nem existe mais na Pluggy. E o
+    veredito NÃO pode ser verde — era o caminho pelo qual `state:"paused"` caía
+    no default do refreshVerdict e virava "Tudo em dia!"."""
+    p1 = _conexao(user_id, "item-pausado")
+    p2 = _conexao(user_id, "item-removido")
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("update open_finance_connections set status='PAUSED' where id=%s", (p1["id"],))
+            cur.execute("update open_finance_connections set status='DELETED' where id=%s", (p2["id"],))
+        c.commit()
+    patches: list[str] = []
+    _mundo_pluggy(monkeypatch, patches)
+
+    saida = ps.refresh_and_sync_pluggy_user(user_id, wait_seconds=0)
+
+    assert patches == [], f"item terminal não pode levar PATCH: {patches}"
+    estados = {i["item_id"]: i["state"] for i in saida["items"]}
+    assert estados == {"item-pausado": "paused", "item-removido": "removed"}
+    assert saida["ok"] is False, "pausado/removido nunca é 'tudo em dia'"
+
+
+# ── job de saúde: o motivo `item_missing` tem que poder VOLTAR atrás ─────────
+# CONTROLE NEGATIVO: voltar `status_reason = coalesce(%s, status_reason)` em
+# `mark_sync_result` (ou tirar o `volta` do run_of_health_check) deixa este
+# teste vermelho — a tela continua mandando refazer a conexão.
+
+def test_item_que_volta_saudavel_para_de_mandar_refazer_a_conexao(user_id, monkeypatch):
+    from core.services.pluggy import PluggyApiError
+    from core.services.pluggy_health import connection_ui_state
+
+    _conexao(user_id, "item-404-transitorio")
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("sumiu", status_code=404)))
+
+    ps.run_of_health_check()
+    assert connection_ui_state(_linha("item-404-transitorio"))["state"] == "item_missing"
+
+    # 12h depois (o job só remede saúde velha — OF_HEALTH_MAX_AGE_SEC), o item
+    # voltou e a passada seguinte confirma que está saudável.
+    _envelhece_saude("item-404-transitorio")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "executionStatus": "SUCCESS",
+        "statusDetail": {"accounts": {"isUpdated": True,
+                                      "lastUpdatedAt": "2026-08-20T11:00:00Z"}}})
+    ps.run_of_health_check()
+
+    linha = _linha("item-404-transitorio")
+    assert linha["status_reason"] is None, "o motivo tinha que cair quando o item voltou"
+    assert connection_ui_state(linha)["state"] != "item_missing"
+
+
+def _envelhece_saude(item_id: str) -> None:
+    """Empurra `health.observed_at` pro passado — o job só remede saúde velha."""
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "update open_finance_connections"
+                " set health = jsonb_set(health, '{observed_at}',"
+                "     to_jsonb((now() - interval '2 days')::text))"
+                " where provider_item_id=%s",
+                (item_id,),
+            )
+        c.commit()
+
+
+def test_job_de_saude_nao_apaga_motivo_que_ele_nao_sabe_avaliar(user_id, monkeypatch):
+    """CONTROLE POSITIVO/limite: com o espelho AINDA vazio, `no_accounts` fica de
+    pé. O job não leu `/accounts` — ele só não desmente o que o espelho confirma.
+    Limpar aqui devolveria a mentira do "Atualizado" por outro caminho."""
+    conexao = _conexao(user_id, "item-motivo")
+    db.mark_sync_result(conexao["id"], ok=False, status_reason="no_accounts")
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}})
+
+    ps.run_of_health_check()
+
+    assert _linha("item-motivo")["status_reason"] == "no_accounts"
+
+
+# ── disjuntor do job de saúde ────────────────────────────────────────────────
+# O job roda ligado por default e ESCREVE status='ERROR' em conexão de usuário.
+# Credencial apontando pro client errado → 404 para todos → uma passada marcaria
+# a base inteira como item_missing, que é pegajoso.
+# CONTROLE NEGATIVO: tirar o bloco do disjuntor faz o primeiro teste ficar
+# vermelho (5 conexões viram ERROR).
+
+def test_disjuntor_aborta_passada_com_404_generalizado(user_id, monkeypatch):
+    from core.services.pluggy import PluggyApiError
+
+    ids = [f"item-disj-{n}" for n in range(5)]
+    for item in ids:
+        _conexao(user_id, item)
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("sumiu", status_code=404)))
+
+    out = ps.run_of_health_check()
+
+    assert out["aborted"] == "too_many_missing", out
+    assert out["missing"] == 0
+    for item in ids:
+        linha = _linha(item)
+        assert linha["status"] == "UPDATED", f"{item} não podia ter sido escrito"
+        assert linha["status_reason"] is None
+        assert linha["health"] is None
+
+
+def test_disjuntor_nao_atrapalha_um_item_realmente_sumido(user_id, monkeypatch):
+    """CONTROLE POSITIVO: 1 ausente em 5 está abaixo do limite e continua sendo
+    marcado — sem isto o disjuntor viraria um 'nunca marque nada'."""
+    from core.services.pluggy import PluggyApiError
+
+    ids = [f"item-mix-{n}" for n in range(5)]
+    for item in ids:
+        _conexao(user_id, item)
+
+    def _get(i, k=None):
+        if i == "item-mix-3":
+            raise PluggyApiError("sumiu", status_code=404)
+        return {"id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}}
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", _get)
+
+    out = ps.run_of_health_check()
+
+    assert out.get("aborted") is None, out
+    assert out["missing"] == 1 and out["checked"] == 4
+    assert _linha("item-mix-3")["status_reason"] == "item_missing"
+    assert _linha("item-mix-0")["status"] == "ACTIVE", "quem respondeu vivo não vira erro"
+
+
+# ── RODADA 3: o disjuntor tem que CONVERGIR, e o motivo tem que cair inteiro ──
+
+def test_disjuntor_converge_quando_alguem_responde(user_id, monkeypatch):
+    """6 mortos em 10 conexões: 60% > 50%, mas 4 responderam — a credencial está
+    boa, logo os 6 sumiram de verdade e TÊM que ser marcados na mesma passada.
+
+    Medido antes do conserto: tick 1 marcava 0 de 6; as 4 sadias saíam do lote
+    (saúde fresca) e do tick 2 em diante a amostra era só a dos mortos, 100% >
+    50% PARA SEMPRE — as 6 nunca saíam de "Atualizado"."""
+    from core.services.pluggy import PluggyApiError
+
+    vivos = [f"item-conv-ok-{n}" for n in range(4)]
+    mortos = [f"item-conv-x-{n}" for n in range(6)]
+    for item in vivos + mortos:
+        _conexao(user_id, item)
+
+    def _get(i, k=None):
+        if i in mortos:
+            raise PluggyApiError("sumiu", status_code=404)
+        return {"id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}}
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", _get)
+
+    out = ps.run_of_health_check()
+
+    assert out.get("aborted") is None, out
+    assert (out["checked"], out["missing"]) == (4, 6), out
+    assert all(_linha(i)["status_reason"] == "item_missing" for i in mortos)
+
+
+def test_disjuntor_ainda_abre_quando_ninguem_responde(user_id, monkeypatch):
+    """CONTROLE POSITIVO do conserto acima: com credencial errada NINGUÉM
+    responde, e aí o disjuntor continua abrindo — o conserto não pode virar um
+    'marque sempre'. (É o cenário do `test_disjuntor_aborta...` acima, aqui com
+    a condição de saída explícita: `checked == 0`.)"""
+    from core.services.pluggy import PluggyApiError
+
+    ids = [f"item-cred-{n}" for n in range(6)]
+    for item in ids:
+        _conexao(user_id, item)
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("sumiu", status_code=404)))
+
+    out = ps.run_of_health_check()
+
+    assert out["aborted"] == "too_many_missing" and out["checked"] == 0, out
+    assert all(_linha(i)["status_reason"] is None for i in ids)
+
+
+def test_item_que_volta_limpa_status_e_motivo_juntos(user_id, monkeypatch):
+    """A6 estava pela metade: o job limpava o motivo e deixava o `status='ERROR'`
+    que ele mesmo tinha escrito. Medido: a tela saía de "Refaça a conexão" e
+    entrava em "Erro temporário" — para sempre, pelo mesmo motivo."""
+    from core.services.pluggy import PluggyApiError
+    from core.services.pluggy_health import connection_ui_state
+
+    conexao = _conexao(user_id, "item-volta-inteiro")
+    _espelha_uma_conta(conexao["id"])
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("sumiu", status_code=404)))
+    ps.run_of_health_check()
+    assert _linha("item-volta-inteiro")["status"] == "ERROR"
+
+    _envelhece_saude("item-volta-inteiro")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}})
+    ps.run_of_health_check()
+
+    linha = _linha("item-volta-inteiro")
+    assert (linha["status"], linha["status_reason"]) == ("ACTIVE", None), linha
+    assert connection_ui_state(linha)["state"] == "updated"
+
+
+def test_no_accounts_cai_quando_o_espelho_tem_dado(user_id, monkeypatch):
+    """`no_accounts` deixa de ser pegajoso: quem responde se ele ainda vale é o
+    ESPELHO (`has_data`, lido na mesma query do job), não a memória."""
+    from core.services.pluggy_health import connection_ui_state
+
+    conexao = _conexao(user_id, "item-tinha-dado")
+    _espelha_uma_conta(conexao["id"])
+    db.mark_sync_result(conexao["id"], ok=False, status="ACTIVE",
+                        status_reason="no_accounts", at=None)
+    _set_last_sync(conexao["id"])
+    assert connection_ui_state(_linha("item-tinha-dado"))["state"] == "no_accounts"
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}})
+    ps.run_of_health_check()
+
+    linha = _linha("item-tinha-dado")
+    assert linha["status_reason"] is None
+    assert connection_ui_state(linha)["state"] == "updated"
+
+
+def _set_last_sync(connection_id: int) -> None:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("update open_finance_connections set last_sync_at=now() where id=%s",
+                        (connection_id,))
+        c.commit()
+
+
+def _espelha_uma_conta(connection_id: int) -> None:
+    db.save_open_finance_sync(connection_id, [{
+        "provider_account_id": f"acc-{connection_id}", "name": "Conta", "type": "BANK",
+        "currency": "BRL", "balance": 10, "raw": {}, "transactions": [],
+    }])
+
+
+# ── RODADA 3: uma coluna, dois relógios (§0.7) ──────────────────────────────
+
+def test_tick_periodico_nao_queima_o_cooldown_do_botao(user_id):
+    """Medido antes: depois de um tick, `claim_manual_refresh` voltava vazio por
+    120s — o usuário apertava "Atualizar" e recebia "já está tudo em dia" sem
+    que nada tivesse sido pedido. `last_refresh_requested_at` é o relógio do
+    MANUAL; o do tick é `next_refresh_at`."""
+    _conexao(user_id, "item-2relogios")
+
+    reivindicados = db.claim_items_for_refresh(
+        cooldown_sec=3600, jitter_pct=0, origin="periodic", limit=10, user_id=user_id)
+    assert [r["provider_item_id"] for r in reivindicados] == ["item-2relogios"]
+
+    manual = db.claim_manual_refresh(user_id, ["item-2relogios"], cooldown_sec=120)
+    assert manual == ["item-2relogios"], "o botão do usuário não pode ficar preso ao tick"
+
+    # CONTROLE POSITIVO: o cooldown do manual continua valendo contra ELE MESMO.
+    assert db.claim_manual_refresh(user_id, ["item-2relogios"], cooldown_sec=120) == []
+
+
+# ── RODADA 4: a metade `has_data=False` do item que volta ───────────────────
+# O teste acima (`test_item_que_volta_limpa_status_e_motivo_juntos`) semeava o
+# espelho e só exercitava `has_data=True`; a metade sem espelho não tinha teste, e
+# era exatamente ela que ficava presa em ERROR (o resolvedor devolvia "não mexe").
+# Com `OF_REFRESH_ENABLED` off (default) não há sync completo que a tire depois.
+# CONTROLE NEGATIVO (medido): devolver `None` no ramo de espelho vazio de
+# `resolve_connection_state` deixa este teste vermelho no par e na UI.
+
+def test_item_que_volta_com_espelho_vazio_tambem_sai_de_error(user_id, monkeypatch):
+    from core.services.pluggy import PluggyApiError
+    from core.services.pluggy_health import connection_ui_state
+
+    _conexao(user_id, "item-volta-vazio")          # sem `_espelha_uma_conta`: espelho VAZIO
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("sumiu", status_code=404)))
+    ps.run_of_health_check()
+    assert (_linha("item-volta-vazio")["status"],
+            _linha("item-volta-vazio")["status_reason"]) == ("ERROR", "item_missing")
+
+    # o item voltou: três passadas seguidas do job (o repro do defeito ficava em
+    # "Erro temporário" da 1ª à 5ª).
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}})
+    for _ in range(3):
+        _envelhece_saude("item-volta-vazio")
+        ps.run_of_health_check()
+
+    linha = _linha("item-volta-vazio")
+    assert (linha["status"], linha["status_reason"]) == ("ACTIVE", None), linha
+    assert connection_ui_state(linha)["state"] != "error_recoverable"
+
+
+def test_no_accounts_com_espelho_ainda_vazio_fica_de_pe_e_sem_error(user_id, monkeypatch):
+    """A metade `has_data=False` do `test_no_accounts_cai_quando_o_espelho_tem_dado`:
+    o motivo continua, o status sai do ERROR, e a tela diz "Sem dados" — não
+    "Erro temporário"."""
+    from core.services.pluggy_health import connection_ui_state
+
+    conexao = _conexao(user_id, "item-vazio-mesmo")
+    db.mark_sync_result(conexao["id"], ok=False, status="ERROR",
+                        status_reason="no_accounts", at=None)
+    _set_last_sync(conexao["id"])
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {
+        "id": i, "status": "UPDATED", "statusDetail": {"accounts": {"isUpdated": True}}})
+
+    ps.run_of_health_check()
+
+    linha = _linha("item-vazio-mesmo")
+    assert (linha["status"], linha["status_reason"]) == ("ACTIVE", "no_accounts"), linha
+    ui = connection_ui_state(linha)
+    assert (ui["state"], ui["label"]) == ("no_accounts", "Sem dados")
+
+
+# ── RODADA 4: jitter não pode agendar no PASSADO ───────────────────────────
+# Medido com OF_REFRESH_JITTER_PCT=400: 14 de 40 agendamentos caíam no passado e o
+# cooldown persistido (a razão de existir da coluna) deixava de valer.
+# CONTROLE NEGATIVO (medido): tirar o clamp de `claim_items_for_refresh` deixa
+# este teste vermelho.
+
+def test_jitter_absurdo_nunca_agenda_no_passado(user_id):
+    for n in range(20):
+        _conexao(user_id, f"item-jit-abs-{n}")
+    antes = datetime.now(_tz())
+
+    db.claim_items_for_refresh(cooldown_sec=3600, jitter_pct=400, origin="periodic",
+                              limit=50, user_id=user_id)
+
+    alvos = [_linha(f"item-jit-abs-{n}")["next_refresh_at"] for n in range(20)]
+    passado = [a for a in alvos if a <= antes]
+    assert passado == [], f"{len(passado)}/20 agendamentos no passado"
+    assert all((a - antes).total_seconds() >= 3600 * 0.5 - 5 for a in alvos), alvos

--- a/tests/test_piggy_agents.py
+++ b/tests/test_piggy_agents.py
@@ -1014,17 +1014,20 @@ def test_hold_nao_mexe_em_evento_ja_emailado(user_id):
             assert cur.fetchone()["fired_at"] < datetime.now(timezone.utc) - timedelta(hours=5)
 
 
-def test_refresh_manual_segura_email_antes_da_espera(monkeypatch):
+def test_refresh_manual_segura_email_antes_da_espera(user_id, monkeypatch):
     """P1 do Codex (5ª rodada, PR #51): refresh_and_sync_pluggy_user dispara o
     PATCH na Pluggy e ESPERA até OF_REFRESH_WAIT_SEC (18s) antes de chamar
     sync_pluggy_user. O touch de lá vem depois da espera — essa janela inteira
-    ficava descoberta. O hold tem que acontecer antes do PATCH."""
+    ficava descoberta. O hold tem que acontecer antes do PATCH.
+
+    A conexão é criada DE VERDADE (era um snapshot mockado): quem decide se o
+    item leva PATCH agora é `claim_manual_refresh`, que lê a linha do banco."""
     import db
     import core.services.pluggy_sync as ps
 
+    db.save_pluggy_open_finance_item(user_id, {"id": "i1", "status": "UPDATED",
+                                               "connector": {"id": 612, "name": "Nubank"}})
     ordem = []
-    monkeypatch.setattr(ps, "get_open_finance_snapshot", lambda uid: {
-        "connections": [{"provider": "pluggy", "provider_item_id": "i1"}]})
     monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
     monkeypatch.setattr(ps, "update_pluggy_item",
                         lambda item, key=None: ordem.append("PATCH") or True)
@@ -1034,7 +1037,7 @@ def test_refresh_manual_segura_email_antes_da_espera(monkeypatch):
     monkeypatch.setattr(db, "hold_agent_emails",
                         lambda uid, kinds, mins: ordem.append("hold") or 1)
 
-    ps.refresh_and_sync_pluggy_user(42, wait_seconds=0, poll_interval=0.01)
+    ps.refresh_and_sync_pluggy_user(user_id, wait_seconds=0, poll_interval=0.01)
 
     assert "hold" in ordem, "não segurou o e-mail no refresh manual"
     assert ordem.index("hold") < ordem.index("PATCH"), \
@@ -1076,6 +1079,10 @@ def test_webhook_por_item_segura_email_antes_das_leituras(monkeypatch):
                         lambda uid, kinds, mins: ordem.append(("hold", uid)) or 1)
     monkeypatch.setattr(ps, "create_pluggy_api_key",
                         lambda: ordem.append("api_key") or "k")
+    # O sync pergunta pelo item antes de qualquer coisa (Onda 1): sem isso o
+    # `/accounts` vazio de um item DELETADO passava por sucesso.
+    monkeypatch.setattr(ps, "get_pluggy_item",
+                        lambda item, key=None: {"id": item, "status": "UPDATED"})
     monkeypatch.setattr(ps, "list_pluggy_accounts",
                         lambda item, key: ordem.append("le_contas") or [])
     monkeypatch.setattr(ps, "save_open_finance_sync", lambda cid, accs: {})
@@ -1093,22 +1100,22 @@ def test_webhook_por_item_segura_email_antes_das_leituras(monkeypatch):
 
 
 def test_refresh_periodico_segura_email_antes_do_patch(monkeypatch):
-    """Mesmo P1: o tick periódico (refresh_all_pluggy_items) dispara o PATCH
+    """Mesmo P1: o tick periódico (request_pluggy_refresh) dispara o PATCH
     direto. Entre o PATCH e o webhook trazer os dados, o evento maduro seguiria
     reivindicável com o valor velho."""
     import db
     import core.services.pluggy_sync as ps
 
     ordem = []
-    monkeypatch.setattr(ps, "list_pluggy_item_ids", lambda uid=None: ["i1", "i2"])
-    monkeypatch.setattr(ps, "get_open_finance_connection_by_item_id",
-                        lambda item: {"user_id": 42})
+    monkeypatch.setattr(ps, "claim_items_for_refresh",
+                        lambda **kw: [{"id": 1, "user_id": 42, "provider_item_id": "i1"},
+                                      {"id": 2, "user_id": 42, "provider_item_id": "i2"}])
     monkeypatch.setattr(db, "hold_agent_emails",
                         lambda uid, kinds, mins: ordem.append(("hold", uid)) or 1)
     monkeypatch.setattr(ps, "update_pluggy_item",
                         lambda item, key=None: ordem.append(f"PATCH:{item}") or True)
 
-    out = ps.refresh_all_pluggy_items(42)
+    out = ps.request_pluggy_refresh(origin="periodic", user_id=42)
 
     assert out["triggered"] == 2
     assert ordem[0] == ("hold", 42), f"hold tem que vir antes do 1º PATCH: {ordem}"
@@ -1538,6 +1545,8 @@ def test_sync_item_renova_hold_durante_o_sync(monkeypatch):
     monkeypatch.setattr(ps, "_hold_aggregate_emails",
                         lambda uid, origem: holds.append(origem))
     monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item",
+                        lambda item, key=None: {"id": item, "status": "UPDATED"})
     monkeypatch.setattr(ps, "list_pluggy_accounts",
                         lambda item, key: [{"id": "a1"}, {"id": "a2"}])
     # cada conta "pagina" 2 vezes: dispara o on_page 2x por conta


### PR DESCRIPTION
## O problema

Uma conexão do Nubank passou **21 dias exibindo "Tudo em dia!"** com dados congelados em 05/08. A cadeia, medida em produção:

1. `GET /accounts?itemId=<item deletado>` devolve **HTTP 200 com `results:[]`** — só `GET /items/{id}` devolve 404.
2. `list_pluggy_accounts` devolve `[]` sem levantar erro.
3. `sync_pluggy_item` **nunca chamava `get_pluggy_item`** — o único endpoint que denuncia o item morto era o único que o sync não consultava.
4. `save_open_finance_sync` executava incondicionalmente `status='ACTIVE', last_sync_at=now()`.

O botão "Atualizar" engolia o 404 do `PATCH`, o loop de espera descartava o 404 do `GET`, e a tela mostrava o toast verde. Cada clique reafirmava a mentira e recarimbava `last_sync_at`.

**O espelho bruto está íntegro.** Comparação por identidade de transação, todas as páginas, 5 contas vivas: `149=149`, `1001=1001`, `392=392`, `7=7`, `1166=1166`, zero ausentes, zero divergência de valor/data/descrição. O que estava quebrado é o **estado** — e é só isso que esta onda toca.

## O que muda

**Máquina de estados.** `resolve_connection_state` decide `status` **e** `status_reason` juntos; sync, job de saúde e ausentes passam pelo mesmo ponto. Aborta só em `PAUSED` e `DELETED` — **`ERROR` é recuperável** e sai para `ACTIVE` depois de consultar o item remoto, confirmá-lo saudável e concluir um sync real. Item 404 vira `item_missing` sem apagar espelho nem tocar no item remoto. Espelho vazio com item vivo vira `no_accounts`, não sucesso. Estado desconhecido nunca é verde.

**Concorrência e cota.** Lock por item na fase de escrita, coalescência por item, retry só de `DeadlockDetected`/`SerializationFailure` — fecha os 10 deadlocks e o duplicate key medidos. O refresh não roda mais no boot (10 das 15 rodadas em 48h vinham de deploy), com cooldown persistido, claim atômico entre instâncias e jitter com teto.

**Segurança.** Posse do item conferida contra o `clientUserId` remoto; webhook resolve exatamente uma conexão; token bruto nunca vai para o banco. `PluggyApiError` parou de carregar o corpo cru da resposta, que ia para `system_event_logs` e para o painel admin.

**Frontend.** Botão "Atualizar" some só sob `html.pb-app` (app/PWA), onde o pull-to-refresh existe — desktop e mobile web mantêm o botão. O gesto passa a disparar o refresh real e a falha rejeita a promise, deixando o indicador âmbar em vez de fingir sucesso. Dashboard trata `open_finance_synced` com debounce, reusando `sendRefreshSilent`.

## O que o diff não conta

1. **`OF_HEALTH_CHECK_ENABLED` vem LIGADO.** É a única mudança que age em produção sem ninguém ligar nada: o job de saúde roda mesmo com `OF_REFRESH_ENABLED` off e escreve `status='ERROR'` em conexão de usuário. Tem disjuntor, e é o único caminho capaz de marcar a conexão morta enquanto o refresh dorme. Kill switch documentado no `.env.example`.
2. **`save_pluggy_open_finance_item` parou de carimbar `last_sync_at`** — muda o que `user_synced_within` responde, que é o freio do e-mail dos agentes.
3. **O webhook `item/updated` parou de escrever `ACTIVE`** — quem tira a conexão de `UPDATING` agora é só o sync.
4. **`uq_of_conn_provider_item` pode não ser criado** (o `DO $$` engole a falha com warning) se já houver duplicata. O código funciona nos dois mundos.
5. **`item/error` não limpa `ERROR/item_missing`** — webhook não é evidência de item vivo. Só observação do item ou sync bem-sucedido limpam.

## Verificação

| | resultado |
|---|---|
| pytest na `main` (`392ace2`) | 4827 passed, 0 failed |
| pytest neste branch | **4926 passed, 0 failed** |
| comparação | por **nome**, listas idênticas, zero regressão |
| frontend | **65 pass / 0 fail** |

Quatro rodadas de ataque adversarial produziram 27+ achados corrigidos, entre eles uma regressão contra a `main` (um 429 em `/investments` descartava contas e transações já lidas) e um vazamento de PII para os logs. Cada conserto tem controle negativo **medido** — sabotagem aplicada, vermelho observado, revertida — e controle positivo onde a mudança restringe algo.

## Riscos e rollback

Migrations 100% aditivas: 6 `add column if not exists`, 2 `create index if not exists`, 1 `create table if not exists`, 1 `create unique index` embrulhado em `DO $$ ... exception`. Zero `drop`, zero `update`, zero `alter type`. **Nenhum valor, sinal, data, categoria, fatura, classificação ou reconciliação foi alterado.**

Rollback em camadas: `OF_HEALTH_CHECK_ENABLED=0` desliga só o job de saúde; `OF_REFRESH_ENABLED=0` desliga o refresh periódico; o revert do frontend é independente do backend; o revert de código não exige desfazer migration (as colunas ficam inertes).

Critério de aceitação após o deploy, só leitura: a conexão hoje `ACTIVE` com dados de 05/08 deve aparecer como `ERROR` / `item_missing`, com `last_sync_at` congelado e `last_attempt_at` avançando.

## Limitações conhecidas

- **Nada foi validado contra produção nem contra a Pluggy real** — todo o comportamento remoto está mockado.
- **Pull-to-refresh e WKWebView só se confirmam no aparelho, depois do build.** No headless a classe `pb-app` foi ligada por UA e a regra medida com `getComputedStyle`: cobre a aritmética, não o gesto.
- **`item_status` fora das listas conhecidas com espelho vazio é tratado como saudável.** Não é regressão (com `has_data=True` já era assim); corrigir exigiria adivinhar a taxonomia da Pluggy sem evidência.
- **O universo de items na Pluggy não é enumerável**: `GET /items` responde 401 com a credencial atual. O registry novo rastreia o que passa por nós, mas não vê item que nunca chegou por callback ou webhook — o painel/suporte da Pluggy continua necessário.
- Corrida estreita entre dois usuários postando o mesmo item pode dar 500 em vez de 409 (o `on conflict` do upsert não cobre o índice novo). Registrado, não corrigido nesta onda.
- **A pílula não olha a idade de `last_sync_at`.** "Atualizado" quer dizer "o item está saudável na Pluggy", não "nosso espelho está fresco". Um banco que responde 429 de forma persistente mostra "Erro temporário" e volta ao verde em até 12h com dado velho — o job de saúde não lê contas, só `GET /items`. Medido, registrado no código, corrigir na Onda 2.
- `OF_REFRESH_POLL_SEC` continua sem documentação no `.env.example` — dívida que já vinha da `main`, não deste PR.

## Fora do escopo

**Onda 2** — sinal do cartão (275 de 328 compras gravadas como estorno), fuso da data (602 de 4.552 transações um dia à frente), descrição das compras (328 de 328 com `nota` nula).
**Onda 3** — classificação, auto-merge cego (66 de 94), fila `pending` sem saída (99 pares), movimento interno com falso positivo, investimento contado como gasto.
**Onda 4** — exclusão dos items órfãos na Pluggy, `closing_day`/`due_day`, modo estreia dos agentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

