### PR TITLE
Open Finance Onda 2: "Tudo em dia!" para de valer sem sync nenhum

### DIFF
--- a/core/services/pluggy_health.py
+++ b/core/services/pluggy_health.py
@@ -310,6 +310,19 @@ def connection_ui_state(connection_row: dict) -> dict:
         if state == "updated" and reason not in _REASONS_OK:
             state = reason if reason in _LABELS else "error_recoverable"
             detail = _FIXED_DETAIL.get(state)
+        # ONDA 2: "Atualizado" exige SYNC REAL, não só item saudável. O job de
+        # saúde grava `health` com `ok=None` (só faz GET /items, nunca toca em
+        # last_sync_at), então um banco recém-conectado/reconectado caía no ramo
+        # do health e ficava verde antes de qualquer sync — com "Última sync:
+        # pendente" logo abaixo, na mesma linha da tela.
+        # Vem DEPOIS do default seguro, e a ordem foi medida: com ela na frente,
+        # `no_accounts` e `read_failed` de uma conexão nova (que também têm
+        # last_sync_at NULL, porque `mark_sync_result(ok=False)` não carimba)
+        # perdiam o motivo e viravam "Atualizando…" — "Sem dados" sumia da tela e
+        # a pílula do `read_failed` descia de vermelho para âmbar. Só o verde SEM
+        # motivo é que vira "Ainda não sincronizou".
+        elif state == "updated" and row.get("last_sync_at") is None:
+            state, detail = "updating", "Ainda não sincronizou"
         return {
             "state": state,
             "label": _LABELS[state],
@@ -355,5 +368,8 @@ def connection_ui_state(connection_row: dict) -> dict:
         # temporário" (linha legada gravada antes desta onda também cai aqui).
         return out("no_accounts" if reason == "no_accounts" else "error_recoverable")
     if row.get("last_sync_at") is None:
+        # Não é redundante com o `out()`: aqui ele vem ANTES do default seguro,
+        # que é como a base se comporta neste ramo. Sem esta linha, um
+        # `no_accounts` sem health medido trocaria de veredito.
         return out("updating", "Ainda não sincronizou")
     return out("updated")

--- a/core/services/pluggy_health.py
+++ b/core/services/pluggy_health.py
@@ -375,9 +375,15 @@ def connection_ui_state(connection_row: dict) -> dict:
         # Mesma classe do ramo com health: o motivo explica melhor que "Erro
         # temporário" (linha legada gravada antes desta onda também cai aqui).
         return out("no_accounts" if reason == "no_accounts" else "error_recoverable")
-    if sem_sync:
-        # Não é redundante com o `out()`: aqui ele vem ANTES do default seguro,
-        # que é como a base se comporta neste ramo. Sem esta linha, um
-        # `no_accounts` sem health medido trocaria de veredito.
+    if ultimo is None:
+        # `ultimo is None`, NÃO `sem_sync`: este early-return pula o default
+        # seguro do `out()` — é assim na base, e por isso ele só pode valer no
+        # escopo EXATO que a base lhe dava ("nunca sincronizou"). Alargá-lo para
+        # `sem_sync` fez o caso da reconexão descartar `no_accounts`,
+        # `read_failed` e motivo desconhecido: medido, 60 combinações com perda,
+        # e a pílula do `read_failed` caindo de vermelho para âmbar logo depois
+        # de o usuário reconectar e o sync falhar. Quem reconectou desce pelo
+        # `out("updated")` abaixo, onde o motivo fala primeiro e o `sem_sync` só
+        # decide o que restar de verde.
         return out("updating", "Ainda não sincronizou")
     return out("updated")

--- a/core/services/pluggy_health.py
+++ b/core/services/pluggy_health.py
@@ -302,6 +302,14 @@ def connection_ui_state(connection_row: dict) -> dict:
     health = row.get("health") if isinstance(row.get("health"), dict) else None
     stale = list((health or {}).get("stale_products") or [])
 
+    # "Sincronizou" tem que significar "sincronizou DEPOIS da autorização atual".
+    # O upsert preserva o `last_sync_at` velho numa reconexão de propósito
+    # (reconectar não é sincronizar), então só olhar se ele existe deixava o
+    # espelho ANTERIOR à reconexão voltar à tela como "Atualizado" assim que o
+    # job de saúde media o item novo como saudável — apontado pelo Codex no #162.
+    ultimo, religado = row.get("last_sync_at"), row.get("reconnected_at")
+    sem_sync = ultimo is None or (religado is not None and ultimo < religado)
+
     def out(state: str, detail: str | None = None) -> dict:
         # DEFAULT SEGURO: estado desconhecido nunca é verde. Um `status_reason`
         # pendente que este arquivo não conhece (gravado por um caminho novo)
@@ -321,7 +329,7 @@ def connection_ui_state(connection_row: dict) -> dict:
         # perdiam o motivo e viravam "Atualizando…" — "Sem dados" sumia da tela e
         # a pílula do `read_failed` descia de vermelho para âmbar. Só o verde SEM
         # motivo é que vira "Ainda não sincronizou".
-        elif state == "updated" and row.get("last_sync_at") is None:
+        elif state == "updated" and sem_sync:
             state, detail = "updating", "Ainda não sincronizou"
         return {
             "state": state,
@@ -367,7 +375,7 @@ def connection_ui_state(connection_row: dict) -> dict:
         # Mesma classe do ramo com health: o motivo explica melhor que "Erro
         # temporário" (linha legada gravada antes desta onda também cai aqui).
         return out("no_accounts" if reason == "no_accounts" else "error_recoverable")
-    if row.get("last_sync_at") is None:
+    if sem_sync:
         # Não é redundante com o `out()`: aqui ele vem ANTES do default seguro,
         # que é como a base se comporta neste ramo. Sem esta linha, um
         # `no_accounts` sem health medido trocaria de veredito.

--- a/core/services/pluggy_sync.py
+++ b/core/services/pluggy_sync.py
@@ -351,8 +351,20 @@ def _sync_pluggy_item_confirmado(provider_item_id: str, connection: dict, api_ke
         # lock de propósito — ele afirma que as escritas acima valeram.
         status, reason = resolve_connection_state(health=health, has_data=True,
                                                   leitura_completa=investments_ok)
+        # `reconnected_at_visto`: o valor lido em `sync_pluggy_item`, ANTES da
+        # fase de leitura. Se o usuário reconectou no meio dela (minutos, fora do
+        # lock), este run leu sob a autorização velha e não pode se declarar
+        # sucesso — o espelho fica (o dado é real), o carimbo não. A rota de
+        # reconexão agenda um sync novo, então o âmbar é transitório.
+        #
+        # SÃO DOIS MECANISMOS INDEPENDENTES, e quem simplificar um achando que o
+        # outro cobre reabre o buraco: este guarda protege só `last_sync_at` — o
+        # run atrasado AINDA escreve `status`, `status_reason` e `health`, medidos
+        # sob a autorização velha. Quem impede a tela de ficar verde com esse
+        # health é o `sem_sync` de `connection_ui_state`, não este parâmetro.
         mark_sync_result(connection["id"], ok=True, status=status, status_reason=reason,
-                         health=health, at=datetime.now(_tz()))
+                         health=health, at=datetime.now(_tz()),
+                         reconnected_at_visto=connection.get("reconnected_at"))
 
     # Agentes do Piggy — gatilho pós-sync: Xerife roda só sobre o delta deste
     # usuário. IMPORTANTE: depois da reconciliação/import acima (merge-silencioso

--- a/core/services/pluggy_sync.py
+++ b/core/services/pluggy_sync.py
@@ -307,6 +307,21 @@ def _sync_pluggy_item_confirmado(provider_item_id: str, connection: dict, api_ke
         if not locked:
             return {"ok": False, "reason": "sync_in_progress", "item_id": provider_item_id,
                     "connection_id": connection["id"], "user_id": connection["user_id"]}
+
+        # GERAÇÃO DA AUTORIZAÇÃO, relida DENTRO do lock e ANTES de qualquer
+        # escrita. O `reconnected_at_visto` do `mark_sync_result` lá embaixo
+        # recusa só o CARIMBO do run velho — o espelho ele já teria sobrescrito.
+        # Com duas réplicas isso é alcançável: o sync pós-reconexão termina
+        # primeiro e carimba um `last_sync_at` legítimo; o run pré-reconexão
+        # chega depois, pega o lock, escreve contas/investimentos/status/health
+        # do snapshot VELHO e tem só o carimbo recusado — a tela segue
+        # "Atualizado" sobre espelho velho. O `_INFLIGHT` não cobre: é por
+        # processo. Run de geração velha morre aqui, sem escrever nada.
+        atual = get_open_finance_connection_by_item_id(provider_item_id)
+        if not atual or atual.get("reconnected_at") != connection.get("reconnected_at"):
+            return {"ok": False, "reason": "stale_authorization", "item_id": provider_item_id,
+                    "connection_id": connection["id"], "user_id": connection["user_id"]}
+
         # Tentativa carimbada DEPOIS do lock: quem não conseguiu escrever não
         # tentou sincronizar, e antes o perdedor da corrida já mexia na linha.
         mark_sync_attempt(connection["id"], origin="sync")
@@ -352,16 +367,18 @@ def _sync_pluggy_item_confirmado(provider_item_id: str, connection: dict, api_ke
         status, reason = resolve_connection_state(health=health, has_data=True,
                                                   leitura_completa=investments_ok)
         # `reconnected_at_visto`: o valor lido em `sync_pluggy_item`, ANTES da
-        # fase de leitura. Se o usuário reconectou no meio dela (minutos, fora do
-        # lock), este run leu sob a autorização velha e não pode se declarar
-        # sucesso — o espelho fica (o dado é real), o carimbo não. A rota de
-        # reconexão agenda um sync novo, então o âmbar é transitório.
+        # fase de leitura. A relectura lá em cima já matou o run de geração
+        # velha; este parâmetro fecha a janela que sobra — a rota de reconexão
+        # (`/pluggy/item`) NÃO pega o `pluggy_item_lock`, então uma reconexão
+        # ainda pode cair entre a relectura e este carimbo. Aí o espelho fica (o
+        # dado é real) e o carimbo não; a rota de reconexão agenda um sync novo,
+        # então o âmbar é transitório.
         #
-        # SÃO DOIS MECANISMOS INDEPENDENTES, e quem simplificar um achando que o
-        # outro cobre reabre o buraco: este guarda protege só `last_sync_at` — o
-        # run atrasado AINDA escreve `status`, `status_reason` e `health`, medidos
-        # sob a autorização velha. Quem impede a tela de ficar verde com esse
-        # health é o `sem_sync` de `connection_ui_state`, não este parâmetro.
+        # SÃO TRÊS MECANISMOS INDEPENDENTES, e quem simplificar um achando que o
+        # outro cobre reabre o buraco: a relectura recusa o run inteiro, este
+        # parâmetro recusa só `last_sync_at` na janela residual, e quem impede a
+        # tela de ficar verde com um `health` velho é o `sem_sync` de
+        # `connection_ui_state`.
         mark_sync_result(connection["id"], ok=True, status=status, status_reason=reason,
                          health=health, at=datetime.now(_tz()),
                          reconnected_at_visto=connection.get("reconnected_at"))

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -244,7 +244,7 @@ def get_open_finance_snapshot(user_id: int, limit: int = 8) -> dict:
             cur.execute(
                 """
                 select id, provider, provider_item_id, status, institution_name, last_sync_at,
-                       last_attempt_at, status_reason, health
+                       last_attempt_at, status_reason, health, reconnected_at
                 from open_finance_connections
                 where user_id=%s
                 order by updated_at desc, id desc
@@ -469,15 +469,24 @@ def save_pluggy_open_finance_item(user_id: int, item: dict) -> dict:
                               -- de o usuário ter refeito — e um health velho com
                               -- item_status MISSING ainda pintava a tela.
                               status_reason = null,
-                              health = null
+                              health = null,
+                              -- Só no ramo do CONFLITO: conexão nova nasce com
+                              -- isto NULL e já é barrada pelo `last_sync_at`
+                              -- NULL. O único chamador de produção é a rota
+                              -- /pluggy/item (o widget), então isto carimba uma
+                              -- vez por reconexão — webhook e sync não passam aqui.
+                              reconnected_at = excluded.updated_at
                 -- NÃO carimba last_sync_at: conectar não é sincronizar. Carimbar
                 -- aqui fazia a conexão nascer "Atualizado agora" antes de qualquer
                 -- sync e ligava `user_synced_within`, que segura o e-mail dos
                 -- agentes achando que uma carteira estava se mexendo. Quem carimba
                 -- sucesso é `mark_sync_result`, no fim de um sync real.
                 -- `status` continua sendo escrito: é ele que tira a conexão de
-                -- DELETED quando o usuário reconecta pelo widget.
-                returning id, provider, provider_item_id, status, institution_name, last_sync_at
+                -- DELETED quando o usuário reconecta pelo widget. E o
+                -- `reconnected_at` acima é o que impede o espelho ANTERIOR à
+                -- reconexão de voltar à tela como "Atualizado".
+                returning id, provider, provider_item_id, status, institution_name,
+                          last_sync_at, reconnected_at
                 """,
                 (
                     user_id,

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -126,7 +126,11 @@ def mark_sync_result(
     — e carimbaria `last_sync_at > reconnected_at` com dado buscado sob a
     autorização ANTIGA, devolvendo o verde que esta onda existe para tirar.
     Mesmo idioma otimista de `pending_actions`: só grava se ainda for o que leu.
-    A escrita do espelho continua valendo (o dado é real, só velho); o que se
+    NÃO é o guarda principal: quem mata o run de geração velha é a relectura de
+    `reconnected_at` dentro do `pluggy_item_lock` (`_sync_pluggy_item_confirmado`),
+    antes de qualquer escrita. Este aqui fecha a janela que sobra — a rota de
+    reconexão não pega aquele lock, então ela ainda pode cair entre a relectura e
+    este carimbo. Nessa janela o espelho fica (o dado é real, só velho); o que se
     recusa é chamá-la de sucesso — e a própria rota de reconexão agenda um sync
     novo, então o âmbar é transitório.
     """

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -63,7 +63,7 @@ def get_connections_by_item_id(item_id: str, provider: str = "pluggy") -> list[d
                 """
                 select id, user_id, provider, provider_item_id, status, institution_name,
                        last_sync_at, last_attempt_at, status_reason, health,
-                       next_refresh_at, last_refresh_origin
+                       next_refresh_at, last_refresh_origin, reconnected_at
                 from open_finance_connections
                 where provider=%s and provider_item_id=%s
                 order by id

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -93,6 +93,11 @@ def mark_sync_attempt(connection_id: int, *, origin: str = "sync") -> int:
     return updated
 
 
+# Sentinela: `None` é um valor VÁLIDO de `reconnected_at` (nunca reconectou),
+# então não serve de "não checar".
+_SEM_CHECAGEM: Any = object()
+
+
 def mark_sync_result(
     connection_id: int,
     *,
@@ -101,6 +106,7 @@ def mark_sync_result(
     status_reason: str | None = None,
     health: dict | None = None,
     at: datetime | None = None,
+    reconnected_at_visto: Any = _SEM_CHECAGEM,
 ) -> int:
     """Resultado de um sync (ou do job de saúde, com ok=None).
 
@@ -112,6 +118,17 @@ def mark_sync_result(
     existir — com `coalesce` puro, um `item_missing` gravado por um 404
     transitório só saía num sync completo, e o sync periódico é dormente por
     padrão (`OF_REFRESH_ENABLED`): a tela mandava refazer a conexão para sempre.
+
+    `reconnected_at_visto`: o `reconnected_at` que o sync leu ao COMEÇAR. Só o
+    sucesso o consulta, e só para decidir se ainda pode carimbá-lo. A fase de
+    leitura roda FORA do lock e leva minutos (transações paginadas por conta),
+    então um sync que começou antes de o usuário reconectar pode terminar depois
+    — e carimbaria `last_sync_at > reconnected_at` com dado buscado sob a
+    autorização ANTIGA, devolvendo o verde que esta onda existe para tirar.
+    Mesmo idioma otimista de `pending_actions`: só grava se ainda for o que leu.
+    A escrita do espelho continua valendo (o dado é real, só velho); o que se
+    recusa é chamá-la de sucesso — e a própria rota de reconexão agenda um sync
+    novo, então o âmbar é transitório.
     """
     now = at or datetime.now(_tz())
     with get_conn() as conn:
@@ -124,7 +141,9 @@ def mark_sync_result(
                                             else coalesce(%s, status_reason) end,
                        health = coalesce(%s, health),
                        last_attempt_at = case when %s then last_attempt_at else %s end,
-                       last_sync_at = case when %s then %s else last_sync_at end,
+                       last_sync_at = case when %s and (%s or reconnected_at
+                                                        is not distinct from %s)
+                                           then %s else last_sync_at end,
                        updated_at = %s
                  where id=%s
                    and upper(coalesce(status,'')) not in {_TERMINAL}
@@ -134,7 +153,12 @@ def mark_sync_result(
                     status_reason, status_reason,
                     (Jsonb(health) if health is not None else None),
                     ok is None, now,          # job de saúde não é tentativa de sync
-                    bool(ok), now,            # só sucesso avança last_sync_at
+                    # só sucesso avança last_sync_at, e só se ninguém reconectou
+                    # no meio (`is not distinct from` para casar NULL com NULL)
+                    bool(ok),
+                    reconnected_at_visto is _SEM_CHECAGEM,
+                    (None if reconnected_at_visto is _SEM_CHECAGEM else reconnected_at_visto),
+                    now,
                     now,
                     connection_id,
                 ),

--- a/db/schema.py
+++ b/db/schema.py
@@ -448,6 +448,14 @@ def init_db():
         """
         alter table open_finance_connections add column if not exists last_refresh_origin text
         """,
+        # Onda 2: quando o usuário refez a autorização. O upsert preserva o
+        # `last_sync_at` velho de propósito (reconectar não é sincronizar), então
+        # sem esta coluna não dá para distinguir "sincronizou" de "sincronizou
+        # DEPOIS de reconectar" — e o espelho pré-reconexão voltava à tela como
+        # atual assim que o job de saúde media o item novo como saudável.
+        """
+        alter table open_finance_connections add column if not exists reconnected_at timestamptz
+        """,
         """
         create index if not exists idx_of_conn_refresh_due
           on open_finance_connections(next_refresh_at)

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -82,6 +82,11 @@ _DIRTY: set[str] = set()
 # 3x é o mesmo erro 3x — e ainda esconde o defeito no log.
 _SYNC_MAX_ATTEMPTS = 3
 
+# Tentativas de pegar o lock ao gravar uma reconexão. Cada uma já espera até
+# `OF_SYNC_LOCK_WAIT_MS` (15s) lá dentro, então 2 é o teto do que cabe num
+# request HTTP — a janela do lock é só a fase de escrita e passa em segundos.
+_RECONNECT_LOCK_ATTEMPTS = 2
+
 # HTTP da Pluggy que some sozinho: cota estourada e erro do lado dela. 404 fica
 # de fora de propósito (é `item_missing`, tratado no sync), 4xx de credencial
 # também — repetir não conserta chave errada.
@@ -121,13 +126,54 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str) -> tuple[dict
     reconexão espera; enquanto a reconexão grava, nenhum sync entra na fase de
     escrita — e o próximo a entrar relê a geração nova e aborta.
 
-    A janela do lock é curta de propósito (só escrita, nunca a leitura remota),
-    então esperar a vez é barato. Estourou o teto (`OF_SYNC_LOCK_WAIT_MS`, 15s):
-    grava assim mesmo e devolve `False`. Recusar seria pior — o item já existe na
-    Pluggy, e não gravar deixaria o banco conectado lá e invisível aqui.
+    Sem o lock NÃO grava. A primeira versão disto gravava assim mesmo e só logava
+    o aviso — e essa é exatamente a escrita que o lock existe para serializar
+    (Codex #162, P1): se o teto estourou é porque um sync ESTÁ na fase de
+    escrita, já passou pela checagem de geração, e vai importar lançamento e
+    compra de cartão da autorização velha. O fallback anulava o conserto no único
+    caso em que ele importa.
     """
     with pluggy_item_lock(item_id) as locked:
-        return save_pluggy_open_finance_item(user_id, remote), bool(locked)
+        if not locked:
+            return None, False
+        return save_pluggy_open_finance_item(user_id, remote), True
+
+
+async def _grava_reconexao(user_id: int, remote: dict, item_id: str) -> dict:
+    """Grava a reconexão sob o lock, RETENTANDO antes de desistir.
+
+    Não é escolha entre dois males. Gravar sem lock cria lançamento fantasma;
+    recusar de primeira deixa o banco conectado na Pluggy e invisível aqui. O
+    passo que faltava é esperar de novo: a janela do lock é só a fase de escrita
+    de um sync (nunca a leitura remota), então ela passa em segundos e a segunda
+    tentativa quase sempre entra.
+
+    Esgotou: 503 com mensagem de "tente de novo". O item continua existindo na
+    Pluggy e o mesmo POST reaproveita, então a reconexão é recuperável — o
+    lançamento fantasma não seria.
+    """
+    for tentativa in range(1, _RECONNECT_LOCK_ATTEMPTS + 1):
+        connection, sob_lock = await asyncio.to_thread(
+            _salva_item_sob_lock, user_id, remote, item_id)
+        if sob_lock:
+            return connection
+        if tentativa < _RECONNECT_LOCK_ATTEMPTS:
+            await log_system_event(
+                "warning", "of_reconnect_lock_retry",
+                f"Lock ocupado ao gravar reconexão ({tentativa}/{_RECONNECT_LOCK_ATTEMPTS}): {item_id}",
+                source="open_finance", details={"item_id": item_id, "attempt": tentativa},
+            )
+            await asyncio.sleep(_backoff_sec(tentativa))
+
+    await log_system_event(
+        "error", "of_reconnect_lock_timeout",
+        f"Reconexão NÃO gravada: lock do item ocupado: {item_id}",
+        source="open_finance", details={"item_id": item_id},
+    )
+    raise HTTPException(
+        status_code=503,
+        detail="Não foi possível concluir a conexão agora. Tente de novo em alguns segundos.",
+    )
 
 
 async def _run_pluggy_sync_bg(item_id: str) -> None:
@@ -576,16 +622,9 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
 
     await _enforce_bank_limit(session_uid, new_item_id)
     try:
-        connection, sob_lock = await asyncio.to_thread(
-            _salva_item_sob_lock, session_uid, remote, new_item_id)
+        connection = await _grava_reconexao(session_uid, remote, new_item_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if not sob_lock:
-        await log_system_event(
-            "warning", "of_reconnect_sem_lock",
-            f"Reconexão gravada sem o lock de escrita: {new_item_id}",
-            source="open_finance", details={"item_id": new_item_id},
-        )
 
     await asyncio.to_thread(
         register_item, session_uid,

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -45,6 +45,7 @@ from db import (
     get_open_finance_connection_by_item_id,
     get_open_finance_snapshot,
     list_pluggy_item_ids,
+    pluggy_item_lock,
     register_item,
     save_pluggy_open_finance_item,
     token_hash,
@@ -102,6 +103,31 @@ def _retryable(exc: BaseException) -> bool:
         return isinstance(exc, (pg_errors.DeadlockDetected, pg_errors.SerializationFailure))
     except Exception:  # psycopg ausente/alterado: não retenta
         return False
+
+
+def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str) -> tuple[dict, bool]:
+    """Grava a reconexão DENTRO do `pluggy_item_lock` do item.
+
+    A relectura da geração em `_sync_pluggy_item_confirmado` não é atômica com as
+    escritas que vêm depois dela. Uma reconexão que caísse nessa fresta deixava o
+    run de geração velha gravar o espelho E rodar `import_open_finance_launches` /
+    `import_open_finance_credit` — que criam LANÇAMENTO e COMPRA DE CARTÃO do
+    usuário. O carimbo era recusado, mas nenhum sync posterior remove lançamento:
+    o upsert só acrescenta. Resultado medido pelo Codex (#162, P1): transação
+    fantasma de uma autorização que não vale mais, sobrevivendo à recuperação —
+    tipicamente a conta que o usuário DESMARCOU ao reconectar.
+
+    Pegar o mesmo lock aqui fecha a fresta na origem: enquanto um sync escreve, a
+    reconexão espera; enquanto a reconexão grava, nenhum sync entra na fase de
+    escrita — e o próximo a entrar relê a geração nova e aborta.
+
+    A janela do lock é curta de propósito (só escrita, nunca a leitura remota),
+    então esperar a vez é barato. Estourou o teto (`OF_SYNC_LOCK_WAIT_MS`, 15s):
+    grava assim mesmo e devolve `False`. Recusar seria pior — o item já existe na
+    Pluggy, e não gravar deixaria o banco conectado lá e invisível aqui.
+    """
+    with pluggy_item_lock(item_id) as locked:
+        return save_pluggy_open_finance_item(user_id, remote), bool(locked)
 
 
 async def _run_pluggy_sync_bg(item_id: str) -> None:
@@ -550,10 +576,16 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
 
     await _enforce_bank_limit(session_uid, new_item_id)
     try:
-        # Grava o REMOTO: status e instituição vêm da Pluggy, não do navegador.
-        connection = await asyncio.to_thread(save_pluggy_open_finance_item, session_uid, remote)
+        connection, sob_lock = await asyncio.to_thread(
+            _salva_item_sob_lock, session_uid, remote, new_item_id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not sob_lock:
+        await log_system_event(
+            "warning", "of_reconnect_sem_lock",
+            f"Reconexão gravada sem o lock de escrita: {new_item_id}",
+            source="open_finance", details={"item_id": new_item_id},
+        )
 
     await asyncio.to_thread(
         register_item, session_uid,

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -87,6 +87,13 @@ _SYNC_MAX_ATTEMPTS = 3
 _HTTP_TRANSITORIO = {429, 500, 502, 503, 504}
 
 
+def _backoff_sec(tentativa: int) -> float:
+    """Espera exponencial com jitter. Dois chamadores: a exceção `_retryable` e o
+    `sync_in_progress`, que NÃO é exceção — duas cópias da fórmula seriam a
+    mesma regra em dois lugares (§0.7)."""
+    return 0.5 * (2 ** (tentativa - 1)) * (0.75 + random.random() / 2)
+
+
 def _retryable(exc: BaseException) -> bool:
     if isinstance(exc, PluggyApiError) and exc.status_code in _HTTP_TRANSITORIO:
         return True
@@ -108,11 +115,36 @@ async def _run_pluggy_sync_bg(item_id: str) -> None:
         for tentativa in range(1, _SYNC_MAX_ATTEMPTS + 1):
             try:
                 result = await asyncio.to_thread(sync_pluggy_item, item_id)
-                break
+                # `sync_in_progress` não é exceção: volta como dict, então o
+                # `break` abaixo encerrava a tarefa em silêncio e NINGUÉM mais
+                # sincronizava. Cenário medido (Codex #162): o run de geração
+                # velha segura o `pluggy_item_lock` enquanto escreve, o sync que
+                # a reconexão agendou bate no lock e desiste — e com
+                # `OF_REFRESH_ENABLED` off (o default) nada mais roda sozinho, o
+                # espelho velho fica indefinidamente e a tela fica em âmbar até
+                # o usuário tocar "Atualizar".
+                #
+                # SÓ `sync_in_progress`. `stale_authorization` NÃO se retenta: ele
+                # significa "alguém mais novo assumiu", e quem assumiu já agendou
+                # o próprio sync — retentar seria correr atrás de um trabalho que
+                # já tem dono, e num par de runs que se atropelam viraria laço.
+                if (result or {}).get("reason") != "sync_in_progress":
+                    break
+                if tentativa == _SYNC_MAX_ATTEMPTS:
+                    break
+                espera = _backoff_sec(tentativa)
+                await log_system_event(
+                    "warning", "pluggy_sync_retry",
+                    f"Sync Pluggy vai repetir ({tentativa}/{_SYNC_MAX_ATTEMPTS}): {item_id}",
+                    source="open_finance",
+                    details={"item_id": item_id, "attempt": tentativa,
+                             "error": "sync_in_progress", "sleep_sec": round(espera, 3)},
+                )
+                await asyncio.sleep(espera)
             except Exception as exc:
                 if not _retryable(exc) or tentativa == _SYNC_MAX_ATTEMPTS:
                     raise
-                espera = 0.5 * (2 ** (tentativa - 1)) * (0.75 + random.random() / 2)
+                espera = _backoff_sec(tentativa)
                 await log_system_event(
                     "warning", "pluggy_sync_retry",
                     f"Sync Pluggy vai repetir ({tentativa}/{_SYNC_MAX_ATTEMPTS}): {item_id}",

--- a/tests/frontend/of_refresh_ui.test.mjs
+++ b/tests/frontend/of_refresh_ui.test.mjs
@@ -115,6 +115,34 @@ test("botão Atualizar do OF: some no modo app, fica no mobile web", async () =>
     assert.equal(await noWeb.evaluate(() => document.documentElement.classList.contains("pb-app")), false);
     assert.equal(await botaoVisivel(noWeb), true, "no mobile web o botão CONTINUA");
   } finally { await noWeb.__ctx.close(); }
+
+  // ONDA 2: as outras duas superfícies da lista. Desktop web é a mais óbvia e a
+  // que ninguém media; a PWA instalada entra pelo `display-mode: standalone` do
+  // app-mode.js, um ramo do gate que o caso do UA acima NUNCA exercita —
+  // esconder o botão lá depende dele, e só dele.
+  const desktop = await newPage({ viewport: { width: 1440, height: 900 } });
+  try {
+    await desktop.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await sleep(300);
+    assert.equal(await desktop.evaluate(() => document.documentElement.classList.contains("pb-app")), false);
+    assert.equal(await botaoVisivel(desktop), true, "no desktop web o botão CONTINUA");
+  } finally { await desktop.__ctx.close(); }
+
+  const pwa = await newPage({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+  try {
+    // `navigator.standalone` é EXATAMENTE o que o Safari do iOS expõe numa PWA
+    // na tela de início — não é um mock meu, é o sinal real que o gate lê.
+    // A outra porta do gate, `matchMedia("(display-mode: standalone)")`, NÃO é
+    // alcançável aqui: medido, o Chromium não emula `display-mode` nem por CDP
+    // (`Emulation.setEmulatedMedia` devolve `matches: false` nas duas formas).
+    // Sem UA de app de propósito — a PWA é Safari puro, e é esse o ponto.
+    await pwa.addInitScript(() =>
+      Object.defineProperty(window.navigator, "standalone", { value: true, configurable: true }));
+    await pwa.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => pwa.evaluate(() => document.documentElement.classList.contains("pb-app")),
+                  "html.pb-app na PWA instalada");
+    assert.equal(await botaoVisivel(pwa), false, "na PWA o botão some igual ao app (o gesto substitui)");
+  } finally { await pwa.__ctx.close(); }
 });
 
 /**
@@ -159,6 +187,99 @@ test("veredito do refresh: só estado conhecido-bom fica verde", async () => {
       ok: true, items: [{ item_id: "a", state: "rate_limited" }] }));
     assert.equal(cooldown.tone, "ok");
     assert.match(cooldown.msg, /acabou de atualizar/i, cooldown.msg);
+  } finally { await page.__ctx.close(); }
+});
+
+/**
+ * ONDA 2, regressão dos dois invariantes do gesto que ainda não tinham teste:
+ *
+ *  a) puxar a tela em `?view=open-finance` chama o REFRESH (POST .../refresh =
+ *     PATCH na Pluggy + sync), não só o `loadData` que relê o snapshot. Antes da
+ *     Onda 1 era loadData: o gesto repintava dado velho e parecia ter funcionado.
+ *  b) `settings.html` NÃO abre WebSocket. O auto-update ao vivo é só do
+ *     dashboard, que já tem a conexão; abrir uma segunda aqui dobra socket por
+ *     usuário sem ninguém escutar do outro lado.
+ *
+ * Discrimina: trocar o corpo do PBRefresh de open-finance por `loadData(...)`
+ * deixa (a) vermelho; um `new WebSocket(...)` em qualquer script da página
+ * deixa (b) vermelho.
+ */
+test("PTR do OF chama o refresh real, e settings não abre WebSocket", async () => {
+  const page = await newPage({ userAgent: APP_UA, viewport: { width: 390, height: 844 },
+                               hasTouch: true, isMobile: true });
+  try {
+    await page.addInitScript(() => {
+      window.__ws = [];
+      const Real = window.WebSocket;
+      window.WebSocket = function (url, ...rest) { window.__ws.push(String(url)); return new Real(url, ...rest); };
+      window.WebSocket.prototype = Real.prototype;
+    });
+    // A aba de OF só existe com a flag de rollout ligada; sem ela o
+    // `showSettingsSection` cai em `security` e o gesto não tem o que atualizar.
+    await page.route("**/auth/me", (route) =>
+      route.fulfill(json({ app_access: true, plan_tier: "pro", of_ui_enabled: true })));
+    const chamadas = [];
+    await page.route("**/open-finance/**", (route) => {
+      const req = route.request();
+      chamadas.push(`${req.method()} ${new URL(req.url()).pathname}`);
+      return route.fulfill(json({ sync: { ok: true, still_updating: 0, items: [] },
+                                  connections: [], accounts: [], transactions: [] }));
+    });
+
+    await page.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => page.evaluate(() => typeof window.PBRefresh === "function"),
+                  "PBRefresh existir");
+    await waitFor(() => page.evaluate(() =>
+      new URLSearchParams(location.search).get("view") === "open-finance"),
+      "a aba de Open Finance ficar ativa");
+    await sleep(300);
+    chamadas.length = 0;                       // ignora o load inicial
+    await page.evaluate(() => window.PBRefresh());
+
+    const refresh = chamadas.filter((c) => c.startsWith("POST") && c.endsWith("/refresh"));
+    assert.equal(refresh.length, 1, `o gesto tem que pedir refresh real, veio: ${chamadas.join(", ")}`);
+
+    // (b) nenhuma das duas portas: nem WebSocket nativo, nem socket.io.
+    assert.deepEqual(await page.evaluate(() => window.__ws), [],
+                     "settings.html não pode abrir WebSocket — o ao vivo é do dashboard");
+  } finally { await page.__ctx.close(); }
+});
+
+/**
+ * ONDA 2: o backend já prova que `connection_ui_state` devolve
+ * `updating`/"Ainda não sincronizou"; isto prova o que o USUÁRIO vê. A linha da
+ * conexão mostra `Última sync: pendente` (fmtDate(null)) e a pílula tem que
+ * concordar com ela — dizer "Tudo em dia!" logo acima de "pendente" foi
+ * exatamente o sintoma desta onda.
+ *
+ * Discrimina: com `OF_PILL_CLASS[ui.state]` caindo em "ok" para `updating`, ou
+ * com a pílula pintada de verde, a 2ª asserção fica vermelha.
+ */
+test("linha da conexão sem sync: pílula pendente e 'Última sync: pendente'", async () => {
+  const page = await newPage({ viewport: { width: 390, height: 844 } });
+  try {
+    await page.goto(`${ORIGIN}/settings.html?view=open-finance`);
+    await waitFor(() => page.evaluate(() => typeof window.renderConnections === "function"),
+                  "renderConnections existir");
+
+    const linha = await page.evaluate(() => {
+      window.renderConnections([{
+        institution_name: "Nubank", provider_item_id: "i1", last_sync_at: null,
+        ui: { state: "updating", label: "Atualizando…", detail: "Ainda não sincronizou" },
+      }]);
+      const row = document.querySelector("#connections-list .connection-row");
+      const pill = row.querySelector(".pill");
+      return { texto: row.innerText, pill: pill.className, label: pill.textContent.trim() };
+    });
+
+    assert.match(linha.texto, /Última sync: pendente/, linha.texto);
+    assert.match(linha.texto, /Ainda não sincronizou/, linha.texto);
+    assert.equal(linha.label, "Atualizando…");
+    // "active" é a classe VERDE do mapa (OF_PILL_CLASS, settings.html:2792) — a
+    // única que o estado sem sync não pode receber.
+    assert.ok(!/\bactive\b/.test(linha.pill),
+              `a pílula não pode ser verde ao lado de "pendente" (veio "${linha.pill}")`);
+    assert.match(linha.pill, /pending/, linha.pill);
   } finally { await page.__ctx.close(); }
 });
 

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -376,6 +376,64 @@ def test_stale_authorization_nao_vira_laco(user_id, monkeypatch):
     assert [e for e in eventos if e[1] == "pluggy_sync_retry"] == []
 
 
+# ── ONDA 2 / Codex #162 (5º achado, P1): a reconexão participa do lock ──────
+# A relectura da geração não é atômica com as escritas que vêm DEPOIS dela. Uma
+# reconexão caindo nessa fresta deixava o run de geração velha gravar o espelho
+# E rodar `import_open_finance_launches`/`import_open_finance_credit`, que criam
+# LANÇAMENTO e COMPRA DE CARTÃO. O carimbo era recusado, mas nenhum sync
+# posterior remove lançamento — o upsert só acrescenta. Transação fantasma de
+# uma autorização que não vale mais, sobrevivendo à recuperação.
+#
+# Pegar o mesmo lock na reconexão fecha a fresta na origem.
+
+def test_reconexao_grava_dentro_do_lock_de_escrita(user_id, monkeypatch):
+    """O que se mede é a ORDEM: o `save` tem que acontecer entre o enter e o exit
+    do lock. Sem isso o teste passaria com o lock pego e solto ao lado da escrita.
+
+    CONTROLE NEGATIVO: chamar `save_pluggy_open_finance_item` direto (como antes)
+    deixa o evento "save" fora do par enter/exit e este teste vermelho."""
+    from contextlib import contextmanager
+
+    ordem = []
+
+    @contextmanager
+    def _lock_espiao(item_id):
+        ordem.append(("enter", item_id))
+        try:
+            yield True
+        finally:
+            ordem.append(("exit", item_id))
+
+    monkeypatch.setattr(of_routes, "pluggy_item_lock", _lock_espiao)
+    monkeypatch.setattr(of_routes, "save_pluggy_open_finance_item",
+                        lambda uid, remote: ordem.append(("save", uid)) or {"id": 1})
+
+    conexao, sob_lock = of_routes._salva_item_sob_lock(user_id, {"id": "item-lk"}, "item-lk")
+
+    assert sob_lock is True
+    assert ordem == [("enter", "item-lk"), ("save", user_id), ("exit", "item-lk")], ordem
+    assert conexao == {"id": 1}
+
+
+def test_reconexao_grava_mesmo_se_o_lock_estourar(user_id, monkeypatch):
+    """CONTROLE POSITIVO, e não é zelo: recusar a reconexão porque o lock demorou
+    deixaria o banco conectado NA PLUGGY e invisível aqui. Grava e denuncia."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _lock_ocupado(item_id):
+        yield False
+
+    monkeypatch.setattr(of_routes, "pluggy_item_lock", _lock_ocupado)
+    monkeypatch.setattr(of_routes, "save_pluggy_open_finance_item",
+                        lambda uid, remote: {"id": 2})
+
+    conexao, sob_lock = of_routes._salva_item_sob_lock(user_id, {"id": "item-lk2"}, "item-lk2")
+
+    assert conexao == {"id": 2}, "a reconexão NÃO pode ser perdida"
+    assert sob_lock is False, "e o chamador tem que saber, pra logar o aviso"
+
+
 # ── RODADA 3: o lock não pode esperar para sempre nem abrir conexão sem teto ──
 
 def test_lock_wait_zero_nao_significa_espera_infinita(user_id, monkeypatch):

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -415,10 +415,17 @@ def test_reconexao_grava_dentro_do_lock_de_escrita(user_id, monkeypatch):
     assert conexao == {"id": 1}
 
 
-def test_reconexao_grava_mesmo_se_o_lock_estourar(user_id, monkeypatch):
-    """CONTROLE POSITIVO, e não é zelo: recusar a reconexão porque o lock demorou
-    deixaria o banco conectado NA PLUGGY e invisível aqui. Grava e denuncia."""
+def test_sem_lock_nao_grava(user_id, monkeypatch):
+    """Sem o lock, NÃO grava. A 1ª versão gravava assim mesmo e só logava — e é
+    justamente a escrita que o lock existe para serializar (Codex #162, P1): se o
+    teto estourou é porque um sync ESTÁ escrevendo, já passou pela checagem de
+    geração, e vai importar lançamento da autorização velha.
+
+    CONTROLE NEGATIVO: devolver `save_pluggy_open_finance_item(...)` no ramo sem
+    lock deixa este teste vermelho."""
     from contextlib import contextmanager
+
+    salvou = []
 
     @contextmanager
     def _lock_ocupado(item_id):
@@ -426,12 +433,72 @@ def test_reconexao_grava_mesmo_se_o_lock_estourar(user_id, monkeypatch):
 
     monkeypatch.setattr(of_routes, "pluggy_item_lock", _lock_ocupado)
     monkeypatch.setattr(of_routes, "save_pluggy_open_finance_item",
-                        lambda uid, remote: {"id": 2})
+                        lambda uid, remote: salvou.append(uid) or {"id": 2})
 
     conexao, sob_lock = of_routes._salva_item_sob_lock(user_id, {"id": "item-lk2"}, "item-lk2")
 
-    assert conexao == {"id": 2}, "a reconexão NÃO pode ser perdida"
-    assert sob_lock is False, "e o chamador tem que saber, pra logar o aviso"
+    assert (conexao, sob_lock) == (None, False)
+    assert salvou == [], "sem lock não se escreve nada"
+
+
+def test_reconexao_retenta_o_lock_antes_de_desistir(user_id, monkeypatch):
+    """A terceira opção: nem gravar sem lock, nem recusar de primeira. A janela
+    do lock é só a fase de escrita de um sync, então ela passa em segundos.
+
+    CONTROLE POSITIVO do grupo: sem o retry, um lock ocupado por um instante
+    viraria 503 na cara do usuário."""
+    tentativas = []
+
+    async def _log(level, event_type, *a, **kw):
+        return None
+
+    async def _sleep_rapido(_s):
+        return None
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
+
+    def _libera_na_segunda(uid, remote, item_id):
+        tentativas.append(item_id)
+        if len(tentativas) == 1:
+            return None, False
+        return {"id": 7}, True
+
+    monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _libera_na_segunda)
+
+    conexao = asyncio.run(of_routes._grava_reconexao(user_id, {"id": "i"}, "item-retry"))
+
+    assert conexao == {"id": 7}
+    assert len(tentativas) == 2, "esperou a vez em vez de desistir ou gravar solto"
+
+
+def test_lock_ocupado_ate_o_fim_recusa_com_503(user_id, monkeypatch):
+    """Esgotadas as tentativas, RECUSA — não grava solto. 503 é recuperável: o
+    item continua na Pluggy e o mesmo POST reaproveita. Lançamento fantasma não
+    seria recuperável, e é essa a troca.
+
+    CONTROLE NEGATIVO: voltar a gravar sem lock no fim deixa este teste vermelho."""
+    from fastapi import HTTPException
+
+    eventos = []
+
+    async def _log(level, event_type, *a, **kw):
+        eventos.append((level, event_type))
+
+    async def _sleep_rapido(_s):
+        return None
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
+    monkeypatch.setattr(of_routes, "_salva_item_sob_lock",
+                        lambda uid, remote, item_id: (None, False))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(of_routes._grava_reconexao(user_id, {"id": "i"}, "item-preso"))
+
+    assert exc.value.status_code == 503
+    assert "tente de novo" in str(exc.value.detail).lower()
+    assert ("error", "of_reconnect_lock_timeout") in eventos
 
 
 # ── RODADA 3: o lock não pode esperar para sempre nem abrir conexão sem teto ──

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -284,6 +284,98 @@ def test_retry_dispara_em_deadlock_e_nao_em_erro_de_programacao(monkeypatch):
     assert [e for e in eventos if e[1] == "pluggy_sync_retry"] == []
 
 
+# ── ONDA 2 / Codex #162 (4º P2): `sync_in_progress` travava indefinidamente ──
+# `sync_pluggy_item` devolve `sync_in_progress` como DICT, não como exceção, e o
+# loop de `_run_pluggy_sync_bg` só retentava exceção `_retryable` — então a
+# tarefa encerrava em silêncio e ninguém mais sincronizava aquele item.
+#
+# Por que dói: o run de geração velha segura o `pluggy_item_lock` enquanto
+# escreve; o sync que a RECONEXÃO agendou bate no lock, recebe
+# `sync_in_progress` e desiste. Com `OF_REFRESH_ENABLED` off (o default) nada
+# mais roda sozinho — o espelho velho fica indefinidamente e a tela só sai do
+# âmbar se o usuário tocar "Atualizar" ou puxar a tela.
+
+def test_sync_in_progress_e_retentado(user_id, monkeypatch):
+    """CONTROLE NEGATIVO: com o `break` incondicional de volta, `tentativas`
+    vira 1 e o `pluggy_sync_retry` some — o travamento indefinido volta."""
+    eventos = []
+
+    async def _log(level, event_type, *a, **kw):
+        eventos.append((level, event_type))
+
+    async def _sleep_rapido(_s):
+        return None
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
+
+    tentativas = []
+
+    def _lock_ocupado(item_id):
+        tentativas.append(item_id)
+        return {"ok": False, "reason": "sync_in_progress", "item_id": item_id}
+
+    monkeypatch.setattr(of_routes, "sync_pluggy_item", _lock_ocupado)
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-ocupado"))
+
+    assert len(tentativas) == 3, f"o lock ocupado tem que ser retentado: {tentativas}"
+    assert len([e for e in eventos if e[1] == "pluggy_sync_retry"]) == 2
+
+
+def test_sync_in_progress_que_libera_para_de_retentar(user_id, monkeypatch):
+    """CONTROLE POSITIVO: o retry existe para ALCANÇAR o sync, não para gastar
+    três tentativas sempre. Liberou o lock na 2ª, a 3ª não acontece."""
+    async def _log(level, event_type, *a, **kw):
+        return None
+
+    async def _sleep_rapido(_s):
+        return None
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
+
+    tentativas = []
+
+    def _libera_na_segunda(item_id):
+        tentativas.append(item_id)
+        if len(tentativas) == 1:
+            return {"ok": False, "reason": "sync_in_progress", "item_id": item_id}
+        return {"ok": True, "item_id": item_id, "user_id": None}
+
+    monkeypatch.setattr(of_routes, "sync_pluggy_item", _libera_na_segunda)
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-libera"))
+
+    assert len(tentativas) == 2, "parou assim que conseguiu sincronizar"
+
+
+def test_stale_authorization_nao_vira_laco(user_id, monkeypatch):
+    """`stale_authorization` significa "alguém mais novo assumiu", e quem assumiu
+    já agendou o próprio sync. Retentar seria correr atrás de trabalho que já tem
+    dono — e num par de runs que se atropelam, laço. UMA tentativa e pronto."""
+    eventos = []
+
+    async def _log(level, event_type, *a, **kw):
+        eventos.append((level, event_type))
+
+    async def _sleep_rapido(_s):
+        return None
+
+    monkeypatch.setattr(of_routes, "log_system_event", _log)
+    monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
+
+    tentativas = []
+
+    def _geracao_velha(item_id):
+        tentativas.append(item_id)
+        return {"ok": False, "reason": "stale_authorization", "item_id": item_id}
+
+    monkeypatch.setattr(of_routes, "sync_pluggy_item", _geracao_velha)
+    asyncio.run(of_routes._run_pluggy_sync_bg("item-velho"))
+
+    assert len(tentativas) == 1, f"stale_authorization não se retenta: {tentativas}"
+    assert [e for e in eventos if e[1] == "pluggy_sync_retry"] == []
+
+
 # ── RODADA 3: o lock não pode esperar para sempre nem abrir conexão sem teto ──
 
 def test_lock_wait_zero_nao_significa_espera_infinita(user_id, monkeypatch):

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -552,6 +552,64 @@ def test_reconexao_com_sync_falho_mostra_o_motivo_e_nao_o_generico(
     assert ui["detail"] == detalhe
 
 
+# ── 11d. RODADA CODEX 2 (#162, P2): reconexão NO MEIO de um sync ────────────
+# A fase de leitura roda FORA do lock (`pluggy_sync.py:263-300`, transações
+# paginadas por conta) e o carimbo de tentativa só vem DEPOIS dele (`:312`),
+# então `last_attempt_at` não serve de início de corrida. Enumerando sync ×
+# reconexão sobram quatro interposições, e só uma estava aberta:
+#
+#   R … início … fim   → fim > R, verde                        ok
+#   início … fim … R   → fim < R, não-verde                    ok (commit d1550ed)
+#   início … R … fim   → fim > R com dado da autorização VELHA  ← este teste
+#   início … R … falha → sem carimbo, o motivo fala            ok
+#
+# CONTROLE NEGATIVO: tirar o `reconnected_at_visto` do `mark_sync_result` em
+# `pluggy_sync.py` deixa o 1º teste vermelho.
+
+def test_reconexao_no_meio_do_sync_nao_carimba_sucesso(user_id, monkeypatch, relogio_fixo):
+    """O sync leu tudo sob a autorização antiga; o usuário reconectou enquanto
+    ele lia. O espelho FICA (o dado é real, só velho) — o que não pode é o
+    carimbo de sucesso, que devolveria "Atualizado" para a autorização nova."""
+    _conexao(user_id, "item-corrida")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-corrida"},
+                 contas=[_conta_pluggy("acc-corrida")], txs=[_tx_pluggy("tx-corrida")])
+
+    # A reconexão acontece DEPOIS de o sync ler a linha e no meio da leitura
+    # remota — que é onde ela cabe na vida real (a leitura leva minutos).
+    real = ps.list_pluggy_transactions
+    def reconecta_no_meio(account_id, api_key=None, **kw):
+        db.save_pluggy_open_finance_item(
+            user_id, {"id": "item-corrida", "status": "UPDATED",
+                      "connector": {"id": 612, "name": "Nubank"}})
+        return real(account_id, api_key, **kw)
+    monkeypatch.setattr(ps, "list_pluggy_transactions", reconecta_no_meio)
+
+    ps.sync_pluggy_item("item-corrida")
+
+    linha = _linha("item-corrida")
+    assert _espelho(linha["id"]) == (1, 1), "o espelho FICA: o dado é real, só velho"
+    assert linha["last_sync_at"] == ANTES, \
+        "sync que começou antes da reconexão não carimba sucesso depois dela"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] != "updated"
+
+
+def test_sync_sem_reconexao_no_meio_carimba_normalmente(user_id, monkeypatch, relogio_fixo):
+    """CONTROLE POSITIVO: a checagem otimista não pode recusar o caso comum —
+    ninguém reconectou, o `reconnected_at` continua o mesmo (aqui, NULL), e o
+    sucesso é carimbado. Sem isto, a guarda passaria num código que recusa tudo."""
+    _conexao(user_id, "item-sem-corrida")
+    assert _linha("item-sem-corrida")["reconnected_at"] is None
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-sem-corrida"},
+                 contas=[_conta_pluggy("acc-sc")], txs=[_tx_pluggy("tx-sc")])
+
+    assert ps.sync_pluggy_item("item-sem-corrida")["ok"] is True
+
+    assert _linha("item-sem-corrida")["last_sync_at"] == AGORA
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "updated"
+
+
 # ── 12. RODADA 3: a máquina de estados, evento por evento ───────────────────
 # A tabela vive no topo de `core/services/pluggy_health.py`. Estes testes são a
 # tabela executável — cada um é uma linha dela.

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -878,3 +878,80 @@ def test_run_velho_nao_sobrescreve_o_espelho_do_run_novo(user_id, monkeypatch, r
     assert res["ok"] is False and res["reason"] == "stale_authorization"
     ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
     assert ui["state"] == "updated", "e ele está dizendo a verdade: o espelho é o novo"
+
+
+# ── 11f. ONDA 3: a janela que a relectura NÃO fecha ─────────────────────────
+# Desde que o run de geração velha morre na relectura dentro do lock (11e),
+# NENHUM teste que passa por `sync_pluggy_item` chega mais ao
+# `reconnected_at_visto` — o controle negativo de 11d ("tirar o
+# `reconnected_at_visto` do call site") passou a não derrubar nada, ou seja, o
+# parâmetro ficaria sem cobertura nenhuma. Ele não é redundante: a rota de
+# reconexão (`/pluggy/item` → `save_pluggy_open_finance_item`) NÃO pega o
+# `pluggy_item_lock`, então uma reconexão ainda cabe entre a relectura e o
+# carimbo. Este teste ataca essa fresta direto no `mark_sync_result`.
+#
+# CONTROLE NEGATIVO: omitir o `reconnected_at_visto` na 1ª chamada deixa este
+# teste vermelho. CONTROLE POSITIVO: a 2ª chamada, com o valor que de fato está
+# no banco, carimba — sem ela a guarda passaria recusando todo carimbo.
+
+def test_reconexao_entre_a_relectura_e_o_carimbo_ainda_e_recusada(user_id, relogio_fixo):
+    conexao = _conexao(user_id, "item-janela")
+    visto = _linha("item-janela")["reconnected_at"]
+    assert visto is None, "a relectura de dentro do lock leu isto"
+
+    # …e só DEPOIS dela o usuário reconecta, fora do lock.
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-janela", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    assert _linha("item-janela")["reconnected_at"] == AGORA
+
+    db.mark_sync_result(conexao["id"], ok=True, status="ACTIVE", status_reason="",
+                        reconnected_at_visto=visto)
+    assert _linha("item-janela")["last_sync_at"] == ANTES, \
+        "carimbo com autorização velha não pode avançar o last_sync_at"
+
+    db.mark_sync_result(conexao["id"], ok=True, status="ACTIVE", status_reason="",
+                        reconnected_at_visto=AGORA)
+    assert _linha("item-janela")["last_sync_at"] == AGORA, \
+        "quem leu a autorização ATUAL carimba normalmente"
+
+
+def test_reconexao_dentro_do_lock_ainda_recusa_o_carimbo(user_id, monkeypatch, relogio_fixo):
+    """A mesma janela residual, agora pelo CAMINHO REAL — o call site em
+    `pluggy_sync`, não o `mark_sync_result` na mão.
+
+    Este teste existe por causa de uma medição: depois da relectura de 11e, a
+    sabotagem "tirar o `reconnected_at_visto` do call site" passou a deixar ZERO
+    vermelhos. O parâmetro continuava certo e continuava necessário, mas nada
+    mais o exercitava — e parâmetro sem controle negativo é parâmetro que a
+    próxima pessoa apaga achando que é resíduo.
+
+    A reconexão é interposta DENTRO do lock (o `import_open_finance_launches`
+    roda entre a escrita do espelho e o carimbo), que é exatamente a fresta que
+    a relectura não fecha: a rota `/pluggy/item` não pega o `pluggy_item_lock`.
+
+    CONTROLE NEGATIVO: tirar o `reconnected_at_visto` do call site deixa este
+    teste vermelho — e volta a dar 1, como na Onda 2."""
+    conexao = _conexao(user_id, "item-janela-lock")
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-janela-lock"},
+                 contas=[_conta_pluggy("acc-jl")], txs=[_tx_pluggy("tx-jl")])
+
+    real = ps.import_open_finance_launches
+
+    def reconecta_dentro_do_lock(uid, cid, *a, **kw):
+        db.save_pluggy_open_finance_item(
+            user_id, {"id": "item-janela-lock", "status": "UPDATED",
+                      "connector": {"id": 612, "name": "Nubank"}})
+        return real(uid, cid, *a, **kw)
+
+    monkeypatch.setattr(ps, "import_open_finance_launches", reconecta_dentro_do_lock)
+
+    res = ps.sync_pluggy_item("item-janela-lock")
+
+    assert res["ok"] is True, "passou pela relectura: na entrada do lock era a geração certa"
+    linha = _linha("item-janela-lock")
+    assert _espelho(conexao["id"]) == (1, 1), "o espelho FICA: o dado é real"
+    assert linha["last_sync_at"] == ANTES, \
+        "reconectaram entre a relectura e o carimbo — o carimbo não vale"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] != "updated"

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -55,6 +55,11 @@ class _Relogio(datetime):
 def relogio_fixo(monkeypatch):
     monkeypatch.setattr(ps, "datetime", _Relogio)
     monkeypatch.setattr("db.open_finance_state.datetime", _Relogio)
+    # `db.open_finance` também carimba hora nesta tabela (o `reconnected_at` do
+    # upsert). Deixá-lo no relógio real fazia a reconexão nascer DEPOIS de um
+    # sync com hora fixa, e a comparação `last_sync_at >= reconnected_at`
+    # invertia — armadilha para quem viesse depois.
+    monkeypatch.setattr("db.open_finance.datetime", _Relogio)
 
 
 def _conexao(user_id: int, item_id: str = "item-g1", status: str = "UPDATED") -> dict:
@@ -454,6 +459,55 @@ def test_reconexao_nao_devolve_o_verde_sozinha(user_id, monkeypatch, relogio_fix
     ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
     assert ui["state"] != "updated"
     assert ui["detail"] == "Ainda não sincronizou"
+
+
+# ── 11c. RODADA CODEX (#162, P2): reconexão de quem JÁ tinha sincronizado ────
+# O apontamento: o upsert preserva o `last_sync_at` velho de propósito, então uma
+# guarda que só pergunta "existe last_sync_at?" aceita o carimbo PRÉ-reconexão —
+# e o espelho velho volta à tela como "Atualizado" assim que o job de saúde mede
+# o item novo como saudável, antes de a nova autorização ter sincronizado nada.
+# O meu teste da rodada anterior escapava disso por acidente: ele zerava o
+# `last_sync_at`, que é justamente o caso fácil.
+# CONTROLE NEGATIVO: trocar `sem_sync` por `ultimo is None` em
+# `connection_ui_state` deixa o 1º teste vermelho.
+
+def test_reconexao_nao_reaproveita_o_sync_anterior(user_id, monkeypatch, relogio_fixo):
+    _conexao(user_id, "item-religa")                    # nasce com last_sync_at=ANTES
+    assert _linha("item-religa")["last_sync_at"] == ANTES
+
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-religa", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    linha = _linha("item-religa")
+    assert linha["last_sync_at"] == ANTES, "reconectar não pode MEXER no last_sync_at"
+    assert linha["reconnected_at"] is not None, "mas tem que registrar a reconexão"
+
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: {**ITEM_SAUDAVEL, "id": i})
+    ps.run_of_health_check()
+
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] != "updated", "espelho de antes da reconexão não é 'Atualizado'"
+    assert ui["detail"] == "Ainda não sincronizou"
+
+
+def test_sync_depois_da_reconexao_devolve_o_verde(user_id, monkeypatch, relogio_fixo):
+    """CONTROLE POSITIVO: sem ele a guarda podia recusar para sempre depois de
+    qualquer reconexão — que é pior que o bug."""
+    _conexao(user_id, "item-religa-ok")
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-religa-ok", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-religa-ok"},
+                 contas=[_conta_pluggy("acc-religa")], txs=[_tx_pluggy("tx-religa")])
+    assert ps.sync_pluggy_item("item-religa-ok")["ok"] is True
+
+    linha = _linha("item-religa-ok")
+    assert linha["last_sync_at"] == AGORA
+    assert linha["last_sync_at"] >= linha["reconnected_at"], "o sync é POSTERIOR à reconexão"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "updated", "sincronizou depois de reconectar: verde de novo"
 
 
 # ── 12. RODADA 3: a máquina de estados, evento por evento ───────────────────

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -357,6 +357,105 @@ def test_reconexao_saindo_de_deleted_continua_funcionando(user_id, monkeypatch, 
     assert _linha("item-volta")["last_sync_at"] == AGORA
 
 
+# ── 11b. ONDA 2: o job de saúde não pode pintar de verde o que nunca sincronizou
+# Caminho medido, todo em código deste repositório: o upsert zera `health`, o job
+# de saúde é elegível na hora (`health is null`), o `GET /items` volta saudável e
+# `mark_sync_result(ok=None)` grava o health SEM tocar em `last_sync_at`. O ramo
+# do health de `connection_ui_state` devolvia "updated" — a conexão nascia
+# "Tudo em dia!" com "Última sync: pendente" na linha de baixo e zero contas
+# espelhadas. Este teste é o par negativo+positivo da guarda: sem ela a 1ª metade
+# fica vermelha; se ela recusasse tudo, a 2ª metade ficaria.
+
+def test_recem_conectado_com_item_saudavel_nao_e_atualizado(user_id, monkeypatch, relogio_fixo):
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-fresco", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item",
+                        lambda i, k=None: {**ITEM_SAUDAVEL, "id": i})
+
+    ps.run_of_health_check()
+
+    linha = _linha("item-fresco")
+    assert linha["health"], "o job mediu a saúde (é o que torna o bug alcançável)"
+    assert linha["last_sync_at"] is None, "medir saúde não é sincronizar"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] != "updated", "item vivo na Pluggy não é espelho nosso"
+    assert ui["detail"] == "Ainda não sincronizou"
+
+    # CONTROLE POSITIVO: o sync real é que libera o verde.
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-fresco"},
+                 contas=[_conta_pluggy("acc-fresco")], txs=[_tx_pluggy("tx-fresco")])
+    assert ps.sync_pluggy_item("item-fresco")["ok"] is True
+
+    assert _linha("item-fresco")["last_sync_at"] == AGORA
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "updated", "sync concluído: agora sim"
+
+
+def test_conexao_nova_sem_contas_mostra_sem_dados_e_nao_o_generico(user_id, monkeypatch, relogio_fixo):
+    """O helper `_conexao()` carimba `last_sync_at=ANTES`, então TODO teste de
+    `no_accounts` da Onda 1 nasce do lado da tabela onde a guarda desta onda não
+    age — a categoria era inobservável pela suíte. Aqui a conexão é NOVA
+    (last_sync_at NULL, que é o que `mark_sync_result(ok=False)` deixa) e o
+    motivo concreto tem de sobreviver: "Sem dados", não "Ainda não sincronizou"."""
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-novo-vazio", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-novo-vazio"}, contas=[])
+
+    res = ps.sync_pluggy_item("item-novo-vazio")
+
+    assert res["ok"] is False and res["reason"] == "no_accounts"
+    linha = _linha("item-novo-vazio")
+    assert linha["last_sync_at"] is None, "sync sem espelho não é sucesso"
+    assert linha["status_reason"] == "no_accounts"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "no_accounts", "o motivo fala mais alto que a falta de sync"
+    assert ui["label"] == "Sem dados"
+
+
+def test_conexao_nova_com_leitura_pela_metade_continua_vermelha(user_id, monkeypatch, relogio_fixo):
+    """Irmão do de cima para `read_failed` — a pílula dele é `error` (vermelha) em
+    OF_PILL_CLASS, e virar `updating` a rebaixaria para âmbar numa conexão nova."""
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-novo-429", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-novo-429"}, contas=[])
+    monkeypatch.setattr(ps, "list_pluggy_investments", lambda i, k=None: (_ for _ in ()).throw(
+        PluggyApiError("rate limit", status_code=429)))
+
+    assert ps.sync_pluggy_item("item-novo-429")["reason"] == "read_failed"
+
+    linha = _linha("item-novo-429")
+    assert linha["last_sync_at"] is None
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "error_recoverable"
+    assert ui["detail"] == "Tentaremos de novo automaticamente"
+
+
+def test_reconexao_nao_devolve_o_verde_sozinha(user_id, monkeypatch, relogio_fixo):
+    """Reconectar zera `status_reason` e `health` (linha G) — o que ele NÃO pode
+    fazer é devolver o veredito verde antes de um sync novo."""
+    conexao = _conexao(user_id, "item-reconecta")
+    _set_estado(conexao["id"], status="ERROR", status_reason="item_missing",
+                last_sync_at=None)
+
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-reconecta", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(ps, "get_pluggy_item",
+                        lambda i, k=None: {**ITEM_SAUDAVEL, "id": i})
+    ps.run_of_health_check()
+
+    linha = _linha("item-reconecta")
+    assert linha["last_sync_at"] is None, "reconectar não é sincronizar"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] != "updated"
+    assert ui["detail"] == "Ainda não sincronizou"
+
+
 # ── 12. RODADA 3: a máquina de estados, evento por evento ───────────────────
 # A tabela vive no topo de `core/services/pluggy_health.py`. Estes testes são a
 # tabela executável — cada um é uma linha dela.

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -108,6 +108,17 @@ def _espelho(connection_id: int) -> tuple[int, int]:
     return contas, txs
 
 
+def _contas_espelhadas(connection_id: int) -> set[str]:
+    """Os IDs, não a contagem: sobrescrita por snapshot velho troca CONTEÚDO."""
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute(
+                "select provider_account_id from open_finance_accounts where connection_id=%s",
+                (connection_id,),
+            )
+            return {r["provider_account_id"] for r in (cur.fetchall() or [])}
+
+
 def _mock_pluggy(monkeypatch, *, item, contas=(), txs=()):
     """Mocka o mundo remoto. `item` pode ser um dict ou uma exceção a levantar."""
     def _get_item(item_id, api_key=None):
@@ -568,9 +579,11 @@ def test_reconexao_com_sync_falho_mostra_o_motivo_e_nao_o_generico(
 
 def test_reconexao_no_meio_do_sync_nao_carimba_sucesso(user_id, monkeypatch, relogio_fixo):
     """O sync leu tudo sob a autorização antiga; o usuário reconectou enquanto
-    ele lia. O espelho FICA (o dado é real, só velho) — o que não pode é o
-    carimbo de sucesso, que devolveria "Atualizado" para a autorização nova."""
-    _conexao(user_id, "item-corrida")
+    ele lia. O run inteiro é descartado: nem espelho, nem carimbo.
+
+    A versão anterior deste teste afirmava "o espelho FICA (o dado é real, só
+    velho)". Estava errado, e a rodada 5 do Codex mostrou por quê — ver 11e."""
+    conexao = _conexao(user_id, "item-corrida")
     _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-corrida"},
                  contas=[_conta_pluggy("acc-corrida")], txs=[_tx_pluggy("tx-corrida")])
 
@@ -584,10 +597,11 @@ def test_reconexao_no_meio_do_sync_nao_carimba_sucesso(user_id, monkeypatch, rel
         return real(account_id, api_key, **kw)
     monkeypatch.setattr(ps, "list_pluggy_transactions", reconecta_no_meio)
 
-    ps.sync_pluggy_item("item-corrida")
+    res = ps.sync_pluggy_item("item-corrida")
 
+    assert res["reason"] == "stale_authorization"
     linha = _linha("item-corrida")
-    assert _espelho(linha["id"]) == (1, 1), "o espelho FICA: o dado é real, só velho"
+    assert _espelho(conexao["id"]) == (0, 0), "run de geração velha não escreve espelho"
     assert linha["last_sync_at"] == ANTES, \
         "sync que começou antes da reconexão não carimba sucesso depois dela"
     ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
@@ -793,3 +807,74 @@ def test_sync_de_item_vazio_tira_o_error_e_diz_sem_dados(user_id, monkeypatch, r
     assert linha["last_sync_at"] == ANTES, "espelho vazio continua não sendo sucesso"
     ui = _ui("item-preso")
     assert (ui["state"], ui["label"]) == ("no_accounts", "Sem dados")
+
+
+# ── 11e. RODADA CODEX 3 (#162, P2): dois workers, o velho chega por último ───
+# O apontamento: o `reconnected_at_visto` recusa só o CARIMBO do run de geração
+# velha — as escritas do espelho acontecem TODAS antes dele, e já foram feitas
+# quando o carimbo é recusado. Com duas réplicas (o deploy do Railway sobe a
+# nova antes de derrubar a velha) a interposição é alcançável:
+#
+#   A começa … R (reconexão) … B começa … B escreve+carimba … A escreve
+#
+# B carimbou um `last_sync_at` legítimo, então `connection_ui_state` diz
+# "Atualizado" — e A, chegando depois, sobrescreve contas, investimentos,
+# `status` e `health` com o snapshot PRÉ-reconexão. Tela verde sobre espelho
+# velho, que é o defeito que esta onda existe para tirar. O `_INFLIGHT` não
+# cobre: é coalescing por PROCESSO.
+#
+# O conserto é reler o `reconnected_at` DENTRO do lock e abortar o run inteiro
+# antes de qualquer escrita (`_sync_pluggy_item_confirmado`).
+#
+# CONTROLE NEGATIVO (medido): remover a relectura + o early-return de
+# `stale_authorization` de `pluggy_sync.py` deixa 2 testes vermelhos — este e o
+# `test_reconexao_no_meio_do_sync_nao_carimba_sucesso` de 11d.
+# CONTROLE POSITIVO: `test_sync_sem_reconexao_no_meio_carimba_normalmente`
+# (11d) prova que o caminho comum — ninguém reconectou — continua escrevendo e
+# carimbando. Sem ele a guarda passaria num código que recusa todo sync.
+
+def test_run_velho_nao_sobrescreve_o_espelho_do_run_novo(user_id, monkeypatch, relogio_fixo):
+    """Worker A (pré-reconexão) chega no lock DEPOIS de o worker B ter
+    reconectado, espelhado e carimbado. A tem de morrer sem escrever."""
+    conexao = _conexao(user_id, "item-2workers")
+    # A leu a linha com `reconnected_at` NULL e traz o snapshot VELHO.
+    _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-2workers"},
+                 contas=[_conta_pluggy("acc-VELHA")], txs=[_tx_pluggy("tx-VELHA")])
+
+    real = ps.list_pluggy_transactions
+
+    def reconecta_e_deixa_o_worker_b_terminar(account_id, api_key=None, **kw):
+        # No meio da leitura remota de A: o usuário reconecta…
+        db.save_pluggy_open_finance_item(
+            user_id, {"id": "item-2workers", "status": "UPDATED",
+                      "connector": {"id": 612, "name": "Nubank"}})
+        nova = _linha("item-2workers")
+        assert nova["reconnected_at"] == AGORA
+        # …e o worker B, que começou DEPOIS dela, espelha e carimba primeiro.
+        db.save_open_finance_sync(nova["id"], [{
+            "provider_account_id": "acc-NOVA", "name": "Conta", "type": "BANK",
+            "currency": "BRL", "balance": 2000, "raw": {},
+            "transactions": [{"provider_transaction_id": "tx-NOVA",
+                              "description": "Mercado", "amount": -10,
+                              "transaction_date": AGORA.date(), "raw": {}}],
+        }])
+        db.mark_sync_result(nova["id"], ok=True, status="ACTIVE", status_reason="",
+                            health=ps.derive_item_health(ITEM_SAUDAVEL),
+                            reconnected_at_visto=nova["reconnected_at"])
+        return real(account_id, api_key, **kw)
+
+    monkeypatch.setattr(ps, "list_pluggy_transactions",
+                        reconecta_e_deixa_o_worker_b_terminar)
+
+    res = ps.sync_pluggy_item("item-2workers")
+
+    # O espelho PRIMEIRO: é a afirmação forte, e é ela que o controle negativo
+    # tem de derrubar. `ok is False` sozinho passaria num código que só recusa o
+    # retorno depois de já ter escrito.
+    assert _contas_espelhadas(conexao["id"]) == {"acc-NOVA"}, \
+        "o snapshot pré-reconexão não pode voltar ao espelho"
+    linha = _linha("item-2workers")
+    assert linha["last_sync_at"] == AGORA, "o carimbo legítimo do worker B fica"
+    assert res["ok"] is False and res["reason"] == "stale_authorization"
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == "updated", "e ele está dizendo a verdade: o espelho é o novo"

--- a/tests/test_of_connection_state.py
+++ b/tests/test_of_connection_state.py
@@ -491,13 +491,22 @@ def test_reconexao_nao_reaproveita_o_sync_anterior(user_id, monkeypatch, relogio
     assert ui["detail"] == "Ainda não sincronizou"
 
 
-def test_sync_depois_da_reconexao_devolve_o_verde(user_id, monkeypatch, relogio_fixo):
+@pytest.mark.parametrize("religado_em, rotulo", [(AGORA, "no mesmo instante"),
+                                                 (ANTES, "estritamente antes")])
+def test_sync_depois_da_reconexao_devolve_o_verde(user_id, monkeypatch, relogio_fixo,
+                                                  religado_em, rotulo):
     """CONTROLE POSITIVO: sem ele a guarda podia recusar para sempre depois de
-    qualquer reconexão — que é pior que o bug."""
+    qualquer reconexão — que é pior que o bug.
+
+    Os dois lados da borda: com o relógio congelado o upsert e o sync carimbam o
+    MESMO instante, que fixa o `<` (um `<=` no lugar dele ficaria vermelho); o
+    segundo caso empurra a reconexão para trás e é a forma comum em produção —
+    reconectou, sincronizou depois."""
     _conexao(user_id, "item-religa-ok")
     db.save_pluggy_open_finance_item(
         user_id, {"id": "item-religa-ok", "status": "UPDATED",
                   "connector": {"id": 612, "name": "Nubank"}})
+    _set_estado(_linha("item-religa-ok")["id"], reconnected_at=religado_em)
 
     _mock_pluggy(monkeypatch, item={**ITEM_SAUDAVEL, "id": "item-religa-ok"},
                  contas=[_conta_pluggy("acc-religa")], txs=[_tx_pluggy("tx-religa")])
@@ -505,9 +514,42 @@ def test_sync_depois_da_reconexao_devolve_o_verde(user_id, monkeypatch, relogio_
 
     linha = _linha("item-religa-ok")
     assert linha["last_sync_at"] == AGORA
-    assert linha["last_sync_at"] >= linha["reconnected_at"], "o sync é POSTERIOR à reconexão"
+    assert linha["last_sync_at"] >= linha["reconnected_at"], rotulo
     ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
-    assert ui["state"] == "updated", "sincronizou depois de reconectar: verde de novo"
+    assert ui["state"] == "updated", f"sincronizou depois de reconectar ({rotulo})"
+
+
+@pytest.mark.parametrize("motivo, esperado, detalhe", [
+    ("read_failed", "error_recoverable", "Tentaremos de novo automaticamente"),
+    ("no_accounts", "no_accounts", "O banco não devolveu contas nem investimentos"),
+])
+def test_reconexao_com_sync_falho_mostra_o_motivo_e_nao_o_generico(
+        user_id, relogio_fixo, motivo, esperado, detalhe):
+    """O ramo SEM health, que a rodada anterior quebrou: `_sync_item_contido`
+    (`pluggy_sync.py:574`) grava `mark_sync_result(ok=False, status=None,
+    status_reason=...)` SEM passar health, então `coalesce(null, health)` deixa
+    o health NULL e a conexão desce pelo ramo de baixo de `connection_ui_state`.
+
+    Reconectou + sync falhou = o motivo tem que falar. Dizer "Atualizando…" ali
+    é falso (ninguém está atualizando) e, no `read_failed`, rebaixa a pílula de
+    `error` (vermelha) para `pending` (âmbar) — ver OF_PILL_CLASS em
+    frontend/settings.html:2793.
+
+    CONTROLE NEGATIVO: trocar o `ultimo is None` do fim de `connection_ui_state`
+    por `sem_sync` deixa os dois casos vermelhos."""
+    conexao = _conexao(user_id, f"item-religa-{motivo}")   # last_sync_at = ANTES
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": f"item-religa-{motivo}", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+
+    db.mark_sync_result(conexao["id"], ok=False, status=None, status_reason=motivo)
+
+    linha = _linha(f"item-religa-{motivo}")
+    assert linha["health"] is None, "o handler do lote não mede saúde"
+    assert linha["last_sync_at"] == ANTES and linha["reconnected_at"] == AGORA
+    ui = db.get_open_finance_snapshot(user_id)["connections"][0]["ui"]
+    assert ui["state"] == esperado, "o motivo tem que sobreviver à reconexão"
+    assert ui["detail"] == detalhe
 
 
 # ── 12. RODADA 3: a máquina de estados, evento por evento ───────────────────

--- a/tests/test_of_health.py
+++ b/tests/test_of_health.py
@@ -207,6 +207,79 @@ def test_motivo_ok_ou_vazio_continua_verde():
         assert ui["state"] == "updated", motivo
 
 
+# ── ONDA 2: item saudável na Pluggy NÃO é sync concluído ────────────────────
+# O job de saúde só faz `GET /items` e grava `health` com `ok=None` — nunca toca
+# em `last_sync_at`. O ramo do health devolvia "updated" sem olhar o sucesso,
+# então um banco recém-conectado/reconectado ficava "Tudo em dia!" com
+# "Última sync: pendente" escrito na linha logo abaixo, na mesma tela.
+# CONTROLE NEGATIVO: tirar a branch `last_sync_at is None` do `out()` deixa os
+# dois primeiros testes deste bloco vermelhos.
+# CONTROLE POSITIVO: `test_tudo_atualizado_vira_updated` e
+# `test_motivo_ok_ou_vazio_continua_verde` (mesmo health, COM last_sync_at)
+# continuam verdes — a guarda não recusa quem sincronizou de verdade.
+
+_SAUDAVEL = {"status": "UPDATED", "executionStatus": "SUCCESS",
+             "statusDetail": {"accounts": {"isUpdated": True}}}
+
+
+def test_item_saudavel_sem_sync_nunca_e_atualizado():
+    health = derive_item_health(_SAUDAVEL, now=AGORA)
+    ui = connection_ui_state({"status": "ACTIVE", "health": health, "last_sync_at": None})
+    assert ui["state"] == "updating", "item vivo não é espelho fresco"
+    assert ui["detail"] == "Ainda não sincronizou"
+
+
+def test_nunca_sincronizou_vale_para_todo_status_local_verde():
+    """Reconexão: o upsert escreve o `status` que a Pluggy mandou e zera health.
+    Nenhum desses status pode virar verde enquanto não houver sync.
+
+    Só o ramo COM health entra aqui: sem health, as duas linhas que a Onda 1 já
+    tinha no fim da função respondem igual — incluir `h=None` seria um caso que
+    passa na base e não mede a guarda."""
+    health = derive_item_health(_SAUDAVEL, now=AGORA)
+    for status in ("ACTIVE", "UPDATED", "UPDATING", "LOGIN_ERROR"):
+        ui = connection_ui_state({"status": status, "health": health, "last_sync_at": None})
+        assert ui["state"] != "updated", status
+        assert ui["detail"] == "Ainda não sincronizou"
+
+
+def test_sem_sync_nao_rebaixa_estado_que_ja_era_pior():
+    """A guarda mira SÓ o verde: quem já tinha veredito próprio o mantém, senão
+    ela apagaria "Refaça a conexão" e "Reautorize o banco" de toda conexão nova."""
+    doente = derive_item_health({"status": "LOGIN_ERROR"}, now=AGORA)
+    casos = [
+        ({"status": "ERROR", "status_reason": "item_missing"}, "item_missing"),
+        ({"status": "PAUSED"}, "paused"),
+        ({"status": "DELETED"}, "removed"),
+        ({"status": "ACTIVE", "health": doente}, "needs_user_action"),
+        ({"status": "ERROR"}, "error_recoverable"),
+    ]
+    for linha, esperado in casos:
+        assert connection_ui_state({**linha, "last_sync_at": None})["state"] == esperado, linha
+
+
+def test_sem_sync_nao_engole_o_motivo_do_default_seguro():
+    """O caso que os 5 acima NÃO alcançam: todos eles saem da função antes de
+    chegar em `out("updated")`, então nenhum passa pelo ramo onde a guarda pode
+    causar dano. Aqui o item está SAUDÁVEL — o veredito seria verde — e é o
+    `status_reason` que tem de falar mais alto que "Ainda não sincronizou".
+
+    Alcançável: conexão nova cujo 1º sync não espelhou nada grava
+    `mark_sync_result(ok=False, status="ACTIVE", status_reason="no_accounts")`,
+    que NÃO carimba last_sync_at. Medido: com a guarda ANTES do default seguro,
+    os três casos abaixo viram "Atualizando…/Ainda não sincronizou" — "Sem dados"
+    some da tela e a pílula do `read_failed` cai de vermelho (error) para âmbar
+    (pending), ver OF_PILL_CLASS em frontend/settings.html."""
+    saudavel = derive_item_health(_SAUDAVEL, now=AGORA)
+    for motivo, esperado in (("no_accounts", "no_accounts"),
+                             ("read_failed", "error_recoverable"),
+                             ("motivo_que_ninguem_escreveu_ainda", "error_recoverable")):
+        ui = connection_ui_state({"status": "ACTIVE", "status_reason": motivo,
+                                  "health": saudavel, "last_sync_at": None})
+        assert ui["state"] == esperado, f"{motivo} perdeu o veredito por falta de sync"
+        assert ui["detail"] != "Ainda não sincronizou", motivo
+
+
 # ── RODADA 4: espelho vazio NÃO pode deixar o ERROR grudado ─────────────────
 # Defeito medido: `resolve_connection_state` só corrigia o `status` no ramo
 # `has_data=True`; com o espelho vazio devolvia `None` ("não mexe"), e `None` não

--- a/tests/test_of_refresh_schedule.py
+++ b/tests/test_of_refresh_schedule.py
@@ -483,6 +483,7 @@ def test_item_que_volta_limpa_status_e_motivo_juntos(user_id, monkeypatch):
 
     conexao = _conexao(user_id, "item-volta-inteiro")
     _espelha_uma_conta(conexao["id"])
+    _set_last_sync(conexao["id"])   # ONDA 2: voltar ao verde exige sync real no passado
     monkeypatch.setattr(ps, "create_pluggy_api_key", lambda: "k")
     monkeypatch.setattr(ps, "get_pluggy_item", lambda i, k=None: (_ for _ in ()).throw(
         PluggyApiError("sumiu", status_code=404)))


### PR DESCRIPTION
## O problema

O pedido da Onda 2 apontava o `save_pluggy_open_finance_item`, mas o [#161](https://github.com/JapaLcK/Bot_Financeiro/pull/161) já tinha tirado o carimbo de `last_sync_at` de lá — está no corpo daquele PR, item 2 de "O que o diff não conta". O **efeito** continuava alcançável por outro caminho, e é a pendência que o #161 registrou para esta onda: *"A pílula não olha a idade de `last_sync_at` … corrigir na Onda 2."*

O upsert zera `health`, o que torna a conexão elegível **na hora** para o job de saúde (`health is null`); o job faz `GET /items`, o item volta saudável, e `mark_sync_result(ok=None)` grava o health **sem tocar em `last_sync_at`** — corretamente, medir saúde não é sincronizar. `connection_ui_state` caía no ramo do health e devolvia `updated`.

Na tela: **"Tudo em dia!"** com **"Última sync: pendente"** renderizado na linha logo abaixo e zero contas espelhadas.

## O que muda

"Atualizado" passa a exigir sync real, e "real" quer dizer **concluído sob a autorização atual** — não basta ter sincronizado algum dia, e não basta o carimbo ser recente.

Quatro mecanismos, cada um vindo de um apontamento de revisão, não do plano original:

| | |
|---|---|
| a guarda | veredito verde exige `last_sync_at`, e **depois** do default seguro — nunca antes |
| `reconnected_at` | coluna aditiva: o upsert preserva o `last_sync_at` velho de propósito, então sem ela não dá para distinguir "sincronizou" de "sincronizou depois de reconectar" |
| relectura no lock | `reconnected_at` relido **dentro** do `pluggy_item_lock`, antes de qualquer escrita, abortando o run inteiro com `stale_authorization` |
| `reconnected_at_visto` | fecha a janela residual: a rota `/pluggy/item` não pega aquele lock, então uma reconexão ainda pode cair entre a relectura e o carimbo |

**A superfície cresceu ao longo da revisão** — começou em 16 linhas num arquivo e terminou em 5 arquivos mais uma migration aditiva. Quem revisar esperando o diff pequeno das primeiras rodadas vai levar susto; o crescimento está justificado abaixo, rodada por rodada.

## As cinco rodadas

| # | quem achou | o quê |
|---|---|---|
| 1 | auditoria interna | a guarda posta **antes** do default seguro apagava `no_accounts` e `read_failed` da tela; no `read_failed` a pílula caía de vermelho para âmbar |
| 2 | **Codex, P2** | reconexão de banco que já sincronizou reaproveitava o `last_sync_at` pré-reconexão |
| 3 | auditoria interna | o conserto da rodada 2 reabriu a perda de motivo, no ramo irmão — o early-return do fim entrega veredito sem passar pelo default seguro |
| 4 | **Codex, P2** | sync que começa antes da reconexão e termina depois carimba sucesso com dado da autorização velha |
| 5 | **Codex, P2** | o conserto da rodada 4 protegia só o **carimbo**: as escritas do espelho acontecem todas antes dele |

**Duas das cinco foram defeitos introduzidos consertando as anteriores**, e a 5ª foi consequência direta de a 4ª ter fechado metade do problema. Na rodada 4, seguindo o `CLAUDE.md` §4 (duas rodadas seguidas no mesmo subsistema = parar de remendar e enumerar), a máquina foi enumerada por escrito — mas para **um** sync. A rodada 5 é o que a enumeração de um sync não vê:

```
A começa (autorização velha) … R (reconexão) … B começa … B escreve+carimba … A escreve
```

B carimbou um `last_sync_at` legítimo; A chega depois, pega o lock e sobrescreve contas, investimentos, `status` e `health` com o snapshot pré-reconexão. Tela verde sobre espelho velho. O `_INFLIGHT` não cobre: é coalescing por processo, e o deploy do Railway sobe a réplica nova antes de derrubar a velha.

O conserto é reler a geração **dentro do lock** e matar o run antes de qualquer escrita.

## Enumeração

`connection_ui_state` varrido combinação a combinação contra a `bad3a22` (status × health × motivo × `last_sync_at` × `reconnected_at`):

| versão | divergências | **com perda de informação** |
|---|---|---|
| guarda antes do default seguro (rodada 1) | 20 / 504 | **12** |
| `sem_sync` alargado no early-return (rodada 3) | 900 / 22528 | **60** |
| **versão final** | **828 / 22528** | **0** |

As 828 são todas o mesmo padrão pretendido, `updated → updating / "Ainda não sincronizou"`.

## Controles negativos, todos medidos

| sabotagem | vermelhos |
|---|---|
| guarda do `out()` removida | 4 |
| guarda **antes** do default seguro | 3 (outros) |
| early-return alargado para `sem_sync` | 2 |
| relectura + `stale_authorization` removidos do lock | 2 |
| `reconnected_at_visto` fora do call site | 1 |
| `break` incondicional de volta no `_run_pluggy_sync_bg` | 2 |
| `stale_authorization` também retentado | 1 |
| `save` da reconexão movido para fora do lock | 1 |
| `reconnected_at` fora do `select` | 7 (um deles da Onda 1) |
| `updating: "active"` no `OF_PILL_CLASS` | 1 |
| PTR trocado por `loadData` | 1 |
| `new WebSocket(...)` em settings.html | 1 |
| regra `html.pb-app … #of-refresh-btn` removida | 1 |
| `\|\| standalone` removido do gate | 1 (só o caso da PWA) |

Mais uma matriz de 9 combinações de `(reconnected_at no banco × visto × ok)` contra o Postgres, confirmando que `ok=False`, `ok=None` e o sentinela mantêm o comportamento anterior.

Os testes de integração fogem do helper `_conexao()`, que carimba `last_sync_at` — é por isso que a suíte inteira era cega a esta categoria.

## Verificação

| | resultado |
|---|---|
| pytest na base (`bad3a22`) | 4926 passed, 1 xfailed, **0 failed** |
| pytest neste head (`8025a11`) | **4949 passed**, 1 xfailed, **0 failed** |
| comparação | por nome, zero vermelho dos dois lados |
| frontend | **67 pass / 0 fail** (Onda 1: 65) |

## A lacuna que a rodada 5 abriu, e como foi fechada

O conserto da rodada 5 **apagou um controle negativo sem que ninguém percebesse**. Desde que o run de geração velha morre na relectura dentro do lock, nenhum teste que passa por `sync_pluggy_item` chega mais ao `reconnected_at_visto`: a sabotagem "tirar o kwarg do call site" passou a deixar **74 passed, 0 failed**. Parâmetro certo, necessário e indefeso é o que a próxima pessoa apaga num cleanup.

Ele não é resíduo — a rota `/pluggy/item` não pega o `pluggy_item_lock`, então a fresta entre a relectura e o carimbo é real. Dois testes a defendem agora, um por camada: `test_reconexao_dentro_do_lock_ainda_recusa_o_carimbo` pelo caminho real (a reconexão é interposta no `import_open_finance_launches`, que roda entre a escrita do espelho e o carimbo) e `test_reconexao_entre_a_relectura_e_o_carimbo_ainda_e_recusada` na camada do banco, com controle positivo. A sabotagem do call site voltou a dar **1 vermelho**.

## Decisão deliberada

O `mark_sync_attempt` do `except` da fase de leitura fica **fora** do lock e antes da relectura, de propósito: ele só dispara quando a leitura remota estoura, e nesse caminho o run nunca chega à fase de escrita. Escreve `last_attempt_at`/`updated_at`/`last_refresh_origin` — "tentamos", não "deu certo".

## Migration

`add column if not exists reconnected_at timestamptz`, sem default e nullable → o Postgres não reescreve a tabela. `init_db()` roda no `lifespan` via `_startup_required`, e o uvicorn só aceita requisição depois que o lifespan cede. Deploy sobreposto é seguro: o código velho não seleciona a coluna. **Ressalva:** subir com `SKIP_INIT_DB=1` num banco sem a coluna faria as duas queries quentes estourarem `UndefinedColumn`.

## Limitações conhecidas

- **`item_status` fora das listas conhecidas continua tratado como saudável.** Varredura atrás de evidência de status externo desse tipo: não existe nenhuma no repositório. Adivinhar a taxonomia da Pluggy é pior que a lacuna. Mantida e documentada em `pluggy_health.py:243-251`.
- **São três mecanismos independentes** — relectura, `reconnected_at_visto` e `sem_sync`. Comentado no call site: simplificar um achando que o outro cobre reabre o buraco.
- ~~**Janela TOCTOU entre a relectura e a escrita do espelho**~~ — **fechada** (Codex, 4º P2 → 5º e 6º achados, ambos P1). A relectura dentro do lock não era atômica com as escritas que vinham depois dela. O que a tornou P1 não foi o espelho velho: o run daquela fresta roda `import_open_finance_launches`/`import_open_finance_credit`, criando **lançamento e compra de cartão** que nenhum sync posterior remove — o upsert só acrescenta. O caso concreto é a conta que o usuário **desmarcou ao reconectar**: sai do consentimento novo e segue alimentando timeline, "sobrou" e budgets. Fechada na origem em `8025a11`: a reconexão passou a gravar **dentro** do `pluggy_item_lock`, o mesmo da fase de escrita do sync — os dois viraram mutuamente exclusivos, e o `pg_advisory_lock` em conexão dedicada serializa entre réplicas, não só entre threads. Em `df0da07` caiu o último resíduo: sem o lock a reconexão **não grava** (a primeira versão gravava assim mesmo, que era exatamente a escrita que o lock existe para serializar). Ela retenta e, esgotado, devolve **503**.
- **A reconexão pode falhar com 503.** Se o lock do item continuar ocupado depois de duas tentativas (cada uma esperando até `OF_SYNC_LOCK_WAIT_MS`, 15s), a rota devolve 503 com "tente de novo em alguns segundos" e loga `of_reconnect_lock_timeout` em nível `error`. **O usuário vê o erro** — é limitação de verdade, não detalhe. A troca é deliberada: 503 é recuperável (o item continua na Pluggy e o mesmo POST reaproveita), lançamento fantasma não é. A frequência real em produção é desconhecida e não dá para estimar daqui; o jeito de saber é contar `of_reconnect_lock_timeout` nos logs depois do deploy.
- **`reconnected_at` e `last_sync_at` vêm do relógio do Python**, não do `now()` do banco.
- **`no_accounts` + `last_sync_at` NULL responde diferente com e sem health medido.** Medido: é assim na base. Preservar a incoerência foi deliberado.

## NÃO verificado

- **Gesto real de puxar a tela, WKWebView e PWA instalada**: só no aparelho, depois do build. O teste chama `window.PBRefresh()` direto e prova o roteamento por aba, não que o gesto chega lá. O caso da PWA usa `navigator.standalone`, o sinal real do gate no iOS; a porta `matchMedia("(display-mode: standalone)")` não é alcançável no Chromium **nem por CDP** — medido: `matches: false` nas duas formas.
- **Pluggy real / sandbox**: exige credenciais. Todo o comportamento remoto está mockado; produção não foi consultada.
- **Cor da pílula no aparelho**: medida classe CSS (`pending` vs `active`), não pixel em iOS.
- **`SKIP_INIT_DB=1` em deploy real.**

## Fora do escopo, registrado

`POST /open-finance/{user_id}/mock-connect` (`frontend/routes/open_finance.py:756`) tem apenas `authorize_dashboard_access` — nenhum gate de ambiente, nenhum caller em `frontend/`. Cria conexão bancária falsa com saldos e transações inventadas, viva em produção para qualquer usuário logado. PR próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



