### PR TITLE
Forma legada do `tipo` também conta na tendência mensal

### DIFF
--- a/db/accounts.py
+++ b/db/accounts.py
@@ -10,7 +10,9 @@ from psycopg.types.json import Json, Jsonb
 import db_support as _db_support
 from utils_date import _tz, day_tz
 
-from .connection import get_conn, cat_key_sql, TIPO_DESPESA_SQL
+from .connection import (
+    get_conn, cat_key_sql, TIPO_CANON_SQL, TIPO_DESPESA_SQL, TIPO_RECEITA_SQL,
+)
 from .users import ensure_user, ensure_user_tx
 
 
@@ -382,14 +384,19 @@ def get_spending_trend(user_id: int, months: int = 6) -> list[dict]:
                        sum(case when tipo = 'despesa' then valor else 0 end) as despesa,
                        sum(case when tipo = 'receita' then valor else 0 end) as receita
                 from (
+                    -- `TIPO_CANON_SQL` colapsa a forma legada na moderna AQUI, na
+                    -- perna de launches, para o `case when tipo = 'despesa'` de
+                    -- fora continuar valendo sem virar uma segunda lista de
+                    -- aliases. Sem isto, 'saida'/'entrada' eram filtradas fora e
+                    -- a tendência da IA divergia do dashboard no mesmo mês.
                     select extract(year from criado_em at time zone %s)::int as y,
                            extract(month from criado_em at time zone %s)::int as m,
-                           tipo, valor
+                           {TIPO_CANON_SQL} as tipo, valor
                     from launches
                     where user_id = %s
                       and criado_em >= %s
                       and is_internal_movement = false
-                      and tipo in ('despesa', 'receita')
+                      and ({TIPO_DESPESA_SQL} or {TIPO_RECEITA_SQL})
                     union all
                     select extract(year from purchased_at)::int as y,
                            extract(month from purchased_at)::int as m,

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -300,16 +300,19 @@ def compute_evolution(user_id: int, months: int = 6) -> list[dict]:
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 SELECT mes, tipo, SUM(valor) AS total
                 FROM (
+                  -- mesma canonização do `compute_kpis`: o front busca os dois
+                  -- endpoints para a MESMA tela, então a receita legada não pode
+                  -- entrar no KPI de income e ficar fora da barra do mês.
                   SELECT TO_CHAR(DATE_TRUNC('month', criado_em), 'YYYY-MM') AS mes,
-                         tipo, valor
+                         {TIPO_CANON_SQL} AS tipo, valor
                   FROM launches
                   WHERE user_id = %s
                     AND criado_em >= %s AND criado_em < %s
                     AND is_internal_movement = false
-                    AND tipo IN ('receita', 'despesa', 'saida')
+                    AND ({TIPO_DESPESA_SQL} OR {TIPO_RECEITA_SQL})
                   UNION ALL
                   SELECT TO_CHAR(DATE_TRUNC('month', b.period_end), 'YYYY-MM') AS mes,
                          'despesa' AS tipo, ct.valor
@@ -341,9 +344,10 @@ def compute_evolution(user_id: int, months: int = 6) -> list[dict]:
             continue
         t = (r["tipo"] or "").strip().lower()
         v = _to_float(r["total"])
+        # o SQL já canonizou (`TIPO_CANON_SQL`): só as duas formas modernas
         if t == "receita":
             buckets[k]["income"] += v
-        elif t in ("despesa", "saida"):
+        elif t == "despesa":
             buckets[k]["expense"] += v
 
     for b in buckets.values():
@@ -620,18 +624,21 @@ def compute_history_quick_stats(
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 SELECT
-                  SUM(CASE WHEN tipo = 'receita'                      THEN 1 ELSE 0 END) AS receitas,
-                  SUM(CASE WHEN tipo IN ('despesa', 'saida', 'credito') THEN 1 ELSE 0 END) AS despesas,
+                  SUM(CASE WHEN tipo = 'receita'                THEN 1 ELSE 0 END) AS receitas,
+                  SUM(CASE WHEN tipo IN ('despesa', 'credito')  THEN 1 ELSE 0 END) AS despesas,
                   COUNT(*) AS total
                 FROM (
-                  SELECT tipo
+                  -- canonizado na perna de launches: a linha legada 'entrada'
+                  -- ficava fora do filtro e não era contada NEM como receita NEM
+                  -- no total, então a contagem da tela vinha menor que a lista.
+                  SELECT {TIPO_CANON_SQL} AS tipo
                   FROM launches
                   WHERE user_id = %s
                     AND criado_em >= %s AND criado_em < %s
                     AND is_internal_movement = false
-                    AND tipo IN ('despesa', 'receita', 'saida')
+                    AND ({TIPO_DESPESA_SQL} OR {TIPO_RECEITA_SQL})
                   UNION ALL
                   SELECT 'credito' AS tipo
                   FROM credit_transactions ct
@@ -759,12 +766,16 @@ def list_history(
         if uncategorized:
             clauses.append("(categoria IS NULL OR categoria = '')")
         if tipo_norm in ("despesa", "receita"):
-            clauses.append("tipo = %s")
-            launches_params.append(tipo_norm)
+            # a forma legada junto: filtrar `tipo = 'receita'` cru deixava a
+            # linha 'entrada' invisível no histórico, que é a pior classe de
+            # erro num caminho de dinheiro (mesma regra de `_TIPO_ALIASES`).
+            clauses.append(
+                TIPO_DESPESA_SQL if tipo_norm == "despesa" else TIPO_RECEITA_SQL
+            )
         else:
-            # 'all': mantém só despesa/receita (resto é movimentação interna,
-            # criar_caixinha, etc.)
-            clauses.append("tipo IN ('despesa', 'receita', 'saida')")
+            # 'all': mantém só despesa/receita nas duas grafias (resto é
+            # movimentação interna, criar_caixinha, etc.)
+            clauses.append(f"({TIPO_DESPESA_SQL} OR {TIPO_RECEITA_SQL})")
         clauses.append("is_internal_movement = false")
         search_sql, search_params = _search_clause("")
         if search_sql:

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -1104,17 +1104,28 @@ def _compute_salary_burn(user_id: int, from_date: date, to_date: date) -> dict:
     Considera só meses fechados (exclui o corrente). Se a janela só tem o
     mês corrente, retorna ok=false.
     """
-    # Receita média mensal (todos os meses na janela, incluindo corrente)
+    # Receita média mensal (todos os meses na janela, incluindo corrente).
+    # O SQL abaixo é f-string por causa do `TIPO_RECEITA_SQL` — e por isso não
+    # pode conter o sinal de porcentagem nem dentro de comentário `--`: o psycopg
+    # o lê como início de placeholder e a query estoura antes de rodar
+    # ("incomplete placeholder", medido). Escreva "oitenta por cento" por extenso.
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 SELECT date_part('year', criado_em)::int AS y,
                        date_part('month', criado_em)::int AS m,
                        SUM(valor)::float AS total
                 FROM launches
                 WHERE user_id=%s
-                  AND tipo = 'receita'
+                  -- a query de despesa logo abaixo já aceita ('despesa','saida');
+                  -- esta fixava a receita moderna, então a linha legada 'entrada'
+                  -- não entrava no `expected_income`. O efeito é assimétrico e
+                  -- silencioso: a renda esperada sai MENOR, o alvo de oitenta por
+                  -- cento cai junto, e o "dia em que você queima o salário" é
+                  -- reportado mais cedo do que a realidade — ou `ok=false` por
+                  -- falta de receita.
+                  AND {TIPO_RECEITA_SQL}
                   AND is_internal_movement = false
                   AND criado_em >= %s AND criado_em < %s
                 GROUP BY 1, 2

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -26,7 +26,10 @@ from typing import Any
 # (`user_categories.name`, normalizado por `CAT_META_SQL` com a mesma
 # expressão). Trocar só um lado quebraria o join; e o rótulo daquele grupo é
 # a grafia crua do lançamento, não a chave — mudar isso é outro assunto.
-from .connection import get_conn, cat_norm_sql, cat_key_sql, CAT_META_SQL
+from .connection import (
+    get_conn, cat_norm_sql, cat_key_sql, CAT_META_SQL,
+    TIPO_CANON_SQL, TIPO_DESPESA_SQL, TIPO_RECEITA_SQL,
+)
 
 # Casamento de categoria pela `cat_key_sql` (fonte única, db/connection.py). Isto
 # aqui já colapsava o vazio por conta própria, mas sob o rótulo `''` — então a
@@ -110,15 +113,20 @@ def compute_kpis(user_id: int, from_date: date, to_date: date) -> dict:
         with get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    """
+                    f"""
                     SELECT tipo, SUM(valor) AS total, SUM(cnt) AS count
                     FROM (
-                      SELECT tipo, valor, 1 AS cnt
+                      -- `TIPO_CANON_SQL` colapsa 'saida'/'entrada' na forma
+                      -- moderna já no SQL: o agregador Python abaixo passa a ver
+                      -- só 'despesa'/'receita' e não precisa repetir a lista de
+                      -- aliases. A versão anterior aceitava 'saida' e esquecia
+                      -- 'entrada' — a receita legada sumia do income.
+                      SELECT {TIPO_CANON_SQL} AS tipo, valor, 1 AS cnt
                       FROM launches
                       WHERE user_id = %s
                         AND criado_em >= %s AND criado_em < %s
                         AND is_internal_movement = false
-                        AND tipo IN ('receita', 'despesa', 'saida')
+                        AND ({TIPO_DESPESA_SQL} OR {TIPO_RECEITA_SQL})
                       UNION ALL
                       SELECT 'despesa' AS tipo, ct.valor, 1 AS cnt
                       FROM credit_transactions ct
@@ -141,9 +149,12 @@ def compute_kpis(user_id: int, from_date: date, to_date: date) -> dict:
             total = _to_float(r["total"])
             cnt = int(r["count"] or 0)
             count += cnt
+            # o SQL já canonizou o tipo (`TIPO_CANON_SQL`): aqui só existem as
+            # duas formas modernas, e repetir os aliases seria a terceira cópia
+            # da mesma regra.
             if t == "receita":
                 income += total
-            elif t in ("despesa", "saida"):
+            elif t == "despesa":
                 expense += total
 
         net = income - expense

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -782,7 +782,13 @@ def list_history(
             clauses.append(search_sql)
             launches_params.extend(search_params)
         launches_sql = f"""
-          SELECT id, tipo, valor, alvo, nota, categoria, criado_em,
+          -- `TIPO_CANON_SQL` também na PROJEÇÃO, não só no filtro: o front
+          -- decide a cor, o sinal e o ícone com `i.tipo === "receita"` estrito
+          -- (`_historyRowHTML`, frontend/dashboard.js:5932 — outras partes do
+          -- mesmo arquivo tratam 'entrada', esta não). Devolver o tipo cru fazia
+          -- a receita legada, agora visível, ser desenhada em vermelho com sinal
+          -- de menos e ícone de despesa — inclusive sob o filtro "Receitas".
+          SELECT id, {TIPO_CANON_SQL} AS tipo, valor, alvo, nota, categoria, criado_em,
                  -- launches não tem parcelamento (isso só existe em
                  -- credit_transactions); NULL mantém as colunas do UNION.
                  NULL::int AS installments_total, NULL::int AS installment_no,

--- a/db/insights.py
+++ b/db/insights.py
@@ -35,7 +35,7 @@ from typing import Any
 from utils_text import fmt_brl
 
 from .budgets import get_budgets_status_for_month
-from .connection import get_conn
+from .connection import TIPO_DESPESA_SQL, TIPO_RECEITA_SQL, get_conn
 from .recurring import list_recurring_expenses
 from .users import ensure_user
 
@@ -142,7 +142,7 @@ def _detect_category_spike(user_id: int) -> list[dict[str, Any]]:
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 with spent_per_month as (
                   select lower(categoria) as cat,
                          date_part('year',  criado_em)::int as y,
@@ -150,7 +150,7 @@ def _detect_category_spike(user_id: int) -> list[dict[str, Any]]:
                          sum(valor)::float as total
                   from launches
                   where user_id=%s
-                    and tipo in ('despesa', 'saida')
+                    and {TIPO_DESPESA_SQL}
                     and is_internal_movement = false
                     and categoria is not null
                     and criado_em >= make_date(%s, %s, 1) - interval '4 months'
@@ -278,8 +278,10 @@ def _detect_recurring_increase(user_id: int) -> list[dict[str, Any]]:
 def _detect_salary_burn_fast(user_id: int) -> list[dict[str, Any]]:
     """Despesas do mês > % do mês decorrido + 15pp vs receita esperada.
 
-    Usa média de receita dos 3 meses anteriores como proxy de "salário esperado"
-    (não dá pra confiar só na receita do mês corrente — pode ainda não ter caído).
+    Usa a média de receita dos meses anteriores presentes na janela de 4 meses da
+    query como proxy de "salário esperado" (não dá pra confiar só na receita do
+    mês corrente — pode ainda não ter caído). Ver a nota na query abaixo: o
+    `_prev_n_months(today, 3)` não recorta essa janela.
 
     Ex: dia 10 (33% do mês), gastou 50% da receita esperada → alerta.
     """
@@ -294,17 +296,24 @@ def _detect_salary_burn_fast(user_id: int) -> list[dict[str, Any]]:
     if len(prev_months) < 2:
         return []
 
-    # Receita média mensal dos 3 meses anteriores
+    # Receita média mensal dos meses anteriores presentes na janela: a query pega
+    # 4 meses (`- interval '4 months'` até o 1º do mês corrente), não 3. O
+    # `_prev_n_months(today, 3)` acima só alimenta o guard `len < 2`, que com n=3
+    # nunca dispara — divergência PREEXISTENTE, não mexida neste PR (mudar a
+    # janela mudaria número em produção).
+    # A forma legada 'entrada' conta: sem ela o `expected_income` sai menor (ou os
+    # meses reconhecidos caem abaixo de 2 e o alerta some), enquanto o endpoint de
+    # patterns reporta a renda certa — o mesmo painel, dois números.
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 select date_part('year', criado_em)::int as y,
                        date_part('month', criado_em)::int as m,
                        sum(valor)::float as total
                 from launches
                 where user_id=%s
-                  and tipo = 'receita'
+                  and {TIPO_RECEITA_SQL}
                   and is_internal_movement = false
                   and criado_em >= make_date(%s, %s, 1) - interval '4 months'
                   and criado_em <  make_date(%s, %s, 1)
@@ -329,12 +338,12 @@ def _detect_salary_burn_fast(user_id: int) -> list[dict[str, Any]]:
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 select
                   coalesce((
                     select sum(valor) from launches
                     where user_id=%s
-                      and tipo in ('despesa', 'saida')
+                      and {TIPO_DESPESA_SQL}
                       and is_internal_movement = false
                       and date_part('year',  criado_em) = %s
                       and date_part('month', criado_em) = %s

--- a/tests/test_categoria_vazia_donut_e_lista.py
+++ b/tests/test_categoria_vazia_donut_e_lista.py
@@ -20,18 +20,54 @@ de sempre; ele passa com o conserto e passaria sem ele. Está aqui porque a
 mudança RESTRINGE o casamento, e uma chave que só achasse o vazio — ou que
 varresse a linha sem categoria para dentro de 'alimentação' — seria pior que o
 bug original.
+
+DUAS ÂNCORAS DE DATA, de propósito — a escolha é da produção, não do teste.
+Dois leitores derivam ano/mês de `date.today()` por DENTRO, sem parâmetro de
+janela: `sum_spent_in_category_this_month` (db/budgets.py:200) e
+`get_budgets_status_for_month(month=None)` (via `_parse_ym`, :300-302). Os
+outros caminhos daqui caem em `month_range_today()` → `today_tz()` — é o que
+`spend_query` e `_responder_categoria` (core/handlers/launches.py:924, :851)
+usam quando não há período no texto. Nesses dois primeiros a chamada é SEM
+janela de propósito, para exercitar o caminho default da produção:
+`sum_spent_in_category_this_month(user_id, categoria)` não tem parâmetro de
+janela nenhum, e `get_budgets_status_for_month(user_id, month=None)` tem
+(`month="YYYY-MM"` realinha o mês) e o teste não o usa. Nos dois, o único ponto
+que o teste alcança é a data de GRAVAÇÃO, e por isso eles são gravados em
+`date.today()`; os outros leitores aceitam janela,
+o teste a controla (o donut por ano/mês, os de período pelo `resolve_window`) e a
+gravação deles vai em `today_tz()`. As duas âncoras divergem sempre que o fuso
+do APP ≠ o fuso do PROCESSO: `date.today()` não conhece `REPORT_TIMEZONE`, então
+definir só ela já separa as duas (medido, `REPORT_TIMEZONE=Etc/GMT+12` às
+08:52 UTC de 2026-08-28: `date.today()=2026-08-28`, `today_tz()=2026-08-27`), e o
+CI, que não define nenhuma das duas, roda em UTC contra o default
+America/Sao_Paulo de `today_tz()` — já `TZ` sozinha NÃO separa, porque o `_tz()`
+(utils_date.py:13) a lê no fallback e move as duas pontas juntas.
+
+Divergir como DATA não basta para o teste ficar vermelho: os dois leitores
+ancorados em `date.today()` filtram por `date_part('year'/'month')`, então
+divergência de DIA dentro do mesmo mês não muda o resultado — só a que cruza
+virada de MÊS ou de ANO derruba. Em `tests/test_tipo_legado_na_tendencia.py` é o
+contrário, e a frase de lá ("não precisa da virada do mês") vale só lá: as
+janelas daquele arquivo são diárias, e qualquer divergência basta.
+
+Quem monta janela AQUI monta com fim INCLUSIVO (`db/budgets.py:259-260`,
+`db/accounts.py:467-468`, `db/accounts.py:645,658`). Por isso o `resolve_window`
+entra com `- timedelta(days=1)`: ele devolve fim EXCLUSIVO, e entregá-lo cru
+alargaria a janela em um dia. É o oposto de `tests/test_tipo_legado_na_tendencia.py`,
+onde o fim vai para leitores exclusivos e o `resolve_window` entra inteiro.
 """
 import asyncio
-from datetime import datetime, time
+from datetime import date, datetime, time, timedelta
 
 import db
 from core.handlers import launches as h
+from db.analytics import resolve_window
 from db.connection import CAT_VAZIA_LABEL
 from utils_date import month_range_today, today_tz
 import frontend.finance_bot_websocket_custom as dashboard
 
 
-def _grava(user_id, valor, categoria, tipo="despesa", interna=False):
+def _grava(user_id, valor, categoria, tipo="despesa", interna=False, dia=None):
     """`add_launch_and_update_balance` sempre grava alguma categoria; a linha sem
     categoria entra por SQL, que é como o importador do Open Finance a cria."""
     with db.get_conn() as conn, conn.cursor() as cur:
@@ -39,13 +75,13 @@ def _grava(user_id, valor, categoria, tipo="despesa", interna=False):
             "insert into launches (user_id, tipo, valor, categoria, nota, "
             "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,%s)",
             (user_id, tipo, valor, categoria, "importado",
-             datetime.combine(today_tz(), time(10, 0)), interna),
+             datetime.combine(dia or today_tz(), time(10, 0)), interna),
         )
         conn.commit()
 
 
-def _donut(user_id):
-    hoje = today_tz()
+def _donut(user_id, dia=None):
+    hoje = dia or today_tz()
     d = asyncio.run(dashboard.get_financial_data(user_id, year=hoje.year, month=hoje.month))
     return {c["categoria"]: c["total"] for c in d["expense_categories"]}
 
@@ -152,9 +188,13 @@ def test_orcamento_sem_categoria_ve_o_mesmo_gasto_do_donut(pro_user_id):
     `cat_norm_sql` → o assert do `this_month` fica vermelho.
     """
     db.upsert_budget(pro_user_id, CAT_VAZIA_LABEL, 500)
-    _grava(pro_user_id, 100, "")
+    # `date.today()`: `sum_spent_in_category_this_month` não tem parâmetro de
+    # janela, e `get_budgets_status_for_month` tem (`month`) mas é chamada sem
+    # ele de propósito — as duas fixam o mês por dentro, e o donut é o leitor
+    # daqui que dá para realinhar com elas.
+    _grava(pro_user_id, 100, "", dia=date.today())
 
-    barras = _donut(pro_user_id)
+    barras = _donut(pro_user_id, dia=date.today())
     assert barras == {CAT_VAZIA_LABEL: 100.0}, barras
 
     assert db.sum_spent_in_category_this_month(pro_user_id, CAT_VAZIA_LABEL) == 100.0
@@ -207,13 +247,18 @@ def test_despesa_moderna_responde_exatamente_o_mesmo(pro_user_id):
     devolveram; um alias que mudasse o número da despesa moderna seria pior que
     o descasamento que ele conserta.
     """
+    # `date.today()` nas TRÊS: o último assert é `sum_spent_in_category_this_month`,
+    # que fixa o mês por dentro. Inclusive a interna — fora da janela, o
+    # `== 45.0` passaria sem provar o filtro `is_internal_movement`.
     db.add_launch_and_update_balance(
         pro_user_id, "despesa", 45, "compra", None, categoria="mercado",
-        criado_em=datetime.combine(today_tz(), time(12, 0)),
+        criado_em=datetime.combine(date.today(), time(12, 0)),
     )
-    _grava(pro_user_id, 30, None)                     # moderna, sem categoria
-    _grava(pro_user_id, 25, "mercado", interna=True)  # interna: fora do gasto
-    start, end = month_range_today()
+    _grava(pro_user_id, 30, None, dia=date.today())   # moderna, sem categoria
+    _grava(pro_user_id, 25, "mercado", interna=True,  # interna: fora do gasto
+           dia=date.today())
+    start, end_excl = resolve_window(months=1)  # fim EXCLUSIVO
+    end = end_excl - timedelta(days=1)          # os leitores daqui querem INCLUSIVO
 
     assert db.sum_spent_in_category_period(pro_user_id, "mercado", start, end) == 45.0
     assert db.sum_spent_in_category_period(pro_user_id, CAT_VAZIA_LABEL, start, end) == 30.0

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -1,0 +1,134 @@
+"""A forma legada do `tipo` também conta nos leitores de TENDÊNCIA mensal.
+
+Irmão do `tests/test_tipo_legado_no_dashboard.py`, encaminhado do #158 para cá
+por verificabilidade (`CLAUDE.md` §4): lá o conserto foi nos números do MÊS do
+dashboard, aqui são os três leitores que respondem a mesma pergunta por outras
+telas —
+
+| leitor                          | onde aparece        | lia antes                    |
+|---------------------------------|---------------------|------------------------------|
+| `get_spending_trend`            | tool de tendência   | só a moderna, as duas fora   |
+|                                 | da IA               |                              |
+| `compute_kpis` (SQL)            | KPI da Análise      | 'saida' sim, 'entrada' NÃO   |
+| `compute_kpis` (Python)         | o mesmo             | espelhava a assimetria       |
+
+O `entrada` faltando nos dois últimos é o pior dos três: a receita legada some
+do income, o `net` sobe, e a `savings_rate` (net/income) sai errada nos DOIS
+sentidos ao mesmo tempo.
+
+Conserto: `TIPO_CANON_SQL` colapsa a forma legada na moderna no SQL, e o Python
+deixa de repetir a lista de aliases — uma regra, um lugar (§0.7).
+
+Medido na produção (Railway) em 27/08/2026 21:50 UTC: `count(*) filter (where
+tipo='saida')` = 0 e o mesmo para 'entrada' em `launches`. Nenhum número de
+usuário muda hoje; isto fecha a classe, não apaga um incêndio.
+
+Controle NEGATIVO: volte `{TIPO_CANON_SQL} as tipo` + o filtro para
+`tipo, valor` + `and tipo in ('despesa','receita')` em `get_spending_trend`
+(db/accounts.py), ou o par equivalente em `compute_kpis` (db/analytics.py) —
+`test_tendencia_conta_as_duas_formas` e `test_kpis_contam_as_duas_formas` ficam
+vermelhos, cada um pelo seu lado.
+Controle POSITIVO: `test_base_moderna_responde_o_mesmo_de_sempre` — a base de
+100% da produção hoje, que não pode ter mudado de número.
+"""
+from datetime import datetime, time, timedelta
+
+import db
+from db.analytics import compute_kpis
+from utils_date import month_range_today, today_tz
+
+
+def _grava(user_id, tipo, valor, categoria="mercado", dia=None):
+    """A forma legada não tem escritor (nem deve ter): entra por SQL, que é como
+    ela existe numa base de verdade."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "insert into launches (user_id, tipo, valor, categoria, nota, "
+            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,false)",
+            (user_id, tipo, valor, categoria, "legado",
+             datetime.combine(dia or today_tz(), time(10, 0))),
+        )
+        conn.commit()
+
+
+def _mes_corrente(trend):
+    hoje = today_tz()
+    linha = [t for t in trend if t["year"] == hoje.year and t["month"] == hoje.month]
+    assert linha, trend
+    return linha[0]
+
+
+# ── get_spending_trend: a tool de tendência da IA ──────────────────────────
+
+def test_tendencia_conta_as_duas_formas(pro_user_id):
+    _grava(pro_user_id, "despesa", 50)
+    _grava(pro_user_id, "saida", 100)      # despesa legada
+    _grava(pro_user_id, "receita", 200, categoria="rendimentos")
+    _grava(pro_user_id, "entrada", 300, categoria="rendimentos")   # receita legada
+
+    linha = _mes_corrente(db.get_spending_trend(pro_user_id, months=1))
+    assert linha["despesa"] == 150.0, linha
+    assert linha["receita"] == 500.0, linha
+
+
+# ── compute_kpis: o SQL e o agregador Python da Análise ────────────────────
+
+def test_kpis_contam_as_duas_formas(pro_user_id):
+    """`entrada` era a que faltava: sem ela o income cai, o net sobe e a
+    savings_rate mente nos dois sentidos de uma vez."""
+    _grava(pro_user_id, "despesa", 50)
+    _grava(pro_user_id, "saida", 100)
+    _grava(pro_user_id, "receita", 200, categoria="rendimentos")
+    _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
+
+    start, end = month_range_today()
+    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+
+    assert k["total_expense"] == 150.0, k
+    assert k["total_income"] == 500.0, k
+    assert k["net"] == 350.0, k
+    assert k["transactions_count"] == 4, k
+
+
+def test_as_duas_telas_dao_o_mesmo_numero(pro_user_id):
+    """O ponto do apontamento: o mesmo mês não pode valer um número na Análise e
+    outro na tendência da IA."""
+    _grava(pro_user_id, "saida", 100)
+    _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
+
+    start, end = month_range_today()
+    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    linha = _mes_corrente(db.get_spending_trend(pro_user_id, months=1))
+
+    assert (k["total_expense"], k["total_income"]) == (linha["despesa"], linha["receita"])
+
+
+# ── controle positivo ──────────────────────────────────────────────────────
+
+def test_base_moderna_responde_o_mesmo_de_sempre(pro_user_id):
+    """Controle POSITIVO — 100% da produção hoje (zero linhas legadas, medido em
+    27/08/2026 21:50 UTC). Um alias que mudasse ESTES números seria pior que o
+    descasamento que ele conserta.
+
+    A movimentação interna continua fora dos dois leitores, que é a outra coisa
+    que um alias mal escrito quebraria.
+    """
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 45, "compra", None, categoria="mercado",
+        criado_em=datetime.combine(today_tz(), time(12, 0)),
+    )
+    db.add_launch_and_update_balance(
+        pro_user_id, "receita", 80, "freela", None, categoria="rendimentos",
+        criado_em=datetime.combine(today_tz(), time(13, 0)),
+    )
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 500, "aporte", None, categoria="investimento_aporte",
+        criado_em=datetime.combine(today_tz(), time(14, 0)), is_internal_movement=True,
+    )
+
+    linha = _mes_corrente(db.get_spending_trend(pro_user_id, months=1))
+    assert (linha["despesa"], linha["receita"]) == (45.0, 80.0), linha
+
+    start, end = month_range_today()
+    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    assert (k["total_expense"], k["total_income"]) == (45.0, 80.0), k

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -40,6 +40,7 @@ Controle POSITIVO: `test_base_moderna_responde_o_mesmo_de_sempre` — a base de
 from datetime import date, datetime, time, timedelta
 
 import db
+from db import insights
 from db.analytics import (
     compute_behavioral_patterns, compute_evolution, compute_history_quick_stats,
     compute_kpis, list_history,
@@ -239,10 +240,12 @@ def test_os_tres_sites_novos_nao_mudam_a_base_moderna(pro_user_id):
 
 # ── salary burn: o irmão que ainda lia só a receita moderna ────────────────
 
-def _mes_passado(dia: int) -> date:
-    """Um dia do mês anterior — o `salary_burn` só olha meses FECHADOS."""
-    primeiro = today_tz().replace(day=1)
-    return (primeiro - timedelta(days=1)).replace(day=dia)
+def _mes_passado(dia: int, meses: int = 1, hoje: date | None = None) -> date:
+    """Um dia de N meses atrás — o `salary_burn` só olha meses FECHADOS."""
+    primeiro = (hoje or today_tz()).replace(day=1)
+    for _ in range(meses):
+        primeiro = (primeiro - timedelta(days=1)).replace(day=1)
+    return primeiro.replace(day=dia)
 
 
 def test_salary_burn_conta_a_receita_legada(pro_user_id):
@@ -276,3 +279,179 @@ def test_salary_burn_com_receita_moderna_nao_muda(pro_user_id):
     assert burn["expected_income"] == 1000.0, burn
     assert burn["ok"] is True, burn
     assert burn["avg_day_to_80pct"] == 3, burn
+
+
+# ── e o irmão do salary_burn no caminho de FALLBACK ────────────────────────
+#
+# `_detect_salary_burn_fast` (db/insights.py) é o que o painel de Análise mostra
+# quando o LLM cai — mesma pergunta, outro caminho. A receita lá era
+# `tipo = 'receita'` cru enquanto a despesa, na função de baixo, já aceitava as
+# duas formas.
+#
+# Chamado DIRETO de propósito: `compute_active_insights` engole exceção de
+# detector (`except Exception: continue`, db/insights.py), então um teste que
+# passasse por ele ficaria verde com a query quebrada.
+#
+# REFERENCIAL DE DATA — por que estes testes usam `date.today()` e não
+# `today_tz()` como os de cima: `_detect_salary_burn_fast` lê `date.today()`
+# (db/insights.py:288), que é o fuso do PROCESSO — UTC no CI, America/Sao_Paulo
+# na máquina local. Entre 00:00 e 03:00 UTC do dia 1º os dois referenciais
+# apontam meses DIFERENTES (31/08 23:30 em SP já é 01/09 em UTC), e um teste que
+# gravasse em `today_tz()` ficaria vermelho nessa janela de ~3h por mês sem
+# regressão nenhuma. Gravar no referencial que a função LÊ é o que os torna
+# determinísticos.
+#     O descasamento em si é defeito PREEXISTENTE de outra classe, fora do
+# escopo deste PR: `db/insights.py` chama `date.today()` em 6 lugares — neste
+# working tree 57, 85, 133, 235, 288, 415; no HEAD 57, 85, 133, 235, 286, 406 — e não
+# importa `today_tz` em lugar nenhum. Quem for consertar essa classe: os CINCO
+# testes ancorados aqui voltam para `today_tz()` junto — os quatro `burn_fast`
+# abaixo mais o `spike` no fim do arquivo (`_mes_utc`/`date.today()`, :448-450).
+#     A CLASSE NÃO ESTÁ FECHADA. Sete testes deste arquivo seguem
+# gravando em `today_tz()` e lendo por `date.today()`, mas isso NÃO os derruba
+# todos. Medido na borda que este bloco descreve (processo em UTC, 01:00 do dia
+# 1º: `date.today()` já virou o mês nos módulos leitores, `today_tz()` não),
+# falham CINCO — `test_tendencia_conta_as_duas_formas`,
+# `test_as_duas_telas_dao_o_mesmo_numero`,
+# `test_base_moderna_responde_o_mesmo_de_sempre`, `test_evolucao_conta_as_duas_formas`
+# e `test_os_tres_sites_novos_nao_mudam_a_base_moderna`.
+#     Os dois `test_salary_burn_*` usam o mesmo referencial misto
+# (`db/analytics.py:77` e `:1144` leem `date.today()`) e PASSAM nessa borda: a
+# janela de 6 meses CHEIOS do `compute_behavioral_patterns` continua contendo o
+# mês gravado depois do deslocamento de um mês. Mesmo referencial, outra
+# sensibilidade — quem fechar a classe mexe nos sete, mas só os cinco de cima
+# quebram nesta janela.
+#     A janela é entre 00:00 e 03:00 UTC do dia 1º de cada mês num processo em
+# UTC — a condição do CI. Num processo em −03 os dois referenciais coincidem
+# (`today_tz` lê `REPORT_TIMEZONE` ou `TZ` ou America/Sao_Paulo, utils_date.py:13),
+# então não há "direção oposta": lá eles simplesmente não divergem. Isso é
+# preexistente e idêntico no HEAD, medido: o conjunto de falhas é o mesmo com e sem
+# este diff. Não foi consertado aqui para não alargar o PR.
+
+_MSG_70_EM_50 = (
+    "Já consumiu 70% da sua receita média mensal "
+    "e só 50% do mês passou. Vale dar uma freada."
+)
+
+
+def _mes_utc(meses: int, dia: int = 5) -> date:
+    """`_mes_passado`, mas ancorado no `date.today()` que a função lê."""
+    return _mes_passado(dia, meses, hoje=date.today())
+
+
+def _burn_fast(user_id, monkeypatch, progresso=50.0):
+    """Fixa o progresso do mês; sem isso o gate 25–90 faz o teste passar ou
+    falhar conforme o DIA em que a suíte roda."""
+    monkeypatch.setattr(insights, "_month_progress_pct", lambda *_a, **_k: progresso)
+    return insights._detect_salary_burn_fast(user_id)
+
+
+def _renda_legada(user_id):
+    _grava(user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_utc(1))
+    _grava(user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_utc(2))
+
+
+def test_burn_fast_conta_a_receita_legada(pro_user_id, monkeypatch):
+    """Com a receita legada fora, `incomes` fica com menos de 2 meses e a função
+    devolve [] — o alerta some do painel enquanto o endpoint de patterns segue
+    reportando a renda. Duas telas, o mesmo número, respostas diferentes.
+
+    Discrimina o lado da RECEITA sozinho: a despesa aqui é moderna de propósito,
+    então reverter `{TIPO_DESPESA_SQL}` não mexe neste teste.
+
+    Controle NEGATIVO: `{TIPO_RECEITA_SQL}` de volta para `tipo = 'receita'` →
+    lista vazia aqui.
+    """
+    _renda_legada(pro_user_id)
+    _grava(pro_user_id, "despesa", 700, dia=date.today())
+
+    alertas = _burn_fast(pro_user_id, monkeypatch)
+    assert len(alertas) == 1, alertas
+    assert alertas[0]["type"] == "salary_burn_fast", alertas
+    assert alertas[0]["severity"] == "warning", alertas
+    # 700/1000 = 70% da receita esperada contra 50% do mês → gap de 20pp.
+    # A mensagem carrega DOIS percentuais; comparar a string inteira é o que
+    # separa "imprimiu 70 e 50" de "imprimiu o gasto nas duas posições".
+    assert alertas[0]["message"] == _MSG_70_EM_50, alertas
+
+
+def test_burn_fast_despesa_legada_segue_contando(pro_user_id, monkeypatch):
+    """GUARDA, não conserto: o lado da despesa desta função nunca esteve quebrado.
+    O predicado já era `tipo in ('despesa','saida')` e a troca por
+    `{TIPO_DESPESA_SQL}` é no-op — este teste passa COM e SEM este diff.
+
+    Ele existe para o depois: fica vermelho se alguém tirar o `'saida'` da
+    constante compartilhada, ou quebrar a f-string desta query.
+    """
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(1))
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(2))
+    _grava(pro_user_id, "saida", 700, dia=date.today())
+
+    alertas = _burn_fast(pro_user_id, monkeypatch)
+    assert len(alertas) == 1, alertas
+    assert alertas[0]["message"] == _MSG_70_EM_50, alertas
+
+
+def test_burn_fast_com_a_base_moderna_nao_muda(pro_user_id, monkeypatch):
+    """Controle POSITIVO — a base de 100% da produção hoje (zero linhas legadas):
+    a mesma cena nas formas modernas tem que dar o MESMO alerta. Um alias que
+    mexesse neste número seria pior que o descasamento que ele conserta."""
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(1))
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(2))
+    _grava(pro_user_id, "despesa", 700, dia=date.today())
+
+    alertas = _burn_fast(pro_user_id, monkeypatch)
+    assert len(alertas) == 1, alertas
+    assert alertas[0]["type"] == "salary_burn_fast", alertas
+    assert alertas[0]["severity"] == "warning", alertas
+    assert alertas[0]["message"] == _MSG_70_EM_50, alertas
+
+
+def test_burn_fast_sem_gap_nao_alerta(pro_user_id, monkeypatch):
+    """Controle POSITIVO do outro lado: aceitar a forma legada não pode virar
+    alerta em quem gasta no ritmo do mês (gap de 10pp, abaixo do corte de 15).
+
+    O `[]` sozinho NÃO provaria isso — com a receita legada invisível a função
+    também devolve [], por `len(incomes) < 2`. Por isso os dois passos no mesmo
+    teste, sobre a MESMA renda legada: o segundo mostra que ela foi reconhecida,
+    e aí o `[]` do primeiro só pode ter vindo do gap.
+    """
+    _renda_legada(pro_user_id)
+    _grava(pro_user_id, "despesa", 600, dia=date.today())
+
+    # 600/1000 = 60% contra 50% do mês → gap de 10pp, abaixo do corte
+    assert _burn_fast(pro_user_id, monkeypatch) == []
+
+    # +100 → 70%, gap de 20pp: agora alerta. Este passo é o controle negativo
+    # embutido — com a receita legada fora do filtro ele fica vermelho.
+    _grava(pro_user_id, "despesa", 100, dia=date.today())
+    alertas = _burn_fast(pro_user_id, monkeypatch)
+    assert len(alertas) == 1, alertas
+    assert alertas[0]["message"] == _MSG_70_EM_50, alertas
+
+
+# ── e o irmão convertido junto: _detect_category_spike ─────────────────────
+
+def test_spike_query_convertida_ainda_executa(pro_user_id, monkeypatch):
+    """GUARDA da f-string, não conserto: em `_detect_category_spike` o predicado já
+    era `tipo in ('despesa','saida')` e a troca por `{TIPO_DESPESA_SQL}` é no-op —
+    este teste passa COM e SEM este diff.
+
+    Ele existe porque a conversão para f-string é o risco real: uma chave ou um
+    `%` a mais e a query estoura, e `compute_active_insights` engole exceção de
+    detector (`except Exception: continue`), então o insight sumiria do painel SEM
+    erro nenhum. Chamado direto, é o mínimo que fica vermelho aí — e também se
+    alguém tirar o `'saida'` da constante compartilhada.
+
+    Mesmo referencial de data dos `burn_fast`: a função lê `date.today()`.
+    """
+    monkeypatch.setattr(insights, "_month_progress_pct", lambda *_a, **_k: 87.0)
+    _grava(pro_user_id, "saida", 100, dia=_mes_utc(1))
+    _grava(pro_user_id, "saida", 100, dia=_mes_utc(2))
+    _grava(pro_user_id, "saida", 500, dia=date.today())
+
+    spikes = insights._detect_category_spike(pro_user_id)
+    assert len(spikes) == 1, spikes
+    # 500 contra média de 100 nos dois meses anteriores com dado = +400%
+    assert spikes[0]["type"] == "category_spike", spikes
+    assert spikes[0]["key"] == "spike:mercado", spikes
+    assert spikes[0]["title"] == "Mercado subiu 400% no mês", spikes

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -203,6 +203,16 @@ def test_historico_lista_a_linha_legada_nos_dois_filtros(pro_user_id):
     despesas = list_history(pro_user_id, tipo="despesa", **janela)
     assert [i["valor"] for i in despesas["items"]] == [100.0], despesas
 
+    # e o `tipo` DEVOLVIDO tem que vir na forma moderna: o front decide cor,
+    # sinal e ícone com `i.tipo === "receita"` estrito (`_historyRowHTML`,
+    # frontend/dashboard.js:5932). Cru, a receita legada — agora visível — era
+    # desenhada como despesa, inclusive sob o filtro "Receitas".
+    assert [i["tipo"] for i in receitas["items"]] == ["receita"], receitas
+    assert [i["tipo"] for i in despesas["items"]] == ["despesa"], despesas
+    assert sorted(i["tipo"] for i in list_history(pro_user_id, **janela)["items"]) == [
+        "despesa", "receita",
+    ]
+
 
 def test_os_tres_sites_novos_nao_mudam_a_base_moderna(pro_user_id):
     """Controle POSITIVO dos três — a base de 100% da produção hoje."""

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -2,19 +2,25 @@
 
 Irmão do `tests/test_tipo_legado_no_dashboard.py`, encaminhado do #158 para cá
 por verificabilidade (`CLAUDE.md` §4): lá o conserto foi nos números do MÊS do
-dashboard, aqui são os três leitores que respondem a mesma pergunta por outras
-telas —
+dashboard, aqui são os leitores que respondem a mesma pergunta por outras telas —
 
-| leitor                          | onde aparece        | lia antes                    |
-|---------------------------------|---------------------|------------------------------|
-| `get_spending_trend`            | tool de tendência   | só a moderna, as duas fora   |
-|                                 | da IA               |                              |
-| `compute_kpis` (SQL)            | KPI da Análise      | 'saida' sim, 'entrada' NÃO   |
-| `compute_kpis` (Python)         | o mesmo             | espelhava a assimetria       |
+| leitor                        | onde aparece         | lia antes                  |
+|-------------------------------|----------------------|----------------------------|
+| `get_spending_trend`          | tendência da IA      | só a moderna, as duas fora |
+| `compute_kpis` (SQL + Python) | KPI da Análise       | 'saida' sim, 'entrada' NÃO |
+| `compute_evolution`           | barra do mês, mesma  | 'saida' sim, 'entrada' NÃO |
+|                               | tela do KPI          |                            |
+| `compute_history_quick_stats` | cards do Histórico   | a legada nem no total      |
+| `list_history`                | lista do Histórico   | 'all' E o filtro por tipo  |
 
-O `entrada` faltando nos dois últimos é o pior dos três: a receita legada some
-do income, o `net` sobe, e a `savings_rate` (net/income) sai errada nos DOIS
-sentidos ao mesmo tempo.
+Os três últimos vieram de varrer `db/analytics.py` atrás do mesmo defeito depois
+que o revisor nomeou só o `compute_evolution` — a regra de sempre: "achei um
+caso" não é "resolvi a categoria" (`CLAUDE.md` §2).
+
+O `entrada` faltando é o pior deles: a receita legada some do income, o `net`
+sobe, e a `savings_rate` (net/income) sai errada nos DOIS sentidos ao mesmo
+tempo. No `list_history` o efeito é outro e igualmente ruim — a linha some da
+tela sem erro nenhum.
 
 Conserto: `TIPO_CANON_SQL` colapsa a forma legada na moderna no SQL, e o Python
 deixa de repetir a lista de aliases — uma regra, um lugar (§0.7).
@@ -34,7 +40,9 @@ Controle POSITIVO: `test_base_moderna_responde_o_mesmo_de_sempre` — a base de
 from datetime import datetime, time, timedelta
 
 import db
-from db.analytics import compute_kpis
+from db.analytics import (
+    compute_evolution, compute_history_quick_stats, compute_kpis, list_history,
+)
 from utils_date import month_range_today, today_tz
 
 
@@ -132,3 +140,87 @@ def test_base_moderna_responde_o_mesmo_de_sempre(pro_user_id):
     start, end = month_range_today()
     k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
     assert (k["total_expense"], k["total_income"]) == (45.0, 80.0), k
+
+
+# ── os outros três sites que a varredura do arquivo achou ──────────────────
+#
+# O apontamento nomeou o `compute_evolution`. Varrendo `db/analytics.py` atrás do
+# mesmo defeito — 'receita' aceita SEM 'entrada' —, ele aparecia em três lugares,
+# cada um de uma forma:
+#
+#   compute_evolution            filtro + agregador Python  (a barra do mês)
+#   compute_history_quick_stats  contagem: a legada nem no total entrava
+#   list_history                 filtro 'all' E o filtro por tipo pedido
+#
+# Os três estão aqui porque um teste por site é o que impede o próximo achado de
+# ser "faltou o irmão".
+
+def test_evolucao_conta_as_duas_formas(pro_user_id):
+    """O front busca `compute_kpis` e `compute_evolution` para a MESMA tela: a
+    receita legada não pode entrar no KPI de income e faltar na barra do mês."""
+    _grava(pro_user_id, "saida", 100)
+    _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
+
+    mes = today_tz().strftime("%Y-%m")
+    linha = [b for b in compute_evolution(pro_user_id, months=1) if b["month"] == mes]
+    assert linha, compute_evolution(pro_user_id, months=1)
+    assert (linha[0]["income"], linha[0]["expense"]) == (300.0, 100.0), linha
+    assert linha[0]["net"] == 200.0, linha
+
+    start, end = month_range_today()
+    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    assert (k["total_income"], k["total_expense"]) == (300.0, 100.0), k
+
+
+def test_contagem_do_historico_nao_perde_a_linha_legada(pro_user_id):
+    """`compute_history_quick_stats` filtrava `('despesa','receita','saida')`: a
+    linha 'entrada' não era contada NEM como receita NEM no total, então os
+    cards do topo do Histórico vinham menores que a lista logo abaixo."""
+    _grava(pro_user_id, "despesa", 50)
+    _grava(pro_user_id, "saida", 100)
+    _grava(pro_user_id, "receita", 200, categoria="rendimentos")
+    _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
+
+    start, end = month_range_today()
+    st = compute_history_quick_stats(pro_user_id, start, end + timedelta(days=1))
+    assert st["total_count"] == 4, st
+
+
+def test_historico_lista_a_linha_legada_nos_dois_filtros(pro_user_id):
+    """Duas portas no mesmo `list_history`: o 'all' e o filtro por tipo pedido.
+    A segunda montava `tipo = 'receita'` cru — a linha 'entrada' ficava invisível
+    no histórico, que é a pior classe de erro num caminho de dinheiro."""
+    _grava(pro_user_id, "saida", 100)
+    _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
+    start, end = month_range_today()
+    janela = dict(from_date=start, to_date=end + timedelta(days=1))
+
+    assert list_history(pro_user_id, **janela)["total"] == 2
+
+    receitas = list_history(pro_user_id, tipo="receita", **janela)
+    assert [i["valor"] for i in receitas["items"]] == [300.0], receitas
+
+    despesas = list_history(pro_user_id, tipo="despesa", **janela)
+    assert [i["valor"] for i in despesas["items"]] == [100.0], despesas
+
+
+def test_os_tres_sites_novos_nao_mudam_a_base_moderna(pro_user_id):
+    """Controle POSITIVO dos três — a base de 100% da produção hoje."""
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 45, "compra", None, categoria="mercado",
+        criado_em=datetime.combine(today_tz(), time(12, 0)),
+    )
+    db.add_launch_and_update_balance(
+        pro_user_id, "receita", 80, "freela", None, categoria="rendimentos",
+        criado_em=datetime.combine(today_tz(), time(13, 0)),
+    )
+    start, end = month_range_today()
+    janela = dict(from_date=start, to_date=end + timedelta(days=1))
+
+    mes = today_tz().strftime("%Y-%m")
+    linha = [b for b in compute_evolution(pro_user_id, months=1) if b["month"] == mes][0]
+    assert (linha["income"], linha["expense"]) == (80.0, 45.0), linha
+    assert compute_history_quick_stats(pro_user_id, **janela)["total_count"] == 2
+    assert list_history(pro_user_id, **janela)["total"] == 2
+    assert [i["valor"] for i in
+            list_history(pro_user_id, tipo="receita", **janela)["items"]] == [80.0]

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -29,6 +29,31 @@ Medido na produção (Railway) em 27/08/2026 21:50 UTC: `count(*) filter (where
 tipo='saida')` = 0 e o mesmo para 'entrada' em `launches`. Nenhum número de
 usuário muda hoje; isto fecha a classe, não apaga um incêndio.
 
+Referencial de data: `date.today()` — fuso do PROCESSO — governa a JANELA, não o
+rótulo do mês. É dele que saem o `range_start` do `get_spending_trend`
+(`db/accounts.py:367,377`), o `resolve_window` (`db/analytics.py:77`) e as chaves
+de bucket do `compute_evolution` (`db/analytics.py:335`). Por isso o arquivo
+inteiro grava e lê por ele, com janela explícita de `resolve_window(months=1)` em
+vez de `month_range_today()`: gravar em `today_tz()` — que cai em
+`America/Sao_Paulo` quando ninguém define `REPORT_TIMEZONE`/`TZ`, e o workflow do
+CI não define (`utils_date.py:13`) — e ler por uma janela de `date.today()` põe a
+escrita fora da janela e fora do mês procurado quando os dois apontam dias
+diferentes (31/08 23:30 em São Paulo já é 01/09 em UTC). Era essa a flakiness que
+este commit fecha, e ela não precisa da virada do mês para existir.
+
+O RÓTULO do mês, esse, vem de outro lugar em cada leitor, e em nenhum deles é o
+processo: `get_spending_trend` converte `criado_em at time zone
+'America/Sao_Paulo'`, hardcoded (`db/accounts.py:392-393`, o parâmetro em `:413`),
+e `compute_evolution` usa `DATE_TRUNC('month', criado_em)` sobre um `timestamptz`
+(`db/schema.py:216`), isto é, o fuso da SESSÃO do Postgres (`db/analytics.py:309`)
+— o mesmo instante pode sair em meses diferentes nos dois. O que protege os
+testes disso é a HORA de escrita: sempre no meio do dia (10h a 14h), com folga
+larga sobre os offsets em jogo. Quem mexer nessas horas mexe nessa folga.
+
+Ou seja, não há um referencial só: este arquivo ancora a JANELA, que é o que está
+ao alcance dele. O `America/Sao_Paulo` hardcoded e o fuso da sessão continuam
+fora — consertá-los é mudança em `db/*`, não aqui.
+
 Controle NEGATIVO: volte `{TIPO_CANON_SQL} as tipo` + o filtro para
 `tipo, valor` + `and tipo in ('despesa','receita')` em `get_spending_trend`
 (db/accounts.py), ou o par equivalente em `compute_kpis` (db/analytics.py) —
@@ -43,9 +68,8 @@ import db
 from db import insights
 from db.analytics import (
     compute_behavioral_patterns, compute_evolution, compute_history_quick_stats,
-    compute_kpis, list_history,
+    compute_kpis, list_history, resolve_window,
 )
-from utils_date import month_range_today, today_tz
 
 
 def _grava(user_id, tipo, valor, categoria="mercado", dia=None):
@@ -56,13 +80,13 @@ def _grava(user_id, tipo, valor, categoria="mercado", dia=None):
             "insert into launches (user_id, tipo, valor, categoria, nota, "
             "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,false)",
             (user_id, tipo, valor, categoria, "legado",
-             datetime.combine(dia or today_tz(), time(10, 0))),
+             datetime.combine(dia or date.today(), time(10, 0))),
         )
         conn.commit()
 
 
 def _mes_corrente(trend):
-    hoje = today_tz()
+    hoje = date.today()
     linha = [t for t in trend if t["year"] == hoje.year and t["month"] == hoje.month]
     assert linha, trend
     return linha[0]
@@ -91,8 +115,8 @@ def test_kpis_contam_as_duas_formas(pro_user_id):
     _grava(pro_user_id, "receita", 200, categoria="rendimentos")
     _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
 
-    start, end = month_range_today()
-    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    k = compute_kpis(pro_user_id, start, end)
 
     assert k["total_expense"] == 150.0, k
     assert k["total_income"] == 500.0, k
@@ -106,8 +130,8 @@ def test_as_duas_telas_dao_o_mesmo_numero(pro_user_id):
     _grava(pro_user_id, "saida", 100)
     _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
 
-    start, end = month_range_today()
-    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    k = compute_kpis(pro_user_id, start, end)
     linha = _mes_corrente(db.get_spending_trend(pro_user_id, months=1))
 
     assert (k["total_expense"], k["total_income"]) == (linha["despesa"], linha["receita"])
@@ -125,22 +149,22 @@ def test_base_moderna_responde_o_mesmo_de_sempre(pro_user_id):
     """
     db.add_launch_and_update_balance(
         pro_user_id, "despesa", 45, "compra", None, categoria="mercado",
-        criado_em=datetime.combine(today_tz(), time(12, 0)),
+        criado_em=datetime.combine(date.today(), time(12, 0)),
     )
     db.add_launch_and_update_balance(
         pro_user_id, "receita", 80, "freela", None, categoria="rendimentos",
-        criado_em=datetime.combine(today_tz(), time(13, 0)),
+        criado_em=datetime.combine(date.today(), time(13, 0)),
     )
     db.add_launch_and_update_balance(
         pro_user_id, "despesa", 500, "aporte", None, categoria="investimento_aporte",
-        criado_em=datetime.combine(today_tz(), time(14, 0)), is_internal_movement=True,
+        criado_em=datetime.combine(date.today(), time(14, 0)), is_internal_movement=True,
     )
 
     linha = _mes_corrente(db.get_spending_trend(pro_user_id, months=1))
     assert (linha["despesa"], linha["receita"]) == (45.0, 80.0), linha
 
-    start, end = month_range_today()
-    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    k = compute_kpis(pro_user_id, start, end)
     assert (k["total_expense"], k["total_income"]) == (45.0, 80.0), k
 
 
@@ -163,14 +187,14 @@ def test_evolucao_conta_as_duas_formas(pro_user_id):
     _grava(pro_user_id, "saida", 100)
     _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
 
-    mes = today_tz().strftime("%Y-%m")
+    mes = date.today().strftime("%Y-%m")
     linha = [b for b in compute_evolution(pro_user_id, months=1) if b["month"] == mes]
     assert linha, compute_evolution(pro_user_id, months=1)
     assert (linha[0]["income"], linha[0]["expense"]) == (300.0, 100.0), linha
     assert linha[0]["net"] == 200.0, linha
 
-    start, end = month_range_today()
-    k = compute_kpis(pro_user_id, start, end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    k = compute_kpis(pro_user_id, start, end)
     assert (k["total_income"], k["total_expense"]) == (300.0, 100.0), k
 
 
@@ -183,8 +207,8 @@ def test_contagem_do_historico_nao_perde_a_linha_legada(pro_user_id):
     _grava(pro_user_id, "receita", 200, categoria="rendimentos")
     _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
 
-    start, end = month_range_today()
-    st = compute_history_quick_stats(pro_user_id, start, end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    st = compute_history_quick_stats(pro_user_id, start, end)
     assert st["total_count"] == 4, st
 
 
@@ -194,8 +218,8 @@ def test_historico_lista_a_linha_legada_nos_dois_filtros(pro_user_id):
     no histórico, que é a pior classe de erro num caminho de dinheiro."""
     _grava(pro_user_id, "saida", 100)
     _grava(pro_user_id, "entrada", 300, categoria="rendimentos")
-    start, end = month_range_today()
-    janela = dict(from_date=start, to_date=end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    janela = dict(from_date=start, to_date=end)
 
     assert list_history(pro_user_id, **janela)["total"] == 2
 
@@ -220,16 +244,16 @@ def test_os_tres_sites_novos_nao_mudam_a_base_moderna(pro_user_id):
     """Controle POSITIVO dos três — a base de 100% da produção hoje."""
     db.add_launch_and_update_balance(
         pro_user_id, "despesa", 45, "compra", None, categoria="mercado",
-        criado_em=datetime.combine(today_tz(), time(12, 0)),
+        criado_em=datetime.combine(date.today(), time(12, 0)),
     )
     db.add_launch_and_update_balance(
         pro_user_id, "receita", 80, "freela", None, categoria="rendimentos",
-        criado_em=datetime.combine(today_tz(), time(13, 0)),
+        criado_em=datetime.combine(date.today(), time(13, 0)),
     )
-    start, end = month_range_today()
-    janela = dict(from_date=start, to_date=end + timedelta(days=1))
+    start, end = resolve_window(months=1)
+    janela = dict(from_date=start, to_date=end)
 
-    mes = today_tz().strftime("%Y-%m")
+    mes = date.today().strftime("%Y-%m")
     linha = [b for b in compute_evolution(pro_user_id, months=1) if b["month"] == mes][0]
     assert (linha["income"], linha["expense"]) == (80.0, 45.0), linha
     assert compute_history_quick_stats(pro_user_id, **janela)["total_count"] == 2
@@ -242,7 +266,7 @@ def test_os_tres_sites_novos_nao_mudam_a_base_moderna(pro_user_id):
 
 def _mes_passado(dia: int, meses: int = 1, hoje: date | None = None) -> date:
     """Um dia de N meses atrás — o `salary_burn` só olha meses FECHADOS."""
-    primeiro = (hoje or today_tz()).replace(day=1)
+    primeiro = (hoje or date.today()).replace(day=1)
     for _ in range(meses):
         primeiro = (primeiro - timedelta(days=1)).replace(day=1)
     return primeiro.replace(day=dia)
@@ -291,51 +315,11 @@ def test_salary_burn_com_receita_moderna_nao_muda(pro_user_id):
 # Chamado DIRETO de propósito: `compute_active_insights` engole exceção de
 # detector (`except Exception: continue`, db/insights.py), então um teste que
 # passasse por ele ficaria verde com a query quebrada.
-#
-# REFERENCIAL DE DATA — por que estes testes usam `date.today()` e não
-# `today_tz()` como os de cima: `_detect_salary_burn_fast` lê `date.today()`
-# (db/insights.py:288), que é o fuso do PROCESSO — UTC no CI, America/Sao_Paulo
-# na máquina local. Entre 00:00 e 03:00 UTC do dia 1º os dois referenciais
-# apontam meses DIFERENTES (31/08 23:30 em SP já é 01/09 em UTC), e um teste que
-# gravasse em `today_tz()` ficaria vermelho nessa janela de ~3h por mês sem
-# regressão nenhuma. Gravar no referencial que a função LÊ é o que os torna
-# determinísticos.
-#     O descasamento em si é defeito PREEXISTENTE de outra classe, fora do
-# escopo deste PR: `db/insights.py` chama `date.today()` em 6 lugares — neste
-# working tree 57, 85, 133, 235, 288, 415; no HEAD 57, 85, 133, 235, 286, 406 — e não
-# importa `today_tz` em lugar nenhum. Quem for consertar essa classe: os CINCO
-# testes ancorados aqui voltam para `today_tz()` junto — os quatro `burn_fast`
-# abaixo mais o `spike` no fim do arquivo (`_mes_utc`/`date.today()`, :448-450).
-#     A CLASSE NÃO ESTÁ FECHADA. Sete testes deste arquivo seguem
-# gravando em `today_tz()` e lendo por `date.today()`, mas isso NÃO os derruba
-# todos. Medido na borda que este bloco descreve (processo em UTC, 01:00 do dia
-# 1º: `date.today()` já virou o mês nos módulos leitores, `today_tz()` não),
-# falham CINCO — `test_tendencia_conta_as_duas_formas`,
-# `test_as_duas_telas_dao_o_mesmo_numero`,
-# `test_base_moderna_responde_o_mesmo_de_sempre`, `test_evolucao_conta_as_duas_formas`
-# e `test_os_tres_sites_novos_nao_mudam_a_base_moderna`.
-#     Os dois `test_salary_burn_*` usam o mesmo referencial misto
-# (`db/analytics.py:77` e `:1144` leem `date.today()`) e PASSAM nessa borda: a
-# janela de 6 meses CHEIOS do `compute_behavioral_patterns` continua contendo o
-# mês gravado depois do deslocamento de um mês. Mesmo referencial, outra
-# sensibilidade — quem fechar a classe mexe nos sete, mas só os cinco de cima
-# quebram nesta janela.
-#     A janela é entre 00:00 e 03:00 UTC do dia 1º de cada mês num processo em
-# UTC — a condição do CI. Num processo em −03 os dois referenciais coincidem
-# (`today_tz` lê `REPORT_TIMEZONE` ou `TZ` ou America/Sao_Paulo, utils_date.py:13),
-# então não há "direção oposta": lá eles simplesmente não divergem. Isso é
-# preexistente e idêntico no HEAD, medido: o conjunto de falhas é o mesmo com e sem
-# este diff. Não foi consertado aqui para não alargar o PR.
 
 _MSG_70_EM_50 = (
     "Já consumiu 70% da sua receita média mensal "
     "e só 50% do mês passou. Vale dar uma freada."
 )
-
-
-def _mes_utc(meses: int, dia: int = 5) -> date:
-    """`_mes_passado`, mas ancorado no `date.today()` que a função lê."""
-    return _mes_passado(dia, meses, hoje=date.today())
 
 
 def _burn_fast(user_id, monkeypatch, progresso=50.0):
@@ -346,8 +330,8 @@ def _burn_fast(user_id, monkeypatch, progresso=50.0):
 
 
 def _renda_legada(user_id):
-    _grava(user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_utc(1))
-    _grava(user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_utc(2))
+    _grava(user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_passado(5, 1))
+    _grava(user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_passado(5, 2))
 
 
 def test_burn_fast_conta_a_receita_legada(pro_user_id, monkeypatch):
@@ -382,8 +366,8 @@ def test_burn_fast_despesa_legada_segue_contando(pro_user_id, monkeypatch):
     Ele existe para o depois: fica vermelho se alguém tirar o `'saida'` da
     constante compartilhada, ou quebrar a f-string desta query.
     """
-    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(1))
-    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(2))
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_passado(5, 1))
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_passado(5, 2))
     _grava(pro_user_id, "saida", 700, dia=date.today())
 
     alertas = _burn_fast(pro_user_id, monkeypatch)
@@ -395,8 +379,8 @@ def test_burn_fast_com_a_base_moderna_nao_muda(pro_user_id, monkeypatch):
     """Controle POSITIVO — a base de 100% da produção hoje (zero linhas legadas):
     a mesma cena nas formas modernas tem que dar o MESMO alerta. Um alias que
     mexesse neste número seria pior que o descasamento que ele conserta."""
-    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(1))
-    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_utc(2))
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_passado(5, 1))
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_passado(5, 2))
     _grava(pro_user_id, "despesa", 700, dia=date.today())
 
     alertas = _burn_fast(pro_user_id, monkeypatch)
@@ -445,8 +429,8 @@ def test_spike_query_convertida_ainda_executa(pro_user_id, monkeypatch):
     Mesmo referencial de data dos `burn_fast`: a função lê `date.today()`.
     """
     monkeypatch.setattr(insights, "_month_progress_pct", lambda *_a, **_k: 87.0)
-    _grava(pro_user_id, "saida", 100, dia=_mes_utc(1))
-    _grava(pro_user_id, "saida", 100, dia=_mes_utc(2))
+    _grava(pro_user_id, "saida", 100, dia=_mes_passado(5, 1))
+    _grava(pro_user_id, "saida", 100, dia=_mes_passado(5, 2))
     _grava(pro_user_id, "saida", 500, dia=date.today())
 
     spikes = insights._detect_category_spike(pro_user_id)

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -37,11 +37,12 @@ vermelhos, cada um pelo seu lado.
 Controle POSITIVO: `test_base_moderna_responde_o_mesmo_de_sempre` — a base de
 100% da produção hoje, que não pode ter mudado de número.
 """
-from datetime import datetime, time, timedelta
+from datetime import date, datetime, time, timedelta
 
 import db
 from db.analytics import (
-    compute_evolution, compute_history_quick_stats, compute_kpis, list_history,
+    compute_behavioral_patterns, compute_evolution, compute_history_quick_stats,
+    compute_kpis, list_history,
 )
 from utils_date import month_range_today, today_tz
 
@@ -234,3 +235,44 @@ def test_os_tres_sites_novos_nao_mudam_a_base_moderna(pro_user_id):
     assert list_history(pro_user_id, **janela)["total"] == 2
     assert [i["valor"] for i in
             list_history(pro_user_id, tipo="receita", **janela)["items"]] == [80.0]
+
+
+# ── salary burn: o irmão que ainda lia só a receita moderna ────────────────
+
+def _mes_passado(dia: int) -> date:
+    """Um dia do mês anterior — o `salary_burn` só olha meses FECHADOS."""
+    primeiro = today_tz().replace(day=1)
+    return (primeiro - timedelta(days=1)).replace(day=dia)
+
+
+def test_salary_burn_conta_a_receita_legada(pro_user_id):
+    """`_compute_salary_burn` fixava `tipo = 'receita'` enquanto a query de
+    despesa logo abaixo, no mesmo helper, já aceitava ('despesa','saida').
+
+    A assimetria é silenciosa e enviesa para o lado errado: sem a receita legada
+    o `expected_income` sai MENOR, o alvo de 80% cai junto, e o "dia em que você
+    queima o salário" é reportado mais cedo do que a realidade — ou o helper
+    devolve `ok=false` por achar que não houve receita nenhuma.
+
+    Controle NEGATIVO: `AND {TIPO_RECEITA_SQL}` de volta para
+    `AND tipo = 'receita'` → `expected_income` cai para 0.0 e `ok` vira False.
+    """
+    _grava(pro_user_id, "entrada", 1000, categoria="rendimentos", dia=_mes_passado(5))
+    _grava(pro_user_id, "saida", 900, dia=_mes_passado(3))
+
+    burn = compute_behavioral_patterns(pro_user_id, months=6)["salary_burn"]
+    assert burn["expected_income"] == 1000.0, burn
+    assert burn["ok"] is True, burn
+    assert burn["avg_day_to_80pct"] == 3, burn
+
+
+def test_salary_burn_com_receita_moderna_nao_muda(pro_user_id):
+    """Controle POSITIVO — a base de 100% da produção hoje: mesma cena com as
+    formas modernas responde exatamente o mesmo."""
+    _grava(pro_user_id, "receita", 1000, categoria="rendimentos", dia=_mes_passado(5))
+    _grava(pro_user_id, "despesa", 900, dia=_mes_passado(3))
+
+    burn = compute_behavioral_patterns(pro_user_id, months=6)["salary_burn"]
+    assert burn["expected_income"] == 1000.0, burn
+    assert burn["ok"] is True, burn
+    assert burn["avg_day_to_80pct"] == 3, burn


### PR DESCRIPTION
Encaminhado do #158 pelo gatilho de corte de escopo: o Codex levantou este irmão em `a045a7e` e a decisão foi não alargar o #158 pela quarta vez.

**Base atualizada:** o #158 foi mergeado (`fb31f66`, squash), então este PR foi rebaseado com `git rebase --onto origin/main a045a7e` e passou a ter base `main`. O rebase replicou os 7 commits sem nenhum conflito, e os cinco arquivos ficaram byte a byte idênticos ao que estava antes dele — conferido arquivo por arquivo. O conflito que o GitHub apontava era o efeito do squash: a `main` contava o #158 num commit só, e este branch contava nos seis originais. Não havia divergência de conteúdo (`git diff a045a7e origin/main` é vazio nos arquivos que este PR toca).

## O que muda

Três leitores respondem "quanto entrou e saiu neste mês" por telas diferentes e discordavam entre si quando a base tem uma linha `tipo='saida'` ou `'entrada'`:

| leitor | onde aparece | lia antes |
|---|---|---|
| `db/accounts.py::get_spending_trend` | tool de tendência da IA | só a moderna — as **duas** legadas fora |
| `db/analytics.py::compute_kpis` (SQL) | KPI da Análise | `'saida'` sim, `'entrada'` **não** |
| `db/analytics.py::compute_kpis` (Python) | o mesmo número | espelhava a assimetria do SQL |

O `entrada` faltando é o pior dos três: a receita legada some do `income`, o `net` sobe, e a `savings_rate` (`net/income`) erra nos dois sentidos ao mesmo tempo.

O conserto é o `TIPO_CANON_SQL` (`db/connection.py`, criado no #158) colapsando a forma legada na moderna **no SQL**. Com isso o agregador Python vê só `'despesa'`/`'receita'` e deixa de repetir a lista de aliases — uma regra num lugar (§0.7), em vez de uma terceira cópia dela.

## Alcance — medido, não estimado

**Nenhum número de usuário muda hoje.** `count(*) filter (where tipo='saida')` = 0 e o mesmo para `'entrada'` em `launches`, consultado na produção (Railway) em **27/08/2026 21:50 UTC**. Isto fecha a classe; não apaga um incêndio.

Também **não é regressão** do #158: os predicados modernos-apenas nesses leitores são anteriores a ele. O que o #158 trouxe foi a constante que torna o conserto barato.

## Testes

`4943 passed, 1 xfailed` neste branch, medido no head `2590a37`.

`tests/test_tipo_legado_na_tendencia.py`, cobrindo `'saida'` **e** `'entrada'`:

| teste | o que prova |
|---|---|
| `test_tendencia_conta_as_duas_formas` | a tendência da IA soma R$ 150,00 de despesa e R$ 500,00 de receita com metade de cada uma na forma legada |
| `test_kpis_contam_as_duas_formas` | o KPI da Análise dá os mesmos números, incluindo o `entrada` que faltava |
| `test_as_duas_telas_dao_o_mesmo_numero` | o ponto do apontamento: o mesmo mês não vale um número na Análise e outro na tendência |
| `test_base_moderna_responde_o_mesmo_de_sempre` | controle **positivo** — a base sem linha legada, que é 100% da produção hoje, responde o de sempre, e a movimentação interna continua fora dos dois leitores |

**Controle negativo medido em cada leitor separadamente**, não nos dois juntos: voltando só o `get_spending_trend` ao predicado antigo, 2 testes ficam vermelhos; repondo e voltando só o `compute_kpis`, outros 2 ficam vermelhos. Nas duas injeções o controle positivo segue verde.

## A cauda que fica para depois — registro durável

Este PR **não** fecha a classe inteira. Sobram **9 leitores** que ainda ignoram a forma legada, decididos por PR próprio, a ser aberto **só depois do merge do #160**. Ficam listados aqui para não dependerem de memória de conversa:

| falta | arquivo | função | o que quebra |
|---|---|---|---|
| `'entrada'` | `core/services/piggy_agents.py` | `_month_stats` | medido: `entrou` vira 0 e `sobrou` sai **negativo** com o usuário no azul |
| `'entrada'` | `db/open_finance.py` | `detect_open_finance_salary` | salário do Open Finance não é detectado |
| `'entrada'` + `'saida'` | `db/accounts.py` | `_CONTA_CORRENTE_LAUNCH_FILTER` | compartilhado entre `count_launches` e `delete_all_launches_and_rollback` — ampliar muda comportamento de **escrita**, a linha legada passa a ser contada e apagada, e sem `efeitos` cai em `failed` |
| `'saida'` | `db/recurring.py` | `find_recurring_candidate` | |
| `'saida'` | `db/categories.py` | `get_uncategorized_launches` | |
| `'saida'` | `db/cards.py` | `monthly_summary_credit_debit` | sem nenhum chamador no repo hoje |
| `'saida'` | `db/accounts.py` | `get_internal_movement_total` | |
| `'saida'` | `db/accounts.py` | `get_top_expense_categories` | |
| `'saida'` | `db/open_finance.py` | `detect_open_finance_bill_increase` | |

**Por que esperar o #160:** três deles estão em `db/accounts.py`, e o #160 (`feat/lancamentos-por-categoria`) conflita com este PR nesse arquivo — medido com `git merge-tree`, os dois reescrevem `list_launches_by_category`. Ordem combinada: **#158 (mergeado em `fb31f66`) → #165 → #159 → #160 → PR da cauda**. O #159 e o #160 foram empilhados sobre a cabeça ANTIGA do #158 e vão precisar do mesmo rebase que este PR levou.

**Como fechar, para quem pegar:** as constantes já existem (`TIPO_DESPESA_SQL`, `TIPO_RECEITA_SQL`, `TIPO_CANON_SQL`, em `db/connection.py`); a query vira f-string. E a varredura certa é pela **ausência** — grepar `'receita'`/`'despesa'` desacompanhados do par legado. Grepar os literais `'saida'`/`'entrada'` acha os sites que já estão certos, e foi assim que dois irmãos escaparam de varreduras anteriores deste PR.

**Armadilha medida:** query que vira f-string não pode conter `%` **nem dentro de comentário SQL `--`** — o psycopg lê como início de placeholder e a query estoura com `incomplete placeholder` antes de rodar.

## Não verificado

Nada foi visto no aparelho nem em produção — só o `SELECT` de contagem acima, que é leitura. A tela da Análise e a resposta da IA não foram exercitadas fora do teste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


