### PR TITLE
ci: push na main deixa de cancelar o run anterior

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,19 @@ on:
 
 # Cancela runs anteriores do mesmo ref quando um novo push chega — vários
 # commits seguidos numa branch deixam de acumular runs paralelos até o fim.
+#
+# Só em `pull_request`, e isso NÃO é economia de minutos: em `push` na main o
+# `github.ref` é `refs/heads/main` para TODO push, então os merges caem no mesmo
+# grupo e cada um cancelava o anterior. Medido com `gh run list --branch main`:
+# `pytest` cancelado em fc38f31 (#143), e4b19b2 (#122) e 0db01b3 (#140), e o job
+# `frontend` vermelho em 26a111d (#123) — quatro dos dez últimos pushes sem
+# veredito, incluindo os dois PRs de dinheiro mais densos do lote. Um commit na
+# main sem suíte concluída é um commit que ninguém testou.
+# Em PR o `github.ref` é `refs/pull/N/merge`, único por PR, então lá o
+# cancelamento continua fazendo o que se espera dele.
 concurrency:
   group: tests-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pytest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,20 +8,29 @@ on:
     branches: [main]
   pull_request:
 
-# Cancela runs anteriores do mesmo ref quando um novo push chega — vários
-# commits seguidos numa branch deixam de acumular runs paralelos até o fim.
+# Em PR: um grupo por PR (`github.ref` é `refs/pull/N/merge`), com cancelamento —
+# push novo no PR mata o run velho daquele PR, que é o que se espera.
 #
-# Só em `pull_request`, e isso NÃO é economia de minutos: em `push` na main o
-# `github.ref` é `refs/heads/main` para TODO push, então os merges caem no mesmo
-# grupo e cada um cancelava o anterior. Medido com `gh run list --branch main`:
-# `pytest` cancelado em fc38f31 (#143), e4b19b2 (#122) e 0db01b3 (#140), e o job
-# `frontend` vermelho em 26a111d (#123) — quatro dos dez últimos pushes sem
-# veredito, incluindo os dois PRs de dinheiro mais densos do lote. Um commit na
-# main sem suíte concluída é um commit que ninguém testou.
-# Em PR o `github.ref` é `refs/pull/N/merge`, único por PR, então lá o
-# cancelamento continua fazendo o que se espera dele.
+# Na main: um grupo POR COMMIT. Não é exagero, são duas regras diferentes do
+# GitHub, e desligar só o `cancel-in-progress` fecharia metade do buraco:
+#
+#   1. `cancel-in-progress: true` cancela o run EM EXECUÇÃO do grupo. Como o
+#      `github.ref` de todo push na main é `refs/heads/main`, os merges caíam no
+#      mesmo grupo e cada um matava o anterior. Medido com
+#      `gh run list --branch main`: `pytest` cancelado em fc38f31 (#143),
+#      e4b19b2 (#122) e 0db01b3 (#140), e o job `frontend` vermelho em 26a111d
+#      (#123) — quatro dos dez últimos pushes sem veredito, incluindo os dois
+#      PRs de dinheiro mais densos do lote.
+#   2. Mesmo com ele desligado, o GitHub admite UM run em execução e UM pendente
+#      por grupo, e ao enfileirar um terceiro CANCELA o pendente. Três merges
+#      rápidos e o do meio continuava sem veredito — o mesmo defeito por outra
+#      porta (Codex, #167).
+#
+# Com o SHA no grupo, cada commit da main tem grupo próprio: não enfileira atrás
+# de ninguém e não é cancelado por ninguém. O preço é runs em paralelo quando os
+# merges vêm em rajada; um commit sem suíte concluída custa mais.
 concurrency:
-  group: tests-${{ github.workflow }}-${{ github.ref }}
+  group: tests-${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## O problema, medido

Em `push` na `main` o `github.ref` é `refs/heads/main` para **todo** push, então todos os merges caem no mesmo grupo de concorrência.

`gh run list --branch main`:

| commit | PR | job | resultado |
|---|---|---|---|
| `fc38f31` | #143 | pytest | **cancelled** |
| `e4b19b2` | #122 | pytest | **cancelled** |
| `0db01b3` | #140 | pytest | **cancelled** |
| `26a111d` | #123 | frontend | **failure** |

Quatro dos dez últimos pushes na `main` sem veredito — incluindo o #140 (filtro de dano da pergunta de valor) e o #143 (categoria em todas as portas), os dois PRs de dinheiro mais densos do lote.

E o vermelho do #122 só apareceu **dois merges depois**, no run do #123. Já está registrado no corpo do #154: *"o CI do #122 foi CANCELADO pelo `cancel-in-progress` quando o merge seguinte chegou, e o vermelho só apareceu no run do #123."* O mecanismo foi diagnosticado lá e não foi consertado.

## São duas regras do GitHub, não uma

A primeira versão deste PR desligava só o `cancel-in-progress` fora de PR. **Isso fecha metade do buraco** — apontamento do Codex, procedente:

1. `cancel-in-progress` governa o run **em execução** do grupo. É o que matava os três `pytest` acima.
2. Independente dele, o GitHub admite **um** run em execução e **um** pendente por grupo, e ao enfileirar um terceiro **cancela o pendente**. Com o grupo compartilhado, três merges rápidos deixavam o do meio sem veredito — o mesmo defeito por outra porta.

## A mudança

```yaml
concurrency:
  group: tests-${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **Na `main`**: grupo por commit. Cada push fica sozinho no seu grupo — não enfileira atrás de ninguém e não é cancelado por ninguém.
- **Em PR**: grupo por `github.ref` (`refs/pull/N/merge`, único por PR) com cancelamento ligado — push novo mata o run velho **daquele** PR, que é o comportamento desejado.

## Custo

Runs em paralelo na `main` quando os merges vêm em rajada (~10 pushes/dia). Um commit sem suíte concluída custa mais.

## O que este PR NÃO cobre

Marcar `pytest` e `frontend` como **required status checks** em branch protection. Sem isso, uma suíte cancelada continua não bloqueando merge — e o arquivo de workflow não consegue expressar essa regra. É configuração do repositório, fica para o dono.

## Verificação

- Push novo neste PR: o run anterior **deve** ser cancelado (comportamento preservado em PR).
- Depois do merge, dois ou três merges seguidos na `main` devem produzir um run concluído **por commit**.

## Contexto

Achado da auditoria de regressão dos merges de 19–26/08. É a Fase 0 do plano de correções: as demais precisam de baseline confiável, e não há baseline enquanto commits entram na `main` sem suíte concluída.

🤖 Generated with [Claude Code](https://claude.com/claude-code)