### PR TITLE
fix(valor): resposta da porta 2 para de virar descrição e gravar dinheiro errado

### DIFF
--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -661,6 +661,15 @@ def _ja_tem_o_valor(entities: dict | None) -> bool:
     divergirem, uma pergunta de descrição vira pergunta de valor e o dinheiro já
     digitado some.
 
+    SEMPRE sobre o payload como foi GRAVADO — as entities da pendência que o
+    usuário viu na tela —, nunca sobre um dicionário já enriquecido por outra
+    fonte. Os dois chamadores obedecem: `_clarification_abandonada` lê
+    `clarif["payload"]["entities"]`, e o `_resolve_clarification` decide no topo
+    da função (`pedia_o_valor`), antes do merge das entities da IA. Foi por
+    consultar o dicionário pós-merge que a mesma pergunta era classificada de
+    dois jeitos no mesmo turno, e o ramo da descrição pulava o filtro de dano —
+    dinheiro errado gravado sem confirmação. O detalhe está no `pedia_o_valor`.
+
     São 5 produtores de `clarification`, e 4 deles foram lidos um a um:
 
       grava `entities["valor"]`  →  pede DESCRIÇÃO/destino, nunca abandona
@@ -723,6 +732,44 @@ def _clarification_abandonada(clarif: dict, text: str) -> bool:
     return abandona_pergunta_de_valor(text)
 
 
+_SO_NUMERO_RE = re.compile(r"[\d.,\s]+")
+_ESPACO_NO_SEPARADOR_RE = re.compile(r"(?<=\d)\s*([.,])\s*(?=\d)")
+
+
+def _cola_separador_decimal(resposta: str) -> str:
+    """"132, 50" vira "132,50" antes de o texto seguir para o `launches.add`.
+
+    A porta 2 é a ÚNICA das quatro que re-serializa o valor aceito de volta para
+    TEXTO — as portas 1, 3 e 4 registram por entities/`mark_bill_paid` e nunca
+    passam pelo `split_financial_transactions`. É por isso que só ela precisa
+    disto, e é por isso que o problema pertence a este conserto.
+
+    O `valor_perigoso` já decidiu, uma linha acima, que aquela vírgula é
+    separador DECIMAL — `_espaco_ambiguo` tem exceção explícita para a forma
+    (utils_text.py). O texto entregue adiante tem de dizer a mesma coisa. Sem
+    isto, medido: `split_financial_transactions("gastei 132, 50 a luz")` devolve
+    `['gastei 132', 'gastei 50 a luz']` (`,\\s+` seguido de dígito, parsers.py;
+    o pedaço sem verbo herda o anterior) e um valor vira DOIS lançamentos. Com
+    a colagem, `"gastei 132,50 a luz"` volta a ser uma parte só.
+
+    Só quando a resposta é NUMÉRICA por inteiro. O recorte é o mesmo predicado
+    da porta 1 (`_NUMERO_AMBIGUO_RE`, core/handlers/bills.py): sem letras não há
+    palavra do usuário para danificar, e o comentário logo abaixo do chamador
+    registra que a palavra digitada é o que categoriza. Resposta com letra
+    ("mercado, 20") sai intocada, como hoje.
+
+    Inócuo para o dinheiro: `parse_money` já apaga espaço dentro do bloco
+    numérico, então o valor lido é idêntico antes e depois — o que muda é só o
+    ponto onde o splitter corta.
+
+    Fora do alcance, medido: "1, 2, 3" nunca chega aqui, porque
+    `_extract_valor` devolve None e o chamador re-pergunta antes.
+    """
+    if not _SO_NUMERO_RE.fullmatch(resposta):
+        return resposta
+    return _ESPACO_NO_SEPARADOR_RE.sub(r"\1", resposta)
+
+
 def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platform: str, external_id: str) -> str:
     """
     O bot tinha feito uma pergunta e está esperando a resposta do usuário.
@@ -734,6 +781,21 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
     original_intent  = payload.get("intent", "launches.list")
     original_entities = dict(payload.get("entities") or {})
     orig_text        = payload.get("orig_text", "")
+
+    # A pergunta que o usuário VIU pedia o valor ou a descrição? Decidido AQUI,
+    # sobre o payload como foi GRAVADO, e não lá embaixo sobre o
+    # `original_entities` — que a essa altura já foi reescrito com as entities
+    # que a IA devolveu (:780). O prompt manda o classificador extrair `valor`
+    # (core/intent_classifier.py:832-834), então numa conta Pro ele quase sempre
+    # preenche: `_ja_tem_o_valor` virava True, o fluxo entrava no ramo "a
+    # resposta é a DESCRIÇÃO" e pulava o filtro de dano do #140 inteiro. Medido
+    # em produção: "paguei a luz" + "-10" gravava R$ 10,00, "132 50" gravava
+    # R$ 13.250,00, e "fatura" virava descrição do gasto ("mercado - fatura").
+    #
+    # Isto RESTAURA a fonte única em vez de quebrá-la: o outro consumidor,
+    # `_clarification_abandonada` (:721), já lia `clarif["payload"]["entities"]`
+    # cru. Os dois discordavam sobre a mesma pergunta, no mesmo turno.
+    pedia_o_valor = not _ja_tem_o_valor(original_entities)
 
     # Consome ANTES de executar, e condicionado ao que foi lido: a intent
     # original é re-executada abaixo (pode registrar/gastar). Se a linha já não
@@ -825,7 +887,7 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
         tipo = (original_entities.get("tipo") or "despesa").lower()
         verbo = "recebi" if tipo == "receita" else "gastei"
         resposta = limpa_pontuacao_final(user_response.strip())
-        if _ja_tem_o_valor(original_entities):
+        if not pedia_o_valor:
             # já tínhamos o valor → a resposta é a descrição/alvo que faltava.
             # Testado ANTES de parsear a resposta como valor: "gastei 50" +
             # "mercado 20" tem um número na resposta e virava R$ 2.050,00.
@@ -878,7 +940,7 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
                 r"^\s*(gastei|gasto|paguei|pagar|comprei|debitei|mandei|enviei|pixei|recebi|receita|ganhei)\b",
                 "", orig_text, flags=re.IGNORECASE,
             ).strip()
-            combined = f"{verbo} {resposta} {desc}".strip()
+            combined = f"{verbo} {_cola_separador_decimal(resposta)} {desc}".strip()
         return _execute("launches.add", user_id, combined, original_entities, platform, external_id)
 
     # demais intents (ex: launches.list "dia 4 de qual mês?") → extrai data

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -2759,25 +2759,44 @@ def test_as_quatro_portas_nao_ganharam_escrita_incondicional():
 # quatro ataques.
 # ---------------------------------------------------------------------------
 
-# (texto, valores que a `main` registra na porta 2). A porta 2 recombina a
-# resposta com o texto original ("gastei <resposta> a luz"), e em cinco delas o
-# separador dentro da frase faz o splitter de multi-lançamento criar DOIS
-# lançamentos — é o que a `main` faz, e o branch tem que fazer igual.
+# (texto, valores registrados na porta 2). A porta 2 recombina a resposta com o
+# texto original ("gastei <resposta> a luz") — é a ÚNICA das quatro que
+# re-serializa o valor de volta para texto.
+#
+# ESTA TABELA MUDOU, e a mudança é deliberada. A versão do #140 congelava seis
+# destas linhas com DOIS valores, pela regra "é o que a `main` faz, e o branch
+# tem que fazer igual". A regra era certa para o que o #140 mediu — recusa —,
+# mas aqui ela congelou um defeito: o splitter de multi-lançamento corta em
+# `,\s+` seguido de dígito (parsers.py), então uma resposta a uma pergunta de
+# UM valor virava DOIS lançamentos. Medido em produção pelo dono: "paguei a
+# luz" seguido de "132, 50" gravava R$ 132 em *moradia* e R$ 50 em *outros*.
+#
+# O princípio que decide: `"132,500"` SEM espaço já dá 132.5 hoje. O espaço
+# depois do separador não pode mudar o significado — e o `valor_perigoso` já
+# aceitou a forma como decimal uma linha antes (`_espaco_ambiguo` tem exceção
+# explícita para ela). O `_cola_separador_decimal`
+# (core/intent_router.py) apenas faz o texto entregue adiante dizer o que a
+# porta já tinha decidido.
+#
+# Monotonicidade MEDIDA sobre as 14 linhas: 6 saem de dois lançamentos para um,
+# 8 ficam idênticas, ZERO pioram — e nenhuma linha que já era um só lançamento
+# muda de valor. Só existe transformação de "dois lançamentos" em "um com o
+# valor que a pessoa quis dizer".
 ESPACO_PORTA_2 = [
-    ("132, 50",   [50.0, 132.0]),
-    ("132 , 50",  [50.0, 132.0]),
+    ("132, 50",   [132.5]),      # era [50.0, 132.0]
+    ("132 , 50",  [132.5]),      # era [50.0, 132.0]
     ("132 ,50",   [132.5]),
     ("132. 50",   [132.5]),
     ("132 . 50",  [132.5]),
-    ("1.234, 56", [56.0, 1234.0]),
+    ("1.234, 56", [1234.56]),    # era [56.0, 1234.0]
     ("1 234,56",  [1234.56]),
     ("1.234 ,56", [1234.56]),
-    ("132, 5",    [5.0, 132.0]),
-    ("132, 500",  [132.0, 500.0]),
+    ("132, 5",    [132.5]),      # era [5.0, 132.0]
+    ("132, 500",  [132.5]),      # era [132.0, 500.0]
     ("132,50 ",   [132.5]),
     ("1 500",     [1500.0]),
     ("12 345",    [12345.0]),
-    ("1 500, 50", [50.0, 1500.0]),
+    ("1 500, 50", [1500.5]),     # era [50.0, 1500.0]
 ]
 
 # Portas 3 e 4 recebem a resposta sozinha: um valor só, o mesmo nas duas.

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -392,6 +392,221 @@ def test_clarification_de_recorrente_nao_vira_despesa_avulsa(pro_uid, spy_ai):
 
 
 # ---------------------------------------------------------------------------
+# Porta 2 COM a IA de contexto — o caminho que a suíte nunca exercitou.
+#
+# Os casos acima passam há meses e não provavam nada sobre produção: o
+# `classify_with_context` (`core/intent_router.py`, dentro de
+# `_resolve_clarification`) é INERTE na suíte. `_classify_llm_call` devolve
+# `out_of_scope 0.0` sem `OPENAI_API_KEY` (core/intent_classifier.py), o
+# `conftest.py` não define a variável, e a fixture autouse
+# `_block_outbound_network` ainda troca `openai.OpenAI` por um cliente que
+# levanta em qualquer atributo — então exportar a chave também não resolveria.
+# `grep classify_with_context tests/` devolvia ZERO. O `if` que consome o
+# resultado nunca era entrado, e a suíte exercitava sempre o ramo protegido.
+#
+# Em produção, para conta Pro, é o outro ramo que roda. O prompt manda o
+# classificador extrair `valor` (core/intent_classifier.py), então o LLM quase
+# sempre preenche; `_ja_tem_o_valor` virava True sobre o dicionário JÁ mesclado
+# e o fluxo entrava no ramo "a resposta é a DESCRIÇÃO", que pula o filtro de
+# dano do #140 inteiro. Medido no WhatsApp: "paguei a luz" seguido de "-10"
+# gravava R$ 10,00; "132 50" gravava R$ 13.250,00; e "fatura" virava descrição
+# do gasto — a pergunta voltava como "Quanto foi no *luz - fatura*?".
+#
+# Todo teste deste bloco afirma que a IA FOI consultada. Sem isso a bateria
+# volta a ser verde e vazia, que é exatamente como o defeito sobreviveu.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def ia_de_esclarecimento(monkeypatch):
+    """Instala um `classify_with_context` que responde como o LLM responde.
+
+    Devolve a lista de chamadas — vazia significa que o caminho da IA não foi
+    tocado e o teste não mede nada.
+
+    O patch é em `core.intent_classifier`, NÃO em `core.intent_router`: o
+    import lá é dentro da função, então não existe binding de módulo no router
+    para substituir. Um `monkeypatch.setattr(router, "classify_with_context",
+    ...)` cria um atributo que ninguém lê e o teste passa sem exercitar nada.
+    """
+    chamadas: list[dict] = []
+
+    def instala(**entities):
+        import core.intent_classifier as ic
+
+        def fake(orig_text, question, answer, user_id=None):
+            chamadas.append({"orig_text": orig_text, "question": question,
+                             "answer": answer, "user_id": user_id})
+            return ic.IntentResult(
+                intent="launches.add",
+                confidence=0.9,
+                entities={"tipo": "despesa", **entities},
+                needs_clarification=False,
+            )
+
+        monkeypatch.setattr(ic, "classify_with_context", fake)
+        return chamadas
+
+    return instala
+
+
+def test_ia_de_contexto_e_mesmo_chamada_no_caminho_de_producao(pro_uid, monkeypatch):
+    """Fiação: a resposta a uma pergunta de valor chega ao LLM com o contexto.
+
+    Seam FUNDO (`_classify_llm_call`), de propósito: prova que o
+    `classify_with_context` é montado e chamado de verdade a partir do
+    `handle_incoming`, e não que o mock foi instalado. Os demais testes do
+    bloco usam o seam estreito, que dá controle sobre as entities.
+    """
+    import core.intent_classifier as ic
+
+    vistos: list[str] = []
+
+    def fake_llm(user_content, user_id):
+        vistos.append(user_content)
+        return ic.IntentResult(intent="out_of_scope", confidence=0.0)
+
+    uid = pro_uid
+    _pergunta_de_valor(uid)
+    monkeypatch.setattr(ic, "_classify_llm_call", fake_llm)
+
+    _send(uid, "132")
+
+    contexto = [c for c in vistos if "CONTEXTO DE ESCLARECIMENTO" in c]
+    assert contexto, f"o classify_with_context não foi montado: {vistos}"
+    assert "paguei a luz" in contexto[0], contexto[0]
+    assert "Quanto foi" in contexto[0], contexto[0]
+    assert '"132"' in contexto[0], contexto[0]
+
+
+# As seis formas medidas em produção. A fixture é o DISCRIMINANTE, não a
+# entrada: os mesmos textos já são verdes sem ela (bloco acima), porque sem IA
+# o fluxo cai no ramo protegido. Com `valor` preenchido pela IA, o código
+# anterior desviava para o ramo da descrição e gravava dinheiro errado.
+@pytest.mark.parametrize("resposta,esperado,medido", [
+    ("-10",       "maior que zero",       "gravava R$ 10,00"),
+    ("0,001",     "maior que zero",       "gravava R$ 0,00"),
+    ("132 50",    "Não entendi o valor",  "gravava R$ 13.250,00"),
+    ("1.23.456",  "Não entendi o valor",  "gravava R$ 123.456,00"),
+    (",50",       "Não entendi o valor",  "gravava R$ 50,00 — 100x"),
+])
+def test_ia_com_valor_nao_desvia_a_pergunta_para_o_ramo_da_descricao(
+    pro_uid, ia_de_esclarecimento, resposta, esperado, medido,
+):
+    """A recusa vale mesmo quando a IA devolve `valor` nas entities."""
+    import db
+
+    uid = pro_uid
+    _pergunta_de_valor(uid)
+    chamadas = ia_de_esclarecimento(valor=132.5)
+
+    resp = _send(uid, resposta)
+
+    assert chamadas, "a IA não foi consultada — o teste não mede nada"
+    assert esperado in resp, f"{medido}: {resp}"
+    assert "Quanto foi" in resp, f"pergunta não voltou: {resp}"
+    pend = _pendencia(uid)
+    assert pend is not None, "a pergunta morreu — usuário cai no fallback genérico"
+    assert pend["payload"]["orig_text"] == "paguei a luz", pend["payload"]
+    assert not db.list_launches(uid, limit=5), f"{medido}: gravou lançamento"
+
+
+def test_ia_com_valor_um_lancamento_so_para_virgula_com_espaco(
+    pro_uid, ia_de_esclarecimento,
+):
+    """"132, 50" é R$ 132,50 — e UM lançamento, não dois.
+
+    A porta 2 é a única das quatro que re-serializa o valor aceito de volta
+    para texto, e o `split_financial_transactions` quebra em `,\\s+` seguido de
+    dígito. Medido: `"paguei a luz - 132, 50"` virava
+    `['paguei a luz - 132', 'paguei 50']` → R$ 132 em *moradia* e R$ 50 em
+    *outros*. Este caso é o que obriga o `_cola_separador_decimal`; só a guarda
+    do ramo INVERTE os dois lançamentos em vez de eliminá-los.
+    """
+    import db
+
+    uid = pro_uid
+    _pergunta_de_valor(uid)
+    chamadas = ia_de_esclarecimento(valor=132.5)
+
+    resp = _send(uid, "132, 50")
+
+    assert chamadas, "a IA não foi consultada — o teste não mede nada"
+    lancamentos = db.list_launches(uid, limit=5)
+    assert len(lancamentos) == 1, f"esperado 1 lançamento, veio {len(lancamentos)}: {lancamentos}"
+    assert float(lancamentos[0]["valor"]) == 132.50, lancamentos[0]
+    assert "132,50" in resp, resp
+
+
+def test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta(pro_uid, ia_de_esclarecimento):
+    """"fatura" não pode virar descrição do gasto.
+
+    Medido no WhatsApp: "gastei no mercado" → "Quanto foi no *mercado*?" →
+    "fatura" → "Quanto foi no *mercado - fatura*?". O `orig_text` crescia a
+    cada turno e a palavra do usuário ficava gravada como alvo do lançamento.
+    """
+    import db
+
+    uid = pro_uid
+    _pergunta_de_valor(uid, "gastei no mercado")
+    chamadas = ia_de_esclarecimento(valor=44.0)
+
+    resp = _send(uid, "fatura")
+
+    assert chamadas, "a IA não foi consultada — o teste não mede nada"
+    assert "mercado - fatura" not in resp, f"o alvo engordou: {resp}"
+    pend = _pendencia(uid)
+    assert pend is not None, resp
+    assert pend["payload"]["orig_text"] == "gastei no mercado", pend["payload"]
+    assert not db.list_launches(uid, limit=5), "gravou com a resposta como alvo"
+
+
+def test_ia_com_valor_o_caminho_legitimo_segue_registrando(pro_uid, ia_de_esclarecimento):
+    """CONTROLE POSITIVO: pergunta de DESCRIÇÃO continua no ramo da descrição.
+
+    "gastei 50" grava `valor` no payload (core/handlers/launches.py), então a
+    pergunta é "Em que você gastou R$ 50,00?" e a resposta É a descrição. A
+    guarda lê o payload GRAVADO, então este caso não muda — e é a primeira vez
+    que ele roda com a IA no caminho, que é como ele roda em produção.
+    """
+    import db
+
+    uid = pro_uid
+    pergunta = _send(uid, "gastei 50")
+    assert "Em que você" in pergunta, pergunta
+    chamadas = ia_de_esclarecimento(valor=50.0, alvo="mercado")
+
+    resp = _send(uid, "mercado")
+
+    assert chamadas, "a IA não foi consultada — o teste não mede nada"
+    lancamentos = db.list_launches(uid, limit=5)
+    assert len(lancamentos) == 1, lancamentos
+    assert float(lancamentos[0]["valor"]) == 50.0, lancamentos[0]
+    assert "mercado" in (lancamentos[0].get("alvo") or "").lower(), lancamentos[0]
+    assert "50,00" in resp, resp
+
+
+def test_ia_com_valor_valor_legitimo_continua_passando(pro_uid, ia_de_esclarecimento):
+    """CONTROLE POSITIVO: a guarda não fechou a porta para o valor bom.
+
+    Sem este caso, o grupo passaria num código que recusa tudo — que é pior
+    que o bug (CLAUDE.md §3).
+    """
+    import db
+
+    uid = pro_uid
+    _pergunta_de_valor(uid)
+    chamadas = ia_de_esclarecimento(valor=132.5)
+
+    resp = _send(uid, "132,50")
+
+    assert chamadas, "a IA não foi consultada — o teste não mede nada"
+    lancamentos = db.list_launches(uid, limit=5)
+    assert len(lancamentos) == 1, lancamentos
+    assert float(lancamentos[0]["valor"]) == 132.50, lancamentos[0]
+    assert "132,50" in resp, resp
+
+
+# ---------------------------------------------------------------------------
 # Porta 3 (numeração em `core/intent_router.py`): a fila do `multi_launch_values`
 # (`core/handlers/launches.py::resolve_multi_launch_value`).
 #


### PR DESCRIPTION
Fase 1 do plano de correções da auditoria de regressão. É o único item que **grava dinheiro errado sem confirmação**.

## Medido no WhatsApp, conta Pro

`paguei a luz` (sem conta a pagar com esse nome) arma uma `clarification` de valor. As respostas seguintes **gravavam**:

| resposta | gravava | deveria |
|---|---|---|
| `-10` | R$ 10,00 | recusar — `parse_money` ignora o sinal |
| `0,001` | R$ 0,00 | recusar |
| `132 50` | R$ 13.250,00 | re-perguntar |
| `1.23.456` | R$ 123.456,00 | re-perguntar |
| `,50` | R$ 50,00 | re-perguntar — 100× o pretendido |
| `132, 50` | **DOIS** gastos: R$ 132 *moradia* + R$ 50 *outros* | um de R$ 132,50 |

E o mesmo buraco engordava o alvo: `gastei no mercado` + `fatura` devolvia *"Quanto foi no **mercado - fatura**?"*, com a palavra do usuário virando descrição do gasto.

## A causa

`_resolve_clarification` chama `classify_with_context` (LLM, só Pro) e mescla as entities devolvidas em `original_entities`. O prompt manda o classificador extrair `valor`, então ele quase sempre preenche. Vinte linhas abaixo, `_ja_tem_o_valor(original_entities)` lia o dicionário **já mesclado**, virava `True`, e o fluxo entrava no ramo *"a resposta é a DESCRIÇÃO"* — que pula o filtro de dano do #140 inteiro.

`valor_perigoso` tem 4 call sites, um por porta. O caminho normal de `launches.add` não tem filtro nenhum.

## Por que o #140 não pegou

O caminho defeituoso é **inerte na suíte**. `_classify_llm_call` degrada para `out_of_scope` sem `OPENAI_API_KEY`, o `conftest.py` não define a variável, e a fixture autouse `_block_outbound_network` ainda troca `openai.OpenAI` por um cliente que levanta em qualquer atributo — exportar a chave também não resolveria.

`grep classify_with_context tests/` devolvia **zero**. O `if` que consome o resultado nunca era entrado, e a suíte exercitava sempre o ramo protegido. Os casos com `-10` e `132 50` já existiam e passavam com o bug de pé.

## As duas mudanças

**1 · O veredito vem do payload gravado.** `pedia_o_valor` é capturado no topo da função, sobre a pendência que o usuário viu na tela.

Isto **restaura** a fonte única em vez de quebrá-la: `_clarification_abandonada` já lia `clarif["payload"]["entities"]` cru, e os dois consumidores discordavam sobre a mesma pergunta no mesmo turno.

Custo funcional zero — `_execute` → `launches.add` **re-parseia o texto**; as entities só entram no último fallback. O `valor` que a IA inventou nunca virava dinheiro por si só; o único efeito dele era virar a chave do ramo.

**2 · `_cola_separador_decimal`.** A porta 2 é a única das quatro que re-serializa o valor aceito de volta para texto, e o `split_financial_transactions` corta em `,\s+` seguido de dígito. Só a mudança 1 **inverte** os dois lançamentos em vez de eliminá-los. Restrito a resposta numérica por inteiro (mesmo predicado da porta 1), então `mercado, 20` sai intocada.

## A tabela congelada que mudou

`ESPACO_PORTA_2` congelava seis linhas com dois valores, pela regra do #140 *"é o que a `main` faz, e o branch tem que fazer igual"*. A regra era certa para o que o #140 media — **recusa** — mas aqui congelou o defeito medido em produção.

O princípio que decide: **`132,500` sem espaço já dá 132.5 hoje.** O espaço depois do separador não pode mudar o significado, e o `valor_perigoso` já aceitou a forma como decimal uma linha antes.

Monotonicidade medida sobre as 14 linhas: **6 saem de dois lançamentos para um, 8 ficam idênticas, zero pioram**, e nenhuma linha que já era um lançamento só muda de valor.

## Controles

**Negativos, por mudança, disjuntos:**

| injeção | vermelhos |
|---|---|
| só a guarda desligada | 7 — as 5 da tabela + `132, 50` + `fatura` |
| só a colagem desligada | **1** — apenas `132, 50` |

**Positivos:** pergunta de *descrição* (`gastei 50` → `mercado`) continua no ramo da descrição; `132,50` continua registrando. Sem eles o grupo passaria num código que recusa tudo.

**Prova de vida:** todo teste do bloco afirma que a IA foi consultada. Um deles usa o seam fundo (`_classify_llm_call`) e prova a fiação — o `user_content` chega com `CONTEXTO DE ESCLARECIMENTO`, a pergunta e a resposta.

## Suíte

`5018 passed` (baseline `5007`), comparado **por nome**. As 2 falhas restantes são artefato do Windows local (separador de caminho em `test_pending_registry`; limite de 32767 chars de variável de ambiente no id de teste com milhares de emojis) e estão ausentes no CI.

## Fora deste PR, com issue própria

- vírgula no ramo da **descrição** (`gastei 50` + `padaria, 20`) — exige decidir se vírgula numa descrição pode ser lista;
- a **"5ª porta"**: `launches.add` genérico sem filtro de dano — mexe na aceitação do caminho mais quente do app;
- trocar a inferência por presença de `valor` por um **campo explícito** no payload (`clarification_kind`), nos 5 produtores de `clarification`.

## Não verificado aqui

Comportamento no WhatsApp real. A suíte mocka o LLM e o envio — a tabela de 12 entradas precisa ser refeita no aparelho, com conta **Pro** (com conta grátis o caminho defeituoso não é alcançado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)