### PR TITLE
docs: apontamento do Codex é hipótese a verificar, não ordem de mudança

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,23 @@ Nunca deixe thread sem resposta e nunca afirme que threads estão respondidas se
 abrir e conferir. **Se você pediu revisão, é sua obrigação ir ler o parecer** — não
 espere alguém perguntar.
 
+**Apontamento do Codex não é ordem de mudança — é hipótese a verificar.** Ele não
+tem contexto de negócio, lê a árvore do branch (§3) e erra. Antes de tocar no código,
+para cada apontamento:
+
+1. **localize o trecho citado** e confirme que o problema existe mesmo ali;
+2. **leia o contexto inteiro** e o comportamento anterior — não só as linhas do diff;
+3. **verifique se o caso é alcançável em produção** (quem chama, com que entrada);
+4. **avalie o risco da correção**: ela pode introduzir regressão pior que o achado?
+5. **procure proteção que já exista** — validação, guarda ou função que já resolve (§0.1);
+6. **decida**: corrigir, simplificar, manter como está, ou apenas documentar.
+
+Só implemente com evidência de que a correção é necessária e melhora o sistema. Se o
+apontamento estiver errado, for só teórico, ou custar mais complexidade que benefício,
+**explique na thread e não altere o código** — resposta com evidência fecha a thread
+tão bem quanto um commit. Vale sempre a menor mudança segura: nada de abstração,
+tratamento ou teste criado só para satisfazer o revisor.
+
 **Ataque antes de empurrar. O parecer do Codex tem de ser confirmação, não descoberta.**
 Se ele está achando coisa, o ataque não foi feito. Rode o Tester (e o Manager) **antes**
 do push, não depois do apontamento — é a diferença entre revisar e terceirizar a revisão.


### PR DESCRIPTION
## O que muda

Um bloco novo na §4 do `CLAUDE.md` (PR, Codex e threads), entre o ciclo de resposta às
threads e o "Ataque antes de empurrar". Só documentação de processo — nenhum código,
nenhum teste, nenhuma rota tocada.

O bloco define que apontamento do Codex é **hipótese a verificar**, não ordem automática
de alteração, e lista os 6 passos antes de tocar no código:

1. localizar o trecho citado e confirmar que o problema existe ali;
2. ler o contexto inteiro e o comportamento anterior — não só as linhas do diff;
3. verificar se o caso é alcançável em produção (quem chama, com que entrada);
4. avaliar o risco da correção — ela pode introduzir regressão pior que o achado;
5. procurar proteção que já exista (validação, guarda, função);
6. decidir entre corrigir, simplificar, manter como está ou apenas documentar.

Fecha com a regra de só implementar com evidência: quando o achado está errado, é só
teórico, ou custa mais complexidade que benefício, **a resposta com evidência na thread
fecha o assunto no lugar do commit** — sempre a menor mudança segura, sem abstração,
tratamento ou teste criado só para satisfazer o revisor.

## Por quê

O ciclo do §4 já mandava "corrija — ou explique por que o apontamento não procede", mas
não dizia **como** chegar a essa conclusão. Na prática o apontamento vinha sendo tratado
como ordem, e o próprio arquivo registra o custo disso: no PR #60, de 21 apontamentos,
quase metade nasceu das próprias correções, não do código original.

## Para o revisor

- Duas ligações intencionais com o que o arquivo já dizia, para não virar regra solta:
  o passo 5 aponta para a §0.1 (*procure antes de criar*), que é a mesma disciplina; e a
  abertura cita a §3, que já registra que o Codex lê a árvore **do branch** e que um
  branch atrasado produz achado falso de "isso não existe".
- Colocado antes do "Ataque antes de empurrar" de propósito: aquele parágrafo trata do
  parecer como um todo (atacar antes do push), este trata de cada apontamento
  individual depois que ele chega.
- Diff: `CLAUDE.md`, +17 linhas, 0 remoções. Não há o que medir aqui — a suíte não é
  afetada e não foi rodada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
