### PR TITLE
fix(auth): senha errada para de apagar o estado do aparelho (#173)

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2728,12 +2728,40 @@ async def auth_refresh(request: Request, response: Response):
       3. Emite novo access token (15min) + dashboard_token.
       4. Atualiza auth_sessions.last_seen_at.
 
-    Falhas (token revogado, expirado, replay, idle, sessão revogada): retorna 401
-    e limpa cookies. Frontend deve mandar pro login.
+    Os DOIS ramos de falha, e por que o status difere entre eles. Aqui o status
+    não classifica o erro: responde "a sessão acabou?", porque é isso que o
+    `frontend/static/auth-refresh.js` lê — um 401 nesta rota faz o interceptor
+    apagar o estado do aparelho (storage derivado de conta, Cache Storage,
+    service worker).
+
+      400 missing_refresh_token  sem cookie de refresh, mas com access token
+                                 ainda válido: não dá para renovar e a sessão
+                                 está de pé. 401 aqui apagaria o aparelho de
+                                 quem só errou a senha noutra rota (#173).
+      401 missing_refresh_token  sem cookie de refresh e sem access válido: não
+                                 há sessão. É o fim de vida natural — o cookie
+                                 de refresh vence em 14d e some do jar.
+      401 invalid_refresh_token  revogado, expirado, replay, idle ou sessão
+                                 revogada. Fim de sessão.
+
+    "Sem cookie de refresh" não é sinônimo de sessão viva: os dois primeiros
+    ramos têm o mesmo `detail` e estados opostos. O que os separa é a checagem
+    do access — que valida assinatura, `exp` e `type`, e NÃO a revogação de
+    sessão por `jti` nem exclusão agendada de conta. Sessão revogada com JWT
+    ainda no prazo cai em 400, e tudo bem: quem revogou (logout, exclusão) já
+    limpou o aparelho na mesma origem.
+
+    O `_clear_session_cookies` do ramo `invalid` NÃO chega ao cliente — o
+    `HTTPException` descarta os headers do sub-response (medido, #175). Está
+    fora do escopo deste conserto, mas não é para ser lido como funcionando.
     """
     refresh_in_cookie = (request.cookies.get(REFRESH_COOKIE_NAME) or "").strip()
     if not refresh_in_cookie:
-        raise HTTPException(status_code=401, detail="missing_refresh_token")
+        token = _get_auth_token_from_request(request, None)
+        sessao_viva = bool(token) and (_decode_jwt(token) or {}).get("type") == "auth"
+        raise HTTPException(
+            status_code=400 if sessao_viva else 401, detail="missing_refresh_token",
+        )
 
     from core.refresh_tokens import consume_refresh_token
     ip = get_remote_address(request) or None

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2749,10 +2749,12 @@ async def auth_refresh(request: Request, response: Response):
     do **cookie** de access — que valida assinatura, `exp` e `type`, e NÃO a
     revogação de sessão por `jti` nem exclusão agendada de conta. Duas
     consequências, as duas de propósito: sessão revogada com JWT ainda no prazo
-    cai em 400 (tudo bem — quem revogou, logout ou exclusão, já limpou o
-    aparelho na mesma origem), e quem se autentica por `Authorization: Bearer`
-    cai em 401 (é o comportamento de sempre; os dois clientes desta rota,
-    `login.html` e o interceptor, são de cookie).
+    cai em 400 — e tudo bem, porque chegar neste ramo exige ter perdido o cookie
+    de refresh TAMBÉM. Enquanto ele estiver no jar a revogação é vista pelo
+    `consume_refresh_token` e o ramo é 401, mesmo quando quem revogou foi outro
+    aparelho (reset de senha → `revoke_user_refresh_tokens`). E quem se autentica
+    por `Authorization: Bearer` cai em 401 (é o comportamento de sempre; os dois
+    clientes desta rota, `login.html` e o interceptor, são de cookie).
 
     O `_clear_session_cookies` do ramo `invalid` NÃO chega ao cliente — o
     `HTTPException` descarta os headers do sub-response (medido, #175). Está

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2746,10 +2746,13 @@ async def auth_refresh(request: Request, response: Response):
 
     "Sem cookie de refresh" não é sinônimo de sessão viva: os dois primeiros
     ramos têm o mesmo `detail` e estados opostos. O que os separa é a checagem
-    do access — que valida assinatura, `exp` e `type`, e NÃO a revogação de
-    sessão por `jti` nem exclusão agendada de conta. Sessão revogada com JWT
-    ainda no prazo cai em 400, e tudo bem: quem revogou (logout, exclusão) já
-    limpou o aparelho na mesma origem.
+    do **cookie** de access — que valida assinatura, `exp` e `type`, e NÃO a
+    revogação de sessão por `jti` nem exclusão agendada de conta. Duas
+    consequências, as duas de propósito: sessão revogada com JWT ainda no prazo
+    cai em 400 (tudo bem — quem revogou, logout ou exclusão, já limpou o
+    aparelho na mesma origem), e quem se autentica por `Authorization: Bearer`
+    cai em 401 (é o comportamento de sempre; os dois clientes desta rota,
+    `login.html` e o interceptor, são de cookie).
 
     O `_clear_session_cookies` do ramo `invalid` NÃO chega ao cliente — o
     `HTTPException` descarta os headers do sub-response (medido, #175). Está

--- a/frontend/static/auth-refresh.js
+++ b/frontend/static/auth-refresh.js
@@ -50,8 +50,9 @@
           headers,
         });
         // O refresh interno não passa pelo wrapper, então a limpeza é aplicada
-        // aqui: um 401 nele é deslogue involuntário, e o backend limpa o cookie
-        // de sessão nesse mesmo ramo (finance_bot_websocket_custom.py).
+        // aqui. Só o 401 conta: o backend responde 400 quando o cookie de
+        // refresh falta mas o access token ainda vale — sessão de pé, nada a
+        // apagar (finance_bot_websocket_custom.py, #173).
         await _comLimpeza("/auth/refresh", r);
         return r.ok;
       } catch (_) {
@@ -81,9 +82,19 @@
    *
    *   POST   /auth/logout    encerra quando dá certo
    *   DELETE /auth/account   idem — a exclusão agendada desloga na hora
-   *   POST   /auth/refresh   encerra quando FALHA (401): refresh inválido é
-   *                          deslogue involuntário, e o backend limpa o cookie
-   *                          nesse mesmo ramo
+   *   POST   /auth/refresh   encerra quando dá 401, e SÓ 401. O status desta
+   *                          rota responde "a sessão acabou?", não classifica
+   *                          o erro: 400 é refresh ausente com access ainda
+   *                          válido (sessão de pé, nada a apagar), 401 é
+   *                          refresh invalidado/revogado ou ausente sem access
+   *                          válido. Tratar todo 401 como fim de sessão
+   *                          apagava o aparelho de quem só errou a senha
+   *                          noutra rota (#173).
+   *
+   * Por que 401 aqui justifica apagar: o refresh token acabou, então não há
+   * como renovar de novo — o que estiver no aparelho é lixo de uma sessão que
+   * não volta. NÃO é "a sessão já acabou no servidor": o cookie de access pode
+   * sobreviver até 15 min (e o backend nem o expira aqui — #175).
    *
    * `tests/test_static_pages_routes.py` compara esta lista com as rotas que o
    * Python realmente tem, por `ast`. Duplicação inevitável — JS não importa

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -299,7 +299,7 @@ const PREFERENCIA_DO_APARELHO = {
   "finbot_logout_at": "1756400000000",
 };
 
-function comStorageCheio(arquivo) {
+function comStorageCheio(arquivo, prepara) {
   const local = new Map(Object.entries({ ...DERIVADO_DE_CONTA, ...PREFERENCIA_DO_APARELHO }));
   const sessao = new Map(Object.entries({ "pb_home_42": "x", "pb_snap_42_2026_08": "y", "pbSpa": "1" }));
   // Proxy, não snapshot: `Object.keys(storage)` tem que refletir o Map VIVO,
@@ -321,6 +321,7 @@ function comStorageCheio(arquivo) {
   const { ctx } = paginaComCache(arquivo, (c) => {
     c.localStorage = mapa(local);
     c.sessionStorage = mapa(sessao);
+    if (prepara) prepara(c);
   });
   return { ctx, local, sessao };
 }
@@ -460,6 +461,72 @@ test("refresh interno que falha (401) limpa — deslogue involuntario", async ()
   assert.equal(resp.status, 401);
   assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
                    "refresh 401 e' fim de sessao e nao limpou o cache");
+});
+
+// Os DOIS ramos de falha do /auth/refresh. O status dessa rota responde "a
+// sessao acabou?", nao classifica o erro: 401 e' refresh invalidado, ou
+// ausente sem access valido; 400 e' ausente com a sessao de pe. O caso acima
+// cobre o 401; os tres abaixo cobrem o 400 e o teto de renovacoes (#173).
+
+test("refresh interno que devolve 400 NAO limpa — a sessao esta' de pe", async () => {
+  // Senha errada no MFA leva 401 de APLICACAO. O interceptor renova por
+  // reflexo (#176), o backend responde 400 porque o access token ainda vale, e
+  // tratar isso como fim de sessao apagava o aparelho de quem so' errou a senha.
+  const apagados = [];
+  const falso = fetchPorRota({ "/auth/mfa/setup": 401, "/auth/refresh": 400 });
+  const { ctx } = paginaComCache("static/auth-refresh.js", (c) => {
+    c.fetch = falso.fn;
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  const resp = await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+
+  assert.ok(falso.chamadas.some((c) => c.caminho === "/auth/refresh"),
+            "o interceptor nem tentou renovar — o teste nao mede o caminho certo");
+  assert.equal(resp.status, 401, "o 401 da senha errada tem que chegar ao chamador");
+  assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao viva");
+});
+
+test("senha errada com refresh ausente: o estado fica E a chamada seguinte funciona", async () => {
+  // O cenario inteiro, ponta a ponta: nao basta nao apagar, a sessao tem que
+  // seguir utilizavel depois. Sem a segunda metade o caso passaria num
+  // interceptor que engoliu a sessao de outro jeito.
+  const apagados = [];
+  const falso = fetchPorRota({
+    "/auth/mfa/setup": 401, "/auth/refresh": 400, "/data/42": 200,
+  });
+  const { ctx, local, sessao } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = falso.fn;
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  const erro = await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+  assert.equal(erro.status, 401);
+
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), true, `${k} foi apagado com a sessao viva`);
+  }
+  assert.equal(sessao.has("pb_home_42"), true, "pb_home_ foi apagado da sessao");
+  assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao viva");
+
+  const ok = await ctx.window.fetch("/data/42");
+  assert.equal(ok.ok, true, "a chamada autenticada seguinte parou de funcionar");
+  assert.deepEqual(apagados, [], "a chamada seguinte apagou o Cache Storage");
+});
+
+test("uma renovacao por 401 interceptado, e nenhum retry quando ela falha", async () => {
+  // O teto. O interceptor renova em QUALQUER 401 (#176), entao o que segura o
+  // custo e' nao haver recursao: uma renovacao, e a request original refeita
+  // so' quando a renovacao da' certo.
+  const falso = fetchPorRota({ "/auth/mfa/setup": 401, "/auth/refresh": 400 });
+  const { ctx } = paginaComCache("static/auth-refresh.js", (c) => { c.fetch = falso.fn; });
+
+  await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+
+  const refresh = falso.chamadas.filter((c) => c.caminho === "/auth/refresh");
+  const setup = falso.chamadas.filter((c) => c.caminho === "/auth/mfa/setup");
+  assert.equal(refresh.length, 1, `esperado 1 refresh, vieram ${refresh.length}`);
+  assert.equal(setup.length, 1, "a request original foi refeita com o refresh falhando");
 });
 
 test("retry pos-refresh que encerra a sessao limpa", async () => {

--- a/tests/test_auth_cookie.py
+++ b/tests/test_auth_cookie.py
@@ -123,6 +123,87 @@ def test_login_sets_auth_token_cookie(monkeypatch):
     assert "secure" in refresh
 
 
+# ── /auth/refresh: o status responde "a sessão acabou?" ──────────────────────
+#
+# O `frontend/static/auth-refresh.js` apaga o estado do aparelho (storage
+# derivado de conta, Cache Storage inteiro, service worker) quando ESTA rota
+# devolve 401. Por isso o ramo do refresh ausente escolhe o status pela validade
+# do access token, e não pelo tipo do erro: 401 para os dois casos apagava o
+# aparelho de quem só errou a senha noutra rota, com a sessão de pé (#173).
+#
+# "Sem cookie de refresh" NÃO é sinônimo de sessão viva — os dois primeiros
+# casos abaixo têm o mesmo `detail` e estados opostos.
+
+
+def _post_refresh(client: TestClient):
+    return client.post("/auth/refresh", headers=_csrf_headers(client))
+
+
+def test_refresh_sem_cookie_com_access_valido_nao_encerra_sessao():
+    client = TestClient(dashboard.app)
+    client.cookies.set(
+        dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(123, "user@example.com"),
+    )
+
+    response = _post_refresh(client)
+
+    assert response.status_code == 400, (
+        "401 aqui faz o auth-refresh.js apagar o estado do aparelho com a sessão viva"
+    )
+    assert response.json()["detail"] == "missing_refresh_token"
+
+
+def test_refresh_sem_cookie_com_access_expirado_encerra_sessao():
+    # O outro lado do mesmo ramo, e o caminho COMUM: o cookie de refresh vence
+    # em 14d e some do jar do navegador junto com o access. Aí a sessão é
+    # irrecuperável e a limpeza do aparelho tem de continuar acontecendo.
+    from datetime import datetime, timedelta, timezone
+
+    import jwt as pyjwt
+
+    vencido = pyjwt.encode(
+        {
+            "sub": "123",
+            "email": "user@example.com",
+            "type": "auth",
+            "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+        },
+        dashboard.JWT_SECRET,
+        algorithm="HS256",
+    )
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, vencido)
+
+    response = _post_refresh(client)
+
+    assert response.status_code == 401, (
+        "sessão irrecuperável: 400 aqui deixaria o estado privado no aparelho"
+    )
+    assert response.json()["detail"] == "missing_refresh_token"
+
+
+def test_refresh_sem_cookie_nenhum_encerra_sessao():
+    client = TestClient(dashboard.app)
+
+    response = _post_refresh(client)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "missing_refresh_token"
+
+
+def test_refresh_com_token_desconhecido_continua_encerrando_sessao():
+    # O ramo que já era fim de sessão, intocado: refresh inválido/revogado/
+    # replay. Controle positivo do par — sem ele o grupo passaria num backend
+    # que nunca devolve 401.
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.REFRESH_COOKIE_NAME, "rt_naoexiste")
+
+    response = _post_refresh(client)
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_refresh_token"
+
+
 def test_dashboard_token_accepts_auth_cookie_without_authorization_header():
     token = dashboard._make_jwt(123, "user@example.com")
     client = TestClient(dashboard.app)


### PR DESCRIPTION
Fecha #173.

## O defeito

`frontend/static/auth-refresh.js` tratava **qualquer** 401 do `/auth/refresh` como fim de
sessão e apagava o estado do aparelho (storage derivado de conta, Cache Storage inteiro,
desregistro do service worker). Mas o backend devolvia 401 em dois estados opostos, e o
interceptor não tinha como distingui-los.

Com access token válido e sem cookie de refresh, errar a senha em `/auth/mfa/setup`,
`/auth/account/export` ou `DELETE /auth/account` apagava o aparelho **com a sessão de pé**.

## O conserto

O status do `/auth/refresh` passa a responder **"a sessão acabou?"**, em vez de classificar o
erro — é isso que o interceptor lê:

| status | quando | o JS apaga? |
|---|---|---|
| `400 missing_refresh_token` | sem cookie de refresh, **com** access token válido | não |
| `401 missing_refresh_token` | sem cookie de refresh e **sem** access válido | sim |
| `401 invalid_refresh_token` | revogado, expirado, replay, idle | sim (como antes) |

O predicado do JS (`resp.status === 401`) **não mudou uma linha** — ele passou a ser
verdadeiro. Sem `resp.clone()`, sem string do corpo espelhada no JS, sem header novo
duplicando o que o corpo já diz (§0.7).

**"Sem cookie de refresh" não prova sessão viva** — por isso a checagem do access, e não um
400 seco. O caminho comum de expiração (o cookie de refresh vence em 14d e some do jar junto
com o access) continua caindo em 401 e continua limpando o aparelho, como o #170 quis.

A checagem reusa `_get_auth_token_from_request` + `_decode_jwt`, já combinados assim em
`:2682` e `:4794`. Valida assinatura, `exp` e `type`; **não** valida revogação de sessão por
`jti` nem exclusão agendada — está dito no docstring. Nenhuma query nova.

### Inventário de consumidores

`grep -rln "auth/refresh"` na árvore inteira, sem filtro de extensão: `frontend/login.html:104`
e o `_doRefresh` do próprio interceptor — **os dois só olham `.ok`** — mais duas menções de
documentação (`db/schema.py:1474`, `docs/CLAUDE.md:101`), que não afirmam nada sobre 401 e não
mudaram. Os 3 `.swift` de `mobile/` não citam `auth/refresh`, `refresh_token` nem `401`: o
`AppDelegate.swift` só faz `wk.load(URLRequest(url:))`, quem fala com a API é o JS da página.

## O que este PR NÃO resolve (declarado de propósito)

- **O interceptor renova em QUALQUER 401**, inclusive senha errada — #176. Este PR conserta o
  predicado de fim de sessão, não o gatilho. Toda senha errada continua gastando um
  `POST /auth/refresh` inútil.
- **O `_clear_session_cookies` do ramo `invalid` é um no-op** — #175, medido: o
  `HTTPException` descarta os `Set-Cookie` do sub-response. O docstring passou a dizer isso em
  vez de descrever um comportamento que não existe.
- `missing_refresh_token` continua sendo **um só `detail` para dois estados**. O que os separa
  é o status.

## Verificação

Máquina local (Windows), `.venv` com todos os pacotes, Postgres 16 no ar.

**Controles negativos, medidos — cada injeção num caso que estava VERDE:**

| injeção | resultado |
|---|---|
| ramo fixo em `401` (o comportamento de hoje) | `test_refresh_sem_cookie_com_access_valido_nao_encerra_sessao` vermelho, os outros 3 verdes |
| ramo fixo em `400` | `..._com_access_expirado_encerra_sessao` e `..._sem_cookie_nenhum_encerra_sessao` vermelhos |
| predicado do JS → `resp.status >= 400` | os 2 casos do 400 vermelhos, o do 401 verde |
| retry mesmo com o refresh falhando | `uma renovacao por 401 interceptado` vermelho |

Repostos, tudo verde de novo. Controles positivos, verdes o tempo todo:
`refresh interno que falha (401) limpa` e `request comum que renova e da' certo NAO limpa` —
sem eles o grupo passaria num código que nunca limpa (ou que limpa sempre).

**Suítes** (comparadas por NOME com a baseline da mesma árvore):

- pytest: `1 failed, 5106 passed, 1 xfailed, 2 errors` → `1 failed, 5110 passed, 1 xfailed, 2 errors` (os 4 casos novos). Lista de falhas idêntica.
- frontend: 100 → **103** passam, mesmas 2 falhas de nível de arquivo.

As falhas restantes são artefato do Windows local, não regressão — o CI (Linux) está verde nas
mesmas:

1. `test_pending_registry.py::test_todo_tipo_gravado_esta_no_registro` — `_ENCANAMENTO =
   "db/pending.py"` versus `str(py.relative_to(_RAIZ))`, que no Windows dá `db\pending.py`.
2. `test_category_normalization.py::test_nome_de_categoria_gigante_recusado` (2 casos) — o id
   do teste parametrizado com milhares de emojis não cabe no `PYTEST_CURRENT_TEST` (limite de
   32767 chars do Windows).
3. `tests/frontend/hiw_rail.test.mjs` — no nível do ARQUIVO: os 16 casos internos passam, o que
   estoura é `assert(!this.paused)` no teardown.
4. `tests/frontend/dashboard_category_escape.test.mjs` — no nível do ARQUIVO: o worktree tem
   `dashboard.html` com CRLF e o teste faz `split("\n")` + `l === "</div>"`, que nunca casa.

**Não exercitável aqui:** o navegador de verdade descartando o cookie de refresh no WKWebView
— só no aparelho, depois do build. Os testes provam o contrato dos três estados e o
comportamento do interceptor, não o descarte do cookie pelo navegador.
