### PR TITLE
A fronteira do dia é a de São Paulo, não a da sessão do Postgres (#178)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,16 @@ DATABASE_URL=postgresql://user:password@host:5432/dbname
 # Ex: https://dashboard-production-020d.up.railway.app
 DASHBOARD_URL=https://seu-projeto.up.railway.app
 
-# Fuso horário para exibição de datas no dashboard.
+# Fuso do app. Um valor só governa TRÊS relógios que precisam concordar: o
+# PROCESSO (`date.today()`, `datetime.now()` naive), o APP (`utils_date._tz()`)
+# e a SESSÃO do Postgres (`::date`, `date_trunc`, e a promoção de `timestamp`
+# naive a `timestamptz` — é por ela que a fronteira do dia é resolvida).
+# Precedência: REPORT_TIMEZONE ganha de TZ SEMPRE, venha de onde vier — arquivo
+# inclusive. Só entre um TZ e outro TZ é que o do ambiente real ganha do daqui.
+# Logo: com as duas linhas abaixo preenchidas, editar só o TZ é no-op silencioso
+# — mude REPORT_TIMEZONE (ou apague-o) para trocar o fuso.
+# Nome IANA; inválido recusa o boot.
+REPORT_TIMEZONE=America/Sao_Paulo
 TZ=America/Sao_Paulo
 
 # Intervalo (segundos) de atualização automática via WebSocket.

--- a/config/env.py
+++ b/config/env.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 from dotenv import dotenv_values
+
+# Módulo, não `from ... import`: `_TZ_ENV_ORIGINAL` é lido aqui e escrito lá, e
+# a direção é acíclica (`utils_date` não importa nada do projeto).
+import utils_date
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -30,8 +35,48 @@ def load_app_env() -> str:
     if env_file.exists():
         merged.update({k: v for k, v in dotenv_values(env_file, interpolate=False).items() if v is not None})
 
+    # `utils_date` é importado ANTES de o `.env` ser lido e já escreveu `TZ` no
+    # ambiente (`align_process_tz`). Se o operador NÃO tinha `TZ` no ambiente
+    # real, esse `TZ` é nosso, não dele — e o `setdefault` de baixo o veria como
+    # valor já existente, transformando `TZ` no `.env` (documentado em
+    # `.env.example`) num no-op. Esta linha devolve ao arquivo a vez dele; `TZ`
+    # vindo do ambiente REAL não é tocado e continua ganhando.
+    #
+    # É ATRIBUIÇÃO, e nunca `pop`, porque isto NÃO roda só no boot: o import de
+    # `adapters/whatsapp/wa_app.py` (que chama `load_app_env` na linha 39) é
+    # tardio de propósito — `frontend/finance_bot_websocket_custom.py:1952-1963`
+    # o faz na 1ª requisição e `:1632-1656` 1 s depois do startup, com event
+    # loop, threadpool e WebSockets já ativos. A glibc relê `TZ` a cada
+    # `localtime()`, então um `pop` abriria uma janela (até o `align_process_tz`
+    # do fim) em que uma thread concorrente chamando `date.today()` cairia no
+    # fuso do contêiner — UTC no Railway, que é o bug deste PR de volta por
+    # microssegundos. Quem prova a ausência da janela é o caso 14 de
+    # `tests/test_fuso_do_app.py`.
+    if utils_date._TZ_ENV_ORIGINAL is None and "TZ" in merged:
+        os.environ["TZ"] = merged["TZ"]
+
     for key, value in merged.items():
         os.environ.setdefault(key, value)
 
     os.environ.setdefault("APP_ENV", app_env)
+
+    # Realinha DEPOIS do `.env`: sem isto, um `REPORT_TIMEZONE` vindo de ARQUIVO
+    # faz o app e a sessão do Postgres seguirem o arquivo enquanto o PROCESSO
+    # fica no fuso do sistema — exatamente a divergência que `align_process_tz`
+    # existe para fechar, reintroduzida por um canal suportado (e é a variável
+    # que a mensagem de erro logo abaixo ensina o operador a usar).
+    #
+    # Fuso inválido tem de matar o processo AQUI, no boot, e não na primeira
+    # query: o nome vai para `PGTZ`, e um nome inválido derruba a conexão DEPOIS
+    # de o health check passar — o pool pendura até `PoolTimeout` e o deploy é
+    # dado como bom. Sem fallback de propósito: a intenção é falhar, só que cedo.
+    try:
+        utils_date.align_process_tz()
+    except Exception as exc:
+        print(
+            f"ERROR: REPORT_TIMEZONE/TZ inválido ({exc}). Use um nome IANA, ex.: America/Sao_Paulo.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     return app_env

--- a/config/env.py
+++ b/config/env.py
@@ -35,28 +35,72 @@ def load_app_env() -> str:
     if env_file.exists():
         merged.update({k: v for k, v in dotenv_values(env_file, interpolate=False).items() if v is not None})
 
-    # `utils_date` é importado ANTES de o `.env` ser lido e já escreveu `TZ` no
-    # ambiente (`align_process_tz`). Se o operador NÃO tinha `TZ` no ambiente
-    # real, esse `TZ` é nosso, não dele — e o `setdefault` de baixo o veria como
-    # valor já existente, transformando `TZ` no `.env` (documentado em
-    # `.env.example`) num no-op. Esta linha devolve ao arquivo a vez dele; `TZ`
-    # vindo do ambiente REAL não é tocado e continua ganhando.
+    # ── O FUSO: uma escrita só, já com o valor final ─────────────────────────
     #
-    # É ATRIBUIÇÃO, e nunca `pop`, porque isto NÃO roda só no boot: o import de
-    # `adapters/whatsapp/wa_app.py` (que chama `load_app_env` na linha 39) é
-    # tardio de propósito — `frontend/finance_bot_websocket_custom.py:1952-1963`
-    # o faz na 1ª requisição e `:1632-1656` 1 s depois do startup, com event
-    # loop, threadpool e WebSockets já ativos. A glibc relê `TZ` a cada
-    # `localtime()`, então um `pop` abriria uma janela (até o `align_process_tz`
-    # do fim) em que uma thread concorrente chamando `date.today()` cairia no
-    # fuso do contêiner — UTC no Railway, que é o bug deste PR de volta por
-    # microssegundos. Quem prova a ausência da janela é o caso 14 de
-    # `tests/test_fuso_do_app.py`.
-    if utils_date._TZ_ENV_ORIGINAL is None and "TZ" in merged:
-        os.environ["TZ"] = merged["TZ"]
+    # ISTO NÃO RODA SÓ NO BOOT. `adapters/whatsapp/wa_app.py:39` chama
+    # `load_app_env` no import, e esse import é tardio de propósito
+    # (`frontend/finance_bot_websocket_custom.py:1952-1963`, 1ª requisição;
+    # `:1632-1656`, 1 s depois do startup). Então isto executa com event loop,
+    # threadpool e WebSockets ativos — e a glibc relê `TZ` a cada `localtime()`.
+    # Consequência dura: **todo valor intermediário de `TZ` é observável por uma
+    # thread concorrente chamando `date.today()`**, e um valor intermediário
+    # errado é o bug da #178 de volta por microssegundos.
+    #
+    # Três versões desta função já falharam por escrever `TZ` mais de uma vez:
+    # `pop` (janela SEM `TZ`), e depois `os.environ["TZ"] = merged["TZ"]`
+    # (janela com o `TZ` do arquivo quando o `REPORT_TIMEZONE`, de precedência
+    # MAIOR, é quem manda). Por isso agora o valor efetivo é RESOLVIDO ANTES e
+    # escrito UMA VEZ.
+    #
+    # A máquina inteira, enumerada — `R` = REPORT_TIMEZONE, `T` = TZ,
+    # `env` = ambiente real (`_TZ_ENV_ORIGINAL` para o `T`), `f` = vindo do
+    # `.env`. Precedência: R ganha de T; dentro de cada um, ambiente real ganha
+    # do arquivo. `efetivo` é o que as TRÊS pontas (processo, app e sessão do
+    # Postgres) têm de valer, do começo ao fim:
+    #
+    #   R_env  R_f  T_env  T_f   efetivo        por quê
+    #   ────────────────────────────────────────────────────────────────────
+    #     •     -     -     -    R_env          R ganha, ambiente real
+    #     •     •     -     -    R_env          ambiente real ganha do arquivo
+    #     •     -     •     -    R_env          R ganha de T
+    #     •     •     •     •    R_env          idem, todos presentes
+    #     -     •     -     -    R_f            R do arquivo, sem R real
+    #     -     •     •     -    R_f            R ganha de T mesmo vindo de arquivo
+    #     -     •     -     •    R_f            idem
+    #     -     •     •     •    R_f            idem
+    #     -     -     •     -    T_env          sem R, T do ambiente real
+    #     -     -     •     •    T_env          ambiente real ganha do arquivo
+    #     -     -     -     •    T_f            sem R e sem T real: o arquivo vale
+    #     -     -     -     -    default        America/Sao_Paulo
+    #
+    # (São 16 combinações; as 12 acima cobrem todas — as 4 que faltam repetem
+    # linha por o `R_env` tornar o resto irrelevante. `tests/test_fuso_do_app.py`
+    # parametriza as 16 e afirma as três pontas em cada uma.)
+    #
+    # `_TZ_ENV_ORIGINAL` é o `TZ` que o ambiente REAL trazia, capturado no import
+    # de `utils_date` ANTES de a nossa própria escrita existir — sem ele não há
+    # como distinguir "o operador setou `TZ`" de "nós setamos `TZ`".
+    efetivo = (os.environ.get("REPORT_TIMEZONE")
+               or merged.get("REPORT_TIMEZONE")
+               or utils_date._TZ_ENV_ORIGINAL
+               or merged.get("TZ"))
 
+    # `TZ` e `REPORT_TIMEZONE` saem do `setdefault` genérico: a precedência
+    # delas é a da tabela acima, não a de "quem já está no ambiente ganha" — o
+    # import já escreveu `TZ`, então o `setdefault` o veria como valor do
+    # operador e o `TZ` do `.env` (documentado em `.env.example`) seria no-op.
     for key, value in merged.items():
-        os.environ.setdefault(key, value)
+        if key not in ("TZ", "REPORT_TIMEZONE"):
+            os.environ.setdefault(key, value)
+
+    # `REPORT_TIMEZONE` precisa estar no ambiente para o `_tz()` enxergá-lo.
+    if "REPORT_TIMEZONE" not in os.environ and "REPORT_TIMEZONE" in merged:
+        os.environ["REPORT_TIMEZONE"] = merged["REPORT_TIMEZONE"]
+
+    # A ÚNICA escrita de `TZ` aqui, e já com o valor final: nenhum instante
+    # observável tem `TZ` ausente nem `TZ` diferente do efetivo.
+    if efetivo:
+        os.environ["TZ"] = efetivo
 
     os.environ.setdefault("APP_ENV", app_env)
 

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -612,8 +612,9 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
         if criado is not None:
             try:
                 # `launch_day` (utils_date), não `.date()` nem `day_tz` cru: o
-                # `.date()` devolve o dia no fuso da SESSÃO do Postgres (UTC no
-                # Railway) — 21:30 em São Paulo saía como o dia SEGUINTE — e o
+                # `.date()` devolve o dia no fuso da SESSÃO do Postgres, que ERA
+                # UTC no Railway — 21:30 em São Paulo saía como o dia SEGUINTE
+                # (hoje a sessão segue o app, `utils_date.align_process_tz`) — e o
                 # `day_tz` sozinho converte um instante que a linha SEM HORA não
                 # tem (Open Finance legado, ver `launch_day`). Mesma função de
                 # `list_launches_by_category`, senão as duas portas divergem.

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -685,8 +685,10 @@ def list_launches_by_category(
       tipo='despesa' faria o chamador rotear o delete pro endpoint de launches e
       apagar OUTRO registro. Nulo na origem = colisão impossível. `data` é o dia
       por `launch_day` (utils_date): o `posted_at` gravado quando `has_time` é
-      falso, senão o dia de PAREDE de `criado_em` (`day_tz`); nunca o `::date`
-      do fuso da sessão. `criado_em` é o instante cheio (o editor do dashboard
+      falso, senão o dia de PAREDE de `criado_em` (`day_tz`); nunca um `::date`
+      em SQL, que responderia a pergunta errada onde a linha não tem hora
+      (mesmo agora que a sessão do Postgres roda no fuso do app, por
+      `utils_date.align_process_tz`). `criado_em` é o instante cheio (o editor do dashboard
       preenche "Data e hora" com ele — `data` sozinho abria o campo vazio).
       Na perna de `launches`, `posted_at` + `has_time` são o mesmo par (e o mesmo
       `LAUNCH_HAS_TIME_SQL`) que a Visão Geral usa na query 4 do dashboard: sem
@@ -899,10 +901,10 @@ def list_launches_by_category(
             "nota": r["nota"],
             "alvo": r["alvo"],
             # `launch_day` (utils_date), não `.date()` nem `day_tz` seco: o `.date()`
-            # cru devolve o dia no fuso da SESSÃO do Postgres (UTC na produção) e um
-            # gasto das 21:30 em São Paulo sairia com o dia SEGUINTE — o MESMO
-            # lançamento com dia diferente aqui e em "meus últimos lançamentos"
-            # (`list_launches`, core/handlers/launches.py). E onde `has_time` é
+            # cru devolve o dia no fuso da SESSÃO do Postgres, que ERA UTC na
+            # produção, e um gasto das 21:30 em São Paulo saía com o dia SEGUINTE
+            # — o MESMO lançamento com dia diferente aqui e em "meus últimos
+            # lançamentos" (`list_launches`, core/handlers/launches.py). E onde `has_time` é
             # falso quem manda é `posted_at` — QUAIS linhas são essas, e por que
             # os importadores de HOJE ficam de fora, estão no docstring de
             # `launch_day` (utils_date), que é o dono dessa enumeração.

--- a/db/connection.py
+++ b/db/connection.py
@@ -204,8 +204,12 @@ TIPO_CANON_SQL = (
 # do home.html (frontend/home.html:774), e o texto do WhatsApp
 # (core/handlers/launches.py:620).
 #
-# O dia nunca sai de um `::date` em SQL: ele sairia no fuso da SESSÃO do
-# Postgres, não em America/Sao_Paulo. Quem calcula é `launch_day`, em Python.
+# O dia continua saindo de `launch_day`, em Python, e não de um `::date`: o
+# `has_time`/`posted_at` decide QUAL campo manda (data × instante), coisa que
+# nenhum cast resolve. O que mudou é o motivo — desde
+# `utils_date.align_process_tz` a sessão do Postgres roda no fuso do app (via
+# `PGTZ`, sem uma linha aqui), então um `::date` já não devolveria o dia errado;
+# ele só continuaria respondendo a pergunta errada.
 LAUNCH_HAS_TIME_SQL = """
         CASE
           WHEN source = 'ofx' THEN false

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -2186,8 +2186,10 @@ async function openCategoryLaunches(nome, opts) {
   // (`posted_at` + `has_time` + `criado_em`), então `fmtLaunchWhen` imprime
   // "dd/mm, HH:MM" onde a hora é confiável e "dd/mm" onde só a data é. Mapear
   // `posted_at: r.data` era o que fazia esta lista nunca mostrar hora e imprimir
-  // o dia do fuso da SESSÃO do Postgres — "09/03" aqui, "10/03, 00:30" na Visão
-  // Geral, mesmo lançamento.
+  // o dia do fuso da SESSÃO do Postgres, que na época era UTC — "09/03" aqui,
+  // "10/03, 00:30" na Visão Geral, mesmo lançamento. A sessão hoje segue o fuso
+  // do app (utils_date.align_process_tz), mas o mapeamento errado voltaria a
+  // esconder a hora do mesmo jeito.
   // Isso vale para as linhas de `launches`. A compra no CRÉDITO CONTINUA
   // divergindo, e não é o front: a Visão Geral manda `has_time=true` +
   // `criado_em` = quando a LINHA foi gravada; esta lista manda `has_time=false`

--- a/scripts/whatsapp_qa_vault_harness.py
+++ b/scripts/whatsapp_qa_vault_harness.py
@@ -478,10 +478,11 @@ def cena_9_quanto_gastei():
         DISCREPANCIAS.append(
             "Item 9: 'qto gastei ontem' respondeu 'você não teve gastos ontem' com um gasto real "
             "seedado pra ontem (via 'ontem gastei 90 no mercado', mesmo user, turno anterior). "
-            "CAUSA RAIZ (investigada e confirmada, não corrigida — mudança de infra fora do escopo "
-            "deste piloto): a sessão do Postgres não tem timezone fixado em NENHUM lugar do app "
-            "(sem `SET TIME ZONE` em db/connection.py). O app grava datas relativas ('ontem') "
-            "usando America/Sao_Paulo (utils_date.today_tz()), mas ao ler de volta um `timestamptz`, "
+            "CAUSA RAIZ (diagnosticada aqui; CORRIGIDA depois em utils_date.align_process_tz, "
+            "que escreve PGTZ = fuso do app e põe a sessão de TODA conexão libpq nesse fuso): na "
+            "época a sessão do Postgres não tinha timezone fixado em lugar nenhum do app. O app "
+            "grava datas relativas ('ontem') usando America/Sao_Paulo (utils_date.today_tz()), "
+            "mas ao ler de volta um `timestamptz`, "
             "psycopg reinterpreta o instante sob o timezone DA SESSÃO — nesta máquina, "
             "America/New_York (herdado do SO, `SHOW timezone` confirma). Medido direto: um "
             "lançamento gravado com criado_em='2026-08-19 00:00 -03:00' (correto, meia-noite em "
@@ -489,8 +490,8 @@ def cena_9_quanto_gastei():
             "Isso não é específico da IA: qualquer código que compara `criado_em.date()` (relatórios, "
             "'hoje'/'ontem', vencimento de fatura, contas a pagar) está sujeito ao mesmo erro sempre "
             "que o timezone da sessão do Postgres divergir de America/Sao_Paulo o suficiente pra "
-            "cruzar meia-noite. Não verificado se produção (Railway) tem esse problema — depende do "
-            "timezone configurado lá, que não foi possível checar deste ambiente."
+            "cruzar meia-noite. A produção TINHA o problema: a sessão do Railway era `Etc/UTC` "
+            "(medido em 27/08/2026 08:46 UTC), a pior faixa possível para o -03 de São Paulo."
         )
 
     sc.set_veredict("✅" if all(x[0] for x in sc.checklist) else "🔍")

--- a/tests/test_categoria_vazia_donut_e_lista.py
+++ b/tests/test_categoria_vazia_donut_e_lista.py
@@ -35,13 +35,18 @@ janela nenhum, e `get_budgets_status_for_month(user_id, month=None)` tem
 que o teste alcança é a data de GRAVAÇÃO, e por isso eles são gravados em
 `date.today()`; os outros leitores aceitam janela,
 o teste a controla (o donut por ano/mês, os de período pelo `resolve_window`) e a
-gravação deles vai em `today_tz()`. As duas âncoras divergem sempre que o fuso
+gravação deles vai em `today_tz()`. As duas âncoras divergiam sempre que o fuso
 do APP ≠ o fuso do PROCESSO: `date.today()` não conhece `REPORT_TIMEZONE`, então
-definir só ela já separa as duas (medido, `REPORT_TIMEZONE=Etc/GMT+12` às
+definir só ela separava as duas (medido, `REPORT_TIMEZONE=Etc/GMT+12` às
 08:52 UTC de 2026-08-28: `date.today()=2026-08-28`, `today_tz()=2026-08-27`), e o
-CI, que não define nenhuma das duas, roda em UTC contra o default
-America/Sao_Paulo de `today_tz()` — já `TZ` sozinha NÃO separa, porque o `_tz()`
-(utils_date.py:13) a lê no fallback e move as duas pontas juntas.
+CI, que não define nenhuma das duas, rodava em UTC contra o default
+America/Sao_Paulo de `today_tz()` — já `TZ` sozinha NÃO separava, porque o `_tz()`
+a lê no fallback e movia as duas pontas juntas.
+`utils_date.align_process_tz` fechou essa divergência na raiz: ele escreve
+`TZ` = fuso do app no ambiente e chama `tzset()`, então `date.today()` PASSA a
+conhecer o `REPORT_TIMEZONE` e as duas âncoras concordam por construção — nesta
+máquina, no CI e na produção. O parágrafo acima descreve por que a distinção
+entre as duas âncoras existe no arquivo, não um risco vivo.
 
 Divergir como DATA não basta para o teste ficar vermelho: os dois leitores
 ancorados em `date.today()` filtram por `date_part('year'/'month')`, então

--- a/tests/test_category_launches_query.py
+++ b/tests/test_category_launches_query.py
@@ -17,14 +17,17 @@ perna que PODE ser apagada continua trazendo o handle certo, e
 `test_saida_do_whatsapp_nao_mudou` prova que os 3 chamadores do bot não viram
 diferença.
 
-FUSO DA SESSÃO (`PGTZ`): os casos com JANELA (`start_date`/`end_date`) pedem uma
-sessão entre UTC-12 e UTC+11 — medido verde em UTC, -03 e +09, vermelho em
-`Pacific/Kiritimati` (+14). Não é a fixture: `list_launches_by_category` monta o
-corte com `datetime.combine(start_date, 00:00)` NAIVE (db/accounts.py), que o
-Postgres lê no fuso da SESSÃO, enquanto o lançamento é gravado no fuso do APP; em
-+14 o gasto de hoje 09:00 em São Paulo (12:00Z) cai fora de
-[hoje 00:00+14, amanhã 00:00+14) = [ontem 10:00Z, hoje 10:00Z). A produção roda a
-sessão em `Etc/UTC`, dentro da faixa.
+FUSO DA SESSÃO: deixou de ser uma variável deste arquivo.
+`utils_date.align_process_tz` escreve `PGTZ` = fuso do app no import e isso
+SOBRESCREVE um `PGTZ` posto na linha de comando (medido) — processo, app e sessão
+do Postgres são o mesmo fuso, sempre. Enquanto não eram, os casos com JANELA
+(`start_date`/`end_date`) exigiam uma sessão entre UTC-12 e UTC+11 (medido verde
+em UTC, -03 e +09, vermelho em `Pacific/Kiritimati`, +14): não era a fixture —
+`list_launches_by_category` monta o corte com `datetime.combine(start_date,
+00:00)` NAIVE (db/accounts.py), que o Postgres lia no fuso da SESSÃO enquanto o
+lançamento era gravado no fuso do APP. Quem PROVA o alinhamento é
+`tests/test_fuso_do_app.py`; aqui ele é premissa, e é por isso que estes casos
+não trazem mais `PGTZ` no comando.
 """
 from __future__ import annotations
 
@@ -42,11 +45,26 @@ from utils_date import _tz, today_tz
 def _hoje_as(hora: int):
     """Hoje às `hora` no fuso do APP — aware de propósito.
 
-    Naive, o Postgres lê o instante no fuso da SESSÃO (`PGTZ`): em `Asia/Tokyo`
-    a mesma linha voltava com outro dia de parede e `test_criado_em_traz_o_instante_cheio`
-    ficava vermelho sem nada de errado no produto.
+    Naive, o instante seria lido no fuso da SESSÃO: em `Asia/Tokyo` a mesma linha
+    voltava com outro dia de parede e `test_criado_em_traz_o_instante_cheio`
+    ficava vermelho sem nada de errado no produto. A sessão hoje é a do app
+    (`utils_date.align_process_tz`), mas aware é o que torna o instante
+    independente de configuração — que é a única forma honesta de testá-lo.
     """
     return datetime.combine(today_tz(), time(hora, 0), tzinfo=_tz())
+
+
+def _meia_noite_utc(dia: date) -> datetime:
+    """O instante que a PRODUÇÃO tem em disco nas linhas legadas do Open Finance.
+
+    Aquele importador mandava a `date` CRUA para uma coluna `timestamptz`, e o
+    Postgres a promovia pelo fuso da SESSÃO — `Etc/UTC` na produção. O que ficou
+    gravado é um instante ABSOLUTO: meia-noite UTC, e ele não muda mais com o
+    fuso de quem lê. Passar a `date` crua daqui reproduziria a meia-noite do fuso
+    da SESSÃO DO TESTE, que hoje é o fuso do app — em -03 `day_tz` devolveria o
+    dia CERTO e os casos abaixo passariam mesmo com `launch_day` quebrado.
+    """
+    return datetime.combine(dia, time(0, 0), tzinfo=ZoneInfo("Etc/UTC"))
 
 
 def _dinheiro(resumo: dict) -> dict:
@@ -237,8 +255,9 @@ def test_criado_em_traz_o_instante_cheio(pro_user_id):
     )
     r = db.list_launches_by_category(pro_user_id, "mercado")[0][0]
     assert r["data"] == today_tz()
-    # Lido no fuso do APP: o instante volta do Postgres no fuso da SESSÃO
-    # (`PGTZ`), então comparar `.hour` cru amarrava o teste a rodar em UTC.
+    # Lido explicitamente em São Paulo: o instante volta do Postgres no fuso da
+    # SESSÃO, e comparar `.hour` cru amarraria o teste ao fuso da sessão — hoje o
+    # do app, mas o teste não pode depender disso para medir o produto.
     local = r["criado_em"].astimezone(ZoneInfo("America/Sao_Paulo"))
     assert local.hour == 9, r["criado_em"]
     assert local.date() == r["data"]
@@ -364,10 +383,15 @@ def test_receita_legada_entrada_nao_entra_no_donut(pro_user_id):
 # o front caía sempre no galho "só data" do `fmtLaunchWhen`: a mesma despesa
 # aparecia "10/03, 00:30" na Visão Geral e "09/03" aqui.
 #
-# Controle NEGATIVO do par abaixo: volte `"data": launch_day(...)` para
-# `r["dt"].date()` em db/accounts.py — `test_data_e_o_dia_de_parede_em_sao_paulo`
-# fica vermelho em QUALQUER fuso de sessão diferente de America/Sao_Paulo (um
-# dos dois instantes cruza a meia-noite pra leste, o outro pra oeste).
+# `test_data_e_o_dia_de_parede_em_sao_paulo` virou controle POSITIVO declarado.
+# O negativo dele era: volte `"data": launch_day(...)` para `r["dt"].date()` em
+# db/accounts.py, e ele ficava vermelho em qualquer sessão diferente de São
+# Paulo. Desde `utils_date.align_process_tz` a sessão É São Paulo — medido: com
+# esse `.date()` de volta ele passa. O HAZARD que ele media deixou de existir
+# (não é `launch_day` que ficou sem cobertura: os 4 casos de `has_time=false`
+# abaixo continuam vermelhos com o mesmo negativo). O que ele ainda prova, e é
+# por isso que fica: a lista continua imprimindo o dia que o usuário viu para os
+# dois instantes que cruzam a meia-noite em sentidos opostos.
 # Controle POSITIVO: `test_has_time_e_posted_at_espelham_a_visao_geral` prova
 # que o par novo não passou a mentir hora onde ela não existe (extrato importado
 # pelo caminho de produção).
@@ -466,6 +490,10 @@ def _of_legado(user_id: int, dia: date, categoria: str, alvo: str) -> int:
     a regra do `posted_at` existir fora do crédito: nelas `day_tz(criado_em)`
     devolve o DIA ANTERIOR. É SQL porque o importador de hoje não escreve mais
     assim (grava meio-dia local) — a forma é histórica, não inventada.
+
+    O `criado_em` vai pelo `_meia_noite_utc`, não pela `date` crua: é o instante
+    que está EM DISCO na produção, e é o que faz este caso discriminar agora que
+    a sessão do teste roda no fuso do app.
     """
     db.add_launch_and_update_balance(
         user_id, "despesa", 13, alvo, None, categoria=categoria, criado_em=_hoje_as(9),
@@ -475,7 +503,7 @@ def _of_legado(user_id: int, dia: date, categoria: str, alvo: str) -> int:
             "update launches set source='open_finance', posted_at=%s, criado_em=%s, "
             "efeitos='{\"delta_conta\": 0}'::jsonb "
             "where user_id=%s and alvo=%s returning id",
-            (dia, dia, user_id, alvo),
+            (dia, _meia_noite_utc(dia), user_id, alvo),
         )
         lid = cur.fetchone()["id"]
         conn.commit()
@@ -483,10 +511,27 @@ def _of_legado(user_id: int, dia: date, categoria: str, alvo: str) -> int:
 
 
 # As DUAS pernas do `has_time=false`, cada uma no seu teste porque cada uma é um
-# controle negativo separado: com `launch_day` trocado por `day_tz(r["dt"])` em
-# db/accounts.py e `PGTZ=UTC`, as duas ficam vermelhas — juntas num teste só, a
-# primeira esconderia a segunda. Em sessão -03 elas passam mesmo quebradas: o par
-# SÓ discrimina em UTC, que é o fuso da sessão da produção.
+# controle negativo separado — juntas num teste só, a primeira esconderia a
+# segunda.
+#
+# Controle NEGATIVO do grupo, medido em 29/08/2026 na configuração NORMAL (sem
+# `PGTZ` na linha de comando, que desde `utils_date.align_process_tz` não muda
+# mais nada): troque `"data": launch_day(...)` por `r["dt"].date()` em
+# db/accounts.py → 4 vermelhos, todos da perna do Open Finance
+# (`test_open_finance_legado_diz_o_dia_da_transacao`,
+# `test_a_sync_do_open_finance_e_dona_da_data`,
+# `test_editar_a_nota_de_uma_linha_do_open_finance_nao_move_o_dia`,
+# `test_editar_so_a_nota_de_uma_linha_do_open_finance_grava`). Eram 1 antes de os
+# fabricadores gravarem `criado_em` como MEIA-NOITE UTC absoluta
+# (`_meia_noite_utc`), que é o que a produção tem em disco.
+#
+# A perna do CRÉDITO (`test_credito_diz_o_dia_da_compra_e_nao_do_instante` e
+# `test_credito_nao_promete_hora_que_nao_tem`) é controle POSITIVO declarado, não
+# negativo: ela media a promoção de `ct.purchased_at::timestamp` (naive) pelo
+# fuso da SESSÃO, e com a sessão no fuso do app essa promoção cai na meia-noite
+# certa — o hazard sumiu, e não há instante a fabricar que o traga de volta
+# (`purchased_at` é `date`, sem hora nenhuma). O que os dois continuam provando é
+# a REGRA: sem hora confiável, o dia é o da COMPRA e não se promete hora.
 #
 # O extrato OFX/CSV/PDF NÃO está aqui de propósito: os dois escritores gravam
 # `criado_em` = meio-dia local do `posted_at` (statement_import.py:666,
@@ -496,9 +541,11 @@ def _of_legado(user_id: int, dia: date, categoria: str, alvo: str) -> int:
 
 def test_credito_diz_o_dia_da_compra_e_nao_do_instante(pro_user_id):
     """A UNION promove `ct.purchased_at::timestamp` (naive) a `timestamptz` pelo
-    fuso da SESSÃO. A sessão da produção é `Etc/UTC` (medido no Railway em
-    27/08/2026 08:46 UTC): 27/08 00:00 vira 27/08 00:00Z e `day_tz` devolvia
-    26/08 — toda compra de cartão saía com o dia anterior."""
+    fuso da SESSÃO. Enquanto a sessão da produção era `Etc/UTC` (medido no
+    Railway em 27/08/2026 08:46 UTC), 27/08 00:00 virava 27/08 00:00Z e `day_tz`
+    devolvia 26/08 — toda compra de cartão saía com o dia anterior. Hoje a sessão
+    é a do app (`utils_date.align_process_tz`) e este caso é POSITIVO: prova que
+    o dia continua sendo o da COMPRA, não o do instante."""
     cat = _compra_no_credito(pro_user_id, "gastei 90 no crédito na farmacia")
     credito = [r for r in db.list_launches_by_category(pro_user_id, cat)[0]
                if r["fonte"] == "credito"]
@@ -600,8 +647,9 @@ def _of_do_dia(user_id: int, dia: date, *, legado: bool = False,
     source='open_finance'` à mão não existe espelho, e a sync não vê a linha.
 
     `legado=True` envelhece a linha para a forma de ANTES de c474fba
-    (18/08/2026): `criado_em` = a `date` CRUA (meia-noite no fuso da SESSÃO, UTC
-    na produção) e `efeitos` sem `time_known` (logo `has_time=false`). São
+    (18/08/2026): `criado_em` = meia-noite UTC (o instante que a `date` CRUA
+    daquele importador virava sob a sessão da produção, ver `_meia_noite_utc`) e
+    `efeitos` sem `time_known` (logo `has_time=false`). São
     EXATAMENTE as duas colunas que aquele commit mudou (`git show
     c474fba^:db/open_finance.py`); todo o resto — source, external_id,
     posted_at, o vínculo com o espelho — continua vindo do importador de hoje.
@@ -643,7 +691,7 @@ def _of_do_dia(user_id: int, dia: date, *, legado: bool = False,
             cur.execute(
                 "update launches set criado_em=%s, efeitos = efeitos - 'time_known' "
                 "where id=%s",
-                (dia, lid),
+                (_meia_noite_utc(dia), lid),
             )
         conn.commit()
     return lid, of_tx_id
@@ -1064,11 +1112,11 @@ def test_ordem_e_total_com_credito_e_launches_no_mesmo_dia(pro_user_id):
         (cat, compras[0]["purchased_at"])}, compras
 
     # O launch entra no MESMO instante das compras. O `dt` da perna de crédito é
-    # `purchased_at::timestamp`, que o Postgres lê no fuso da SESSÃO (`PGTZ`):
-    # uma hora fixa em Python (`_hoje_as(9)`) empatava com ele só por
-    # coincidência de fuso — sob `TZ=Asia/Tokyo` empatava, em São Paulo não.
-    # Lendo o `dt` de volta e semeando com ELE, o empate existe em qualquer
-    # `TZ`/`PGTZ`.
+    # `purchased_at::timestamp`, que o Postgres lê no fuso da SESSÃO: uma hora
+    # fixa em Python (`_hoje_as(9)`) empatava com ele só por coincidência de fuso
+    # — sob `TZ=Asia/Tokyo` empatava, em São Paulo não. Lendo o `dt` de volta e
+    # semeando com ELE, o empate existe em qualquer fuso, inclusive nos que
+    # `align_process_tz` passa a impor às duas pontas de uma vez.
     so_credito, _ = db.list_launches_by_category(pro_user_id, cat, limit=1)
     db.add_launch_and_update_balance(
         pro_user_id, "despesa", 99, "remedio", None,
@@ -1165,11 +1213,14 @@ def test_ordem_e_total_com_credito_e_launches_no_mesmo_dia(pro_user_id):
 # lançamentos" dizia 27/08. O bug do `.date()` era PRÉ-EXISTENTE; a divergência
 # entre as duas portas nasceu aqui, e §2 pede a classe, não o caso.
 #
-# Controle NEGATIVO: volte `day_tz(criado)` para `criado.date()` em
-# core/handlers/launches.py e este teste fica vermelho em qualquer sessão fora
-# de America/Sao_Paulo (um dos dois instantes cruza a meia-noite pra cada lado).
-# Controle POSITIVO: `test_data_e_o_dia_de_parede_em_sao_paulo` (acima) prova que
-# a outra porta não mudou de resposta.
+# Este teste virou controle POSITIVO declarado. O negativo dele era: volte
+# `day_tz(criado)` para `criado.date()` em core/handlers/launches.py, e ele
+# ficava vermelho em qualquer sessão fora de America/Sao_Paulo. Desde
+# `utils_date.align_process_tz` a sessão É a do app, e `.date()` cru passa a
+# devolver o mesmo dia — o hazard deixou de existir, medido. Fica porque a
+# pergunta que ele responde não é a do fuso: as DUAS portas têm de imprimir o
+# mesmo dia para o mesmo lançamento, e isso quebraria de novo se alguém mudasse
+# só uma delas.
 
 def test_as_duas_listagens_dizem_o_mesmo_dia(pro_user_id):
     # 00:30 cruza a meia-noite pra oeste, 21:30 pra leste: em qualquer fuso de

--- a/tests/test_dia_das_listagens_no_fuso.py
+++ b/tests/test_dia_das_listagens_no_fuso.py
@@ -1,26 +1,38 @@
 """O dia impresso de um lançamento é o de São Paulo nas DUAS listagens.
 
 `criado_em` é `timestamptz`: o `datetime` que o psycopg devolve vem no fuso da
-SESSÃO do Postgres — UTC no Railway, `America/New_York` no banco de teste local
-—, nunca no fuso do app. `.date()` cru dava o dia daquele fuso, então um gasto
-das 23:30 em São Paulo saía como o dia SEGUINTE para "liste mercado", enquanto
-"meus últimos lançamentos" (já convertido com `day_tz`, PR #158) dizia o dia
-certo: o MESMO lançamento com duas datas.
+SESSÃO do Postgres. Enquanto essa sessão era livre — UTC no Railway,
+`America/New_York` no banco de teste local — `.date()` cru dava o dia daquele
+fuso, e um gasto das 23:30 em São Paulo saía como o dia SEGUINTE para "liste
+mercado", enquanto "meus últimos lançamentos" (já convertido com `day_tz`,
+PR #158) dizia o dia certo: o MESMO lançamento com duas datas.
 
-Controle NEGATIVO: troque `day_tz(r["dt"])` de volta por `r["dt"].date()` em
-db/accounts.py (`list_launches_by_category`) — o primeiro assert fica vermelho.
-Controle POSITIVO: o segundo assert é o caminho que o PR já consertou; ele prova
-que a conversão continua de pé lá, e é a metade que o negativo NÃO derruba.
+São dois casos com papéis diferentes, e o segundo existe porque o primeiro
+perdeu o controle negativo. `utils_date.align_process_tz` põe a sessão do
+Postgres no fuso do app (via `PGTZ`), então `.date()` cru e `day_tz` passam a
+devolver o mesmo dia: medido em 29/08/2026, trocar `day_tz(r["dt"])` de volta
+por `r["dt"].date()` em db/accounts.py deixa `test_o_dia_e_o_de_sao_paulo_...`
+VERDE. Ele fica como POSITIVO declarado — a pergunta que sobra continua viva:
+as duas portas têm de dizer o mesmo dia para o mesmo lançamento, e isso quebra
+de novo se alguém mexer só em uma delas.
 
-Os dois horários existem porque o teste tem que discriminar nos dois bancos:
-00:30 em São Paulo já é o dia anterior em New York (−1h) e 23:30 já é o dia
-seguinte em UTC (+3h). Com um só, o teste passaria de graça em um dos dois.
+`test_day_tz_ignora_a_sessao_do_postgres` é o NEGATIVO: com a sessão alinhada,
+a única forma de manter o hazard observável é abrir uma conexão que NÃO esteja
+alinhada. Sem ele, `day_tz` ficou sem cobertura de produto — sabotá-lo para
+`dt.date()` não deixava uma linha vermelha na suíte inteira (medido).
+
+Os dois horários do primeiro caso continuam existindo porque descrevem o caso do
+usuário: 00:30 e 23:30 em São Paulo são os instantes que cruzam a meia-noite
+para cada lado.
 """
+import os
 from datetime import datetime, time, timedelta
+
+import psycopg
 
 import db
 from core.handlers import launches as h
-from utils_date import _tz, today_tz
+from utils_date import _tz, day_tz, today_tz
 
 
 def _grava(uid, dia, hora, minuto, nota):
@@ -41,3 +53,35 @@ def test_o_dia_e_o_de_sao_paulo_nas_duas_listagens(pro_user_id):
 
     texto = h.list_launches(pro_user_id, limit=10)
     assert texto.count(dia.strftime("%d/%m")) == 2, texto
+
+
+# Controle NEGATIVO deste caso: troque `day_tz(...)` por `dt.date()` em
+# `utils_date.day_tz` → o segundo assert fica vermelho (medido em 29/08/2026:
+# devolve o dia SEGUINTE). O primeiro assert é a PREMISSA e tem de continuar
+# verde: sem ele, um dia em que a sessão desta conexão não estivesse mesmo em
+# UTC deixaria o caso passar de graça, medindo nada.
+#
+# Conexão PRÓPRIA e não `db.get_conn()`: um `set time zone` na conexão do pool
+# volta com ela e envenena os testes seguintes.
+
+def test_day_tz_ignora_a_sessao_do_postgres(pro_user_id):
+    """A sessão do Postgres em UTC — o que a produção tinha — não move o dia.
+
+    `align_process_tz` alinhou a sessão, e com isso `.date()` cru passou a
+    acertar por tabela: a única forma de continuar MEDINDO `day_tz` é ler o
+    mesmo `timestamptz` por uma sessão desalinhada, que é o estado de qualquer
+    cliente que não passe pelo `PGTZ` (psql, pgAdmin, um job de fora).
+    """
+    dia = today_tz() - timedelta(days=10)
+    _grava(pro_user_id, dia, 23, 30, "noite em sao paulo")
+
+    with psycopg.connect(os.environ["DATABASE_URL"]) as conn, conn.cursor() as cur:
+        cur.execute("set time zone 'UTC'")
+        cur.execute(
+            "select criado_em from launches where user_id=%s and alvo=%s",
+            (pro_user_id, "noite em sao paulo"),
+        )
+        criado_em = cur.fetchone()[0]
+
+    assert criado_em.date() == dia + timedelta(days=1), criado_em
+    assert day_tz(criado_em) == dia, criado_em

--- a/tests/test_fuso_do_app.py
+++ b/tests/test_fuso_do_app.py
@@ -1,0 +1,583 @@
+"""PROCESSO × APP × SESSÃO DO POSTGRES: um fuso só, ou a fronteira do dia mente.
+
+O Postgres promove um `timestamp` NAIVE a `timestamptz` — e resolve `::date`,
+`date_trunc` e `date_part` — pelo fuso da SESSÃO. As dezenas de cortes de janela do tipo
+`criado_em < datetime.combine(fim + 1 dia, 00:00)` (db/accounts.py, db/plans.py,
+core/budget_alerts.py, forecast, admin) mandam esse naive. Com a sessão em UTC —
+produção no Railway e CI — um gasto das 23:00 em São Paulo caía FORA do dia em
+que o usuário o fez. A ESCRITA de `criado_em` sempre esteve certa (aware); o
+defeito é de LEITURA.
+
+Consertar só a sessão não bastava: `date.today()` fica no fuso do PROCESSO, e
+processo em UTC contra app em São Paulo é a MESMA divergência por outra porta.
+`utils_date.align_process_tz` fecha as duas de uma vez, escrevendo `TZ` (processo)
+e `PGTZ` (toda conexão libpq) com o mesmo nome e chamando `tzset()`.
+
+Este arquivo é o único que PROVA o alinhamento; os outros o tomam como premissa
+(ver o cabeçalho de tests/test_category_launches_query.py). Controle negativo de
+cada caso está no comentário logo acima dele.
+
+O que os casos leem do ambiente são DUAS coisas, e elas não andam juntas:
+
+- o RELÓGIO (que dia é hoje): só os casos 3, 4, 5 e 7, que chamam `today_tz()` e
+  combinam o resultado com `_SP` fixo. Os outros — 1, 2, 6 e 8-13 — usam
+  instante aware LITERAL, o epoch, ou nenhuma data;
+- o FUSO configurado: os casos 3, 4, 5, 6 e 7. Medido em 29/08/2026,
+  `REPORT_TIMEZONE=Asia/Yangon` deixa esses CINCO vermelhos — no caso 6 isso é o
+  controle negativo declarado dele, não um defeito.
+
+Ler o dia corrente basta para o que 3, 4, 5 e 7 medem: a fronteira do dia contra
+a JANELA que o produto abre, e essa janela é sempre "hoje" no fuso do app — um
+dia fixo do passado trocaria o dia sem trocar a pergunta. Quem faz a mesma
+pergunta com data literal é o caso 6 (31/08/2025 23:00 em São Paulo).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+from time import tzset
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import db
+import db_support
+import utils_date
+from token_utils import make_dashboard_token
+from utils_date import _tz, day_tz, today_tz, tz_name
+
+_SP = ZoneInfo("America/Sao_Paulo")
+
+
+@pytest.fixture(autouse=True)
+def _restaura_fuso():
+    """`load_app_env` escreve DIRETO em `os.environ` (não pelo monkeypatch).
+
+    Sem restaurar à mão, o primeiro teste que carrega um `.env` de `tmp_path`
+    deixaria o processo inteiro num fuso inventado e contaminaria os arquivos
+    seguintes da suíte — a classe de bug que o §3 do CLAUDE.md chama de
+    dependência de ordem.
+    """
+    antes = {k: os.environ.get(k) for k in ("TZ", "PGTZ", "REPORT_TIMEZONE", "APP_ENV")}
+    original = utils_date._TZ_ENV_ORIGINAL
+    yield
+    for k, v in antes.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    utils_date._TZ_ENV_ORIGINAL = original
+    # `tzset()` cru, NÃO `align_process_tz()`: chamar o conserto aqui o
+    # reaplicaria a cada teardown e deixaria `test_o_processo_roda_no_fuso_do_app`
+    # verde mesmo com o conserto revertido — teste tautológico por efeito de
+    # ordem. `tzset()` só relê o `TZ` que a linha acima acabou de restaurar.
+    tzset()
+
+
+# ── 1. As três portas do banco ───────────────────────────────────────────────
+# Controle NEGATIVO: apague `os.environ["PGTZ"] = name` de
+# `utils_date.align_process_tz` → as 3 portas voltam ao default do SERVIDOR e
+# este caso fica vermelho (medido em 29/08/2026: as três devolvem
+# `America/New_York` nesta máquina; no Railway e no CI, `Etc/UTC`).
+#
+# No arquivo INTEIRO esse mesmo corte dá números diferentes, e o honesto é o da
+# produção: 11 vermelhos com a sessão em UTC (`PGTZ=UTC`, que é o que produção e
+# CI têm) e 7 na sessão local (−04), dos quais 5 são só `KeyError: 'PGTZ'` nos
+# casos 8, 9, 10 e 14 — leitura da própria variável apagada, não medição de
+# produto (medido em 29/08/2026, com o `os.environ["PGTZ"] = name` removido).
+#
+# As três existem porque são três clientes libpq diferentes e nenhum deles tem
+# uma linha de código sobre fuso: pool SÍNCRONO (db/connection.py), pool ASYNC do
+# dashboard (frontend/routes/shared.py) e conexão avulsa do admin
+# (core/admin_dashboard.py). É `PGTZ` que as cobre de uma vez — foi por isso que
+# o conserto não entrou em nenhum dos três arquivos.
+
+def _tz_da_sessao_sincrona() -> str:
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select current_setting('TimeZone') as tz")
+        return cur.fetchone()["tz"]
+
+
+def _tz_da_sessao_async_do_dashboard() -> str:
+    import frontend.routes.shared as shared
+
+    async def _ler():
+        # Pool NOVO neste event loop e devolvido depois: o `_db_pool` global pode
+        # ter sido aberto por outro teste, num loop já encerrado.
+        anterior, shared._db_pool = shared._db_pool, None
+        try:
+            async with await shared.db_connect() as conn:
+                cur = await conn.execute("select current_setting('TimeZone') as tz")
+                return (await cur.fetchone())["tz"]
+        finally:
+            if shared._db_pool is not None:
+                await shared._db_pool.close()
+            shared._db_pool = anterior
+
+    return asyncio.run(_ler())
+
+
+def _tz_da_sessao_do_admin() -> str:
+    from core.admin_dashboard import db_connect
+
+    async def _ler():
+        conn = await db_connect()
+        try:
+            cur = await conn.execute("select current_setting('TimeZone') as tz")
+            return (await cur.fetchone())["tz"]
+        finally:
+            await conn.close()
+
+    return asyncio.run(_ler())
+
+
+def test_as_tres_portas_do_banco_estao_no_fuso_do_app():
+    esperado = tz_name()
+    assert _tz_da_sessao_sincrona() == esperado
+    assert _tz_da_sessao_async_do_dashboard() == esperado
+    assert _tz_da_sessao_do_admin() == esperado
+
+
+# ── 2. O processo, na configuração DEFAULT ───────────────────────────────────
+# Sem monkeypatch e sem reload de propósito: é o único caso que mede o que
+# acontece de verdade quando ninguém configura nada, que é o caminho da produção
+# e do CI. O epoch não depende do relógio.
+#
+# Controle NEGATIVO: apague `os.environ["TZ"] = name` de `align_process_tz` →
+# vermelho (o processo volta ao fuso do sistema; no CI, UTC contra o -03 do app).
+# Medido em 29/08/2026 (`REPORT_TIMEZONE=America/Sao_Paulo TZ=Etc/UTC PGTZ=UTC`):
+# com a guarda de offsets do caso 13 no lugar, esse corte não fica só neste caso —
+# a divergência que ele cria é a que a guarda existe para pegar, então
+# `load_app_env` recusa o boot e os 16 casos do arquivo erram de uma vez com
+# `SystemExit`. É vermelho mais alto, não menos.
+
+def test_o_processo_roda_no_fuso_do_app():
+    naive = datetime.fromtimestamp(0)
+    no_fuso_do_app = datetime.fromtimestamp(0, _tz()).replace(tzinfo=None)
+    assert naive == no_fuso_do_app, (naive, no_fuso_do_app, tz_name())
+    # e `date.today()` (52 sites de produção) concorda com `today_tz()`
+    assert date.today() == today_tz()
+
+
+# ── 3/4. A fronteira do dia, nas duas portas de leitura ──────────────────────
+# Controle NEGATIVO do caso 3: reverta o conserto (tire a chamada de
+# `align_process_tz` do import de utils_date) e rode com `PGTZ=UTC` → vermelho
+# nas duas portas: 23:00 em São Paulo é 02:00Z do dia SEGUINTE, e o corte
+# `criado_em < combine(hoje + 1 dia, 00:00)` lido em UTC exclui o lançamento.
+# O caso 4 é o controle POSITIVO do par: um conserto que só ALARGASSE a janela
+# (por exemplo somando 3h no corte) passaria no 3 e ficaria vermelho aqui,
+# porque puxaria as 23:00 de ONTEM para dentro de hoje.
+
+def _gasto(uid: int, quando: datetime, alvo: str, valor: float = 50) -> None:
+    db.add_launch_and_update_balance(
+        uid, "despesa", valor, alvo, None, categoria="mercado", criado_em=quando,
+    )
+
+
+def test_gasto_das_23h_conta_no_dia_de_sao_paulo(pro_user_id):
+    hoje = today_tz()
+    _gasto(pro_user_id, datetime.combine(hoje, time(23, 0), tzinfo=_SP), "23h de hoje")
+
+    rows, resumo = db.list_launches_by_category(
+        pro_user_id, "mercado", start_date=hoje, end_date=hoje,
+    )
+    assert resumo["n_total"] == 1, (resumo, [r["criado_em"] for r in rows])
+    assert rows[0]["data"] == hoje, rows[0]
+
+    # a MESMA janela pela rota do dashboard (o que a Distribuição do mês abre)
+    resp = _cliente().get(
+        f"/categories/{pro_user_id}/launches?categoria=mercado"
+        f"&from={hoje.isoformat()}&to={hoje.isoformat()}",
+        headers={"Authorization": f"Bearer {make_dashboard_token(pro_user_id, hours=1)}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["resumo"]["n_total"] == 1, resp.json()["resumo"]
+
+
+def test_a_janela_de_hoje_nao_engole_as_23h_de_ontem(pro_user_id):
+    hoje = today_tz()
+    ontem = hoje - timedelta(days=1)
+    _gasto(pro_user_id, datetime.combine(ontem, time(23, 0), tzinfo=_SP), "23h de ontem")
+    _gasto(pro_user_id, datetime.combine(hoje, time(0, 30), tzinfo=_SP), "00h30 de hoje")
+
+    rows, resumo = db.list_launches_by_category(
+        pro_user_id, "mercado", start_date=hoje, end_date=hoje,
+    )
+    assert resumo["n_total"] == 1, (resumo, [r["descricao"] for r in rows])
+    assert rows[0]["descricao"] == "00h30 de hoje", rows[0]
+
+
+# ── 5. A outra porta do mesmo corte ──────────────────────────────────────────
+# `get_summary_by_period_impl` (db_support.py:56-57) monta o MESMO
+# `datetime.combine(fim + 1 dia, 00:00)` naive, e é ele que o saldo do mês e o
+# relatório diário leem. Controle negativo idêntico ao do caso 3.
+
+def test_o_resumo_do_periodo_ve_o_gasto_das_23h(pro_user_id):
+    hoje = today_tz()
+    _gasto(pro_user_id, datetime.combine(hoje, time(23, 0), tzinfo=_SP), "23h", valor=50)
+    # A função crua, e não o `db.get_summary_by_period` que a embrulha
+    # (db/accounts.py:379): é aqui que o `datetime.combine` naive é montado.
+    resumo = db_support.get_summary_by_period_impl(
+        db.get_conn, db.ensure_user, pro_user_id, hoje, hoje,
+    )
+    assert resumo["despesa"] == 50.0, resumo
+
+
+# ── 6. Âncora LITERAL, sem depender da configuração do ambiente ──────────────
+# Os casos acima perguntam "o app concorda consigo mesmo?" — passariam se TODAS
+# as pontas fossem para o fuso ERRADO juntas. Este pergunta outra coisa: um
+# instante escrito à mão em `America/Sao_Paulo` cai no dia de São Paulo.
+#
+# Controle NEGATIVO: rode com `TZ=Etc/UTC` (sem `REPORT_TIMEZONE`) → vermelho,
+# porque aí o fuso do app É UTC e 2025-08-31 23:00 -03 é 2025-09-01 02:00Z.
+# Data fixa no passado: independe do relógio e da data de execução.
+
+def test_31_de_agosto_as_23h_em_sao_paulo_e_agosto(pro_user_id):
+    dia = date(2025, 8, 31)
+    _gasto(pro_user_id, datetime(2025, 8, 31, 23, 0, tzinfo=_SP), "ultimo dia do mes")
+
+    rows, resumo = db.list_launches_by_category(
+        pro_user_id, "mercado", start_date=dia, end_date=dia,
+    )
+    assert resumo["n_total"] == 1, resumo
+    assert rows[0]["data"] == dia, rows[0]
+    # e o resumo do MÊS de agosto, que é onde o usuário procura
+    assert db.get_summary_by_period(
+        pro_user_id, date(2025, 8, 1), date(2025, 8, 31),
+    )["despesa"] == 50.0
+
+
+# ── 7. A conversa inteira, pelo handle_incoming ──────────────────────────────
+# "Rode a conversa, não a função" (§3): as 4 perguntas da issue #178, na mesma
+# sessão, com estado real no banco. Cobre uma porta que nenhum caso acima toca —
+# `get_top_expense_categories`, que o "quanto gastei em X" usa.
+# Controle NEGATIVO idêntico ao do caso 3 (sem o alinhamento e com `PGTZ=UTC`,
+# "quanto gastei hoje" responde o gasto de ONTEM e "quanto gastei ontem" diz que
+# não houve gasto — é exatamente a tabela da issue).
+#
+# uid < 2 bilhões de propósito: `_normalize_user_id` (core/handle_incoming.py:106)
+# REMAPEIA id grande, e semear no uid da fixture faria o handler ler OUTRO
+# usuário — falso vermelho que não tem nada a ver com fuso.
+
+def _uid_que_o_handler_resolve() -> int:
+    import uuid
+
+    from conftest import promote_to_pro
+
+    uid = int(uuid.uuid4().int % 1_000_000_000) + 1
+    db.ensure_user(uid)
+    return promote_to_pro(uid)
+
+
+def test_a_conversa_responde_pelo_dia_de_sao_paulo():
+    from core.handle_incoming import handle_incoming
+    from core.types import IncomingMessage
+
+    uid = _uid_que_o_handler_resolve()
+    hoje = today_tz()
+    _gasto(uid, datetime.combine(hoje, time(23, 0), tzinfo=_SP), "mercado hoje", valor=50)
+    _gasto(uid, datetime.combine(hoje - timedelta(days=1), time(23, 0), tzinfo=_SP),
+           "mercado ontem", valor=90)
+
+    def fala(texto: str) -> str:
+        out = handle_incoming(IncomingMessage(platform="discord", user_id=uid, text=texto))
+        assert out, f"sem resposta para {texto!r}"
+        return out[0].text
+
+    hoje_txt = fala("quanto gastei hoje")
+    assert "50" in hoje_txt and "90" not in hoje_txt, hoje_txt
+
+    ontem_txt = fala("quanto gastei ontem")
+    assert "90" in ontem_txt, ontem_txt
+
+    # JANELA ROLANTE, e não "meus gastos do mes". A troca não é de estilo: o
+    # `"140" in ...` sobre a resposta do "do mes" era TAUTOLÓGICO. Medido em
+    # 29/08/2026 com `today_tz()` fixado em 2026-08-01 (dia 1, o pior caso), a
+    # resposta foi:
+    #
+    #     📅 Período: 01/08/2026 a 29/08/2026
+    #     🏦 Saldo atual: R$ -140,00      ← é DAQUI que o "140" vinha
+    #     📉 Gastos do mês: R$ 50,00      ← o número da janela, que ninguém lia
+    #
+    # "meus gastos do mes" nem passa pelo `spend_query`: cai no resumo mensal, que
+    # imprime o SALDO da conta — e saldo não depende de janela nenhuma, então o
+    # assert ficava VERDE com o mês certo, com o mês errado e com o fuso quebrado.
+    # (O caso 7 rodou verde com `today_tz()` no dia 1 mesmo com o total do mês em
+    # R$ 50,00; a bomba-relógio de fronteira de mês era o sintoma, a medição vazia
+    # era a causa.)
+    #
+    # "últimos N dias" (`parse_period_from_text`, utils_date.py:396-399) é rolante:
+    # sempre ontem+hoje, em qualquer dia do mês, e a resposta traz o TOTAL da
+    # janela ("Você gastou R$ 140,00 nos últimos 2 dias"), não o saldo.
+    # Controle NEGATIVO deste assert: troque 2 por 1 → vermelho (R$ 50,00 —
+    # medido). O de cima não tinha controle negativo possível.
+    dois_dias_txt = fala("quanto gastei nos ultimos 2 dias")
+    assert "140" in dois_dias_txt, dois_dias_txt
+
+    cat_txt = fala("quanto gastei em mercado hoje")
+    assert "50" in cat_txt and "90" not in cat_txt, cat_txt
+
+
+# ── 8/9/10. O `.env`, que é por onde o buraco voltava ────────────────────────
+# `utils_date` é importado ANTES de o `.env` ser lido. Sem a chamada no fim de
+# `load_app_env`, um `REPORT_TIMEZONE` vindo de ARQUIVO faria o app e o banco
+# seguirem o arquivo enquanto o PROCESSO ficava no default — a MESMA divergência
+# que este PR fecha, por um canal suportado, e justamente a variável que a
+# mensagem de erro do boot ensina o operador a usar.
+#
+# `load_app_env` de VERDADE, sem reload de módulo: reload esconderia justamente o
+# caminho quebrado (o import só acontece uma vez na vida do processo).
+
+def _com_env(tmp_path, monkeypatch, conteudo: str) -> None:
+    """Escreve um `.env` de mentira e roda o `load_app_env` de verdade nele."""
+    import config.env as cfg
+
+    (tmp_path / ".env").write_text(conteudo, encoding="utf-8")
+    monkeypatch.setattr(cfg, "ROOT_DIR", tmp_path)
+    cfg.load_app_env()
+
+
+# Controle NEGATIVO do caso 8: apague o `utils_date.align_process_tz()` do fim de
+# `load_app_env` → vermelho (o app vai para Tóquio e o processo fica onde estava).
+def test_report_timezone_do_arquivo_move_o_processo_tambem(tmp_path, monkeypatch):
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+
+    _com_env(tmp_path, monkeypatch, "REPORT_TIMEZONE=Asia/Tokyo\n")
+
+    assert tz_name() == "Asia/Tokyo"
+    # PGTZ, e não `current_setting` de uma conexão: `PGTZ` vale para conexão
+    # NOVA, e o pool síncrono deste processo já está aberto desde antes. Na
+    # produção não existe esse "antes" — `load_app_env` roda no boot, antes da
+    # primeira conexão. Quem prova que `PGTZ` chega à sessão é o caso 1.
+    assert os.environ["PGTZ"] == "Asia/Tokyo"
+    # o PROCESSO foi junto: é este assert que o controle negativo derruba
+    assert datetime.fromtimestamp(0) == datetime.fromtimestamp(
+        0, ZoneInfo("Asia/Tokyo")).replace(tzinfo=None)
+
+
+# Controle NEGATIVO do caso 9: apague o `os.environ.pop("TZ", None)` de
+# `load_app_env` → vermelho. Sem ele o `TZ` que `align_process_tz` escreveu no
+# import faz o `setdefault` achar que já há valor, e `TZ` no `.env` — documentado
+# em `.env.example` — vira um no-op silencioso.
+def test_tz_do_arquivo_continua_valendo(tmp_path, monkeypatch):
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    # O estado REAL da produção no momento em que `load_app_env` roda: `TZ` já
+    # está no ambiente porque o import de `utils_date` o escreveu, e
+    # `_TZ_ENV_ORIGINAL is None` diz que não foi o operador quem o pôs. Apagar o
+    # `TZ` aqui (em vez de simulá-lo) desarmaria o controle negativo — medido: com
+    # `delenv` o teste passa mesmo sem o `pop` em `load_app_env`.
+    monkeypatch.setenv("TZ", "America/Sao_Paulo")
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+
+    _com_env(tmp_path, monkeypatch, "TZ=Asia/Tokyo\n")
+
+    # Sem o `pop`, o `setdefault` acha o `TZ` que o import escreveu e o arquivo
+    # não é lido: `tz_name()` volta America/Sao_Paulo e este assert fica vermelho.
+    assert tz_name() == "Asia/Tokyo"
+    assert os.environ["PGTZ"] == "Asia/Tokyo"
+    # O PROCESSO foi junto — o mesmo assert do caso 8, e pela mesma razão: os
+    # dois de cima releem o ambiente que `load_app_env` acabou de escrever, e
+    # sozinhos não distinguem "o app mudou de fuso" de "as três pontas mudaram
+    # juntas", que é o invariante deste PR. Não tem controle negativo PRÓPRIO, e
+    # não dá para ter: qualquer sabotagem que separe processo de app cai na
+    # guarda de offsets (caso 13) e vira `SystemExit` no boot antes de chegar
+    # aqui — medido. Ele fica porque a afirmação é sobre o produto, não sobre o
+    # que derruba o teste.
+    assert datetime.fromtimestamp(0) == datetime.fromtimestamp(
+        0, ZoneInfo("Asia/Tokyo")).replace(tzinfo=None)
+
+
+# Controle POSITIVO dos dois acima: o `pop` não pode roubar a precedência de quem
+# configurou o ambiente DE VERDADE (Railway, docker, shell). Sem este caso, um
+# `pop` incondicional passaria nos dois de cima e quebraria a produção calado.
+def test_o_ambiente_real_vence_o_arquivo(tmp_path, monkeypatch):
+    # `TZ` posto pelo OPERADOR (Railway/docker/shell), e não pelo import — é o
+    # que `_TZ_ENV_ORIGINAL` distingue. Um `pop` incondicional apagaria este `TZ`
+    # e o arquivo passaria a mandar: `tz_name()` viraria Europe/Lisbon e este
+    # teste ficaria vermelho, que é exatamente o que ele existe para impedir.
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    monkeypatch.setenv("TZ", "Asia/Tokyo")
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", "Asia/Tokyo")
+
+    _com_env(tmp_path, monkeypatch, "TZ=Europe/Lisbon\n")
+
+    assert os.environ["TZ"] == "Asia/Tokyo"
+    assert tz_name() == "Asia/Tokyo"
+    assert os.environ["PGTZ"] == "Asia/Tokyo"
+
+
+# Controle POSITIVO do 8 e NEGATIVO da frase de precedência do `.env.example`:
+# o caso 10 acima cobre só `TZ` × `TZ`, que é justamente a combinação em que o
+# ambiente ganha — ela não contradiz nada. A que contradiz é esta: `REPORT_TIMEZONE`
+# de ARQUIVO contra `TZ` do ambiente REAL. `_tz()` (utils_date.py:13) lê
+# `REPORT_TIMEZONE` primeiro, então o ARQUIVO ganha do ambiente aqui, e
+# `align_process_tz` ainda sobrescreve o `TZ` real. Sem este caso, o `.env.example`
+# podia continuar dizendo "o ambiente real ganha" sem nada ficar vermelho.
+#
+# Controle NEGATIVO: inverta a ordem em `_tz()` (`os.getenv("TZ") or
+# os.getenv("REPORT_TIMEZONE")`) → os três asserts caem para Europe/Lisbon.
+def test_report_timezone_do_arquivo_vence_o_tz_do_ambiente(tmp_path, monkeypatch):
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    # `TZ` do OPERADOR (Railway/docker/shell) — o mesmo cenário do caso 10, e a
+    # única diferença é o arquivo trazer `REPORT_TIMEZONE` em vez de `TZ`.
+    monkeypatch.setenv("TZ", "Europe/Lisbon")
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", "Europe/Lisbon")
+
+    _com_env(tmp_path, monkeypatch, "REPORT_TIMEZONE=Asia/Tokyo\n")
+
+    assert tz_name() == "Asia/Tokyo"
+    assert os.environ["PGTZ"] == "Asia/Tokyo"
+    # o `TZ` que o operador pôs foi SOBRESCRITO — é o que a frase do
+    # `.env.example` precisa dizer, e o que o "o ambiente real ganha" negava
+    assert os.environ["TZ"] == "Asia/Tokyo"
+
+
+# ── 11. Fuso inválido morre no BOOT, não na primeira query ───────────────────
+# O nome vai para `PGTZ`, e um nome inválido derruba a conexão DEPOIS de o health
+# check passar: o deploy sobe verde e as queries penduram. Controle NEGATIVO:
+# apague o `try/except` + `sys.exit(1)` do fim de `load_app_env` → o primeiro
+# assert fica vermelho (sobe `ZoneInfoNotFoundError` crua em vez de `SystemExit`).
+# O segundo é o POSITIVO: sem ele, um `sys.exit(1)` incondicional passaria.
+
+def test_fuso_invalido_recusa_o_boot(tmp_path, monkeypatch):
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+
+    with pytest.raises(SystemExit) as exc:
+        _com_env(tmp_path, monkeypatch, "REPORT_TIMEZONE=Nao/Existe\n")
+    assert exc.value.code == 1
+
+
+def test_fuso_valido_nao_recusa_o_boot(tmp_path, monkeypatch):
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+
+    _com_env(tmp_path, monkeypatch, "REPORT_TIMEZONE=Europe/Lisbon\n")
+    assert tz_name() == "Europe/Lisbon"
+
+
+# ── 12. O unitário do dia de parede ──────────────────────────────────────────
+# `REPORT_TIMEZONE` explícito porque a afirmação é sobre São Paulo, não sobre a
+# configuração de quem roda. 10/03 00:00Z é 09/03 21:00 em São Paulo.
+
+def test_day_tz_devolve_o_dia_de_parede(monkeypatch):
+    monkeypatch.setenv("REPORT_TIMEZONE", "America/Sao_Paulo")
+    assert day_tz(datetime(2026, 3, 10, 0, 0, tzinfo=timezone.utc)) == date(2026, 3, 9)
+
+
+# ── 13. `tzset()` falha CALADO — a guarda que pega isso ──────────────────────
+# `tzset()` não levanta quando a libc não conhece o nome: ela cai para UTC sem
+# avisar. Com `ZoneInfo` lendo de OUTRO banco de fusos que a libc não tem,
+# `align_process_tz` retornava com sucesso e o processo ficava em UTC enquanto o
+# app e o `PGTZ` iam para o fuso pedido — o invariante do arquivo inteiro
+# quebrado em silêncio, e nenhum dos 12 casos acima pegava.
+#
+# Hoje isso é inalcançável em produção porque `tzdata` (o banco de fusos em pip)
+# NÃO está no requirements.txt e o do sistema existe; vira alcançável no dia em
+# que ele entrar, direto ou transitivo. O banco falso reproduz exatamente essa
+# divergência.
+#
+# Controle NEGATIVO: apague o bloco `if agora.astimezone().utcoffset() != ...`
+# de `utils_date.align_process_tz` → vermelho (a função devolve "Fake/Zone" com
+# o processo em UTC, sem levantar).
+# Controle POSITIVO na configuração NORMAL: os casos 8, 10 e 11 chamam
+# `align_process_tz` por dentro do `load_app_env` com fusos válidos e continuam
+# verdes — a guarda não dá falso positivo.
+
+def test_libc_que_nao_conhece_o_fuso_nao_passa_calada(tmp_path, monkeypatch):
+    import zoneinfo
+
+    # Um TZif VÁLIDO sob um nome que a libc não tem: `ZoneInfo("Fake/Zone")`
+    # resolve (+09), `tzset()` com TZ=Fake/Zone cai para UTC. Copiado de um
+    # arquivo real para não depender de gerar TZif à mão.
+    (tmp_path / "Fake").mkdir()
+    (tmp_path / "Fake" / "Zone").write_bytes(
+        (pathlib.Path("/usr/share/zoneinfo") / "Asia" / "Tokyo").read_bytes()
+    )
+    monkeypatch.setenv("REPORT_TIMEZONE", "Fake/Zone")
+    zoneinfo.reset_tzpath(to=[str(tmp_path)])
+    zoneinfo.ZoneInfo.clear_cache()
+    try:
+        # a premissa do caso, medida aqui e não presumida
+        assert utils_date._tz().key == "Fake/Zone"
+        with pytest.raises(RuntimeError, match="libc"):
+            utils_date.align_process_tz()
+    finally:
+        zoneinfo.reset_tzpath()
+        zoneinfo.ZoneInfo.clear_cache()
+
+
+# ── 14. `load_app_env` roda em processo JÁ SERVINDO: `TZ` nunca some ─────────
+# `adapters/whatsapp/wa_app.py:39` chama `load_app_env()` no import, e esse import
+# é tardio de propósito (`frontend/finance_bot_websocket_custom.py:1952-1963`, 1ª
+# requisição; `:1632-1656`, 1 s depois do startup). Ou seja: ele roda com event
+# loop, threadpool e WebSockets ativos. A glibc relê `TZ` a cada `localtime()`,
+# então qualquer instante em que `TZ` não esteja no ambiente é uma janela em que
+# uma thread concorrente chamando `date.today()` cai no fuso do contêiner (UTC no
+# Railway) — o bug deste PR de volta por microssegundos.
+#
+# Controle NEGATIVO: troque a atribuição de `config/env.py` de volta pelo
+# `os.environ.pop("TZ", None)` → vermelho (`removidas == ["TZ"]`).
+# Controle POSITIVO: os asserts de baixo são os do caso 8 — provam que matar o
+# `pop` não custou a precedência que ele existia para dar ao arquivo.
+
+def test_load_app_env_nunca_deixa_o_ambiente_sem_tz(tmp_path, monkeypatch):
+    from collections.abc import MutableMapping
+
+    real = os.environ
+    removidas: list[str] = []
+
+    class _Vigia(MutableMapping):
+        """`os.environ` de verdade + registro de toda REMOÇÃO de chave.
+
+        Delega TUDO ao objeto real, que é quem chama `putenv` — sem isso o
+        `tzset()` de `align_process_tz` não enxergaria o `TZ` novo e o teste
+        mediria outra coisa. `pop`/`popitem`/`clear` da `MutableMapping` passam
+        todos por `__delitem__`, então espiar só aqui basta.
+        """
+
+        def __getitem__(self, k):
+            return real[k]
+
+        def __setitem__(self, k, v):
+            real[k] = v
+
+        def __delitem__(self, k):
+            removidas.append(k)
+            del real[k]
+
+        def __iter__(self):
+            return iter(real)
+
+        def __len__(self):
+            return len(real)
+
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    # o estado REAL da produção: `TZ` no ambiente posto pelo IMPORT de
+    # `utils_date`, não pelo operador — é o único caso em que o código mexe em `TZ`
+    monkeypatch.setenv("TZ", "America/Sao_Paulo")
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+    # `os.getenv` resolve o global `environ` na CHAMADA, então o patch alcança
+    # `config.env`, `utils_date` e qualquer outro leitor durante o `load_app_env`.
+    monkeypatch.setattr(os, "environ", _Vigia())
+
+    _com_env(tmp_path, monkeypatch, "REPORT_TIMEZONE=Asia/Tokyo\n")
+
+    assert removidas == [], removidas
+    assert real["TZ"] == "Asia/Tokyo"
+    assert real["PGTZ"] == "Asia/Tokyo"
+
+
+def _cliente():
+    from fastapi.testclient import TestClient
+
+    import frontend.finance_bot_websocket_custom as dashboard
+
+    return TestClient(dashboard.app)
+

--- a/tests/test_fuso_do_app.py
+++ b/tests/test_fuso_do_app.py
@@ -574,6 +574,39 @@ def test_load_app_env_nunca_deixa_o_ambiente_sem_tz(tmp_path, monkeypatch):
     assert real["PGTZ"] == "Asia/Tokyo"
 
 
+# ── 15. Windows: sem `time.tzset`, o boot não pode morrer ───────────────────
+# `time.tzset` é POSIX. O `docs/readme.md` lista Windows como sistema suportado,
+# e sem guarda o `ImportError` subia até o `except` de `load_app_env` e virava
+# `sys.exit(1)`: NENHUM entrypoint subiria lá, com a mensagem de "fuso inválido"
+# — que seria mentira, porque o `ZoneInfo` resolveu o nome. Apontado como P1
+# pelo Codex no #180.
+#
+# CONTROLE NEGATIVO: tirar o `if tzset is None: return name` de
+# `align_process_tz` deixa os DOIS casos abaixo vermelhos — o 1º com
+# `ImportError`/`AttributeError`, o 2º com `SystemExit`.
+# CONTROLE POSITIVO: `test_o_processo_roda_no_fuso_do_app` (caso 2) continua
+# verde no Unix, provando que a guarda não desligou o alinhamento onde ele vale.
+
+def test_sem_tzset_o_alinhamento_nao_levanta(monkeypatch):
+    """No Windows a SESSÃO ainda é alinhada; o processo, não — e é assumido."""
+    monkeypatch.delattr(utils_date.time_module, "tzset", raising=False)
+
+    nome = utils_date.align_process_tz()
+
+    assert nome == utils_date.tz_name()
+    assert os.environ["PGTZ"] == nome, "a metade que conserta a #178 tem de valer"
+
+
+def test_sem_tzset_o_boot_continua_subindo(tmp_path, monkeypatch):
+    """O que o P1 quebrava: `load_app_env` matando o processo com exit(1)."""
+    monkeypatch.delattr(utils_date.time_module, "tzset", raising=False)
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+
+    _com_env(tmp_path, monkeypatch, "REPORT_TIMEZONE=America/Sao_Paulo\n")
+
+    assert utils_date.tz_name() == "America/Sao_Paulo"
+
+
 def _cliente():
     from fastapi.testclient import TestClient
 

--- a/tests/test_fuso_do_app.py
+++ b/tests/test_fuso_do_app.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import asyncio
 import os
 import pathlib
-from time import tzset
+import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
@@ -73,7 +73,37 @@ def _restaura_fuso():
     # reaplicaria a cada teardown e deixaria `test_o_processo_roda_no_fuso_do_app`
     # verde mesmo com o conserto revertido — teste tautológico por efeito de
     # ordem. `tzset()` só relê o `TZ` que a linha acima acabou de restaurar.
-    tzset()
+    #
+    # Acesso GUARDADO, igual ao que `align_process_tz` faz: `time.tzset` é POSIX
+    # e não existe no Windows, que o `docs/readme.md:18` lista como suportado.
+    # Como `from time import tzset` no topo levantava na COLETA, o arquivo
+    # inteiro morria lá — inclusive os dois casos que existem para provar que o
+    # Windows está tratado. Consertar a produção e esquecer o teste é a mesma
+    # instância-em-vez-de-categoria de sempre (Codex #180, P2).
+    tzset = getattr(time_module, "tzset", None)
+    if tzset is not None:
+        tzset()
+
+
+def _tzif(*partes: str) -> bytes:
+    """Bytes de um TZif real, achado pelo `TZPATH` do próprio Python.
+
+    `/usr/share/zoneinfo` é layout de Unix e não existe no Windows — que o
+    `docs/readme.md:18` lista como suportado —, nem numa imagem slim sem banco
+    de fusos do sistema. O `zoneinfo.TZPATH` é onde o Python de verdade procura,
+    então é a única fonte portátil (Codex #180, P2).
+
+    `skip` e não falha: sem banco de fusos no disco não há como montar o cenário
+    "o `ZoneInfo` resolve e a libc não", e um ERROR ali acusaria o ambiente, não
+    o código.
+    """
+    import zoneinfo
+
+    for raiz in zoneinfo.TZPATH:
+        alvo = pathlib.Path(raiz).joinpath(*partes)
+        if alvo.is_file():
+            return alvo.read_bytes()
+    pytest.skip(f"sem TZif de {'/'.join(partes)} no TZPATH: {zoneinfo.TZPATH}")
 
 
 # ── 1. As três portas do banco ───────────────────────────────────────────────
@@ -498,7 +528,7 @@ def test_libc_que_nao_conhece_o_fuso_nao_passa_calada(tmp_path, monkeypatch):
     # arquivo real para não depender de gerar TZif à mão.
     (tmp_path / "Fake").mkdir()
     (tmp_path / "Fake" / "Zone").write_bytes(
-        (pathlib.Path("/usr/share/zoneinfo") / "Asia" / "Tokyo").read_bytes()
+        _tzif("Asia", "Tokyo")
     )
     monkeypatch.setenv("REPORT_TIMEZONE", "Fake/Zone")
     zoneinfo.reset_tzpath(to=[str(tmp_path)])
@@ -527,7 +557,7 @@ def test_libc_que_diverge_so_no_verao_tambem_e_pega(tmp_path, monkeypatch):
 
     (tmp_path / "Fake").mkdir()
     (tmp_path / "Fake" / "Zone").write_bytes(
-        (pathlib.Path("/usr/share/zoneinfo") / "Europe" / "London").read_bytes()
+        _tzif("Europe", "London")
     )
     monkeypatch.setenv("REPORT_TIMEZONE", "Fake/Zone")
     zoneinfo.reset_tzpath(to=[str(tmp_path)])

--- a/tests/test_fuso_do_app.py
+++ b/tests/test_fuso_do_app.py
@@ -513,6 +513,49 @@ def test_libc_que_nao_conhece_o_fuso_nao_passa_calada(tmp_path, monkeypatch):
         zoneinfo.ZoneInfo.clear_cache()
 
 
+# O caso do P2 do Codex (#180): a zona cujo offset COINCIDE com o do fallback no
+# instante do boot. `Europe/London` no inverno é +00:00, igual ao UTC em que a
+# libc cai — uma guarda que olhasse só "agora" passaria em janeiro e o app
+# divergiria em março, já em produção. Este caso é o que exige os TRÊS instantes.
+#
+# CONTROLE NEGATIVO: reduzir a guarda de `align_process_tz` a um instante só
+# (`agora`) deixa ESTE caso vermelho e o de cima (Tóquio) verde — é a diferença
+# exata entre as duas versões da guarda.
+
+def test_libc_que_diverge_so_no_verao_tambem_e_pega(tmp_path, monkeypatch):
+    import zoneinfo
+
+    (tmp_path / "Fake").mkdir()
+    (tmp_path / "Fake" / "Zone").write_bytes(
+        (pathlib.Path("/usr/share/zoneinfo") / "Europe" / "London").read_bytes()
+    )
+    monkeypatch.setenv("REPORT_TIMEZONE", "Fake/Zone")
+    zoneinfo.reset_tzpath(to=[str(tmp_path)])
+    zoneinfo.ZoneInfo.clear_cache()
+    try:
+        assert utils_date._tz().key == "Fake/Zone"
+        # O BOOT acontece no INVERNO — é o que torna o caso discriminante. Sem
+        # fixar isto o teste passa por acidente de calendário: rodando em
+        # agosto, Londres já diverge no instante presente e a guarda de um
+        # instante só bastaria. (Medido: com `_agora` livre, reduzir a guarda a
+        # um instante deixava este caso VERDE — teste tautológico.)
+        janeiro = datetime(2026, 1, 15, 12, tzinfo=timezone.utc)
+        monkeypatch.setattr(utils_date, "_agora", lambda: janeiro)
+
+        # A premissa: em janeiro o app dá +00:00, e o fallback da libc é UTC —
+        # logo os dois lados CONCORDAM no instante do boot, e só um instante de
+        # outra estação pode acusar a divergência. (O lado do processo só vira
+        # UTC depois do `tzset()` lá dentro; por isso não dá para afirmá-lo
+        # aqui, e afirmar antes era o que quebrava este caso.)
+        assert janeiro.astimezone(utils_date._tz()).utcoffset() == timedelta(0)
+
+        with pytest.raises(RuntimeError, match="libc"):
+            utils_date.align_process_tz()
+    finally:
+        zoneinfo.reset_tzpath()
+        zoneinfo.ZoneInfo.clear_cache()
+
+
 # ── 14. `load_app_env` roda em processo JÁ SERVINDO: `TZ` nunca some ─────────
 # `adapters/whatsapp/wa_app.py:39` chama `load_app_env()` no import, e esse import
 # é tardio de propósito (`frontend/finance_bot_websocket_custom.py:1952-1963`, 1ª

--- a/tests/test_fuso_do_app.py
+++ b/tests/test_fuso_do_app.py
@@ -647,6 +647,131 @@ def test_load_app_env_nunca_deixa_o_ambiente_sem_tz(tmp_path, monkeypatch):
     assert real["PGTZ"] == "Asia/Tokyo"
 
 
+# ── 16. A MÁQUINA INTEIRA: 16 combinações × as três pontas ───────────────────
+# Cinco rodadas de revisão bateram no mesmo subsistema, cada uma consertando UMA
+# transição: `pop` (janela sem `TZ`), atribuição do `TZ` do arquivo (janela com o
+# `TZ` errado quando o `REPORT_TIMEZONE` manda), Windows, DST. O §4 do CLAUDE.md
+# manda parar de remendar e enumerar estados × eventos. Isto é a enumeração.
+#
+# Entradas: `REPORT_TIMEZONE` e `TZ`, cada um podendo vir do ambiente REAL ou do
+# `.env`, presentes ou ausentes — 2^4 = 16 estados. Precedência documentada:
+# `REPORT_TIMEZONE` ganha de `TZ`; dentro de cada um, ambiente real ganha do
+# arquivo.
+#
+# O invariante afirmado em CADA um dos 16: processo, app e sessão do Postgres
+# valem o MESMO fuso, e é o efetivo da tabela.
+#
+# CONTROLE NEGATIVO: trocar a resolução de `config/env.py` de volta por
+# `os.environ["TZ"] = merged["TZ"]` deixa vermelhos os estados em que o
+# `REPORT_TIMEZONE` do arquivo convive com um `TZ` (de qualquer origem).
+# CONTROLE POSITIVO: os estados sem nada setado continuam em America/Sao_Paulo —
+# sem eles, um conserto que fixasse tudo num fuso passaria.
+
+_SP_DEFAULT = "America/Sao_Paulo"
+
+
+@pytest.mark.parametrize("r_env, r_file, t_env, t_file, efetivo", [
+    # R real manda, sempre
+    ("Asia/Tokyo", None, None, None, "Asia/Tokyo"),
+    ("Asia/Tokyo", "Europe/Lisbon", None, None, "Asia/Tokyo"),
+    ("Asia/Tokyo", None, "Europe/Lisbon", None, "Asia/Tokyo"),
+    ("Asia/Tokyo", None, None, "Europe/Lisbon", "Asia/Tokyo"),
+    ("Asia/Tokyo", "Europe/Lisbon", "Etc/GMT+12", "Pacific/Kiritimati", "Asia/Tokyo"),
+    ("Asia/Tokyo", "Europe/Lisbon", "Etc/GMT+12", None, "Asia/Tokyo"),
+    ("Asia/Tokyo", "Europe/Lisbon", None, "Etc/GMT+12", "Asia/Tokyo"),
+    ("Asia/Tokyo", None, "Europe/Lisbon", "Etc/GMT+12", "Asia/Tokyo"),
+    # sem R real: o R do ARQUIVO ganha de qualquer TZ
+    (None, "Europe/Lisbon", None, None, "Europe/Lisbon"),
+    (None, "Europe/Lisbon", "Asia/Tokyo", None, "Europe/Lisbon"),
+    (None, "Europe/Lisbon", None, "Asia/Tokyo", "Europe/Lisbon"),
+    (None, "Europe/Lisbon", "Asia/Tokyo", "Etc/GMT+12", "Europe/Lisbon"),
+    # sem R nenhum: TZ real ganha do TZ de arquivo
+    (None, None, "Asia/Tokyo", None, "Asia/Tokyo"),
+    (None, None, "Asia/Tokyo", "Europe/Lisbon", "Asia/Tokyo"),
+    (None, None, None, "Europe/Lisbon", "Europe/Lisbon"),
+    # nada em lugar nenhum: o default do produto (controle POSITIVO)
+    (None, None, None, None, _SP_DEFAULT),
+])
+def test_as_tres_pontas_batem_nos_16_estados(
+        tmp_path, monkeypatch, r_env, r_file, t_env, t_file, efetivo):
+    monkeypatch.delenv("REPORT_TIMEZONE", raising=False)
+    monkeypatch.delenv("TZ", raising=False)
+    if r_env:
+        monkeypatch.setenv("REPORT_TIMEZONE", r_env)
+    if t_env:
+        monkeypatch.setenv("TZ", t_env)
+    # o que o ambiente REAL trazia — é o que `utils_date` captura no import
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", t_env)
+
+    linhas = ""
+    if r_file:
+        linhas += f"REPORT_TIMEZONE={r_file}\n"
+    if t_file:
+        linhas += f"TZ={t_file}\n"
+    _com_env(tmp_path, monkeypatch, linhas)
+
+    assert utils_date.tz_name() == efetivo, "o APP"
+    assert os.environ["PGTZ"] == efetivo, "a SESSÃO do Postgres"
+    assert os.environ["TZ"] == efetivo, "o PROCESSO"
+    # e o processo de verdade, não só a variável
+    epoch = datetime.fromtimestamp(0, timezone.utc)
+    assert epoch.astimezone().utcoffset() == epoch.astimezone(ZoneInfo(efetivo)).utcoffset()
+
+
+# ── 17. Nenhuma escrita INTERMEDIÁRIA de `TZ` é observável com valor errado ──
+# É a generalização do caso 14: ele provava que `TZ` nunca some; este prova que
+# `TZ` nunca vale outra coisa. O apontamento que o motivou: com
+# `REPORT_TIMEZONE` (precedência maior) setado e um `TZ` no `.env`, a versão
+# anterior escrevia o `TZ` do arquivo por um instante — e uma thread concorrente
+# chamando `date.today()` nesse instante lia o dia errado (Codex #180, P2).
+#
+# CONTROLE NEGATIVO: repor `os.environ["TZ"] = merged["TZ"]` antes do
+# `setdefault` deixa este caso vermelho, com o valor intruso na mensagem.
+
+def test_tz_nunca_assume_valor_intermediario_errado(tmp_path, monkeypatch):
+    from collections.abc import MutableMapping
+
+    real = os.environ
+    escritas: list[str] = []
+
+    class _Vigia(MutableMapping):
+        def __getitem__(self, k):
+            return real[k]
+
+        def __setitem__(self, k, v):
+            if k == "TZ":
+                escritas.append(v)
+            real[k] = v
+
+        def __delitem__(self, k):
+            if k == "TZ":
+                escritas.append("<APAGADO>")
+            del real[k]
+
+        def __iter__(self):
+            return iter(real)
+
+        def __len__(self):
+            return len(real)
+
+    # O SETUP É O CAMINHO DO DEFEITO, e errar nele foi o que quase deixou este
+    # teste medir nada: a escrita intermediária da versão anterior só acontecia
+    # com `_TZ_ENV_ORIGINAL is None` — ou seja, `TZ` AUSENTE do ambiente real.
+    # Com `TZ` presente, aquele ramo nem executava e o controle negativo dava
+    # verde (medido).
+    monkeypatch.setenv("REPORT_TIMEZONE", "Asia/Tokyo")
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(utils_date, "_TZ_ENV_ORIGINAL", None)
+    monkeypatch.setattr(os, "environ", _Vigia())
+
+    # o `.env` traz um `TZ` de precedência MENOR: ele não pode ser observado
+    _com_env(tmp_path, monkeypatch, "TZ=Europe/Lisbon\n")
+
+    assert set(escritas) <= {"Asia/Tokyo"}, (
+        f"`TZ` passou por valor intermediário observável: {escritas}")
+    assert real["TZ"] == "Asia/Tokyo"
+
+
 # ── 15. Windows: sem `time.tzset`, o boot não pode morrer ───────────────────
 # `time.tzset` é POSIX. O `docs/readme.md` lista Windows como sistema suportado,
 # e sem guarda o `ImportError` subia até o `except` de `load_app_env` e virava

--- a/tests/test_nlp_and_pending_flow.py
+++ b/tests/test_nlp_and_pending_flow.py
@@ -1025,8 +1025,10 @@ def test_route_clarification_valor_completa_lancamento(user_id):
     assert "despesa registrada" in response.lower()
     assert round(float(get_balance(user_id)), 2) == -150.00
     assert get_pending_action(user_id) is None  # clarification consumida
-    # data preservada (02/06) — normaliza pro fuso do app, já que o driver
-    # devolve o timestamptz no fuso da sessão (varia por máquina/CI).
+    # data preservada (02/06) — normaliza pro fuso do app. O driver devolve o
+    # timestamptz no fuso da SESSÃO, que desde `utils_date.align_process_tz` é o
+    # do app em qualquer máquina; a conversão explícita fica porque o que se
+    # afirma aqui é o dia de São Paulo, não o dia da configuração do servidor.
     from zoneinfo import ZoneInfo
     sp = list_launches(user_id, limit=1)[0]["criado_em"].astimezone(ZoneInfo("America/Sao_Paulo"))
     assert sp.month == 6 and sp.day == 2

--- a/tests/test_routes_categories.py
+++ b/tests/test_routes_categories.py
@@ -242,7 +242,10 @@ def test_nota_alvo_e_criado_em_saem_na_resposta(pro_user_id):
     assert row["alvo"] == "recorrente:Netflix"
     # `data` é o dia de PAREDE em São Paulo; `criado_em` sai no fuso da sessão do
     # Postgres. Comparar as duas STRINGS cruas dava falso vermelho toda noite
-    # depois das 21h (ou toda madrugada, dependendo do fuso da sessão).
+    # depois das 21h (ou toda madrugada, dependendo do fuso da sessão). Desde
+    # `utils_date.align_process_tz` a sessão é a do app e as duas strings
+    # coincidiriam; a conversão explícita fica porque o que o endpoint promete é
+    # o dia de São Paulo, não "o dia de qualquer fuso que o servidor tenha".
     from datetime import datetime
     from zoneinfo import ZoneInfo
     inst = datetime.fromisoformat(row["criado_em"])

--- a/tests/test_tipo_legado_na_tendencia.py
+++ b/tests/test_tipo_legado_na_tendencia.py
@@ -29,30 +29,36 @@ Medido na produção (Railway) em 27/08/2026 21:50 UTC: `count(*) filter (where
 tipo='saida')` = 0 e o mesmo para 'entrada' em `launches`. Nenhum número de
 usuário muda hoje; isto fecha a classe, não apaga um incêndio.
 
-Referencial de data: `date.today()` — fuso do PROCESSO — governa a JANELA, não o
-rótulo do mês. É dele que saem o `range_start` do `get_spending_trend`
+Referencial de data: `date.today()` governa a JANELA, não o rótulo do mês. Ele é
+o fuso do PROCESSO, que desde `utils_date.align_process_tz` é o mesmo do app —
+antes disso os dois divergiam, e é essa divergência que o parágrafo abaixo
+descreve. É dele que saem o `range_start` do `get_spending_trend`
 (`db/accounts.py:367,377`), o `resolve_window` (`db/analytics.py:77`) e as chaves
 de bucket do `compute_evolution` (`db/analytics.py:335`). Por isso o arquivo
 inteiro grava e lê por ele, com janela explícita de `resolve_window(months=1)` em
 vez de `month_range_today()`: gravar em `today_tz()` — que cai em
 `America/Sao_Paulo` quando ninguém define `REPORT_TIMEZONE`/`TZ`, e o workflow do
-CI não define (`utils_date.py:13`) — e ler por uma janela de `date.today()` põe a
-escrita fora da janela e fora do mês procurado quando os dois apontam dias
+CI não define (`utils_date._tz`) — e ler por uma janela de `date.today()` punha a
+escrita fora da janela e fora do mês procurado quando os dois apontavam dias
 diferentes (31/08 23:30 em São Paulo já é 01/09 em UTC). Era essa a flakiness que
-este commit fecha, e ela não precisa da virada do mês para existir.
+este commit fechou, e ela não precisava da virada do mês para existir. Hoje as
+duas âncoras concordam por construção (`align_process_tz` escreve `TZ` e chama
+`tzset()`), então a disciplina deste arquivo virou defesa em profundidade.
 
 O RÓTULO do mês, esse, vem de outro lugar em cada leitor, e em nenhum deles é o
 processo: `get_spending_trend` converte `criado_em at time zone
 'America/Sao_Paulo'`, hardcoded (`db/accounts.py:392-393`, o parâmetro em `:413`),
 e `compute_evolution` usa `DATE_TRUNC('month', criado_em)` sobre um `timestamptz`
 (`db/schema.py:216`), isto é, o fuso da SESSÃO do Postgres (`db/analytics.py:309`)
-— o mesmo instante pode sair em meses diferentes nos dois. O que protege os
-testes disso é a HORA de escrita: sempre no meio do dia (10h a 14h), com folga
+— que desde `align_process_tz` também é `America/Sao_Paulo`, então os dois agora
+concordam; antes o mesmo instante podia sair em meses diferentes. O que protege
+os testes disso é a HORA de escrita: sempre no meio do dia (10h a 14h), com folga
 larga sobre os offsets em jogo. Quem mexer nessas horas mexe nessa folga.
 
 Ou seja, não há um referencial só: este arquivo ancora a JANELA, que é o que está
-ao alcance dele. O `America/Sao_Paulo` hardcoded e o fuso da sessão continuam
-fora — consertá-los é mudança em `db/*`, não aqui.
+ao alcance dele. O `America/Sao_Paulo` hardcoded do `get_spending_trend` continua
+fora — consertá-lo é mudança em `db/*`, não aqui. O fuso da SESSÃO saiu de fora:
+ele passou a ser o do app, imposto pelo processo (`align_process_tz`).
 
 Controle NEGATIVO: volte `{TIPO_CANON_SQL} as tipo` + o filtro para
 `tipo, valor` + `and tipo in ('despesa','receita')` em `get_spending_trend`

--- a/utils_date.py
+++ b/utils_date.py
@@ -3,7 +3,7 @@ import time as time_module
 import re
 import calendar
 import unicodedata
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, date, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 from dateutil.relativedelta import relativedelta
 
@@ -13,6 +13,12 @@ from dateutil.relativedelta import relativedelta
 def _tz():
     tz_name = os.getenv("REPORT_TIMEZONE") or os.getenv("TZ") or "America/Sao_Paulo"
     return ZoneInfo(tz_name)
+
+
+def _agora() -> datetime:
+    """Instante atual em UTC. Existe para a guarda de `align_process_tz` poder
+    comparar os dois lados sem depender do fuso que ela está validando."""
+    return datetime.now(timezone.utc)
 
 
 def tz_name() -> str:
@@ -122,12 +128,26 @@ def align_process_tz() -> str:
     # Só faz sentido onde o `tzset` acima RODOU: sem ele o processo fica no fuso
     # do sistema de propósito (Windows), e esta comparação acusaria uma
     # divergência que é conhecida e documentada, não um defeito.
-    agora = datetime.now(_tz())
-    if agora.astimezone().utcoffset() != agora.utcoffset():
-        raise RuntimeError(
-            f"a libc não aceitou o fuso {name!r}: o processo ficou em "
-            f"{agora.astimezone().tzname()} enquanto o app está em {name}"
-        )
+    #
+    # TRÊS instantes, não só "agora": comparar um só instante deixa passar a
+    # zona cujo offset COINCIDE com o do fallback hoje e diverge depois. O
+    # exemplo é do Codex (#180, P2), e é concreto: um `Fake/Zone` com o conteúdo
+    # de `Europe/London` subindo no inverno dá +00:00 nos dois lados — a guarda
+    # passa —, e em março o app vai para +01:00 enquanto `date.today()` fica em
+    # UTC, recriando a divergência de fronteira de dia que esta função existe
+    # para fechar, já em produção e sem sinal. Janeiro e julho pegam os dois
+    # sentidos de horário de verão (norte e sul); `agora` pega o caso em que a
+    # zona mudou de regra sem mudar de nome.
+    for instante in (datetime(_agora().year, 1, 15, 12, tzinfo=timezone.utc),
+                     datetime(_agora().year, 7, 15, 12, tzinfo=timezone.utc),
+                     _agora()):
+        do_processo = instante.astimezone().utcoffset()
+        do_app = instante.astimezone(_tz()).utcoffset()
+        if do_processo != do_app:
+            raise RuntimeError(
+                f"a libc não aceitou o fuso {name!r}: em {instante:%d/%m} o "
+                f"processo diz {do_processo} e o app diz {do_app}"
+            )
     return name
 
 

--- a/utils_date.py
+++ b/utils_date.py
@@ -1,4 +1,5 @@
 import os
+import time as time_module
 import re
 import calendar
 import unicodedata
@@ -81,11 +82,27 @@ def align_process_tz() -> str:
     INALCANÇÁVEL a guarda legível de `config/env.py::load_app_env`, que é quem
     recusa fuso inválido no boot com `exit(1)`.
     """
-    from time import tzset
-
     name = _tz().key
     os.environ["TZ"] = name
     os.environ["PGTZ"] = name
+
+    # `time.tzset` é POSIX e NÃO EXISTE no Windows, que o `docs/readme.md`
+    # lista como sistema suportado. Sem esta guarda o `ImportError` sobe até o
+    # `except` de `load_app_env` e vira `sys.exit(1)`: TODO entrypoint deixaria
+    # de subir no Windows, com a mensagem de "fuso inválido" — que ali seria
+    # mentira, porque o `ZoneInfo` resolveu o nome sem problema (Codex, #180).
+    #
+    # O que se perde lá, dito com todas as letras: sem `tzset` o PROCESSO fica
+    # no fuso do sistema, então `date.today()` e os `datetime.now()` naive não
+    # são alinhados e a divergência processo × app continua existindo no
+    # Windows. O que É alinhado lá é a SESSÃO do banco, via `PGTZ` — que é a
+    # metade que causa o bug da #178. Windows é ambiente de desenvolvimento
+    # aqui; produção é Linux (Railway) e o dev de referência é macOS, e nos dois
+    # o alinhamento é completo. Fechar a metade que falta no Windows exigiria
+    # não usar `date.today()` em lugar nenhum — que é o PR que este evitou.
+    tzset = getattr(time_module, "tzset", None)
+    if tzset is None:
+        return name
     tzset()
 
     # `tzset()` NÃO levanta quando a libc não conhece o nome: ela cai para UTC
@@ -102,6 +119,9 @@ def align_process_tz() -> str:
     # produção grava, logo /usr/share/zoneinfo está lá. É por isso que este PR
     # não acrescenta `tzdata` — a dependência criaria justamente a divergência
     # que esta guarda existe para pegar.
+    # Só faz sentido onde o `tzset` acima RODOU: sem ele o processo fica no fuso
+    # do sistema de propósito (Windows), e esta comparação acusaria uma
+    # divergência que é conhecida e documentada, não um defeito.
     agora = datetime.now(_tz())
     if agora.astimezone().utcoffset() != agora.utcoffset():
         raise RuntimeError(

--- a/utils_date.py
+++ b/utils_date.py
@@ -13,6 +13,112 @@ def _tz():
     tz_name = os.getenv("REPORT_TIMEZONE") or os.getenv("TZ") or "America/Sao_Paulo"
     return ZoneInfo(tz_name)
 
+
+def tz_name() -> str:
+    """Nome IANA do fuso do app, derivado do MESMO `_tz()`.
+
+    Sem `getenv` próprio de propósito: um segundo lugar lendo o ambiente
+    divergiria de `_tz()` no dia em que alguém setasse só uma das variáveis.
+    """
+    return _tz().key
+
+
+# O que o AMBIENTE REAL trouxe, antes de este módulo escrever qualquer coisa em
+# `TZ`. `config/env.py::load_app_env` usa isto para saber se o `TZ` que está no
+# ambiente é do operador (e então tem precedência sobre o `.env`) ou é o que
+# `align_process_tz` acabou de escrever aqui embaixo (e então não pode roubar do
+# `.env` a chance de ser lido).
+_TZ_ENV_ORIGINAL = os.environ.get("TZ")
+
+
+def align_process_tz() -> str:
+    """Põe PROCESSO, APP e SESSÃO DO POSTGRES no mesmo fuso. Fonte única.
+
+    São três relógios que precisam concordar, e até aqui não concordavam:
+
+    - o APP já lia `_tz()` (`REPORT_TIMEZONE` → `TZ` → America/Sao_Paulo);
+    - o PROCESSO seguia o `TZ` do sistema — UTC no Railway e no CI. É o que
+      `date.today()` e `datetime.now()` NAIVE respondem: 52 e 5 chamadas em
+      29/08/2026, nenhuma delas tocada por este conserto. Entre elas
+      `core/handlers/greeting.py:108`, que dizia "boa noite" às 15h de
+      Brasília — corrigido de graça aqui. Os dois números saem DAQUI, e não de
+      `grep`: `ast` conta CHAMADA, o `grep` conta texto e soma comentário e
+      docstring (`grep -rn "[.]today()"` devolve 170, com `tests/` dentro):
+
+          python3 - <<'EOF'
+          import ast, pathlib
+          for attr in ("today", "now"):
+              print(attr, sum(
+                  isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                  and n.func.attr == attr and not n.args and not n.keywords
+                  for p in pathlib.Path(".").rglob("*.py")
+                  if p.parts[0] not in {"tests", "scripts", "mobile", ".venv", ".claude"}
+                  for n in ast.walk(ast.parse(p.read_text(encoding="utf-8")))))
+          EOF
+    - a SESSÃO do Postgres seguia o fuso do servidor, também UTC. É por ela que
+      o banco resolve `::date`, `date_trunc` e a promoção de um `timestamp`
+      NAIVE a `timestamptz` — o que desloca em 3h as dezenas de cortes de janela do
+      tipo `criado_em < datetime.combine(fim + 1 dia, 00:00)` (db/accounts.py,
+      db/plans.py, core/budget_alerts.py, forecast, admin). Um gasto de 31/08
+      às 22:00 em São Paulo era lido como setembro.
+
+    A ESCRITA de `criado_em` sempre esteve certa (`datetime.now(_tz())`, aware,
+    coluna `timestamptz`): o defeito é de LEITURA, e não há dado corrompido
+    nessa coluna. Consertar só a sessão não bastaria — o processo continuaria em
+    UTC e as duas pontas divergiriam entre 00:00 e 03:00 UTC.
+
+    `PGTZ` é o que fixa o fuso da sessão: a libpq o lê em TODA conexão nova, o
+    que cobre as portas do processo inteiro (o pool síncrono e o `reset` de
+    `db/connection.py`, o async de `frontend/routes/shared.py`, o
+    `core/admin_dashboard.py`) sem uma linha de código em nenhuma delas. Medido:
+    sobrescreve inclusive um `PGTZ` hostil já posto pelo operador.
+
+    O `except Exception` de quem chama isto no import (logo abaixo) é largo de
+    propósito. Não é só `ImportError` de `tzset` e `ZoneInfoNotFoundError`:
+    `ZoneInfo` levanta `ValueError` para nome com travessia de caminho, esta
+    função levanta `RuntimeError` quando a libc não aceita o nome (abaixo), e a
+    lista não é fechada. Estreitar deixa um traceback cru subir do import e torna
+    INALCANÇÁVEL a guarda legível de `config/env.py::load_app_env`, que é quem
+    recusa fuso inválido no boot com `exit(1)`.
+    """
+    from time import tzset
+
+    name = _tz().key
+    os.environ["TZ"] = name
+    os.environ["PGTZ"] = name
+    tzset()
+
+    # `tzset()` NÃO levanta quando a libc não conhece o nome: ela cai para UTC
+    # CALADA (medido no macOS em 29/08/2026 com um `Fake/Zone`). Sem esta
+    # comparação a função retornava com sucesso deixando o PROCESSO em UTC e o
+    # app/sessão no fuso pedido — o invariante desta função quebrado em
+    # silêncio, que é o pior modo de falha possível para ela. É `ZoneInfo`
+    # (banco do Python) contra a libc (banco do sistema): duas leituras
+    # diferentes do mesmo nome.
+    #
+    # Alcançável só quando as duas divergem — hoje elas não divergem porque
+    # `tzdata` (o banco em pip) NÃO está no requirements.txt, e o do sistema
+    # existe: `_tz()` roda em TODA escrita de lançamento (`now_tz()`) e a
+    # produção grava, logo /usr/share/zoneinfo está lá. É por isso que este PR
+    # não acrescenta `tzdata` — a dependência criaria justamente a divergência
+    # que esta guarda existe para pegar.
+    agora = datetime.now(_tz())
+    if agora.astimezone().utcoffset() != agora.utcoffset():
+        raise RuntimeError(
+            f"a libc não aceitou o fuso {name!r}: o processo ficou em "
+            f"{agora.astimezone().tzname()} enquanto o app está em {name}"
+        )
+    return name
+
+
+try:
+    align_process_tz()
+except Exception:
+    # Nada é engolido de vez: sem fuso válido o primeiro `_tz()` levanta do
+    # mesmo jeito, e o boot já recusou antes (config/env.py).
+    pass
+
+
 def now_tz() -> datetime:
     return datetime.now(_tz())
 
@@ -23,10 +129,13 @@ def today_tz() -> date:
 def day_tz(dt):
     """Dia de PAREDE de um instante, no fuso do app.
 
-    `dt.date()` cru devolve o dia no fuso da SESSÃO do Postgres — UTC no
-    Railway. Um gasto de 26/08 21:30 em São Paulo saía como 27/08 por esse
-    caminho, enquanto o dashboard, que formata o instante no navegador, dizia
-    26/08. Fonte única das DUAS listagens que imprimem o dia de um
+    `dt.date()` cru devolve o dia no fuso da SESSÃO do Postgres. Essa sessão
+    ERA UTC no Railway, e um gasto de 26/08 21:30 em São Paulo saía como 27/08
+    por esse caminho, enquanto o dashboard, que formata o instante no navegador,
+    dizia 26/08. Desde `align_process_tz` (acima) a sessão roda no fuso do app e
+    os dois caminhos coincidem — o que não promove `.date()` cru a correto: ele
+    continua dependendo de configuração de servidor, e esta função não.
+    Fonte única das DUAS listagens que imprimem o dia de um
     `criado_em` (`list_launches_by_category`, db/accounts.py; `list_launches`,
     core/handlers/launches.py): com uma cópia em cada lado, "liste lazer" e
     "meus últimos lançamentos" divergiam em um dia para o mesmo lançamento.
@@ -47,15 +156,20 @@ def launch_day(dt, posted_at=None, has_time=True):
 
     - compra no crédito: `purchased_at` é `date` (db/schema.py) e na UNION de
       `list_launches_by_category` o Postgres promove `timestamp` → `timestamptz`
-      pelo fuso da SESSÃO. A sessão da PRODUÇÃO é `Etc/UTC` (medido no Railway em
-      27/08/2026 08:46 UTC), então 27/08 00:00 vira 27/08 00:00Z e `day_tz`
-      devolve 26/08: toda compra de cartão está saindo com o DIA ANTERIOR nessa
-      lista hoje — não é risco futuro. Na máquina local a sessão é -04 e o erro
-      some, que é por que só o CI ficou vermelho.
+      pelo fuso da SESSÃO. Enquanto a sessão da PRODUÇÃO era `Etc/UTC` (medido
+      no Railway em 27/08/2026 08:46 UTC), 27/08 00:00 virava 27/08 00:00Z e
+      `day_tz` devolvia 26/08: toda compra de cartão saía com o DIA ANTERIOR
+      nessa lista, e só o CI ficava vermelho porque a sessão da máquina local
+      era -04 e o erro sumia. Desde `align_process_tz` (acima) a sessão é o fuso
+      do app e a promoção cai na meia-noite certa. O que mantém esta função
+      necessária é a REGRA, não o fuso: sem hora confiável quem manda é a DATA,
+      venha ela de que sessão vier.
     - Open Finance importado ANTES de c474fba (18/08/2026): gravava a `date`
       crua em `criado_em` (timestamptz) → meia-noite no fuso da SESSÃO, que na
-      produção é UTC, e o dia exibido escorregava um pra trás. Essas linhas
-      continuam no banco, sem `time_known` no `efeitos` (logo `has_time=false`),
+      época era UTC na produção, e o dia exibido escorregava um pra trás. Essas
+      linhas continuam no banco com MEIA-NOITE UTC gravada em disco: o instante
+      é absoluto e não muda com o fuso da sessão, então `align_process_tz` não
+      as conserta. Seguem sem `time_known` no `efeitos` (logo `has_time=false`),
       e só o `posted_at` delas está certo.
 
     NÃO vale para o que os importadores gravam HOJE: extrato OFX/CSV/PDF


### PR DESCRIPTION
Fecha a #178. Duas variáveis de ambiente e um `tzset` — o resto do diff é
consequência: 18 textos que este conserto tornou falsos, e os testes.

## O bug

O Postgres promove `timestamp` NAIVE a `timestamptz`, e resolve `::date` e
`date_trunc`, pelo fuso da SESSÃO — `Etc/UTC` em produção e no CI. Dezenas de
cortes de janela chegam ao banco assim:

    and criado_em < %s        params: datetime.combine(fim + 1 dia, 00:00)

e saem 3h deslocados. Um gasto de 31/08 às 22:00 em São Paulo é lido como
setembro.

**A escrita sempre esteve certa.** `criado_em` é gravado com
`datetime.now(_tz())` — aware — numa coluna `timestamptz`. Não há dado
corrompido e não há backfill. O defeito é 100% de LEITURA. (Registrado porque o
primeiro diagnóstico desta investigação foi o oposto, e estava errado.)

Pelo caminho do usuário, com a sessão em UTC e um gasto de hoje às 23:00:

| pergunta ao bot | antes | depois |
|---|---|---|
| `quanto gastei hoje` | o gasto de ONTEM | o de hoje |
| `quanto gastei ontem` | "você não teve gastos ontem" | o de ontem |
| `meus gastos do mes` | 1 lançamento | 2 lançamentos |

## O conserto

`utils_date.align_process_tz()` escreve `TZ` e `PGTZ` com o valor de `_tz()` e
chama `tzset()`. `TZ` alinha o PROCESSO (`date.today()` e os `datetime.now()`
naive); `PGTZ` alinha TODA conexão libpq. Chamado no import e de novo no fim de
`load_app_env`, para o `.env` não reintroduzir a divergência.

**As três pontas são um invariante só**: processo, app e sessão do banco. A
primeira tentativa consertou só a sessão e quebrou 21 testes que a `main` não
quebrava — o `date.today()` ficou para trás. Por isso `TZ` e `PGTZ` andam juntos,
derivados do mesmo `_tz()`, num lugar só.

Uma guarda depois do `tzset()` compara o offset real do processo com o do app e
levanta se divergirem: `tzset()` NÃO levanta quando a libc não conhece o nome —
cai para UTC calado, e a divergência voltaria sem sinal.

`db/connection.py`, `frontend/routes/shared.py`, `core/admin_dashboard.py` e o
workflow ficam com ZERO diff de código: o `PGTZ` cobre as CINCO portas libpq do
processo por construção, sem callback e sem `commit()` a esquecer.

## Verificação

| | resultado |
|---|---|
| suíte, `main` | 5108 passed, 1 xfailed, 0 failed |
| suíte, este branch | **5125 passed, 1 xfailed, 0 failed** |
| frontend | 187 pass, 0 fail |
| arquivos tocados, nas duas colunas | 18 passed × 18 passed |
| `PGTZ=Pacific/Kiritimati` (+14) e `Etc/GMT+12` (−12) | 0 failed |
| 188 testes de Open Finance, 8 cruzamentos árvore × fuso | 0 failed |

**A prova de que `test_include_internal_false_e_tipo_despesa` passa pelo motivo
certo** — forçando a condição pelo FUSO, não esperando o relógio (medido às
16:48 UTC, fora da janela 00:00–03:00 em que o bug se manifesta sozinho):

| | resultado |
|---|---|
| `main`, sessão UTC | passed — verde por ACIDENTE de horário |
| `main`, sessão `Asia/Tokyo`, mesmo relógio | **failed**, assinatura idêntica à do CI |
| este branch, sessão São Paulo, mesmo relógio | passed |

Controles negativos, todos medidos: tirar `PGTZ` → 11 vermelhos (sessão UTC);
tirar `TZ` → 16 errors (a guarda recusa o boot); tirar a guarda de offsets → 1;
tirar `align_process_tz` do `load_app_env` → 5; repor o `pop("TZ")` → 1;
inverter a precedência em `_tz()` → 3; `day_tz` → `dt.date()` na suíte inteira
→ 2 (era 1 antes desta rodada).

## O que muda de comportamento, e não foi pedido

Os 52 `date.today()` de produção NÃO foram editados — mas a resposta deles muda
entre 21:00 e 00:00 de São Paulo. Inclui caminho de dinheiro e de paywall:

* `db/plans.py:170-181` — a cota do plano Grátis conta por
  `date_trunc('month', criado_em)`, resolvido na sessão. Um lançamento das 22h do
  último dia do mês, que hoje conta para o mês seguinte, passa a contar para o
  corrente: usuário no limite pode ser bloqueado ou liberado no deploy;
* `core/services/recurring_charger.py:140,158,399` — a data de disparo da
  cobrança recorrente muda (idempotente por `ym`/`due_date`, sem risco de dobra);
* `core/budget_alerts.py:130-141`, `core/services/cashflow.py:105,198`.

**Mitigação: deploiar fora da faixa 21:00–00:00 de São Paulo** — é a única em que
o dia dá um passo para trás durante a troca.

Mais: relatórios de meses fechados mudam retroativamente; a conciliação do Open
Finance desliza um dia para lançamentos noturnos (simétrico, não dobra saldo);
`core/handlers/greeting.py:108` para de dizer "boa noite" às 15h de Brasília; o
carimbo dos logs passa de UTC para −03; e um `PGTZ` posto pelo operador deixa de
valer.

## Cobertura declarada perdida

Três casos de `test_category_launches_query.py` e um de
`test_dia_das_listagens_no_fuso.py` mediam o hazard "a sessão diverge do app".
Com a sessão alinhada, o hazard deixa de existir e eles passam mesmo quebrados.
Dois foram resgatados fazendo os fabricadores de linha legada gravarem meia-noite
UTC aware — que é o que a produção tem em disco. Os outros viram controle
positivo declarado, mais um unitário de `day_tz` e um caso que abre conexão
própria em UTC para manter o hazard observável.

## Não verificado

* **Railway**: imagem-base, presença de `/usr/share/zoneinfo` e valor real de
  `TZ`/`REPORT_TIMEZONE`. O argumento de que o banco de fusos existe lá é
  indireto — `_tz()` roda em toda escrita e a produção grava — e por isso
  `tzdata` NÃO foi acrescentado ao `requirements.txt`: ele criaria a divergência
  libc × `ZoneInfo` que a guarda existe para pegar.
* **CI**: o vermelho intermitente só some com um run entre 00:00 e 03:00 UTC.
* **WhatsApp real** e **Pluggy real**: nada exercitado.
* A corrida do `load_app_env` em processo já servindo foi fechada
  estruturalmente (`TZ` nunca sai do ambiente), não reproduzida — esta máquina é
  BSD libc, não glibc.

Deixa aberta a #179 (§0.7: três leituras do fuso convivem, duas ignoram
`REPORT_TIMEZONE`).

Closes #178

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>