### PR TITLE
Texto do usuário no PDF é conteúdo, não marcação (#145)

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -1252,6 +1252,7 @@ async def build_pdf(user_id: int, year: int, month: int) -> bytes | None:
 
 def _render_pdf(items: list[dict], year: int, month: int, balance: float = 0.0) -> bytes:
     from datetime import datetime as _dt
+    from html import escape
     from reportlab.lib import colors
     from reportlab.lib.pagesizes import A4
     from reportlab.lib.units import mm
@@ -1278,7 +1279,17 @@ def _render_pdf(items: list[dict], year: int, month: int, balance: float = 0.0) 
     base = getSampleStyleSheet()
 
     def par(text, size=9, color=INK, bold=False, align=TA_LEFT):
-        return Paragraph(str(text), ParagraphStyle(
+        # `Paragraph` interpreta mini-XML, e TODO texto livre do extrato passa por
+        # aqui — `categoria`, `alvo`, `nota`, nome do cartão. Medido no reportlab
+        # 5.0.0, sem escape: `"<b>gastos"` na nota estoura `ValueError` e a
+        # exportação do MÊS INTEIRO vira 500 permanente (o usuário não tem como
+        # saber qual lançamento culpar), e `"<img src='/etc/hosts'/>"` faz o
+        # processo ABRIR o arquivo do servidor — com URL no lugar do caminho, a
+        # request sai. Escapa no funil e não nos 4 call sites: diff menor e o
+        # próximo call site já nasce coberto. Nenhum `par()` passa markup de
+        # propósito — o negrito é o `fontName` abaixo. `quote=False` porque isto é
+        # conteúdo de elemento, não valor de atributo.
+        return Paragraph(escape(str(text), quote=False), ParagraphStyle(
             "p", parent=base["Normal"],
             fontName="Helvetica-Bold" if bold else "Helvetica",
             fontSize=size, textColor=color, alignment=align, leading=size + 3,

--- a/tests/test_export_pdf_escape.py
+++ b/tests/test_export_pdf_escape.py
@@ -1,0 +1,107 @@
+"""Texto do usuário no PDF é CONTEÚDO, não marcação (#145).
+
+`reportlab.platypus.Paragraph` interpreta um dialeto de mini-XML. Todo texto livre
+do extrato — `categoria`, `alvo`, `nota` e o nome do cartão — passa pelo `par()` do
+`_render_pdf`, então sem escape o usuário escreve marcação no PDF do próprio mês.
+
+Medido na `main` (reportlab 5.0.0), antes do conserto:
+
+    "<b>gastos"                -> ValueError: a exportação do MÊS INTEIRO devolve
+                                  500 e CONTINUA 500 enquanto o lançamento existir
+    "<img src='/caminho'/>"    -> OSError com fileName='/caminho': o processo ABRE
+                                  o arquivo do servidor (leitura de arquivo local);
+                                  com uma URL no lugar do caminho, a request sai
+
+CONTROLE NEGATIVO — tire o `escape(...)` do `par()`
+(`frontend/finance_bot_websocket_custom.py`) e volte ao `Paragraph(str(text), ...)`:
+`test_markup_na_nota_nao_derruba_o_pdf` e `test_img_nao_abre_arquivo_do_servidor`
+ficam VERMELHOS. Injetado nos dois casos, que estavam verdes.
+
+CONTROLE POSITIVO — `test_texto_legitimo_continua_no_pdf`: o conserto RESTRINGE
+(passa a escapar), então precisa provar que não mutila o texto de quem escreveu
+certo. `McDonald's`, `café & pão` e `a*b` continuam saindo legíveis no PDF, com o
+caractere original e não com a entidade.
+
+CLASSE CEGA desta verificação: ela cobre o `_render_pdf`. As outras duas saídas do
+mesmo `items` — `_render_xlsx` e o CSV — têm a sua própria classe de injeção
+(fórmula começando com `=`/`+`/`-`/`@`), que NÃO é esta e não é testada aqui.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+pytest.importorskip("reportlab", reason="exportação de PDF não é exercitável sem reportlab")
+pytest.importorskip("pypdf", reason="ler o PDF de volta é o que prova que o texto sobreviveu")
+
+import frontend.finance_bot_websocket_custom as app_mod
+
+
+def _item(*, categoria: str = "alimentação", descricao: str = "mercado") -> dict:
+    """Uma despesa de conta — a forma que o `_fetch_export_items` produz."""
+    return {
+        "data": datetime(2026, 8, 15, 12, 0),
+        "natureza": "despesa",
+        "label": "Despesa",
+        "sign": "-",
+        "categoria": categoria,
+        "descricao": descricao,
+        "valor": 39.90,
+    }
+
+
+def _texto_do_pdf(blob: bytes) -> str:
+    import io
+
+    from pypdf import PdfReader
+
+    return "\n".join(p.extract_text() or "" for p in PdfReader(io.BytesIO(blob)).pages)
+
+
+def test_markup_na_nota_nao_derruba_o_pdf():
+    """`<b>gastos` na nota: 500 permanente na `main`, PDF normal com o conserto."""
+    blob = app_mod._render_pdf([_item(descricao="<b>gastos")], 2026, 8)
+
+    assert blob.startswith(b"%PDF")
+    # A tag sai como TEXTO do lançamento, não como negrito que vaza pelo resto.
+    assert "<b>gastos" in _texto_do_pdf(blob)
+
+
+def test_img_nao_abre_arquivo_do_servidor(tmp_path):
+    """`<img src=...>` deixa de ser tag: o arquivo apontado não é aberto.
+
+    O alvo é um arquivo que EXISTE e não é imagem. Sem escape, o reportlab o abre e
+    estoura ao tentar decodificar — é a prova de que a leitura aconteceu. Com
+    escape, o caminho é só texto e nada no disco é tocado.
+    """
+    alvo = tmp_path / "segredo.txt"
+    alvo.write_text("conteudo que o PDF nao pode ler", encoding="utf-8")
+
+    blob = app_mod._render_pdf(
+        [_item(categoria=f'<img src="{alvo}" width="1" height="1"/>')], 2026, 8
+    )
+
+    assert blob.startswith(b"%PDF")
+    assert "conteudo que o PDF nao pode ler" not in _texto_do_pdf(blob)
+
+
+def test_texto_legitimo_continua_no_pdf():
+    """CONTROLE POSITIVO: escapar não pode mutilar quem escreveu certo.
+
+    `&` é o caractere que o escape reescreve (`&amp;`) — se o PDF mostrasse a
+    entidade em vez do caractere, o conserto teria trocado um bug por outro.
+    """
+    blob = app_mod._render_pdf(
+        [
+            _item(categoria="café & pão", descricao="McDonald's"),
+            _item(categoria="a*b", descricao="conta 100% paga"),
+        ],
+        2026,
+        8,
+    )
+    texto = _texto_do_pdf(blob)
+
+    for esperado in ("café & pão", "McDonald's", "a*b", "conta 100% paga"):
+        assert esperado in texto, f"{esperado!r} sumiu do PDF"
+    assert "&amp;" not in texto


### PR DESCRIPTION
Fecha a issue #145. (Sem keyword em inglês o GitHub não fecha sozinho — fechar na mão depois do merge.)

## O problema

`reportlab.platypus.Paragraph` interpreta um dialeto de mini-XML (`<b>`, `<font>`, `<img>`, `<link>`), e **todo** texto livre do extrato passa pelo `par()` do `_render_pdf`: `categoria`, `alvo`, `nota` e o nome do cartão.

Medido nesta máquina, reportlab 5.0.0, na `main`:

| entrada do usuário | o que acontece hoje |
|---|---|
| `<b>gastos` na nota | `ValueError` na montagem → a exportação do **mês inteiro** devolve **500, permanentemente**, enquanto o lançamento existir. O usuário não tem como saber qual lançamento culpar. |
| `<img src="<caminho>"/>` | o processo **abre o arquivo do servidor**. Com uma URL no lugar do caminho, a request **sai**. |
| `<link href="http://...">` | vira hyperlink de verdade dentro do PDF. |

**Não é regressão.** Existe na `main` pelo campo `nota` desde antes do #143 — o #143 só removeu a proteção acidental de um segundo campo (`categoria`, que antes perdia `<` e `>` no `normalize_text`).

## O conserto

Escape no **funil** (`par()`), não nos 4 call sites de texto de usuário: mesmo efeito, diff menor, e o próximo call site já nasce coberto.

`html.escape` da stdlib, que o repositório já usa como padrão (`frontend/routes/shared.py:20`, `static_pages.py:181`) — sem helper novo (§0.1). `quote=False` porque isto é conteúdo de elemento, não valor de atributo.

**A categoria está fechada, não só a instância** (§2): `grep -rn "Paragraph(" --include="*.py"` devolve **uma única** ocorrência no repositório inteiro. Não há segundo sítio esquecido.

Efeito colateral bom: escapar o `&` conserta de quebra o `café & pão`, que já era frágil na `main`.

## Verificação

`tests/test_export_pdf_escape.py`, 3 casos.

**Controle negativo — medido, não afirmado.** Desligado o `escape(...)`, dois casos que estavam verdes ficam vermelhos:

```
FAILED tests/test_export_pdf_escape.py::test_markup_na_nota_nao_derruba_o_pdf
FAILED tests/test_export_pdf_escape.py::test_img_nao_abre_arquivo_do_servidor
```

O segundo **captura a prova da leitura do arquivo** na própria mensagem de falha:

```
PIL.UnidentifiedImageError: fileName='...\test_img_nao_abre_arquivo_do_s0\segredo.txt'
```

**Controle positivo.** O conserto *restringe* (passa a escapar), então precisa provar que não mutila quem escreveu certo. `test_texto_legitimo_continua_no_pdf` lê o PDF de volta com `pypdf` e afirma que `McDonald's`, `café & pão`, `a*b` e `conta 100% paga` saem com o **caractere original**, não com a entidade.

**Suíte, comparada por nome (§3), mesma árvore:**

| | falhas | passam | erros |
|---|---|---|---|
| baseline (`main` d3ff537) | 20 | 5158 | 2 |
| este branch | 20 | 5161 (+3, os novos) | 2 |

Conjunto de nomes **idêntico** nas duas colunas — nenhum vermelho novo, nenhum a menos.

As 20 falhas da baseline são pré-existentes e nenhuma na área tocada: 19 de `tests/test_fuso_do_app.py` (depende de `time.tzset()`, que é POSIX e não existe no Windows — o CI Linux está verde na mesma árvore), 2 de `test_category_normalization.py` e 1 de `test_pending_registry.py` (artefatos de Windows já conhecidos).

## O que NÃO foi verificado

- **A exportação ponta a ponta pela rota do dashboard.** O teste chama `_render_pdf` direto. A rota tem auth, rate-limit e gate de plano por cima; nada disso foi exercitado aqui.
- **As outras duas saídas do mesmo `items`** — `_render_xlsx` e o CSV — têm **outra** classe de injeção (fórmula iniciada por `=`/`+`/`-`/`@`). Não está coberta por este PR e não foi consertada. Se valer a pena, é issue e PR próprios.
- **Classe cega deste teste:** ele prova o `_render_pdf`. Um defeito na montagem do `items` (`_fetch_export_items`) passaria batido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
