### PR TITLE
Smoke de produção pós-deploy: o CI mede o código, isto mede o site

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,10 +8,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  # TEMPORÁRIO — sai no próximo commit. Uma rodada para provar o listener de
-  # `requestfailed` (risco: ERR_ABORTED de navegação virando vermelho falso).
-  pull_request:
-    branches: [main]
 
 # Cancelar o run velho aqui é CORRETO, ao contrário do tests.yml (que agrupa
 # por SHA justamente para não cancelar nada). O motivo é a diferença de alvo:
@@ -19,14 +15,12 @@ on:
 # nunca mais vai estar no ar — ele ficaria esperando o gate até o timeout e
 # reprovaria por algo que não é defeito.
 concurrency:
-  group: smoke-prod-${{ github.event_name }}  # TEMPORÁRIO, junto com o gatilho
+  group: smoke-prod
   cancel-in-progress: true
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    # TEMPORÁRIO — sai junto com o gatilho.
-    if: github.event_name != 'pull_request' || github.head_ref == 'claude/automate-pr-tests-92bb58'
     # 15 min de gate + as duas baterias. Sem teto, um deploy travado queimaria
     # 6 horas de runner (default do GitHub).
     timeout-minutes: 25
@@ -55,15 +49,11 @@ jobs:
           # como variável SMOKE_HEALTH_TOKEN no serviço do Railway.
           SMOKE_HEALTH_TOKEN: ${{ secrets.SMOKE_HEALTH_TOKEN }}
         run: |
-          if [ -z "$SMOKE_HEALTH_TOKEN" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ -z "$SMOKE_HEALTH_TOKEN" ]; then
             echo "::error title=Gate do deploy sem token::Secret SMOKE_HEALTH_TOKEN ausente. Sem ele não há como saber qual código está no ar, e medir sem saber é o verde falso que este workflow existe para impedir."
             exit 1
           fi
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            python scripts/smoke_prod.py            # TEMPORÁRIO: PR não está deployado
-          else
-            python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
-          fi
+          python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,11 +8,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  # TEMPORÁRIO — sai antes do merge. Serve só para provar, uma vez, que o smoke
-  # de UI funciona de ponta a ponta com os secrets reais. O `if:` do job prende
-  # isto a ESTA branch: nenhum outro PR dispara.
-  pull_request:
-    branches: [main]
 
 # Cancelar o run velho aqui é CORRETO, ao contrário do tests.yml (que agrupa
 # por SHA justamente para não cancelar nada). O motivo é a diferença de alvo:
@@ -20,18 +15,12 @@ on:
 # nunca mais vai estar no ar — ele ficaria esperando o gate até o timeout e
 # reprovaria por algo que não é defeito.
 concurrency:
-  # TEMPORÁRIO: `-${{ github.event_name }}` enquanto o gatilho `pull_request`
-  # existe. Sem isso o evento de PR entra no MESMO grupo do push na main e o
-  # cancela — e o job do PR ainda é pulado pelo `if`, então aquele deploy fica
-  # sem smoke nenhum (Codex, P1). Volta a ser `smoke-prod` quando o gatilho sair.
-  group: smoke-prod-${{ github.event_name }}
+  group: smoke-prod
   cancel-in-progress: true
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    # TEMPORÁRIO — remover junto com o gatilho `pull_request` acima.
-    if: github.event_name != 'pull_request' || github.head_ref == 'claude/automate-pr-tests-92bb58'
     # 15 min de gate + as duas baterias. Sem teto, um deploy travado queimaria
     # 6 horas de runner (default do GitHub).
     timeout-minutes: 25
@@ -60,17 +49,11 @@ jobs:
           # como variável SMOKE_HEALTH_TOKEN no serviço do Railway.
           SMOKE_HEALTH_TOKEN: ${{ secrets.SMOKE_HEALTH_TOKEN }}
         run: |
-          if [ -z "$SMOKE_HEALTH_TOKEN" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ -z "$SMOKE_HEALTH_TOKEN" ]; then
             echo "::error title=Gate do deploy sem token::Secret SMOKE_HEALTH_TOKEN ausente. Sem ele não há como saber qual código está no ar, e medir sem saber é o verde falso que este workflow existe para impedir."
             exit 1
           fi
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # TEMPORÁRIO: num PR o HEAD não está deployado, então esperar por
-            # ele seria esperar para sempre. Mede a produção como ela está.
-            python scripts/smoke_prod.py
-          else
-            python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
-          fi
+          python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,11 +8,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-  # TEMPORÁRIO — sai antes do merge. Serve só para provar, uma vez, que o smoke
-  # de UI funciona de ponta a ponta com os secrets reais. O `if:` do job prende
-  # isto a ESTA branch: nenhum outro PR dispara.
-  pull_request:
-    branches: [main]
 
 # Cancelar o run velho aqui é CORRETO, ao contrário do tests.yml (que agrupa
 # por SHA justamente para não cancelar nada). O motivo é a diferença de alvo:
@@ -26,8 +21,6 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    # TEMPORÁRIO — remover junto com o gatilho `pull_request` acima.
-    if: github.event_name != 'pull_request' || github.head_ref == 'claude/automate-pr-tests-92bb58'
     # 15 min de gate + as duas baterias. Sem teto, um deploy travado queimaria
     # 6 horas de runner (default do GitHub).
     timeout-minutes: 25
@@ -56,17 +49,11 @@ jobs:
           # como variável SMOKE_HEALTH_TOKEN no serviço do Railway.
           SMOKE_HEALTH_TOKEN: ${{ secrets.SMOKE_HEALTH_TOKEN }}
         run: |
-          if [ -z "$SMOKE_HEALTH_TOKEN" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ -z "$SMOKE_HEALTH_TOKEN" ]; then
             echo "::error title=Gate do deploy sem token::Secret SMOKE_HEALTH_TOKEN ausente. Sem ele não há como saber qual código está no ar, e medir sem saber é o verde falso que este workflow existe para impedir."
             exit 1
           fi
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # TEMPORÁRIO: num PR o HEAD não está deployado, então esperar por
-            # ele seria esperar para sempre. Mede a produção como ela está.
-            python scripts/smoke_prod.py
-          else
-            python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
-          fi
+          python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # TEMPORÁRIO — sai no próximo commit. Uma rodada para provar o listener de
+  # `requestfailed` (risco: ERR_ABORTED de navegação virando vermelho falso).
+  pull_request:
+    branches: [main]
 
 # Cancelar o run velho aqui é CORRETO, ao contrário do tests.yml (que agrupa
 # por SHA justamente para não cancelar nada). O motivo é a diferença de alvo:
@@ -15,12 +19,14 @@ on:
 # nunca mais vai estar no ar — ele ficaria esperando o gate até o timeout e
 # reprovaria por algo que não é defeito.
 concurrency:
-  group: smoke-prod
+  group: smoke-prod-${{ github.event_name }}  # TEMPORÁRIO, junto com o gatilho
   cancel-in-progress: true
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # TEMPORÁRIO — sai junto com o gatilho.
+    if: github.event_name != 'pull_request' || github.head_ref == 'claude/automate-pr-tests-92bb58'
     # 15 min de gate + as duas baterias. Sem teto, um deploy travado queimaria
     # 6 horas de runner (default do GitHub).
     timeout-minutes: 25
@@ -49,11 +55,15 @@ jobs:
           # como variável SMOKE_HEALTH_TOKEN no serviço do Railway.
           SMOKE_HEALTH_TOKEN: ${{ secrets.SMOKE_HEALTH_TOKEN }}
         run: |
-          if [ -z "$SMOKE_HEALTH_TOKEN" ]; then
+          if [ -z "$SMOKE_HEALTH_TOKEN" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "::error title=Gate do deploy sem token::Secret SMOKE_HEALTH_TOKEN ausente. Sem ele não há como saber qual código está no ar, e medir sem saber é o verde falso que este workflow existe para impedir."
             exit 1
           fi
-          python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            python scripts/smoke_prod.py            # TEMPORÁRIO: PR não está deployado
+          else
+            python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,14 @@ on:
 # nunca mais vai estar no ar — ele ficaria esperando o gate até o timeout e
 # reprovaria por algo que não é defeito.
 concurrency:
-  group: smoke-prod
+  # Grupo por REF, não fixo: um `workflow_dispatch` lançado de uma branch de
+  # feature entrava no mesmo grupo do push na main, cancelava o run de produção
+  # pelo `cancel-in-progress` e depois ficava esperando um SHA que a produção
+  # nunca vai servir — o deploy real ficava sem smoke (Codex, P2). Com o ref no
+  # grupo, só runs do mesmo ref competem entre si. Push e dispatch a partir da
+  # main continuam no mesmo grupo, que é o desejado: os dois medem a mesma
+  # produção e o mais novo é o que vale.
+  group: smoke-prod-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,7 +20,11 @@ on:
 # nunca mais vai estar no ar — ele ficaria esperando o gate até o timeout e
 # reprovaria por algo que não é defeito.
 concurrency:
-  group: smoke-prod
+  # TEMPORÁRIO: `-${{ github.event_name }}` enquanto o gatilho `pull_request`
+  # existe. Sem isso o evento de PR entra no MESMO grupo do push na main e o
+  # cancela — e o job do PR ainda é pulado pelo `if`, então aquele deploy fica
+  # sem smoke nenhum (Codex, P1). Volta a ser `smoke-prod` quando o gatilho sair.
+  group: smoke-prod-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,82 @@
+name: Smoke (produção)
+
+# Roda DEPOIS que o deploy da main está no ar. Não é um segundo CI: o
+# tests.yml mede o código, este mede o SITE. As falhas que ele existe para
+# pegar (rota que some, asset que não chega, card renderizando o 404 do
+# proxy) passam por 984 testes verdes sem uma linha vermelha.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Cancelar o run velho aqui é CORRETO, ao contrário do tests.yml (que agrupa
+# por SHA justamente para não cancelar nada). O motivo é a diferença de alvo:
+# só existe UMA produção, e quando um segundo merge sobe, o SHA do run velho
+# nunca mais vai estar no ar — ele ficaria esperando o gate até o timeout e
+# reprovaria por algo que não é defeito.
+concurrency:
+  group: smoke-prod
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    # 15 min de gate + as duas baterias. Sem teto, um deploy travado queimaria
+    # 6 horas de runner (default do GitHub).
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      # Só `requests`. Instalar o requirements.txt inteiro aqui seria 2 min por
+      # run para rodar um script que não importa nada do projeto.
+      - name: Install requests
+        run: pip install "requests==2.34.2"
+
+      # Este passo é também o GATE: espera /health reportar o SHA deste push
+      # antes de medir qualquer coisa. Sem ele o smoke poderia medir o deploy
+      # ANTERIOR e passar verde sobre código que nunca foi testado.
+      - name: Smoke HTTP (público) + gate do deploy
+        env:
+          # O /health só devolve o commit para quem manda este token — ele é
+          # infraestrutura e o endpoint é público. O MESMO valor tem de estar
+          # como variável SMOKE_HEALTH_TOKEN no serviço do Railway.
+          SMOKE_HEALTH_TOKEN: ${{ secrets.SMOKE_HEALTH_TOKEN }}
+        run: |
+          if [ -z "$SMOKE_HEALTH_TOKEN" ]; then
+            echo "::error title=Gate do deploy sem token::Secret SMOKE_HEALTH_TOKEN ausente. Sem ele não há como saber qual código está no ar, e medir sem saber é o verde falso que este workflow existe para impedir."
+            exit 1
+          fi
+          python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Playwright + Chromium
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      # Credencial ausente REPROVA o job. Um warning verde diria "smoke passou"
+      # sobre uma rodada que não abriu uma única tela logada — que é a metade
+      # onde estava o card renderizando o 404 do proxy. Verde sem medição é o
+      # falso positivo que este workflow inteiro existe para impedir.
+      - name: Smoke de UI (telas logadas)
+        env:
+          SMOKE_EMAIL: ${{ secrets.SMOKE_EMAIL }}
+          SMOKE_PASSWORD: ${{ secrets.SMOKE_PASSWORD }}
+        run: |
+          if [ -z "$SMOKE_EMAIL" ] || [ -z "$SMOKE_PASSWORD" ]; then
+            echo "::error title=Smoke de UI não rodou::Secrets SMOKE_EMAIL/SMOKE_PASSWORD ausentes. Cadastre em Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+          node scripts/smoke_prod_ui.mjs

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # TEMPORÁRIO — sai antes do merge. Serve só para provar, uma vez, que o smoke
+  # de UI funciona de ponta a ponta com os secrets reais. O `if:` do job prende
+  # isto a ESTA branch: nenhum outro PR dispara.
+  pull_request:
+    branches: [main]
 
 # Cancelar o run velho aqui é CORRETO, ao contrário do tests.yml (que agrupa
 # por SHA justamente para não cancelar nada). O motivo é a diferença de alvo:
@@ -21,6 +26,8 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # TEMPORÁRIO — remover junto com o gatilho `pull_request` acima.
+    if: github.event_name != 'pull_request' || github.head_ref == 'claude/automate-pr-tests-92bb58'
     # 15 min de gate + as duas baterias. Sem teto, um deploy travado queimaria
     # 6 horas de runner (default do GitHub).
     timeout-minutes: 25
@@ -49,11 +56,17 @@ jobs:
           # como variável SMOKE_HEALTH_TOKEN no serviço do Railway.
           SMOKE_HEALTH_TOKEN: ${{ secrets.SMOKE_HEALTH_TOKEN }}
         run: |
-          if [ -z "$SMOKE_HEALTH_TOKEN" ]; then
+          if [ -z "$SMOKE_HEALTH_TOKEN" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "::error title=Gate do deploy sem token::Secret SMOKE_HEALTH_TOKEN ausente. Sem ele não há como saber qual código está no ar, e medir sem saber é o verde falso que este workflow existe para impedir."
             exit 1
           fi
-          python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # TEMPORÁRIO: num PR o HEAD não está deployado, então esperar por
+            # ele seria esperar para sempre. Mede a produção como ela está.
+            python scripts/smoke_prod.py
+          else
+            python scripts/smoke_prod.py --wait-sha "${{ github.sha }}"
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -5,11 +5,13 @@ finance_bot_websocket_custom.py sem mudança de comportamento.
 """
 
 import asyncio
+import hmac
 import html as _html
+import os
 from urllib.parse import quote
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse, RedirectResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel
 
 from frontend.routes.shared import (
@@ -743,5 +745,23 @@ async def contact_submit(request: Request, body: ContactBody):
 
 
 @router.get("/health")
-async def health():
-    return {"status": "ok"}
+async def health(request: Request):
+    # A resposta pública é EXATAMENTE a de sempre. O SHA do deploy é
+    # infraestrutura, e o test_health_endpoint_does_not_expose_infrastructure
+    # (tests/test_auth_cookie.py) existe para impedir que ele vaze daqui — foi
+    # ele que reprovou a primeira versão desta mudança, que devolvia o commit a
+    # qualquer um.
+    #
+    # O gate do smoke pós-deploy (.github/workflows/smoke.yml) não precisa que
+    # o SHA seja público: precisa que QUEM manda o token certo consiga saber
+    # qual código está no ar, para não medir o deploy anterior e passar verde
+    # sobre código que ninguém testou. Sem token — e sem SMOKE_HEALTH_TOKEN no
+    # ambiente — nada muda.
+    #
+    # `no-store` porque uma borda que cacheie esta resposta devolveria o SHA do
+    # deploy ANTERIOR, e o gate abriria cedo: o verde falso que ele impede.
+    corpo = {"status": "ok"}
+    esperado = os.getenv("SMOKE_HEALTH_TOKEN", "")
+    if esperado and hmac.compare_digest(request.headers.get("x-smoke-token", ""), esperado):
+        corpo["commit"] = os.getenv("RAILWAY_GIT_COMMIT_SHA", "unknown")
+    return JSONResponse(corpo, headers={"Cache-Control": "no-store"})

--- a/scripts/smoke_prod.py
+++ b/scripts/smoke_prod.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Smoke de produção pós-deploy — HTTP, read-only, sem login.
+
+Existe porque a suíte do CI mede o CÓDIGO e nada mais. As falhas que só
+aparecem depois do deploy (rota que some, asset que não chega, o
+"Application not found" do proxy no lugar da página) passam por 984 testes
+verdes sem uma linha vermelha. Este script é a única coisa que olha o site
+que está no ar.
+
+Uso:
+    python scripts/smoke_prod.py --wait-sha $GITHUB_SHA
+    python scripts/smoke_prod.py --base https://pigbankai.com   # sem gate
+
+Sai 1 na primeira categoria com falha, listando TODAS as falhas — não para
+na primeira, para render o diagnóstico inteiro numa rodada só.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+from urllib.parse import urljoin
+
+import requests
+
+BASE_PADRAO = "https://pigbankai.com"
+TIMEOUT = 20
+
+# Rotas públicas: as que qualquer visitante alcança sem sessão. NÃO inclui
+# /home, /settings, /dashboard — essas redirecionam para o login e quem as
+# mede é o smoke de UI, logado.
+ROTAS_PUBLICAS = [
+    "/", "/login", "/cadastro", "/precos", "/funcionalidades", "/como-funciona",
+    "/comandos", "/termos", "/privacy", "/suporte", "/whatsapp", "/agents",
+    "/changelog",
+]
+ROTAS_TEXTO = ["/robots.txt", "/sitemap.xml", "/api/commands-catalog"]
+
+# O 404 do Railway quando o serviço não está no ar. Ele responde no lugar do
+# app, com cara de erro de aplicação — foi o que apareceu dentro do card
+# "TODAS AS CATEGORIAS" do dashboard em 2026-08-26.
+MARCA_PROXY_FORA = "Application not found"
+
+# Assets carimbados: o stamp_asset_versions troca o ?v=N por hash do conteúdo.
+# Se o hash no HTML não corresponder a um arquivo servido, o navegador busca
+# um asset que não existe e a página quebra sem erro de servidor.
+RE_ASSET = re.compile(r'(?:src|href)="([^"]+\.(?:css|js)\?v=[0-9a-f]+)"')
+
+
+def _get(sessao: requests.Session, base: str, caminho: str) -> requests.Response:
+    return sessao.get(urljoin(base, caminho), timeout=TIMEOUT, allow_redirects=True)
+
+
+def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool:
+    """Bloqueia até /health reportar `sha`. True se chegou, False se desistiu.
+
+    O commit não é público: o /health só o devolve para quem manda o
+    `X-Smoke-Token` que casa com o `SMOKE_HEALTH_TOKEN` do processo. Sem isso
+    ele é infraestrutura vazando em endpoint aberto — tem teste de segurança
+    dizendo isso (tests/test_auth_cookie.py).
+    """
+    token = os.getenv("SMOKE_HEALTH_TOKEN", "")
+    if not token:
+        falhas.append(
+            "SMOKE_HEALTH_TOKEN ausente no ambiente: sem ele o /health não devolve "
+            "o commit e não há como saber qual código está no ar."
+        )
+        return False
+
+    prazo = time.monotonic() + limite_s
+    visto = "<sem resposta>"
+    while time.monotonic() < prazo:
+        try:
+            corpo = requests.get(urljoin(base, "/health"), timeout=TIMEOUT,
+                                 headers={"X-Smoke-Token": token}).json()
+            visto = str(corpo.get("commit", "<sem campo commit>"))
+            if visto == "<sem campo commit>":
+                falhas.append(
+                    "/health respondeu sem o campo `commit`. Ou o SMOKE_HEALTH_TOKEN "
+                    "daqui não bate com o do serviço, ou a variável não está no "
+                    "ambiente da produção."
+                )
+                return False
+            if visto == "unknown":
+                falhas.append(
+                    "/health devolveu commit='unknown': RAILWAY_GIT_COMMIT_SHA não "
+                    "chegou ao processo. Sem isso não dá para saber QUAL código está "
+                    "no ar, e um smoke verde não provaria nada."
+                )
+                return False
+            if visto.startswith(sha) or sha.startswith(visto):
+                print(f"deploy no ar: {visto}")
+                return True
+        except Exception as e:  # rede, JSON, 502 durante o restart — tudo é "ainda não"
+            visto = f"<{type(e).__name__}>"
+        print(f"aguardando deploy de {sha[:8]} (no ar: {visto})…", flush=True)
+        time.sleep(15)
+    falhas.append(f"deploy de {sha[:8]} não subiu em {limite_s}s (último: {visto})")
+    return False
+
+
+def confere_paginas(sessao: requests.Session, base: str, falhas: list[str]) -> set[str]:
+    """200 + HTML de verdade em toda rota pública. Devolve os assets vistos."""
+    assets: set[str] = set()
+    for caminho in ROTAS_PUBLICAS:
+        try:
+            r = _get(sessao, base, caminho)
+        except Exception as e:
+            falhas.append(f"{caminho}: {type(e).__name__}: {e}")
+            continue
+        if r.status_code != 200:
+            falhas.append(f"{caminho}: HTTP {r.status_code}")
+            continue
+        if MARCA_PROXY_FORA in r.text:
+            falhas.append(f"{caminho}: proxy respondeu '{MARCA_PROXY_FORA}' no lugar da página")
+            continue
+        if "<title" not in r.text.lower():
+            falhas.append(f"{caminho}: 200 sem <title> ({len(r.text)} bytes) — não é a página")
+            continue
+        assets.update(RE_ASSET.findall(r.text))
+    for caminho in ROTAS_TEXTO:
+        try:
+            r = _get(sessao, base, caminho)
+            if r.status_code != 200:
+                falhas.append(f"{caminho}: HTTP {r.status_code}")
+        except Exception as e:
+            falhas.append(f"{caminho}: {type(e).__name__}: {e}")
+    return assets
+
+
+def confere_assets(sessao: requests.Session, base: str, assets: set[str], falhas: list[str]) -> None:
+    if not assets:
+        falhas.append("nenhum asset com ?v=<hash> encontrado no HTML — o stamp parou de agir")
+        return
+    for asset in sorted(assets):
+        try:
+            r = _get(sessao, base, asset)
+        except Exception as e:
+            falhas.append(f"asset {asset}: {type(e).__name__}: {e}")
+            continue
+        if r.status_code != 200:
+            falhas.append(f"asset {asset}: HTTP {r.status_code}")
+
+
+def confere_pagina_de_erro(sessao: requests.Session, base: str, falhas: list[str]) -> None:
+    """Os DOIS lados do 404 (o P1-06 do roteiro de regressão).
+
+    A escolha é pelo `Accept`, não pela rota: navegador (`text/html`) recebe a
+    página do `error_page_response`; cliente de API (`application/json`) recebe
+    JSON. Medir só um lado deixa passar a metade que regride — devolver HTML
+    para o app quebra o parse do cliente, e devolver JSON ao navegador mostra
+    `{"detail":"Not Found"}` cru na tela.
+    """
+    caminho = "/rota-que-nao-existe-smoke"
+    try:
+        html = sessao.get(urljoin(base, caminho), timeout=TIMEOUT,
+                          headers={"Accept": "text/html"})
+        api = sessao.get(urljoin(base, caminho), timeout=TIMEOUT,
+                         headers={"Accept": "application/json"})
+    except Exception as e:
+        falhas.append(f"404: {type(e).__name__}: {e}")
+        return
+
+    for nome, r in (("navegador", html), ("API", api)):
+        if r.status_code != 404:
+            falhas.append(f"404 ({nome}): esperado 404, veio {r.status_code}")
+        if MARCA_PROXY_FORA in r.text:
+            falhas.append(f"404 ({nome}): veio o '{MARCA_PROXY_FORA}' do proxy, não a do app")
+
+    if "<title" not in html.text.lower():
+        falhas.append("404 (navegador): não é HTML — o error_page_response não respondeu")
+    if not api.headers.get("content-type", "").startswith("application/json"):
+        falhas.append(
+            f"404 (API): content-type {api.headers.get('content-type')!r}, esperado JSON — "
+            "cliente de API passou a receber página"
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--base", default=BASE_PADRAO)
+    ap.add_argument("--wait-sha", default="", help="espera /health reportar este commit")
+    ap.add_argument("--wait-timeout", type=int, default=900)
+    args = ap.parse_args()
+
+    falhas: list[str] = []
+    if args.wait_sha and not espera_deploy(args.base, args.wait_sha, args.wait_timeout, falhas):
+        print("\n".join(f"FALHA: {f}" for f in falhas), file=sys.stderr)
+        return 1
+
+    sessao = requests.Session()
+    sessao.headers["User-Agent"] = "PigBankSmoke/1.0"
+    sessao.headers["Accept"] = "text/html,application/xhtml+xml,*/*;q=0.8"
+    assets = confere_paginas(sessao, args.base, falhas)
+    confere_assets(sessao, args.base, assets, falhas)
+    confere_pagina_de_erro(sessao, args.base, falhas)
+
+    total = len(ROTAS_PUBLICAS) + len(ROTAS_TEXTO) + len(assets) + 2
+    if falhas:
+        print(f"\n{len(falhas)} falha(s) em {total} verificações:", file=sys.stderr)
+        print("\n".join(f"  FALHA: {f}" for f in falhas), file=sys.stderr)
+        return 1
+    print(f"smoke HTTP ok: {total} verificações ({len(assets)} assets)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_prod.py
+++ b/scripts/smoke_prod.py
@@ -153,6 +153,14 @@ def confere_paginas(sessao: requests.Session, base: str, falhas: list[str]) -> s
     return assets
 
 
+# O que cada extensão TEM de responder. 200 sozinho não basta: um proxy ou uma
+# página de fallback devolvendo HTML com status 200 satisfaz o código e o
+# navegador recusa o arquivo — a folha de estilo não aplica, o script não
+# executa, e a página fica quebrada com o smoke verde. Medido em produção:
+# .css → `text/css; charset=utf-8`, .js → `application/javascript`.
+TIPOS_DE_ASSET = {".css": ("text/css",), ".js": ("javascript",)}
+
+
 def confere_assets(sessao: requests.Session, base: str, assets: set[str], falhas: list[str]) -> None:
     if not assets:
         falhas.append("nenhum asset com ?v=<hash> encontrado no HTML — o stamp parou de agir")
@@ -165,6 +173,14 @@ def confere_assets(sessao: requests.Session, base: str, assets: set[str], falhas
             continue
         if r.status_code != 200:
             falhas.append(f"asset {asset}: HTTP {r.status_code}")
+            continue
+        ext = ".css" if ".css?" in asset else ".js" if ".js?" in asset else None
+        tipo = r.headers.get("content-type", "").lower()
+        if ext and not any(t in tipo for t in TIPOS_DE_ASSET[ext]):
+            falhas.append(
+                f"asset {asset}: content-type {tipo!r} — o navegador não usa isto como "
+                f"{ext.lstrip('.')}, mesmo com HTTP 200"
+            )
 
 
 def confere_pagina_de_erro(sessao: requests.Session, base: str, falhas: list[str]) -> None:

--- a/scripts/smoke_prod.py
+++ b/scripts/smoke_prod.py
@@ -41,7 +41,16 @@ ROTAS_PUBLICAS = [
 # Estava na lista de públicas seguindo o redirect, então o smoke media a página
 # de login achando que media o changelog — e os assets contados eram os dela.
 ROTAS_COM_GATE = [("/changelog", "/login")]
-ROTAS_TEXTO = ["/robots.txt", "/sitemap.xml", "/api/commands-catalog"]
+# Rotas que não são página: (caminho, pedaço do content-type, sentinela no corpo).
+# 200 sozinho não diz nada aqui — uma página de fallback em HTML com status 200
+# passa, e quem consome quebra: o /comandos lê o catálogo e para de montar a
+# lista, sem erro de servidor em lugar nenhum. Medido em produção: text/plain,
+# application/xml e application/json, com estas sentinelas.
+ROTAS_TEXTO = [
+    ("/robots.txt", "text/plain", "Disallow: /app"),
+    ("/sitemap.xml", "xml", "<urlset"),
+    ("/api/commands-catalog", "application/json", '"catalog"'),
+]
 
 # O 404 do Railway quando o serviço não está no ar. Ele responde no lugar do
 # app, com cara de erro de aplicação — foi o que apareceu dentro do card
@@ -165,13 +174,20 @@ def confere_paginas(sessao: requests.Session, base: str, falhas: list[str]) -> s
             falhas.append(f"{caminho}: esperado desvio para {destino}, veio HTTP {r.status_code}")
         elif not r.headers.get("location", "").startswith(destino):
             falhas.append(f"{caminho}: desviou para {r.headers.get('location')!r}, esperado {destino}")
-    for caminho in ROTAS_TEXTO:
+    for caminho, tipo_esperado, sentinela in ROTAS_TEXTO:
         try:
             r = _get(sessao, base, caminho)
-            if r.status_code != 200:
-                falhas.append(f"{caminho}: HTTP {r.status_code}")
         except Exception as e:
             falhas.append(f"{caminho}: {type(e).__name__}: {e}")
+            continue
+        if r.status_code != 200:
+            falhas.append(f"{caminho}: HTTP {r.status_code}")
+            continue
+        tipo = r.headers.get("content-type", "").lower()
+        if tipo_esperado not in tipo:
+            falhas.append(f"{caminho}: content-type {tipo!r}, esperado {tipo_esperado!r}")
+        elif sentinela not in r.text:
+            falhas.append(f"{caminho}: 200 e content-type certos, mas sem {sentinela!r} no corpo")
     return assets
 
 

--- a/scripts/smoke_prod.py
+++ b/scripts/smoke_prod.py
@@ -91,6 +91,49 @@ def sha_bate(visto: str, esperado: str) -> bool:
     return v.startswith(e) or e.startswith(v)
 
 
+def veredito_do_health(cache_control: str, corpo: dict, sha: str) -> tuple[str, str]:
+    """Uma resposta do /health vira um de três vereditos: abre, espera, falha.
+
+    O caso que obriga a existir esta função: `{"status":"ok"}` **sem** o campo
+    `commit` cobre DOIS estados que exigem reações opostas —
+
+      1. a produção ainda serve o código anterior, que não tinha o campo:
+         é o estado normal enquanto o deploy não terminou → esperar;
+      2. o código novo já está no ar e o token não bate: nada vai mudar até
+         alguém arrumar a variável → reprovar agora.
+
+    Tratar os dois como "espera" custa 15 minutos de timeout em toda
+    configuração errada. Tratar os dois como "falha" reprova o primeiro run
+    depois do merge, antes de o deploy começar.
+
+    O que os separa é o `Cache-Control`, medido em produção: a versão anterior
+    de /health não manda header nenhum; a nova sempre manda `no-store`. Não é
+    detalhe estético — é o mesmo header que impede uma borda de cachear o SHA.
+    """
+    tem_no_store = "no-store" in (cache_control or "").lower()
+    visto = str(corpo.get("commit", "")).strip()
+
+    if not visto:
+        if tem_no_store:
+            return "falha", (
+                "/health já é a versão nova (responde `no-store`) mas não devolveu "
+                "`commit`: o X-Smoke-Token não casou com o SMOKE_HEALTH_TOKEN do "
+                "serviço. Esperar não resolve — confira os dois valores."
+            )
+        return "espera", "<sem campo commit — produção ainda no código anterior>"
+
+    if visto == "unknown":
+        return "falha", (
+            "/health devolveu commit='unknown': RAILWAY_GIT_COMMIT_SHA não chegou "
+            "ao processo. Sem isso não dá para saber QUAL código está no ar, e um "
+            "smoke verde não provaria nada."
+        )
+
+    if sha_bate(visto, sha):
+        return "abre", visto
+    return "espera", visto
+
+
 def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool:
     """Bloqueia até /health reportar `sha`. True se chegou, False se desistiu.
 
@@ -111,36 +154,25 @@ def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool
     visto = "<sem resposta>"
     while time.monotonic() < prazo:
         try:
-            corpo = requests.get(urljoin(base, "/health"), timeout=TIMEOUT,
-                                 headers={"X-Smoke-Token": token}).json()
-            visto = str(corpo.get("commit", "<sem campo commit>"))
-            if visto == "<sem campo commit>":
-                # NÃO é erro de configuração: é o estado esperado enquanto a
-                # produção ainda serve a versão anterior de /health, que não
-                # tinha o campo. Falhar aqui reprovaria justamente o primeiro
-                # run depois deste merge — antes de o deploy sequer começar.
-                # Continua tentando; se persistir até o prazo, o timeout abaixo
-                # reporta, e aí a hipótese do token entra na mensagem.
-                pass
-            elif visto == "unknown":
-                falhas.append(
-                    "/health devolveu commit='unknown': RAILWAY_GIT_COMMIT_SHA não "
-                    "chegou ao processo. Sem isso não dá para saber QUAL código está "
-                    "no ar, e um smoke verde não provaria nada."
-                )
-                return False
-            if sha_bate(visto, sha):
+            r = requests.get(urljoin(base, "/health"), timeout=TIMEOUT,
+                             headers={"X-Smoke-Token": token})
+            veredito, visto = veredito_do_health(
+                r.headers.get("cache-control", ""), r.json(), sha
+            )
+            if veredito == "abre":
                 print(f"deploy no ar: {visto}")
                 return True
+            if veredito == "falha":
+                falhas.append(visto)
+                return False
         except Exception as e:  # rede, JSON, 502 durante o restart — tudo é "ainda não"
             visto = f"<{type(e).__name__}>"
         print(f"aguardando deploy de {sha[:8]} (no ar: {visto})…", flush=True)
         time.sleep(15)
     falhas.append(
         f"deploy de {sha[:8]} não subiu em {limite_s}s (último: {visto}). "
-        "Se o último for `<sem campo commit>`, as causas são: o deploy não "
-        "aconteceu, ou o SMOKE_HEALTH_TOKEN daqui não bate com o do serviço, "
-        "ou a variável não está no ambiente da produção."
+        "Com `<sem campo commit>` até o fim, o deploy não aconteceu — o token já "
+        "teria sido acusado assim que a versão nova entrasse no ar."
     )
     return False
 

--- a/scripts/smoke_prod.py
+++ b/scripts/smoke_prod.py
@@ -34,8 +34,13 @@ TIMEOUT = 20
 ROTAS_PUBLICAS = [
     "/", "/login", "/cadastro", "/precos", "/funcionalidades", "/como-funciona",
     "/comandos", "/termos", "/privacy", "/suporte", "/whatsapp", "/agents",
-    "/changelog",
 ]
+
+# Rotas que EXIGEM sessão: o contrato delas é o desvio, não o conteúdo. Medido:
+# /changelog responde 302 -> /login?next=/changelog para anônimo (gate_pro_page).
+# Estava na lista de públicas seguindo o redirect, então o smoke media a página
+# de login achando que media o changelog — e os assets contados eram os dela.
+ROTAS_COM_GATE = [("/changelog", "/login")]
 ROTAS_TEXTO = ["/robots.txt", "/sitemap.xml", "/api/commands-catalog"]
 
 # O 404 do Railway quando o serviço não está no ar. Ele responde no lugar do
@@ -50,7 +55,9 @@ RE_ASSET = re.compile(r'(?:src|href)="([^"]+\.(?:css|js)\?v=[0-9a-f]+)"')
 
 
 def _get(sessao: requests.Session, base: str, caminho: str) -> requests.Response:
-    return sessao.get(urljoin(base, caminho), timeout=TIMEOUT, allow_redirects=True)
+    # Sem seguir redirect: uma rota que passe a desviar para outra página
+    # saudável satisfaria o 200 e o <title> sem nunca ter sido medida.
+    return sessao.get(urljoin(base, caminho), timeout=TIMEOUT, allow_redirects=False)
 
 
 def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool:
@@ -77,13 +84,14 @@ def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool
                                  headers={"X-Smoke-Token": token}).json()
             visto = str(corpo.get("commit", "<sem campo commit>"))
             if visto == "<sem campo commit>":
-                falhas.append(
-                    "/health respondeu sem o campo `commit`. Ou o SMOKE_HEALTH_TOKEN "
-                    "daqui não bate com o do serviço, ou a variável não está no "
-                    "ambiente da produção."
-                )
-                return False
-            if visto == "unknown":
+                # NÃO é erro de configuração: é o estado esperado enquanto a
+                # produção ainda serve a versão anterior de /health, que não
+                # tinha o campo. Falhar aqui reprovaria justamente o primeiro
+                # run depois deste merge — antes de o deploy sequer começar.
+                # Continua tentando; se persistir até o prazo, o timeout abaixo
+                # reporta, e aí a hipótese do token entra na mensagem.
+                pass
+            elif visto == "unknown":
                 falhas.append(
                     "/health devolveu commit='unknown': RAILWAY_GIT_COMMIT_SHA não "
                     "chegou ao processo. Sem isso não dá para saber QUAL código está "
@@ -97,7 +105,12 @@ def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool
             visto = f"<{type(e).__name__}>"
         print(f"aguardando deploy de {sha[:8]} (no ar: {visto})…", flush=True)
         time.sleep(15)
-    falhas.append(f"deploy de {sha[:8]} não subiu em {limite_s}s (último: {visto})")
+    falhas.append(
+        f"deploy de {sha[:8]} não subiu em {limite_s}s (último: {visto}). "
+        "Se o último for `<sem campo commit>`, as causas são: o deploy não "
+        "aconteceu, ou o SMOKE_HEALTH_TOKEN daqui não bate com o do serviço, "
+        "ou a variável não está no ambiente da produção."
+    )
     return False
 
 
@@ -120,6 +133,16 @@ def confere_paginas(sessao: requests.Session, base: str, falhas: list[str]) -> s
             falhas.append(f"{caminho}: 200 sem <title> ({len(r.text)} bytes) — não é a página")
             continue
         assets.update(RE_ASSET.findall(r.text))
+    for caminho, destino in ROTAS_COM_GATE:
+        try:
+            r = _get(sessao, base, caminho)
+        except Exception as e:
+            falhas.append(f"{caminho}: {type(e).__name__}: {e}")
+            continue
+        if r.status_code not in (301, 302, 303, 307, 308):
+            falhas.append(f"{caminho}: esperado desvio para {destino}, veio HTTP {r.status_code}")
+        elif not r.headers.get("location", "").startswith(destino):
+            falhas.append(f"{caminho}: desviou para {r.headers.get('location')!r}, esperado {destino}")
     for caminho in ROTAS_TEXTO:
         try:
             r = _get(sessao, base, caminho)
@@ -197,7 +220,7 @@ def main() -> int:
     confere_assets(sessao, args.base, assets, falhas)
     confere_pagina_de_erro(sessao, args.base, falhas)
 
-    total = len(ROTAS_PUBLICAS) + len(ROTAS_TEXTO) + len(assets) + 2
+    total = len(ROTAS_PUBLICAS) + len(ROTAS_COM_GATE) + len(ROTAS_TEXTO) + len(assets) + 2
     if falhas:
         print(f"\n{len(falhas)} falha(s) em {total} verificações:", file=sys.stderr)
         print("\n".join(f"  FALHA: {f}" for f in falhas), file=sys.stderr)

--- a/scripts/smoke_prod.py
+++ b/scripts/smoke_prod.py
@@ -60,6 +60,28 @@ def _get(sessao: requests.Session, base: str, caminho: str) -> requests.Response
     return sessao.get(urljoin(base, caminho), timeout=TIMEOUT, allow_redirects=False)
 
 
+# 7 = o menor prefixo que o git considera identificador; abaixo disso a
+# comparação por prefixo deixa de discriminar.
+_MIN_SHA = 7
+
+
+def sha_bate(visto: str, esperado: str) -> bool:
+    """O commit reportado é o esperado? Aceita prefixo, dos dois lados.
+
+    A guarda de comprimento não é higiene: `RAILWAY_GIT_COMMIT_SHA` definida e
+    VAZIA faz /health devolver `commit: ""`, e `"".startswith` /
+    `esperado.startswith("")` são True para qualquer SHA — o gate abriria na
+    hora, contra o deploy anterior, que é exatamente o que ele existe para
+    impedir. Vale para qualquer valor curto ou não-hexadecimal.
+    """
+    v, e = visto.strip().lower(), esperado.strip().lower()
+    if len(v) < _MIN_SHA or len(e) < _MIN_SHA:
+        return False
+    if not all(c in "0123456789abcdef" for c in v + e):
+        return False
+    return v.startswith(e) or e.startswith(v)
+
+
 def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool:
     """Bloqueia até /health reportar `sha`. True se chegou, False se desistiu.
 
@@ -98,7 +120,7 @@ def espera_deploy(base: str, sha: str, limite_s: int, falhas: list[str]) -> bool
                     "no ar, e um smoke verde não provaria nada."
                 )
                 return False
-            if visto.startswith(sha) or sha.startswith(visto):
+            if sha_bate(visto, sha):
                 print(f"deploy no ar: {visto}")
                 return True
         except Exception as e:  # rede, JSON, 502 durante o restart — tudo é "ainda não"

--- a/scripts/smoke_prod_ui.mjs
+++ b/scripts/smoke_prod_ui.mjs
@@ -95,6 +95,20 @@ pagina.on("response", (r) => {
   falhas.push(`[${telaAtual}] HTTP ${r.status()} em ${r.url().replace(BASE, "")}`);
 });
 
+// Falha de TRANSPORTE (DNS, TLS, conexão resetada) não emite `response`, emite
+// `requestfailed` — e o console.error correspondente é justamente o que o
+// listener abaixo descarta. Sem isto, um .css da nossa origem morrendo na
+// conexão passaria batido com a página ainda navegável.
+//
+// ERR_ABORTED fica de fora: é o navegador cancelando request em voo quando a
+// própria navegação troca de página, o que este script faz de propósito quatro
+// vezes. Reprovar por isso encheria o smoke de vermelho de mentira.
+pagina.on("requestfailed", (req) => {
+  const erro = req.failure()?.errorText || "desconhecido";
+  if (!req.url().startsWith(BASE) || erro.includes("ERR_ABORTED")) return;
+  falhas.push(`[${telaAtual}] request falhou (${erro}) em ${req.url().replace(BASE, "")}`);
+});
+
 // pageerror = exceção que subiu até o topo e interrompeu a execução do script
 // que a lançou. Vale mesmo vindo de terceiro: Chart.js estourando deixa o
 // gráfico sem desenhar, e isso É a tela quebrada (o P1-05 do roteiro).

--- a/scripts/smoke_prod_ui.mjs
+++ b/scripts/smoke_prod_ui.mjs
@@ -32,9 +32,14 @@ const TELAS = ["/app", "/home", "/settings"];
  * asserção negativa.
  *
  * O alvo de cada aba é o contêiner de STATS, não a lista: ele é preenchido pelo
- * render de sucesso mesmo com a conta vazia (as tiles mostram zero), e continua
- * vazio quando o fetch falha — que é exatamente o que discrimina. Uma asserção
- * de "tem itens" reprovaria na conta de automação, que não tem dado nenhum.
+ * render de sucesso mesmo com a conta vazia (as tiles mostram zero). Uma
+ * asserção de "tem itens" reprovaria na conta de automação, que não tem dado.
+ *
+ * E o alvo dentro dele é `.stat-value`, não o texto do contêiner: o
+ * loadBudgetsView (dashboard.js:2623) escreve um ESQUELETO síncrono antes do
+ * fetch, com os rótulos já preenchidos — "tem texto" passava nele, e um fetch
+ * pendurado para sempre saía verde. O esqueleto põe `.sk`; só o render de
+ * sucesso põe `.stat-value` com número dentro.
  *
  * São duas abas, não as onze: `categories` é a que quebrou de verdade e
  * `budgets` é a irmã de outro endpoint. Amplia-se quando houver motivo medido,
@@ -133,6 +138,14 @@ try {
       falhas.push(`[${tela}] a página respondeu ${resp ? resp.status() : "nada"}`);
       continue;
     }
+    // `goto` segue redirect e devolve a resposta FINAL: 200 sozinho não prova
+    // que chegou onde pediu. Se /home passar a desviar para /app, a tela some
+    // e o loop passa — nenhuma das marcas de erro está numa página saudável.
+    const chegou = new URL(pagina.url()).pathname;
+    if (chegou !== tela) {
+      falhas.push(`[${tela}] desviou para ${chegou} — a rota pedida não foi servida`);
+      continue;
+    }
     // Os cards enchem por fetch depois do load. networkidle sozinho é frágil
     // (o WebSocket do dashboard nunca fica idle), então: idle com teto, e segue.
     await pagina.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
@@ -159,10 +172,14 @@ try {
       continue;
     }
     try {
-      const alvo = pagina.locator(seletor);
-      await alvo.waitFor({ state: "visible", timeout: 20000 });
+      await pagina.locator(seletor).waitFor({ state: "visible", timeout: 20000 });
       await pagina.waitForFunction(
-        (s) => (document.querySelector(s)?.innerText || "").trim().length > 0,
+        (s) => {
+          const caixa = document.querySelector(s);
+          if (!caixa || caixa.querySelector(".sk")) return false; // ainda no esqueleto
+          const valores = [...caixa.querySelectorAll(".stat-value")];
+          return valores.length > 0 && valores.every((v) => v.innerText.trim().length > 0);
+        },
         seletor,
         { timeout: 20000 },
       );

--- a/scripts/smoke_prod_ui.mjs
+++ b/scripts/smoke_prod_ui.mjs
@@ -1,0 +1,169 @@
+/**
+ * Smoke de produção pós-deploy — as páginas LOGADAS, com JavaScript de verdade.
+ *
+ * O smoke HTTP (scripts/smoke_prod.py) vê o HTML que o servidor manda; ele não
+ * vê o que o JS faz depois. Os cards do dashboard são montados por dezenas de
+ * fetches do dashboard.js, e foi exatamente ali que apareceu o card "TODAS AS
+ * CATEGORIAS" renderizando `Erro: (HTTP 404) {"message":"Application not
+ * found"}` com o servidor respondendo 200 na página.
+ *
+ * Read-only: só navega e troca de aba. Não cria, não edita, não apaga nada.
+ *
+ * Credenciais vêm do ambiente (GitHub Secrets no CI) — nunca do código:
+ *     SMOKE_EMAIL=... SMOKE_PASSWORD=... node scripts/smoke_prod_ui.mjs
+ *
+ * A conta tem de ser exclusiva de automação, sem dados reais, SEM MFA (o
+ * segundo fator não tem como ser respondido aqui) e com plano ativo.
+ */
+import { chromium } from "playwright";
+
+const BASE = process.env.SMOKE_BASE || "https://pigbankai.com";
+const EMAIL = process.env.SMOKE_EMAIL;
+const SENHA = process.env.SMOKE_PASSWORD;
+
+const TELAS = ["/app", "/home", "/settings"];
+
+/**
+ * Verificação POSITIVA — o que tem de EXISTIR na tela, não o que não pode estar.
+ *
+ * Procurar a palavra "Erro" pega o card que falhou reclamando; não pega o card
+ * que simplesmente sumiu (fetch pendurado para sempre, view que não montou,
+ * JS que morreu antes de chegar nela). Uma tela em branco passa em qualquer
+ * asserção negativa.
+ *
+ * O alvo de cada aba é o contêiner de STATS, não a lista: ele é preenchido pelo
+ * render de sucesso mesmo com a conta vazia (as tiles mostram zero), e continua
+ * vazio quando o fetch falha — que é exatamente o que discrimina. Uma asserção
+ * de "tem itens" reprovaria na conta de automação, que não tem dado nenhum.
+ *
+ * São duas abas, não as onze: `categories` é a que quebrou de verdade e
+ * `budgets` é a irmã de outro endpoint. Amplia-se quando houver motivo medido,
+ * não por simetria.
+ */
+const ANCORAS = [
+  { aba: "categories", seletor: "#categories-stats", nome: "Categorias" },
+  { aba: "budgets", seletor: "#budgets-stats", nome: "Orçamentos" },
+];
+
+// Texto de erro renderizado DENTRO da tela.
+const MARCAS_DE_ERRO = ["Application not found", "Erro: (HTTP", "Internal Server Error"];
+
+if (!EMAIL || !SENHA) {
+  console.error("SMOKE_EMAIL e SMOKE_PASSWORD são obrigatórios.");
+  process.exit(2);
+}
+
+const falhas = [];
+const navegador = await chromium.launch();
+const contexto = await navegador.newContext({ viewport: { width: 1280, height: 900 } });
+const pagina = await contexto.newPage();
+
+let telaAtual = "/login";
+
+// Rede: só o que a NOSSA origem serve. Um 4xx de CDN, do Meta Pixel ou de
+// fonte externa não é regressão do PigBank e deixaria o smoke instável — o
+// preço de reprovar por isso é o teste virar ruído e parar de ser lido.
+pagina.on("response", (r) => {
+  if (r.status() >= 400 && r.url().startsWith(BASE)) {
+    falhas.push(`[${telaAtual}] HTTP ${r.status()} em ${r.url().replace(BASE, "")}`);
+  }
+});
+
+// pageerror = exceção que subiu até o topo e interrompeu a execução do script
+// que a lançou. Vale mesmo vindo de terceiro: Chart.js estourando deixa o
+// gráfico sem desenhar, e isso É a tela quebrada (o P1-05 do roteiro).
+pagina.on("pageerror", (e) => falhas.push(`[${telaAtual}] erro de JS: ${e.message}`));
+
+// console.error: só o de script da nossa origem. `console.error` de biblioteca
+// de terceiro é barulho dela, não defeito nosso. Sem `location.url` (chamada
+// de contexto que o CDP não atribui) o registro é ambíguo — não reprova.
+pagina.on("console", (m) => {
+  if (m.type() !== "error") return;
+  const origem = m.location()?.url || "";
+  if (origem.startsWith(BASE)) {
+    falhas.push(`[${telaAtual}] console.error: ${m.text().slice(0, 200)}`);
+  }
+});
+
+try {
+  // ── login ───────────────────────────────────────────────────────────────
+  await pagina.goto(`${BASE}/login`, { waitUntil: "domcontentloaded", timeout: 30000 });
+  await pagina.fill("#email", EMAIL);
+  await pagina.fill("#senha", SENHA);
+  await pagina.click("#btn-login");
+  await pagina.waitForURL((u) => !u.pathname.startsWith("/login"), { timeout: 30000 });
+
+  if (await pagina.locator("#form-mfa").isVisible().catch(() => false)) {
+    throw new Error("PARADA: a conta de automação tem MFA ligado — o smoke não passa do 2º fator");
+  }
+  if (new URL(pagina.url()).pathname.startsWith("/precos")) {
+    throw new Error(`PARADA: login caiu em ${pagina.url().replace(BASE, "")} — a conta não tem plano ativo`);
+  }
+
+  // ── telas ───────────────────────────────────────────────────────────────
+  for (const tela of TELAS) {
+    telaAtual = tela;
+    const resp = await pagina.goto(`${BASE}${tela}`, { waitUntil: "load", timeout: 30000 });
+    if (!resp || resp.status() !== 200) {
+      falhas.push(`[${tela}] a página respondeu ${resp ? resp.status() : "nada"}`);
+      continue;
+    }
+    // Os cards enchem por fetch depois do load. networkidle sozinho é frágil
+    // (o WebSocket do dashboard nunca fica idle), então: idle com teto, e segue.
+    await pagina.waitForLoadState("networkidle", { timeout: 15000 }).catch(() => {});
+    const texto = await pagina.locator("body").innerText();
+    for (const marca of MARCAS_DE_ERRO) {
+      if (texto.includes(marca)) falhas.push(`[${tela}] a tela mostra "${marca}"`);
+    }
+  }
+
+  // ── âncoras positivas, no dashboard ─────────────────────────────────────
+  telaAtual = "/app";
+  await pagina.goto(`${BASE}/app`, { waitUntil: "load", timeout: 30000 });
+  for (const { aba, seletor, nome } of ANCORAS) {
+    telaAtual = `/app#${aba}`;
+    // navigateTo é global (dashboard.js é script clássico) e é o mesmo caminho
+    // do clique no menu: troca a view E dispara o load daquela aba.
+    const existe = await pagina.evaluate((v) => {
+      if (typeof navigateTo !== "function") return false;
+      navigateTo(v);
+      return true;
+    }, aba);
+    if (!existe) {
+      falhas.push(`[${telaAtual}] navigateTo() não existe — o dashboard.js não carregou`);
+      continue;
+    }
+    try {
+      const alvo = pagina.locator(seletor);
+      await alvo.waitFor({ state: "visible", timeout: 20000 });
+      await pagina.waitForFunction(
+        (s) => (document.querySelector(s)?.innerText || "").trim().length > 0,
+        seletor,
+        { timeout: 20000 },
+      );
+    } catch {
+      const grid = await pagina
+        .locator(seletor.replace("-stats", "-grid") + ", " + seletor.replace("-stats", "-list"))
+        .innerText()
+        .catch(() => "");
+      falhas.push(
+        `[${telaAtual}] o card "${nome}" (${seletor}) não terminou de carregar` +
+          (grid ? ` — a lista mostra: ${grid.slice(0, 120).replace(/\s+/g, " ")}` : " — e a lista está vazia"),
+      );
+    }
+  }
+} catch (e) {
+  falhas.push(`[${telaAtual}] ${e.message.split("\n")[0]}`);
+} finally {
+  await navegador.close();
+}
+
+if (falhas.length) {
+  console.error(`\n${falhas.length} falha(s):`);
+  for (const f of falhas) console.error(`  FALHA: ${f}`);
+  process.exit(1);
+}
+console.log(
+  `smoke de UI ok: ${TELAS.length} telas logadas + ${ANCORAS.length} cards carregados, ` +
+    `sem erro de rede nem de console na origem`,
+);

--- a/scripts/smoke_prod_ui.mjs
+++ b/scripts/smoke_prod_ui.mjs
@@ -60,13 +60,34 @@ const pagina = await contexto.newPage();
 
 let telaAtual = "/login";
 
+/**
+ * Respostas >= 400 que são o comportamento CORRETO do produto, não defeito.
+ * Cada uma é (caminho, status, quando) — o par exato, nunca o caminho inteiro:
+ * um 500 em /auth/validate continua reprovando.
+ */
+const ESPERADOS = [
+  // nav-auth.js:242 pergunta "estou logado?" com um fetch. Na tela de login a
+  // resposta certa é 401 — só ali, para não engolir sessão caindo em tela logada.
+  { caminho: "/auth/validate", status: 401, so_em: "/login" },
+  { caminho: "/auth/refresh", status: 401, so_em: "/login" },
+  // frontend/routes/affiliates.py:4, no próprio docstring do módulo: "404 se o
+  // user não é afiliado". A conta de automação não é, e nunca vai ser.
+  { caminho: "/api/affiliate/me", status: 404, so_em: null },
+];
+
+const esperado = (caminho, status) =>
+  ESPERADOS.some(
+    (e) => e.caminho === caminho && e.status === status && (e.so_em === null || e.so_em === telaAtual),
+  );
+
 // Rede: só o que a NOSSA origem serve. Um 4xx de CDN, do Meta Pixel ou de
 // fonte externa não é regressão do PigBank e deixaria o smoke instável — o
 // preço de reprovar por isso é o teste virar ruído e parar de ser lido.
 pagina.on("response", (r) => {
-  if (r.status() >= 400 && r.url().startsWith(BASE)) {
-    falhas.push(`[${telaAtual}] HTTP ${r.status()} em ${r.url().replace(BASE, "")}`);
-  }
+  if (r.status() < 400 || !r.url().startsWith(BASE)) return;
+  const caminho = new URL(r.url()).pathname;
+  if (esperado(caminho, r.status())) return;
+  falhas.push(`[${telaAtual}] HTTP ${r.status()} em ${r.url().replace(BASE, "")}`);
 });
 
 // pageerror = exceção que subiu até o topo e interrompeu a execução do script
@@ -79,6 +100,10 @@ pagina.on("pageerror", (e) => falhas.push(`[${telaAtual}] erro de JS: ${e.messag
 // de contexto que o CDP não atribui) o registro é ambíguo — não reprova.
 pagina.on("console", (m) => {
   if (m.type() !== "error") return;
+  // "Failed to load resource" é o navegador narrando a MESMA resposta que o
+  // listener acima já tratou — e sem o status nem a URL, que ele tem. Contar
+  // os dois dobra toda falha de rede e ressuscita as que ali são esperadas.
+  if (m.text().startsWith("Failed to load resource")) return;
   const origem = m.location()?.url || "";
   if (origem.startsWith(BASE)) {
     falhas.push(`[${telaAtual}] console.error: ${m.text().slice(0, 200)}`);

--- a/tests/test_smoke_prod_gate.py
+++ b/tests/test_smoke_prod_gate.py
@@ -39,3 +39,48 @@ def test_abre_o_gate_no_commit_certo_inclusive_abreviado(visto):
     testes acima e o gate nunca abriria — pior que o bug."""
     assert smoke_prod.sha_bate(visto, _SHA) is True
     assert smoke_prod.sha_bate(_SHA, visto) is True
+
+
+# ── Os três vereditos do /health ────────────────────────────────────────────
+# `{"status":"ok"}` sem `commit` cobre dois estados que pedem reações opostas:
+# produção ainda no código anterior (esperar) e código novo no ar com token
+# errado (reprovar já). O `Cache-Control` é o que os separa — a versão anterior
+# de /health não manda header nenhum, a nova sempre manda `no-store`, medido em
+# produção. Sem isso, toda configuração errada custa o timeout inteiro.
+
+_NO_STORE = "no-store"
+_VELHO = ""  # a versão anterior de /health não manda Cache-Control
+
+
+def test_codigo_velho_sem_commit_espera():
+    veredito, _ = smoke_prod.veredito_do_health(_VELHO, {"status": "ok"}, _SHA)
+    assert veredito == "espera"
+
+
+def test_codigo_novo_sem_commit_reprova_na_hora():
+    veredito, motivo = smoke_prod.veredito_do_health(_NO_STORE, {"status": "ok"}, _SHA)
+    assert veredito == "falha"
+    assert "token" in motivo.lower()
+
+
+@pytest.mark.parametrize("corpo", [{"status": "ok", "commit": ""}, {"status": "ok", "commit": "   "}])
+def test_commit_vazio_conta_como_ausente(corpo):
+    """`commit: ""` é a variável definida e vazia — não é um commit, e sem esta
+    normalização cairia no sha_bate em vez do ramo de ausente."""
+    assert smoke_prod.veredito_do_health(_VELHO, corpo, _SHA)[0] == "espera"
+    assert smoke_prod.veredito_do_health(_NO_STORE, corpo, _SHA)[0] == "falha"
+
+
+def test_unknown_reprova_com_qualquer_header():
+    for cc in (_VELHO, _NO_STORE):
+        veredito, motivo = smoke_prod.veredito_do_health(cc, {"commit": "unknown"}, _SHA)
+        assert veredito == "falha"
+        assert "RAILWAY_GIT_COMMIT_SHA" in motivo
+
+
+def test_commit_certo_abre_e_commit_de_outro_deploy_espera():
+    """Controle positivo: sem ele, um veredito que reprova/espera sempre passaria
+    em todos os testes acima e o gate nunca abriria."""
+    assert smoke_prod.veredito_do_health(_NO_STORE, {"commit": _SHA}, _SHA) == ("abre", _SHA)
+    assert smoke_prod.veredito_do_health(_NO_STORE, {"commit": _SHA[:7]}, _SHA)[0] == "abre"
+    assert smoke_prod.veredito_do_health(_NO_STORE, {"commit": "0" * 40}, _SHA)[0] == "espera"

--- a/tests/test_smoke_prod_gate.py
+++ b/tests/test_smoke_prod_gate.py
@@ -1,0 +1,41 @@
+"""O gate do smoke pós-deploy: a comparação de SHA de scripts/smoke_prod.py.
+
+Vale um teste porque o modo de falha é SILENCIOSO: se a comparação aceitar
+qualquer coisa, o gate abre cedo, o smoke mede o deploy ANTERIOR e sai verde
+sobre código que ninguém testou — o oposto do que ele existe para fazer.
+O script não é importável como módulo do pacote, então é carregado por caminho.
+"""
+import importlib.util
+import pathlib
+
+import pytest
+
+_CAMINHO = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "smoke_prod.py"
+_spec = importlib.util.spec_from_file_location("smoke_prod", _CAMINHO)
+smoke_prod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(smoke_prod)
+
+_SHA = "d3ff5370a1b2c3d4e5f60718293a4b5c6d7e8f90"
+
+
+@pytest.mark.parametrize(
+    "visto",
+    [
+        "",  # RAILWAY_GIT_COMMIT_SHA definida e vazia: "".startswith() casa com tudo
+        "   ",
+        "abc",  # curto demais para identificar commit
+        "unknown",  # o literal que o /health devolve quando a variável não chegou
+        "z" * 40,  # não é hexadecimal
+        "0" * 40,  # hex válido, mas outro commit
+    ],
+)
+def test_nao_abre_o_gate_com_valor_que_nao_identifica_o_commit(visto):
+    assert smoke_prod.sha_bate(visto, _SHA) is False
+
+
+@pytest.mark.parametrize("visto", [_SHA, _SHA[:7], _SHA[:12], _SHA.upper()])
+def test_abre_o_gate_no_commit_certo_inclusive_abreviado(visto):
+    """Controle positivo: sem isto, uma guarda que recusa tudo passaria nos
+    testes acima e o gate nunca abriria — pior que o bug."""
+    assert smoke_prod.sha_bate(visto, _SHA) is True
+    assert smoke_prod.sha_bate(_SHA, visto) is True

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -70,7 +70,46 @@ def test_home_serve_app_mode_com_cache_buster_de_hash():
 def test_health():
     resp = client.get("/health")
     assert resp.status_code == 200
+    # Resposta pública inalterada: o test_health_endpoint_does_not_expose_
+    # infrastructure (tests/test_auth_cookie.py) afirma o mesmo por outro
+    # ângulo, e foi ele que pegou a versão que vazava o commit para qualquer um.
     assert resp.json() == {"status": "ok"}
+    # Sem no-store, uma borda que cacheie /health devolve o SHA do deploy
+    # anterior e o gate do smoke abre em cima do código velho.
+    assert resp.headers["cache-control"] == "no-store"
+
+
+def test_health_entrega_o_commit_so_com_o_token(monkeypatch):
+    """O gate do smoke (scripts/smoke_prod.py) precisa do SHA; mais ninguém.
+
+    Os três casos importam: com token certo o campo aparece (senão o gate nunca
+    abre e o smoke morre no timeout), com token errado e sem token ele não
+    aparece (senão está vazando infraestrutura em endpoint público).
+    """
+    monkeypatch.setenv("SMOKE_HEALTH_TOKEN", "token-de-teste-32-bytes-ou-mais!!")
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc123def456")
+
+    com_token = client.get("/health", headers={"X-Smoke-Token": "token-de-teste-32-bytes-ou-mais!!"})
+    assert com_token.json() == {"status": "ok", "commit": "abc123def456"}
+
+    errado = client.get("/health", headers={"X-Smoke-Token": "token-errado"})
+    assert errado.json() == {"status": "ok"}
+
+    assert client.get("/health").json() == {"status": "ok"}
+
+
+def test_health_sem_token_configurado_nao_aceita_header_vazio(monkeypatch):
+    """Sem SMOKE_HEALTH_TOKEN no ambiente, NADA abre o campo — nem o header vazio.
+
+    `compare_digest("", "")` é True: se a guarda fosse só a comparação, um
+    ambiente sem a variável entregaria o commit a quem mandasse o header em
+    branco, que é todo mundo.
+    """
+    monkeypatch.delenv("SMOKE_HEALTH_TOKEN", raising=False)
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc123def456")
+
+    assert client.get("/health", headers={"X-Smoke-Token": ""}).json() == {"status": "ok"}
+    assert client.get("/health").json() == {"status": "ok"}
 
 
 def test_robots_txt():


### PR DESCRIPTION
## O buraco

A suíte roda em todo PR e em todo push na `main` — 5160 testes — e mede o **código**. A classe de falha que aparece só **depois do deploy** passa por ela sem uma linha vermelha: rota que some, asset que não chega, o 404 do proxy renderizado dentro de um card. Foi assim que o card "TODAS AS CATEGORIAS" apareceu mostrando `Erro: (HTTP 404) {"message":"Application not found"}` com o servidor respondendo 200 na página.

Isto não é um segundo CI. É a única coisa que olha o site que está no ar.

## O que entra

| arquivo | o que faz |
|---|---|
| `frontend/routes/static_pages.py` | `/health` devolve o commit do deploy **para quem manda o token** — é o gate |
| `scripts/smoke_prod.py` | HTTP read-only: gate, 13 rotas públicas, 3 de texto, assets carimbados, os dois lados do 404 |
| `scripts/smoke_prod_ui.mjs` | Playwright logado: `/app`, `/home`, `/settings` + âncoras positivas |
| `.github/workflows/smoke.yml` | `push: main` + manual |

**O gate é a peça que evita o verde falso.** Sem ele o workflow dormiria um tempo chutado e poderia medir o deploy *anterior*. A primeira versão devolvia o commit a qualquer um, e o `test_health_endpoint_does_not_expose_infrastructure` reprovou — com razão, SHA de deploy é infraestrutura. Agora o campo só sai com `X-Smoke-Token` casando com `SMOKE_HEALTH_TOKEN`; sem token, e sem a variável no ambiente, a resposta é byte a byte a de antes.

**Verificação positiva, não só negativa.** Procurar a palavra "Erro" pega o card que reclama, não o que sumiu — tela em branco passa em qualquer asserção negativa. O script troca de aba pelo `navigateTo()` e exige `#categories-stats` e `#budgets-stats` visíveis e com texto. O alvo é o contêiner de *stats* de propósito: o render de sucesso o preenche mesmo com a conta zerada, e ele fica vazio quando o fetch falha.

**Ruído filtrado por origem.** Rede e `console.error` só reprovam vindos da nossa origem — Meta Pixel e CDN não derrubam o smoke. `pageerror` reprova mesmo vindo de terceiro: exceção que sobe ao topo interrompe o script, e Chart.js estourando **é** a tela quebrada (P1-05 do roteiro).

## Medido

- **26 verificações verdes** contra `https://pigbankai.com`.
- **Controles negativos:** apontado para outra origem → 17 falhas, exit 1. Gate sem token, com token errado e com SHA inexistente → cada um reprova com a causa certa. Removida a guarda do token vazio → 2 testes vermelhos.
- **Suíte completa:** `20 failed, 5160 passed, 2 errors` em 113s. Comparado **por nome** contra a mesma árvore sem o diff: as 22 são idênticas e preexistentes (19 de `test_fuso_do_app`, 1 de `test_pending_registry`, 2 erros de `test_category_normalization` — artefatos de Windows conhecidos). `test_auth_cookie` está verde.

## NÃO medido

- **`scripts/smoke_prod_ui.mjs` nunca rodou.** Depende da conta de automação e das credenciais. É o gate do merge deste PR, não do PR.
- **O gate contra um SHA que realmente subiu** — só depois deste merge, porque a produção ainda não tem o endpoint novo.

## Antes de mergear

1. Variável `SMOKE_HEALTH_TOKEN` no serviço do **Railway** (valor forte, aleatório).
2. Secret `SMOKE_HEALTH_TOKEN` no **GitHub**, com o mesmo valor. (`SMOKE_EMAIL` e `SMOKE_PASSWORD` já estão.)
3. Rodar `node scripts/smoke_prod_ui.mjs` com as credenciais no ambiente e ver verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
