### PR TITLE
Perguntas de caixinha, investimento e saque guardam contexto (#136, fatia A)

### DIFF
--- a/core/handlers/investments.py
+++ b/core/handlers/investments.py
@@ -4,6 +4,7 @@ import re
 import db
 from utils_text import fmt_brl, fmt_rate
 from core.dashboard_links import build_dashboard_link
+from core.handlers import pending as h_pending
 from core.services.plan_limits import PlanLimitExceeded
 import logging
 
@@ -330,7 +331,12 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
     amount = entities.get("amount")
 
     if not amount or float(amount) <= 0:
-        return list_investments(user_id, "Qual valor você quer aportar?")
+        # #136: a pergunta guarda o contexto. Sem isso "500 reais" era
+        # reclassificado do zero e virava despesa avulsa. O NOME do investimento
+        # (logo abaixo) já armava pendência desde antes — era só o valor que não.
+        return list_investments(user_id, h_pending.pergunta_guardando_contexto(
+            user_id, "investments.deposit", entities,
+            "Qual valor você quer aportar?", text, falta="amount"))
 
     # Resolve o NOME antes de qualquer coisa. Sem nome, ou com nome que não bate,
     # o bot pergunta E FICA ESPERANDO (pendência armada) — antes ele perguntava e
@@ -474,9 +480,14 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
     want_all = bool(_WITHDRAW_ALL_RX.search(text or ""))
 
     if not investment_name:
-        return list_investments(user_id, "De qual investimento você quer resgatar?")
+        return list_investments(user_id, h_pending.pergunta_guardando_contexto(
+            user_id, "investments.withdraw", entities,
+            "De qual investimento você quer resgatar?", text, falta="investment_name"))
     if not want_all and (not amount or float(amount) <= 0):
-        return list_investments(user_id, "Qual valor você quer resgatar?")
+        return list_investments(user_id, h_pending.pergunta_guardando_contexto(
+            user_id, "investments.withdraw",
+            {**(entities or {}), "investment_name": investment_name},
+            "Qual valor você quer resgatar?", text, falta="amount"))
 
     from core.services import funding
 

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -394,16 +394,18 @@ def pergunta_guardando_contexto(
     # o usuário refazer o comando. Qualquer outra `clarification` é pergunta
     # ALHEIA, que ele já está lendo na tela, e cede a vez.
     #
-    # Consultiva de propósito: o `claim` relê a linha e faz o próprio CAS, então
-    # a janela entre as duas leituras fecha lá. O pior caso é o texto degradado,
-    # não dinheiro na operação errada.
-    atual = db.get_pending_action(user_id) or {}
-    if atual.get("action_type") == "clarification":
-        anterior = atual.get("payload") or {}
-        if (anterior.get("intent"), anterior.get("falta")) != (intent, falta):
-            return _peca_para_terminar_a_outra(user_id, intent)
-
-    ok = db.claim_pending_action(user_id, "clarification", {
+    # A DECISÃO E A ESCRITA no MESMO compare-and-swap. Uma versão anterior
+    # checava e depois chamava o `claim`, e o Codex mostrou que isso não fecha:
+    # entre as duas, outra tarefa pode pôr uma pergunta nova na linha, e aí o
+    # `claim` a relê, vê `clarification == clarification`, conclui "mesma
+    # pergunta" e SOBRESCREVE a pergunta que o usuário acabou de ver — o CAS de
+    # dentro dele compara o payload da substituta, não o que eu inspecionei.
+    #
+    # Aqui o `advance_pending_action` recebe o payload E o `created_at` da linha
+    # que EU li: se ela mudou no meio, o CAS não pega e o usuário recebe o texto
+    # que pede para terminar a outra pergunta. A distinção intent/falta passa a
+    # participar da atualização atômica, que era o que faltava.
+    payload = {
         "intent": intent,
         "entities": dict(entities or {}),
         "question": question,
@@ -414,7 +416,24 @@ def pergunta_guardando_contexto(
         # partir do que falta nas `entities` daria a resposta errada em metade
         # dos casos. Quem sabe é quem perguntou.
         "falta": falta,
-    })
+    }
+    atual = db.get_pending_action(user_id)
+    if atual is None:
+        ok = db.create_pending_action_if_absent(user_id, "clarification", payload)
+    elif atual.get("action_type") == "clarification":
+        anterior = atual.get("payload") or {}
+        if (anterior.get("intent"), anterior.get("falta")) != (intent, falta):
+            return _peca_para_terminar_a_outra(user_id, intent)
+        # Mesma pergunta de novo (o usuário refez o comando): avança a linha que
+        # eu li, e só ela.
+        ok = db.advance_pending_action(
+            user_id, "clarification", anterior, payload,
+            old_created_at=atual.get("created_at"),
+        )
+    else:
+        # Outro tipo na linha: quem decide se cede é a ordem de prioridade do
+        # `db/pending.py` (oferta de conveniência cede, pergunta não).
+        ok = db.claim_pending_action(user_id, "clarification", payload)
     if ok:
         return question
 

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -352,3 +352,66 @@ def get_pending_clarification(user_id: int) -> dict | None:
     if pending and pending.get("action_type") == "clarification":
         return pending
     return None
+
+
+def pergunta_guardando_contexto(
+    user_id: int, intent: str, entities: dict, question: str, orig_text: str,
+    *, falta: str,
+) -> str:
+    """Faz a pergunta E lembra que a fez. Devolve a pergunta, para o `return`.
+
+    O lado ESCRITOR do `get_pending_clarification` acima — os dois vivem juntos
+    porque a forma do payload é uma só (§0.7). Quem lê é o
+    `core.intent_router._resolve_clarification`.
+
+    Sem isto, um handler que devolve "Qual o valor?" como string crua não guarda
+    nada: a resposta seguinte é classificada do zero, e um número solto vira
+    `launches.add` com confiança 0,95. Medido na `main` c917f1c, conta nova, com
+    o LLM fora do caminho (o classificador determinístico basta):
+
+        criar caixinha viagem       -> caixinha criada
+        guardei na caixinha viagem  -> "Qual caixinha?"
+        200 reais                   -> "Em que você gastou R$ 200,00?"
+        viagem                      -> despesa R$ 200 'lazer', SALDO -200,00,
+                                       caixinha intacta em 0
+
+    No saque o sinal ainda inverte: quem pede para TIRAR R$ 100 da caixinha
+    termina com o saldo R$ 100 MENOR.
+
+    `claim_pending_action` e não `set_pending_action`: a linha de pendências é
+    uma por usuário e a ordem de prioridade do `db/pending.py` decide quem cede.
+    Uma pergunta não pode atropelar outra pergunta que o usuário já está lendo
+    na tela — foi o erro que o #133 cometeu e custou um commit de correção.
+    """
+    ok = db.claim_pending_action(user_id, "clarification", {
+        "intent": intent,
+        "entities": dict(entities or {}),
+        "question": question,
+        "orig_text": orig_text or "",
+        # QUAL entidade a pergunta pediu — gravado, não inferido. Cada handler
+        # checa numa ordem diferente (o aporte pergunta o valor primeiro, a
+        # caixinha pergunta o nome primeiro), então deduzir isso no leitor a
+        # partir do que falta nas `entities` daria a resposta errada em metade
+        # dos casos. Quem sabe é quem perguntou.
+        "falta": falta,
+    })
+    if ok:
+        return question
+
+    # Claim PERDIDO: outra pergunta continua de pé, e repetir a nossa seria
+    # mentira — a resposta do usuário seria consumida pela OUTRA pendência.
+    # `core/handlers/bills.py:pergunta_de_valor_sem_contexto` mediu o estrago
+    # nos 19 tipos vivos: em 8 a mensagem é consumida antes de chegar ao
+    # destino, e na `clarification` de `launches.add` o número vira o valor do
+    # lançamento VELHO. `cancelar` também não serve de conselho universal (no
+    # `recategorize_launch_text` vira nome de categoria). O único caminho que
+    # vale em todos é terminar a pergunta viva. Aquela função é a gêmea
+    # especializada em contas; a redação difere, a regra é a mesma.
+    logger.info("pergunta sem contexto (claim perdido) intent=%s uid=%s", intent, user_id)
+    viva = (db.get_pending_action(user_id) or {}).get("payload") or {}
+    outra = viva.get("question")
+    espera = f'esperando: "{outra}"' if outra else "esperando resposta."
+    return (
+        f"Antes disso tem outra pergunta minha {espera}\n"
+        "Me responde ela primeiro e a gente volta pra esta em seguida."
+    )

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -383,6 +383,26 @@ def pergunta_guardando_contexto(
     Uma pergunta não pode atropelar outra pergunta que o usuário já está lendo
     na tela — foi o erro que o #133 cometeu e custou um commit de correção.
     """
+    # GUARDA antes do claim: o `claim_pending_action` considera "mesma pergunta"
+    # o que tem o MESMO `action_type`, e as nove perguntas daqui usam todas o
+    # tipo genérico `clarification` (`db/pending.py:355`). Sem esta guarda, a
+    # pergunta de valor de um DEPÓSITO desalojaria a de um SAQUE como se fosse
+    # repetição, e a resposta do usuário iria para a operação financeira errada.
+    # Apontado pelo Codex no #184 (P1).
+    #
+    # "Mesma pergunta" aqui é a mesma intent pedindo a mesma entidade — o caso de
+    # o usuário refazer o comando. Qualquer outra `clarification` é pergunta
+    # ALHEIA, que ele já está lendo na tela, e cede a vez.
+    #
+    # Consultiva de propósito: o `claim` relê a linha e faz o próprio CAS, então
+    # a janela entre as duas leituras fecha lá. O pior caso é o texto degradado,
+    # não dinheiro na operação errada.
+    atual = db.get_pending_action(user_id) or {}
+    if atual.get("action_type") == "clarification":
+        anterior = atual.get("payload") or {}
+        if (anterior.get("intent"), anterior.get("falta")) != (intent, falta):
+            return _peca_para_terminar_a_outra(user_id, intent)
+
     ok = db.claim_pending_action(user_id, "clarification", {
         "intent": intent,
         "entities": dict(entities or {}),
@@ -407,6 +427,11 @@ def pergunta_guardando_contexto(
     # `recategorize_launch_text` vira nome de categoria). O único caminho que
     # vale em todos é terminar a pergunta viva. Aquela função é a gêmea
     # especializada em contas; a redação difere, a regra é a mesma.
+    return _peca_para_terminar_a_outra(user_id, intent)
+
+
+def _peca_para_terminar_a_outra(user_id: int, intent: str) -> str:
+    """A linha é de OUTRA pergunta, que o usuário já viu na tela."""
     logger.info("pergunta sem contexto (claim perdido) intent=%s uid=%s", intent, user_id)
     viva = (db.get_pending_action(user_id) or {}).get("payload") or {}
     outra = viva.get("question")

--- a/core/handlers/pockets.py
+++ b/core/handlers/pockets.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import db
+from core.handlers import pending as h_pending
 from utils_text import fmt_brl, parse_pocket_deposit_natural
 
 logger = logging.getLogger(__name__)
@@ -70,10 +71,17 @@ def deposit(user_id: int, text: str, entities: dict) -> str:
         pocket_name = entities.get("pocket_name")
         amount      = entities.get("amount")
 
+    # As duas perguntas GUARDAM o contexto (#136). Sem isso a resposta seguinte
+    # era classificada do zero: "200 reais" virava `launches.add` com confiança
+    # 0,95 e gravava uma despesa que ninguém pediu, com a caixinha intacta.
     if not pocket_name:
-        return "Qual caixinha? Tente: *coloquei 200 na caixinha viagem*"
+        return h_pending.pergunta_guardando_contexto(
+            user_id, "pockets.deposit", entities,
+            "Qual caixinha? Tente: *coloquei 200 na caixinha viagem*", text, falta="pocket_name")
     if not amount or float(amount) <= 0:
-        return "Qual o valor? Tente: *coloquei 200 na caixinha viagem*"
+        return h_pending.pergunta_guardando_contexto(
+            user_id, "pockets.deposit", {**(entities or {}), "pocket_name": pocket_name},
+            "Qual o valor? Tente: *coloquei 200 na caixinha viagem*", text, falta="amount")
 
     from core.handlers.investments import _pergunta_origem
     from core.services import funding
@@ -219,7 +227,9 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
         pocket_name = _pocket_name_from_text(text)
 
     if not pocket_name:
-        return "Qual caixinha? Tente: *retirei 100 da caixinha viagem*"
+        return h_pending.pergunta_guardando_contexto(
+            user_id, "pockets.withdraw", entities,
+            "Qual caixinha? Tente: *retirei 100 da caixinha viagem*", text, falta="pocket_name")
 
     if want_all:
         try:
@@ -241,7 +251,9 @@ def withdraw(user_id: int, text: str, entities: dict) -> str:
         return _format_withdraw_reply(user_id, canon, sacado, new_acc, new_pocket, taxes, launch_id, emptied=True, nota=nota_destino)
 
     if not amount or float(amount) <= 0:
-        return "Qual o valor? Tente: *retirei 100 da caixinha viagem*"
+        return h_pending.pergunta_guardando_contexto(
+            user_id, "pockets.withdraw", {**(entities or {}), "pocket_name": pocket_name},
+            "Qual o valor? Tente: *retirei 100 da caixinha viagem*", text, falta="amount")
 
     try:
         launch_id, new_acc, new_pocket, canon, taxes = db.pocket_withdraw_to_account(

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -774,6 +774,28 @@ def _cola_separador_decimal(resposta: str) -> str:
 # contexto via `h_pending.pergunta_guardando_contexto` (#136). Fonte única: quem
 # entra aqui tem de gravar `falta` no payload, e quem grava `falta` tem de estar
 # aqui. O `tests/test_perguntas_guardam_contexto.py` compara as duas pontas.
+# "da caixinha viagem" e "caixinha viagem" são a MESMA caixinha que "viagem" —
+# o usuário repete o substantivo da pergunta. Mesma limpeza do
+# `_pocket_name_from_text` (core/handlers/pockets.py), sem exigir a palavra
+# "caixinha" no texto, porque aqui a resposta curta ("viagem") é o caso comum.
+#
+# NÃO tira "reserva": "reserva de emergência" é nome legítimo de caixinha, e o
+# exemplo da própria pergunta do saque genérico usa esse nome.
+_PREP_RE = re.compile(r"^(?:d[aeo]|n[ao]|para|pra|em)\s+", re.I)
+# Mesma jogada do `_pocket_name_from_text` (core/handlers/pockets.py): o nome é
+# o que vem DEPOIS do substantivo. Generalizado para não EXIGIR o substantivo,
+# porque aqui a resposta curta ("viagem") é o caso comum.
+_SUBST_ALVO_RE = re.compile(r"(?:caixinha|investimento)\s+(.+)$", re.I)
+
+
+def _nome_do_alvo(resposta: str) -> str:
+    t = resposta.strip()
+    achou = _SUBST_ALVO_RE.search(t)
+    if achou:
+        t = achou.group(1)
+    return _PREP_RE.sub("", t).strip() or resposta.strip()
+
+
 _INTENTS_PERGUNTA_DE_HANDLER: frozenset[str] = frozenset({
     "pockets.deposit",
     "pockets.withdraw",
@@ -874,14 +896,26 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
                           else "Não entendi o valor. Manda só o número, por exemplo: *132,50*")
                 return f"{recusa}\n\n{payload.get('question') or 'Qual o valor?'}"
             ents["amount"] = valor
-        else:
-            # Nome de caixinha/investimento/alvo: o texto do usuário É a resposta.
-            ents[falta] = resposta_h
-        # `orig_text` e não o combinado: medido, "tirar da caixinha viagem" +
-        # "100 reais" concatenado faz o parser de saque ler o nome como
-        # "viagem 100 reais" e a caixinha não é encontrada. O valor entra pela
-        # entity, que é o que o handler consulta quando o parse do texto falha.
-        return _execute(original_intent, user_id, orig_text, ents, platform, external_id)
+            # `orig_text` e não o combinado: medido, "tirar da caixinha viagem"
+            # + "100 reais" concatenado faz o parser de saque ler o nome como
+            # "viagem 100 reais" e a caixinha não é encontrada. O valor entra
+            # pela entity, que é o que o handler consulta quando o parse falha.
+            return _execute(original_intent, user_id, orig_text, ents, platform, external_id)
+
+        # NOME de caixinha/investimento/alvo. A RESPOSTA vira o `text`, não o
+        # `orig_text`: a própria pergunta sugere o comando completo ("Tente:
+        # *coloquei 200 na caixinha viagem*"), e tomar a resposta verbatim como
+        # nome fazia o bot RECUSAR o texto que ele acabou de recomendar —
+        # "Caixinha *coloquei 200 na caixinha viagem* não encontrada". Regressão
+        # apontada pelo Codex no #184 e confirmada medindo; na `main` o comando
+        # completo era reclassificado e funcionava.
+        #
+        # Passando a resposta como `text`, o parser natural do próprio handler
+        # (`parse_pocket_deposit_natural`, `_parse_pocket_withdraw_natural`)
+        # extrai nome E valor do comando completo, e a entity abaixo só vale
+        # quando esse parse não acha nada — o caso da resposta curta.
+        ents[falta] = _nome_do_alvo(resposta_h)
+        return _execute(original_intent, user_id, resposta_h, ents, platform, external_id)
 
     # Reclassifica COM contexto (mensagem original + pergunta que o bot fez +
     # resposta). Se a IA montar a intenção completa, despacha por ela — resolve

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -770,6 +770,19 @@ def _cola_separador_decimal(resposta: str) -> str:
     return _ESPACO_NO_SEPARADOR_RE.sub(r"\1", resposta)
 
 
+# As intents cujos handlers PERGUNTAM por uma entidade que falta e guardam o
+# contexto via `h_pending.pergunta_guardando_contexto` (#136). Fonte única: quem
+# entra aqui tem de gravar `falta` no payload, e quem grava `falta` tem de estar
+# aqui. O `tests/test_perguntas_guardam_contexto.py` compara as duas pontas.
+_INTENTS_PERGUNTA_DE_HANDLER: frozenset[str] = frozenset({
+    "pockets.deposit",
+    "pockets.withdraw",
+    "investments.deposit",
+    "investments.withdraw",
+    "funds.withdraw",
+})
+
+
 def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platform: str, external_id: str) -> str:
     """
     O bot tinha feito uma pergunta e está esperando a resposta do usuário.
@@ -823,6 +836,52 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
         db.set_pending_action(user_id, "clarification", payload)
         return ("Não entendi o destino. Responda: *saldo*, *caixinha NOME* ou "
                 "*investimento NOME* (ou *cancelar*).")
+
+    # ── Perguntas feitas por HANDLER (#136) ──────────────────────────────────
+    # Caixinha, investimento e saque genérico. O payload diz QUAL entidade foi
+    # pedida (`falta`), gravado por quem perguntou — não inferido aqui: cada
+    # handler checa numa ordem diferente e deduzir daria a resposta errada em
+    # metade dos casos.
+    #
+    # ANTES da reclassificação por IA, de propósito. Já sabemos o que
+    # perguntamos e o que fazer com a resposta; deixar o LLM redecidir
+    # reintroduziria exatamente o sequestro que esta issue fecha — e só para o
+    # usuário PRO, que é quem paga. O caminho determinístico é o certo aqui.
+    #
+    # A escotilha de abandono NÃO é responsabilidade deste bloco: outro comando
+    # claro já foi desviado pelo `_clarification_abandonada` lá no `route()`,
+    # antes de chegarmos aqui.
+    falta = payload.get("falta")
+    if falta and original_intent in _INTENTS_PERGUNTA_DE_HANDLER:
+        ents = dict(original_entities)
+        resposta_h = limpa_pontuacao_final(user_response.strip())
+        if falta == "amount":
+            from parsers import _extract_valor
+            valor = _extract_valor(resposta_h)
+            perigo = valor_perigoso(resposta_h, valor)
+            if perigo or valor is None:
+                # Recusa MANTÉM a pergunta viva — mesmo contrato das 4 portas do
+                # #140. Descartar jogaria o usuário no fallback genérico e a
+                # caixinha/investimento que ele já escolheu sumiria.
+                #
+                # `create_pending_action_if_absent` e não `set_pending_action`:
+                # o `consume_pending_action` no topo desta função já apagou a
+                # linha, e entre lá e aqui outra tarefa pode ter posto uma
+                # pergunta NOVA — que o usuário já viu. O upsert a atropelaria.
+                db.create_pending_action_if_absent(user_id, "clarification", payload)
+                recusa = ("O valor precisa ser maior que zero."
+                          if perigo == "nao_positivo"
+                          else "Não entendi o valor. Manda só o número, por exemplo: *132,50*")
+                return f"{recusa}\n\n{payload.get('question') or 'Qual o valor?'}"
+            ents["amount"] = valor
+        else:
+            # Nome de caixinha/investimento/alvo: o texto do usuário É a resposta.
+            ents[falta] = resposta_h
+        # `orig_text` e não o combinado: medido, "tirar da caixinha viagem" +
+        # "100 reais" concatenado faz o parser de saque ler o nome como
+        # "viagem 100 reais" e a caixinha não é encontrada. O valor entra pela
+        # entity, que é o que o handler consulta quando o parse do texto falha.
+        return _execute(original_intent, user_id, orig_text, ents, platform, external_id)
 
     # Reclassifica COM contexto (mensagem original + pergunta que o bot fez +
     # resposta). Se a IA montar a intenção completa, despacha por ela — resolve
@@ -984,10 +1043,14 @@ def _execute_generic_withdraw(user_id: int, text: str, entities: dict) -> str:
         return h_investments.withdraw(user_id, text, {"investment_name": target_name, "amount": amount})
 
     if not amount or float(amount) <= 0:
-        return "Qual o valor? Tente: *saquei 200 da reserva de emergência*"
+        return h_pending.pergunta_guardando_contexto(
+            user_id, "funds.withdraw", entities,
+            "Qual o valor? Tente: *saquei 200 da reserva de emergência*", text, falta="amount")
 
     if not target_name:
-        return "Você quer retirar de qual caixinha ou investimento?"
+        return h_pending.pergunta_guardando_contexto(
+            user_id, "funds.withdraw", {**(entities or {}), "amount": amount},
+            "Você quer retirar de qual caixinha ou investimento?", text, falta="target_name")
 
     norm_target = normalize_text(target_name)
 

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -804,6 +804,12 @@ def _alvos_existentes(user_id: int, intent: str) -> list[str]:
     return [n for n in nomes if n]
 
 
+def _eh_nome_do_catalogo(resposta: str, existentes: list[str] | None = None) -> bool:
+    """A resposta INTEIRA já é um alvo do usuário? Fonte única do desempate."""
+    alvo = normalize_text((resposta or "").strip())
+    return bool(alvo) and any(normalize_text(n) == alvo for n in (existentes or []))
+
+
 def _nome_do_alvo(resposta: str, existentes: list[str] | None = None) -> str:
     """O nome do alvo dentro da resposta do usuário.
 
@@ -819,8 +825,7 @@ def _nome_do_alvo(resposta: str, existentes: list[str] | None = None) -> str:
     o recorte vale.
     """
     t = resposta.strip()
-    alvo = normalize_text(t)
-    if alvo and any(normalize_text(n) == alvo for n in (existentes or [])):
+    if _eh_nome_do_catalogo(t, existentes):
         return t
     achou = _SUBST_ALVO_RE.search(t)
     if achou:
@@ -946,11 +951,18 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
         # (`parse_pocket_deposit_natural`, `_parse_pocket_withdraw_natural`)
         # extrai nome E valor do comando completo, e a entity abaixo só vale
         # quando esse parse não acha nada — o caso da resposta curta.
-        ents[falta] = _nome_do_alvo(resposta_h, _alvos_existentes(user_id, original_intent))
+        existentes = _alvos_existentes(user_id, original_intent)
+        ents[falta] = _nome_do_alvo(resposta_h, existentes)
         # O comando completo ("retirei 100 da caixinha viagem") traz o valor
         # junto: aproveita e poupa um turno. Passa pelo MESMO filtro de dano do
         # ramo de cima — um valor perigoso aqui e a pergunta do valor volta.
-        if not ents.get("amount"):
+        #
+        # MAS não quando a resposta é, ela inteira, um nome do catálogo: uma
+        # caixinha "meta 2028" fazia `_extract_valor` devolver 2028 e o saque
+        # levava R$ 2.028 SEM PERGUNTAR quanto. Medido (com R$ 500 na caixinha:
+        # "Saldo insuficiente na caixinha *meta 2028*" — com saldo maior teria
+        # sacado). Nome é nome; dígito dentro dele não é valor. Codex P1, #184.
+        if not _eh_nome_do_catalogo(resposta_h, existentes) and not ents.get("amount"):
             from parsers import _extract_valor
             v = _extract_valor(resposta_h)
             if v is not None and not valor_perigoso(resposta_h, v):

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -10,6 +10,7 @@ Recebe um IntentResult + mensagem original e decide o que fazer:
 """
 from __future__ import annotations
 
+import logging
 import re
 
 import db
@@ -34,6 +35,8 @@ from core.handlers import (
     recurring  as h_recurring,
     bills      as h_bills,
 )
+
+logger = logging.getLogger(__name__)
 
 # Limiar de confiança para executar sem pedir confirmação
 CONFIDENCE_EXECUTE = 0.85
@@ -788,8 +791,37 @@ _PREP_RE = re.compile(r"^(?:d[aeo]|n[ao]|para|pra|em)\s+", re.I)
 _SUBST_ALVO_RE = re.compile(r"(?:caixinha|investimento)\s+(.+)$", re.I)
 
 
-def _nome_do_alvo(resposta: str) -> str:
+def _alvos_existentes(user_id: int, intent: str) -> list[str]:
+    """Nomes de caixinha/investimento do usuário, conforme o que a intent move."""
+    nomes: list[str] = []
+    try:
+        if intent in ("pockets.deposit", "pockets.withdraw", "funds.withdraw"):
+            nomes += [p.get("name") or "" for p in (db.list_pockets(user_id) or [])]
+        if intent in ("investments.deposit", "investments.withdraw", "funds.withdraw"):
+            nomes += [i.get("name") or "" for i in (db.accrue_all_investments(user_id) or [])]
+    except Exception:
+        logger.exception("falha ao listar alvos do usuario %s", user_id)
+    return [n for n in nomes if n]
+
+
+def _nome_do_alvo(resposta: str, existentes: list[str] | None = None) -> str:
+    """O nome do alvo dentro da resposta do usuário.
+
+    "caixinha" no MEIO da string é ambíguo: em "retirei 100 da caixinha viagem"
+    é prefixo sintático e o nome é "viagem"; em "minha caixinha viagem" — nome
+    literal de uma caixinha criada pelo dashboard — faz parte do nome. Recortar
+    sempre respondia "Caixinha *viagem* não encontrada" (medido); não recortar
+    nunca fazia o comando completo funcionar (medido). Apontado pelo Codex no
+    #184, as duas pontas.
+
+    Quem desempata é o CATÁLOGO do usuário, que é definitivo: se a resposta
+    inteira já é um alvo dele, ela é o nome e não se toca. Só quando não é é que
+    o recorte vale.
+    """
     t = resposta.strip()
+    alvo = normalize_text(t)
+    if alvo and any(normalize_text(n) == alvo for n in (existentes or [])):
+        return t
     achou = _SUBST_ALVO_RE.search(t)
     if achou:
         t = achou.group(1)
@@ -914,8 +946,22 @@ def _resolve_clarification(clarif: dict, user_response: str, user_id: int, platf
         # (`parse_pocket_deposit_natural`, `_parse_pocket_withdraw_natural`)
         # extrai nome E valor do comando completo, e a entity abaixo só vale
         # quando esse parse não acha nada — o caso da resposta curta.
-        ents[falta] = _nome_do_alvo(resposta_h)
-        return _execute(original_intent, user_id, resposta_h, ents, platform, external_id)
+        ents[falta] = _nome_do_alvo(resposta_h, _alvos_existentes(user_id, original_intent))
+        # O comando completo ("retirei 100 da caixinha viagem") traz o valor
+        # junto: aproveita e poupa um turno. Passa pelo MESMO filtro de dano do
+        # ramo de cima — um valor perigoso aqui e a pergunta do valor volta.
+        if not ents.get("amount"):
+            from parsers import _extract_valor
+            v = _extract_valor(resposta_h)
+            if v is not None and not valor_perigoso(resposta_h, v):
+                ents["amount"] = v
+        # `orig_text` e NAO a resposta: `want_all` ("esvaziar", "zerar", "tudo")
+        # e derivado do `text` pelos dois handlers de saque, entao trocar o texto
+        # pela resposta curta perdia o marcador e o bot pedia um valor em vez de
+        # esvaziar a caixinha. Medido; apontado pelo Codex no #184. O nome e o
+        # valor chegam pelas entities, que e o que o handler consulta quando o
+        # parse do texto nao acha nada.
+        return _execute(original_intent, user_id, orig_text, ents, platform, external_id)
 
     # Reclassifica COM contexto (mensagem original + pergunta que o bot fez +
     # resposta). Se a IA montar a intenção completa, despacha por ela — resolve

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -277,6 +277,71 @@ def test_nome_literal_com_a_palavra_caixinha(uid):
     assert pockets.get("minha caixinha viagem") == 200.00
 
 
+# ── As 5 portas que a conversa determinística não alcança ───────────────────
+#
+# `investments.deposit`, `investments.withdraw` e as duas de `funds.withdraw`
+# ficavam cobertas SÓ pelo teste de `ast` lá embaixo — que prova que a porta está
+# LIGADA, não que ela funciona. É a mesma armadilha do teste tautológico que o
+# controle negativo pegou mais acima, num eixo diferente.
+#
+# Medido: nenhuma de 9 frases ("aportar", "quero aportar no cdb", "resgatar do
+# cdb", "sacar da reserva"…) classifica para as intents de investimento sem o
+# LLM — todas caem em `out_of_scope`. Então a 1ª mensagem é injetada com a intent
+# já resolvida, que é o que o classificador entregaria numa conta Pro.
+#
+# A RESPOSTA — a 2ª mensagem, onde o bug desta issue vive — passa pelo
+# `handle_incoming` de verdade. É o trecho que importa.
+
+def _pergunta_injetada(uid: int, intent: str, entities: dict, texto: str) -> str:
+    from core.intent_classifier import IntentResult
+    from core.intent_router import route
+
+    return route(IntentResult(intent=intent, confidence=0.95, entities=entities),
+                 IncomingMessage(platform="whatsapp", user_id=uid, text=texto))
+
+
+@pytest.mark.parametrize("intent,entities,texto,pergunta", [
+    ("investments.deposit",  {},                            "aportar",  "Qual valor você quer aportar?"),
+    ("investments.withdraw", {},                            "resgatar", "De qual investimento"),
+    ("investments.withdraw", {"investment_name": "cdb tst"}, "resgatar", "Qual valor você quer resgatar?"),
+    ("funds.withdraw",       {},                            "sacar",    "Qual o valor?"),
+    ("funds.withdraw",       {"amount": 50},                "sacar",    "retirar de qual"),
+])
+def test_portas_de_investimento_e_saque_armam_pendencia(uid, intent, entities, texto, pergunta):
+    """Cada uma das 5 portas restantes pergunta E guarda o contexto."""
+    resposta = _pergunta_injetada(uid, intent, entities, texto)
+
+    assert pergunta in resposta, resposta
+    pend = db.get_pending_action(uid)
+    assert pend is not None, "a pergunta saiu sem guardar contexto"
+    assert pend["action_type"] == "clarification"
+    assert pend["payload"]["intent"] == intent
+    assert pend["payload"]["falta"] in ("amount", "investment_name", "target_name")
+
+
+def test_aporte_a_resposta_nao_vira_despesa(uid):
+    """O bug da issue na porta do APORTE: a resposta ao "Qual valor?" era
+    reclassificada do zero e virava `launches.add`."""
+    # A 3a mensagem NAO e decorativa: sem a pendencia, "500 reais" vira uma
+    # clarification de `launches.add` pedindo a DESCRICAO, e a despesa so e
+    # gravada quando ela chega. Sem este turno o teste passa na `main` — foi
+    # assim que ele nasceu, e o controle negativo pegou.
+    _pergunta_injetada(uid, "investments.deposit", {}, "aportar")
+    _conversa(uid, "500 reais", "cdb")
+
+    assert _despesas(uid) == [], "a resposta ao aporte virou despesa avulsa"
+    assert round(float(db.get_balance(uid)), 2) == 0.00
+
+
+def test_saque_generico_a_resposta_nao_vira_despesa(uid):
+    """Mesma coisa na porta do saque genérico (`funds.withdraw`)."""
+    _pergunta_injetada(uid, "funds.withdraw", {}, "sacar")
+    _conversa(uid, "200 reais", "reserva")
+
+    assert _despesas(uid) == []
+    assert round(float(db.get_balance(uid)), 2) == 0.00
+
+
 # ── As duas pontas da fonte única (§0.7) ────────────────────────────────────
 
 _ARQUIVOS_COM_PERGUNTA = (

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -143,6 +143,62 @@ def test_deposito_legitimo_ainda_funciona(uid):
     assert _despesas(uid) == [], "depósito em caixinha não é despesa"
 
 
+# ── Resposta em linguagem natural ao nome (Codex P2 no #184) ────────────────
+
+@pytest.mark.parametrize("resposta", [
+    "viagem",                            # nome pelado
+    "caixinha viagem",                   # repete o substantivo da pergunta
+    "da caixinha viagem",                # com preposição
+    "coloquei 200 na caixinha viagem",   # o comando COMPLETO que a pergunta sugere
+])
+def test_resposta_natural_ao_nome_da_caixinha(uid, resposta):
+    """A pergunta sugere "Tente: *coloquei 200 na caixinha viagem*" — recusar esse
+    texto seria o bot rejeitar o que ele mesmo recomendou.
+
+    A primeira versão deste PR tomava a resposta VERBATIM como nome e respondia
+    "Caixinha *coloquei 200 na caixinha viagem* não encontrada" — regressão que o
+    Codex apontou e que a medição confirmou. Na `main` o comando completo era
+    reclassificado e funcionava, então era regressão de verdade, não teoria.
+    """
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False,
+    )
+    respostas = _conversa(uid, "criar caixinha viagem",
+                          "guardei na caixinha viagem", resposta, "200")
+
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("viagem") == 200.00, respostas[-2:]
+    assert _despesas(uid) == []
+
+
+def test_saque_com_comando_completo_como_resposta(uid):
+    """Mesmo caso na porta do saque, onde a entity VENCE o parser do handler
+    (`pocket_name or _p`) — por isso um nome mal extraído envenena o fluxo lá,
+    e não no depósito."""
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False,
+    )
+    _conversa(uid, "criar caixinha viagem", "coloquei 300 na caixinha viagem")
+    _conversa(uid, "tirar da caixinha viagem", "retirei 100 da caixinha viagem")
+
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("viagem") == 200.00, "o saque de 100 sobre 300 não fechou"
+
+
+def test_nome_do_alvo_preserva_nome_legitimo():
+    """`reserva de emergência` é nome de caixinha, não preposição + substantivo —
+    e é o exemplo que a própria pergunta do saque genérico usa."""
+    from core.intent_router import _nome_do_alvo
+
+    assert _nome_do_alvo("reserva de emergencia") == "reserva de emergencia"
+    assert _nome_do_alvo("viagem") == "viagem"
+    assert _nome_do_alvo("caixinha viagem") == "viagem"
+    assert _nome_do_alvo("retirei 100 da caixinha viagem") == "viagem"
+    assert _nome_do_alvo("investimento cdb nubank") == "cdb nubank"
+
+
 # ── As duas pontas da fonte única (§0.7) ────────────────────────────────────
 
 _ARQUIVOS_COM_PERGUNTA = (

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -1,0 +1,194 @@
+"""As perguntas de caixinha/investimento/saque guardam o contexto (#136, fatia A).
+
+Antes, um handler que devolvia "Qual o valor?" como string crua não guardava nada:
+a resposta seguinte era classificada do zero e um número solto virava
+`launches.add` com confiança 0,95. Medido na `main` c917f1c, conta nova, SEM IA
+nenhuma no caminho — é o bot determinístico sequestrando a resposta da própria
+pergunta:
+
+    criar caixinha viagem       -> caixinha criada
+    guardei na caixinha viagem  -> "Qual caixinha?"
+    200 reais                   -> "Em que você gastou R$ 200,00?"
+    viagem                      -> despesa R$ 200 'lazer', SALDO -200,00,
+                                   caixinha intacta em 0
+
+No saque o sinal ainda invertia: quem pedia para TIRAR R$ 100 terminava com o
+saldo R$ 100 MENOR.
+
+CONTROLE NEGATIVO — em `core/handlers/pockets.py`, troque as chamadas de
+`h_pending.pergunta_guardando_contexto(...)` de volta pelo `return "<a
+pergunta>"` cru: `test_deposito_nao_vira_despesa_fantasma` e
+`test_saque_nao_vira_despesa_fantasma` ficam VERMELHOS (a despesa fantasma
+volta e o saldo vai a -200/-100). Injetado nos dois, que estavam verdes.
+
+CONTROLE POSITIVO — `test_deposito_legitimo_ainda_funciona`: o conserto
+RESTRINGE (passa a exigir pendência), então precisa provar que o caminho bom
+continua fechando. Sem ele, um código que recusasse TUDO passaria nos negativos.
+
+RODA A CONVERSA, não a função (CLAUDE.md §3): tudo entra pelo `handle_incoming`
+com estado real no banco, porque a classe de bug que esta issue trata só aparece
+quando a mensagem seguinte é classificada do zero.
+
+CLASSE CEGA: o LLM está fora do caminho aqui (sem `OPENAI_API_KEY` nos testes),
+então isto prova o trajeto determinístico. O ramo do `_resolve_clarification`
+que este PR adiciona roda ANTES da reclassificação por IA justamente para que o
+comportamento do usuário Pro seja o mesmo — mas isso não é exercitado aqui.
+Quem exercita é `scripts/whatsapp_qa_vault_harness.py`, que chama a IA de
+verdade, tem custo e roda sob demanda.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import uuid
+
+import pytest
+
+import db
+from core.handle_incoming import handle_incoming
+from core.types import IncomingMessage
+
+_RAIZ = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _conversa(uid: int, *mensagens: str) -> list[str]:
+    """Manda as mensagens em sequência e devolve as respostas concatenadas."""
+    saidas = []
+    for m in mensagens:
+        outs = handle_incoming(IncomingMessage(platform="whatsapp", user_id=uid, text=m))
+        saidas.append(" ".join((o.text or "") for o in (outs or [])))
+    return saidas
+
+
+@pytest.fixture
+def uid() -> int:
+    u = int(uuid.uuid4().int % 1_000_000_000) + 1   # < 2 bi: não sofre remap
+    db.ensure_user(u)
+    return u
+
+
+def _despesas(user_id: int) -> list[dict]:
+    return [l for l in (db.list_launches(user_id, limit=50) or [])
+            if (l.get("tipo") or "") == "despesa"]
+
+
+# ── O bug da issue, nas duas portas de caixinha ──────────────────────────────
+
+def test_deposito_nao_vira_despesa_fantasma(uid):
+    # A ORDEM É A DA ISSUE e não é decorativa: é o valor ANTES da descrição que
+    # reproduz. Com "viagem" antes de "200 reais" o teste passa na `main` também
+    # — foi assim que ele nasceu, tautológico, e o controle negativo o pegou.
+    _conversa(uid, "criar caixinha viagem", "guardei na caixinha viagem",
+              "200 reais", "viagem")
+
+    assert _despesas(uid) == [], "a resposta à pergunta virou despesa avulsa"
+    assert round(float(db.get_balance(uid)), 2) == 0.00
+
+
+def test_saque_nao_vira_despesa_fantasma(uid):
+    """No saque o estrago era pior: o usuário pede para TIRAR e o saldo CAI."""
+    _conversa(uid, "criar caixinha viagem", "tirar da caixinha viagem",
+              "100 reais", "viagem")
+
+    assert _despesas(uid) == []
+    saldo = round(float(db.get_balance(uid)), 2)
+    assert saldo == 0.00, f"saldo mexeu sozinho: {saldo}"
+
+
+# ── Filtro de dano: a recusa mantém a pergunta viva ─────────────────────────
+
+@pytest.mark.parametrize("resposta,trecho", [
+    ("-10",     "maior que zero"),   # sinal engolido: gravava R$ 10,00
+    ("0",       "maior que zero"),   # matava a pendência e caía no fallback
+    ("132 50",  "Não entendi"),      # gravava R$ 13.250,00
+])
+def test_valor_perigoso_recusa_e_repergunta(uid, resposta, trecho):
+    respostas = _conversa(uid, "criar caixinha viagem", "guardei na caixinha viagem",
+                          "viagem", resposta)
+
+    assert trecho in respostas[-1]
+    assert "Qual o valor" in respostas[-1], "a pergunta morreu na recusa"
+    assert _despesas(uid) == []
+    # A pendência continua de pé — é isso que deixa o usuário só repetir o número.
+    pend = db.get_pending_action(uid)
+    assert pend and pend["action_type"] == "clarification"
+    assert pend["payload"]["falta"] == "amount"
+
+
+def test_escotilha_outro_comando_abandona(uid):
+    """"saldo" no meio da pergunta é comando, não resposta."""
+    respostas = _conversa(uid, "criar caixinha viagem",
+                          "guardei na caixinha viagem", "saldo")
+
+    assert "Conta Corrente" in respostas[-1]
+    assert _despesas(uid) == []
+
+
+# ── CONTROLE POSITIVO: o caminho legítimo continua fechando ─────────────────
+
+def test_deposito_legitimo_ainda_funciona(uid):
+    """O conserto restringe; sem este caso, recusar tudo passaria nos negativos."""
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="teste",
+        categoria="salário", is_internal_movement=False,
+    )
+
+    respostas = _conversa(uid, "criar caixinha viagem", "guardei na caixinha viagem",
+                          "viagem", "200 reais")
+
+    assert "Depósito na caixinha" in respostas[-1], respostas[-1]
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("viagem") == 200.00
+    assert round(float(db.get_balance(uid)), 2) == 300.00
+    assert _despesas(uid) == [], "depósito em caixinha não é despesa"
+
+
+# ── As duas pontas da fonte única (§0.7) ────────────────────────────────────
+
+_ARQUIVOS_COM_PERGUNTA = (
+    "core/handlers/pockets.py",
+    "core/handlers/investments.py",
+    "core/intent_router.py",
+)
+
+
+def _chamadas_de_pergunta() -> list[tuple[str, int, str, bool]]:
+    """(arquivo, linha, intent, tem_falta) de cada `pergunta_guardando_contexto`."""
+    achados = []
+    for rel in _ARQUIVOS_COM_PERGUNTA:
+        arvore = ast.parse((_RAIZ / rel).read_text(encoding="utf-8"))
+        for no in ast.walk(arvore):
+            if not isinstance(no, ast.Call):
+                continue
+            alvo = no.func.attr if isinstance(no.func, ast.Attribute) else getattr(no.func, "id", None)
+            if alvo != "pergunta_guardando_contexto":
+                continue
+            intent = no.args[1].value if len(no.args) > 1 and isinstance(no.args[1], ast.Constant) else None
+            tem_falta = any(k.arg == "falta" for k in no.keywords)
+            achados.append((rel, no.lineno, intent, tem_falta))
+    return achados
+
+
+def test_toda_pergunta_declara_intent_conhecida_e_falta():
+    """Quem pergunta tem de estar no `_INTENTS_PERGUNTA_DE_HANDLER` e gravar `falta`.
+
+    Sem isto, uma pergunta nova arma a pendência e o `_resolve_clarification`
+    não a reconhece: a resposta cai no fallback de data e a intent é
+    re-executada SEM a entidade que faltava — laço infinito de pergunta.
+    """
+    from core.intent_router import _INTENTS_PERGUNTA_DE_HANDLER
+
+    chamadas = _chamadas_de_pergunta()
+    assert len(chamadas) == 9, f"o inventário mudou: {chamadas}"
+
+    for rel, linha, intent, tem_falta in chamadas:
+        assert intent in _INTENTS_PERGUNTA_DE_HANDLER, f"{rel}:{linha} intent {intent!r} fora do conjunto"
+        assert tem_falta, f"{rel}:{linha} não grava `falta` — o leitor não saberá o que preencher"
+
+
+def test_conjunto_nao_tem_intent_orfa():
+    """Linha órfã no conjunto é tão ruim quanto ausência: mente sobre a cobertura."""
+    from core.intent_router import _INTENTS_PERGUNTA_DE_HANDLER
+
+    usadas = {intent for _, _, intent, _ in _chamadas_de_pergunta()}
+    assert _INTENTS_PERGUNTA_DE_HANDLER - usadas == set()

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -193,10 +193,88 @@ def test_nome_do_alvo_preserva_nome_legitimo():
     from core.intent_router import _nome_do_alvo
 
     assert _nome_do_alvo("reserva de emergencia") == "reserva de emergencia"
+    # catálogo desempata quando o nome literal contém o substantivo
+    assert _nome_do_alvo("minha caixinha viagem", ["minha caixinha viagem"]) == "minha caixinha viagem"
     assert _nome_do_alvo("viagem") == "viagem"
     assert _nome_do_alvo("caixinha viagem") == "viagem"
     assert _nome_do_alvo("retirei 100 da caixinha viagem") == "viagem"
     assert _nome_do_alvo("investimento cdb nubank") == "cdb nubank"
+
+
+# ── Uma pergunta não desaloja OUTRA pergunta (Codex P1 no #184) ─────────────
+
+def test_pergunta_nao_desaloja_pergunta_alheia(uid):
+    """As nove perguntas usam o tipo genérico `clarification`, e o
+    `claim_pending_action` trata tipo igual como "a mesma pergunta de novo"
+    (`db/pending.py:355`). Sem a guarda, a pergunta de valor de um SAQUE
+    substituía a de um DEPÓSITO e a resposta ia para a operação errada.
+    """
+    import db as _db
+
+    _db.claim_pending_action(uid, "clarification", {
+        "intent": "pockets.deposit", "entities": {"pocket_name": "viagem"},
+        "question": "Qual o valor? (deposito)", "orig_text": "guardei na caixinha viagem",
+        "falta": "amount",
+    })
+
+    from core.handlers import pending as h_pending
+    resposta = h_pending.pergunta_guardando_contexto(
+        uid, "pockets.withdraw", {"pocket_name": "viagem"},
+        "Qual o valor? (saque)", "tirar da caixinha viagem", falta="amount")
+
+    viva = _db.get_pending_action(uid)
+    assert viva["payload"]["intent"] == "pockets.deposit", "a pergunta do saque atropelou a do depósito"
+    assert viva["payload"]["question"] == "Qual o valor? (deposito)"
+    # E o usuário é avisado, em vez de receber uma pergunta que não vai ser ouvida.
+    assert "outra pergunta minha" in resposta
+
+
+def test_mesma_pergunta_de_novo_pode_substituir(uid):
+    """CONTROLE POSITIVO da guarda acima: refazer o MESMO comando não pode
+    travar o usuário — senão a guarda vira cadeado de 10 minutos."""
+    import db as _db
+    from core.handlers import pending as h_pending
+
+    for alvo in ("viagem", "carro"):
+        h_pending.pergunta_guardando_contexto(
+            uid, "pockets.deposit", {"pocket_name": alvo},
+            f"Qual o valor? ({alvo})", f"guardei na caixinha {alvo}", falta="amount")
+
+    viva = _db.get_pending_action(uid)
+    assert viva["payload"]["entities"]["pocket_name"] == "carro", "a repetição não substituiu"
+
+
+# ── want_all e nome literal (Codex P2 no #184) ──────────────────────────────
+
+def test_esvaziar_preserva_o_marcador_de_tudo(uid):
+    """`want_all` é derivado do `text` pelos handlers de saque. Passar a resposta
+    curta como texto perdia "esvaziar" e o bot pedia um valor."""
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False,
+    )
+    _conversa(uid, "criar caixinha viagem", "coloquei 300 na caixinha viagem")
+    respostas = _conversa(uid, "esvaziar caixinha", "viagem")
+
+    assert "esvaziada" in respostas[-1], respostas[-1]
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("viagem") == 0.00
+
+
+def test_nome_literal_com_a_palavra_caixinha(uid):
+    """Caixinha criada pelo dashboard com "caixinha" DENTRO do nome. Recortar
+    sempre respondia "Caixinha *viagem* não encontrada"; quem desempata é o
+    catálogo do usuário."""
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False,
+    )
+    respostas = _conversa(uid, "criar caixinha minha caixinha viagem",
+                          "guardei na caixinha viagem", "minha caixinha viagem", "200")
+
+    assert "Depósito na caixinha" in respostas[-1], respostas[-1]
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("minha caixinha viagem") == 200.00
 
 
 # ── As duas pontas da fonte única (§0.7) ────────────────────────────────────

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -342,6 +342,70 @@ def test_saque_generico_a_resposta_nao_vira_despesa(uid):
     assert round(float(db.get_balance(uid)), 2) == 0.00
 
 
+# ── 3a rodada do Codex (#184) ───────────────────────────────────────────────
+
+def test_nome_de_alvo_com_digitos_nao_vira_valor(uid):
+    """Caixinha "meta 2028": o 2028 é parte do NOME, não o valor do saque.
+
+    Medido antes do conserto, com R$ 500 na caixinha: o bot respondia "Saldo
+    insuficiente na caixinha *meta 2028*" — ou seja, tentou sacar R$ 2.028 sem
+    perguntar quanto. Com saldo maior teria sacado. Codex P1.
+    """
+    db.add_launch_and_update_balance(
+        uid, "receita", 1000.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False,
+    )
+    _conversa(uid, "criar caixinha meta 2028", "coloquei 500 na caixinha meta 2028")
+    respostas = _conversa(uid, "tirar da caixinha", "meta 2028")
+
+    assert "Qual o valor" in respostas[-1], respostas[-1]
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("meta 2028") == 500.00, "sacou sem perguntar o valor"
+
+
+def test_claim_perde_para_pergunta_que_chegou_no_meio(uid):
+    """A decisão e a escrita têm de ser o MESMO compare-and-swap.
+
+    Simula a corrida: entre a leitura da linha e a gravação, outra tarefa põe uma
+    pergunta nova. Sem o CAS sobre a linha lida, o `claim_pending_action` a
+    releria, veria `clarification == clarification` e sobrescreveria a pergunta
+    que o usuário acabou de ver. Codex P1, 3a rodada.
+    """
+    import db as _db
+    from core.handlers import pending as h_pending
+
+    # A linha que a nossa pergunta VAI ler: mesma intent+falta, então passa na guarda.
+    _db.claim_pending_action(uid, "clarification", {
+        "intent": "pockets.deposit", "entities": {}, "question": "Qual caixinha? (velha)",
+        "orig_text": "guardei", "falta": "pocket_name",
+    })
+    lida = _db.get_pending_action(uid)
+
+    # ... e outra tarefa troca a linha DEPOIS dessa leitura.
+    original = _db.get_pending_action
+
+    def _le_e_depois_atropela(u):
+        _db.get_pending_action = original          # só intercepta a 1a leitura
+        _db.set_pending_action(u, "clarification", {
+            "intent": "investments.withdraw", "entities": {},
+            "question": "De qual investimento? (nova)", "orig_text": "resgatar",
+            "falta": "investment_name",
+        })
+        return lida
+
+    _db.get_pending_action = _le_e_depois_atropela
+    try:
+        resposta = h_pending.pergunta_guardando_contexto(
+            uid, "pockets.deposit", {}, "Qual caixinha? (nossa)", "guardei",
+            falta="pocket_name")
+    finally:
+        _db.get_pending_action = original
+
+    viva = _db.get_pending_action(uid)
+    assert viva["payload"]["question"] == "De qual investimento? (nova)",         "a pergunta que chegou no meio foi sobrescrita"
+    assert "outra pergunta minha" in resposta
+
+
 # ── As duas pontas da fonte única (§0.7) ────────────────────────────────────
 
 _ARQUIVOS_COM_PERGUNTA = (


### PR DESCRIPTION
Fatia A da issue #136. As fatias B e C seguem abertas — a issue **não** deve ser fechada com este PR.

## O problema

Nove perguntas de handler devolviam a pergunta como string **crua**, sem guardar que a tinham feito. A resposta seguinte era classificada do zero, e um número solto virava `launches.add` com confiança 0,95.

Medido na `main` c917f1c, conta nova, **sem IA no caminho** — e isso muda a leitura do problema: não é a IA sequestrando a resposta, é o bot **determinístico** sequestrando a resposta da própria pergunta.

```
criar caixinha viagem       -> caixinha criada
guardei na caixinha viagem  -> "Qual caixinha?"
200 reais                   -> "Em que você gastou R$ 200,00?"
viagem                      -> despesa R$ 200 'lazer', SALDO -200,00, caixinha intacta em 0
```

No **saque o sinal ainda invertia**: quem pedia para TIRAR R$ 100 da caixinha terminava com o saldo R$ 100 **menor**. A issue não registra esse detalhe.

## Inventário (§2): são 9 portas, não 5

A issue conta 5 perguntas "de valor". A varredura por **construto** achou 9 — e a que o repro de fato atinge é `"Qual caixinha?"`, que a issue não lista. Consertar só as de valor deixaria a vizinha aberta, que é o erro que o §2 descreve.

| arquivo | portas |
|---|---|
| `core/handlers/pockets.py` | 4 — depósito (nome, valor), saque (nome, valor) |
| `core/handlers/investments.py` | 3 — aporte (valor), resgate (nome, valor) |
| `core/intent_router.py` | 2 — saque genérico (valor, alvo) |

`test_toda_pergunta_declara_intent_conhecida_e_falta` varre com `ast` e prende as **duas** pontas: quem chama tem de estar no `_INTENTS_PERGUNTA_DE_HANDLER` e gravar `falta`; e o conjunto não pode ter intent órfã.

## O conserto

`h_pending.pergunta_guardando_contexto` — o lado **escritor** do `get_pending_clarification` que já existia no mesmo arquivo, porque a forma do payload é uma só (§0.7). `core/handlers/recurring.py:97` já era a implementação de referência; **nenhum tipo de pendência novo** — `clarification` já existe e já está no `_REGISTRO`.

Usa `claim_pending_action` (ordem de prioridade), não `set_pending_action` cru: uma pergunta não pode atropelar outra que o usuário já está lendo na tela. Claim perdido devolve "responda a outra primeiro", mesma regra que `bills.pergunta_de_valor_sem_contexto` já mediu para os 19 tipos vivos.

## Três decisões que a medição forçou

1. **Combinar texto está descartado.** O padrão do `funds.add_ask` (`orig_text + resposta`, reclassifica) funciona no depósito e **quebra no saque**: `"tirar da caixinha viagem 100 reais"` faz o parser ler o nome como `"viagem 100 reais"`. Trocaria um bug por outro. O valor entra pela *entity*.
2. **Qual entidade falta é gravado, não inferido.** O aporte pergunta o valor primeiro, a caixinha pergunta o nome primeiro. Deduzir erraria em metade dos casos. O payload carrega `falta`.
3. **O ramo roda antes da reclassificação por IA.** Já sabemos o que perguntamos. Deixar o LLM redecidir reintroduziria o mesmo sequestro — e só para o usuário **Pro**, que é quem paga.

Recusa mantém a pergunta viva, mesmo contrato das 4 portas do #140: `valor_perigoso` reusado, `create_pending_action_if_absent` (o consumo no topo da função já apagou a linha; upsert atropelaria pergunta nova).

## Controles

**Negativo, medido.** Desligadas as duas primeiras perguntas de caixinha, ficam vermelhos com a mensagem do próprio bug:

```
FAILED test_deposito_nao_vira_despesa_fantasma  - a resposta à pergunta virou despesa avulsa
FAILED test_saque_nao_vira_despesa_fantasma
```

O controle negativo pegou um **teste tautológico meu**: a primeira versão mandava `"viagem"` antes de `"200 reais"` — a ordem do fluxo *já consertado* — e passava com o conserto desligado. A ordem que reproduz é a da issue: valor antes da descrição. Está anotado no teste para não voltar.

**Positivo.** `test_deposito_legitimo_ainda_funciona`: com saldo de R$ 500, o depósito de R$ 200 fecha — caixinha 200, conta 300, zero despesas. O conserto *restringe*, então sem este caso um código que recusasse tudo passaria nos negativos.

**Suíte comparada por nome (§3), mesma árvore:**

| | falhas | passam | erros |
|---|---|---|---|
| baseline `c917f1c` | 20 | 5161 | 2 |
| este branch | 20 | 5170 (+9, os novos) | 2 |

Conjunto de nomes **idêntico**. As 20 são pré-existentes e nenhuma na área tocada (19 de `test_fuso_do_app.py`, que depende de `time.tzset()` e não roda no Windows; 2+1 de artefatos de Windows já conhecidos). O CI Linux é a confirmação.

## O que NÃO foi verificado

- **O LLM está fora do caminho nos testes.** O ramo roda antes da IA de propósito, mas o comportamento do usuário Pro **não foi exercitado aqui**. Quem exercita é `scripts/whatsapp_qa_vault_harness.py`, que chama a API de verdade, tem custo e roda sob demanda.
- **Limitação conhecida:** responder `"200 reais"` a `"Qual caixinha?"` agora grava o nome `"200 reais"` e o fluxo fica pedindo o valor até o usuário cancelar ou mandar outro comando. **Nenhum dinheiro se move** — estritamente melhor que gravar R$ 200 de despesa — mas é um beco. A raiz é outra: o parser não extrai `viagem` de `"guardei na caixinha viagem"`, que é por isso que a primeira pergunta acontece. Issue separada, fora deste PR.
- **Discord** (11 perguntas) e as fatias **B** (3 de apagar) e **C** (4 que perdem a operação) seguem abertas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
