### PR TITLE
prova (descartável): o gate reprova quem mexe no SW sem bumpar

### DIFF
--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -14,6 +14,7 @@
 // v9: o `activate` apaga todo cache de nome diferente deste, então bumpar a
 // versão é o que REMOVE do aparelho o que o v8 já tinha guardado. Não é
 // cosmético — sem o bump, a lista nova só impede gravação NOVA e o dado
+// (linha de prova do gate — este commit NÃO bumpa de propósito)
 // privado que já está lá continua lá.
 const CACHE_NAME = "pigbank-v9";
 

--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -16,7 +16,7 @@
 // cosmético — sem o bump, a lista nova só impede gravação NOVA e o dado
 // (linha de prova do gate — este commit NÃO bumpa de propósito)
 // privado que já está lá continua lá.
-const CACHE_NAME = "pigbank-v9";
+const CACHE_NAME = "pigbank-v10";
 
 // Pré-cache do casco. O Chart.js do cdnjs SAIU daqui de propósito:
 // `cache.addAll` rejeita INTEIRO se qualquer item falhar, então CDN fora do ar,

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -170,14 +170,14 @@ test("CACHE_NAME subiu — é o que apaga do aparelho o que a versão anterior g
 test("o activate apaga todo cache de nome diferente", async () => {
   const apagados = [];
   const { ctx, handlers } = carregaSW();
-  ctx.caches.keys = async () => ["pigbank-v7", "pigbank-v8", "pigbank-v9"];
+  ctx.caches.keys = async () => ["pigbank-v8", "pigbank-v9", "pigbank-v10"];
   ctx.caches.delete = async (k) => { apagados.push(k); return true; };
 
   let pendente;
   await handlers.activate({ waitUntil: (p) => { pendente = p; } });
   await pendente;
 
-  assert.deepEqual(apagados.sort(), ["pigbank-v7", "pigbank-v8"]);
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"]);
 });
 
 // ── A limpeza no logout ──────────────────────────────────────────────────


### PR DESCRIPTION
PR **descartável**, para o aceite nº 2 do #197. Não mergear — vai ser fechado.

- **commit 1** (este): altera um comentário do `frontend/service-worker.js` e não bumpa. Espera-se o job `frontend` **VERMELHO**, no step `Gate do CACHE_NAME do service worker`.
- **commit 2** (a seguir): `pigbank-v9` → `pigbank-v10`. Espera-se **VERDE**.