### PR TITLE
prova (descartável): o ::warning quando o gate não reconhece a base

### DIFF
--- a/frontend/service-worker.js
+++ b/frontend/service-worker.js
@@ -15,11 +15,8 @@
 // versão é o que REMOVE do aparelho o que o v8 já tinha guardado. Não é
 // cosmético — sem o bump, a lista nova só impede gravação NOVA e o dado
 // privado que já está lá continua lá.
+// (head normaliza a forma e mexe no SW; a base é que está malformada)
 const CACHE_NAME = "pigbank-v9";
-
-/* linha morta de prova (o JS ignora, o grep do gate não):
-const CACHE_NAME = "pigbank-v0";
-*/
 
 // Pré-cache do casco. O Chart.js do cdnjs SAIU daqui de propósito:
 // `cache.addAll` rejeita INTEIRO se qualquer item falhar, então CDN fora do ar,


### PR DESCRIPTION
PR **descartável**, para o aceite nº 3 do #197. Não mergear.

A base (`ci/gate-prova-base`) tem uma declaração morta dentro de um bloco `/* */` com valor divergente. O gate não reconhece UMA declaração na base, então **aprova sem comparar** e emite `::warning`. Espera-se job `frontend` **VERDE** e o aviso **renderizado** — é o que separa esse caminho de um verde comum.