### PR TITLE
docs: sem o bump do CACHE_NAME o que fica velho é o cache, não o worker

### DIFF
--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -162,8 +162,10 @@ com `Cache-Control: no-cache` (`frontend/routes/static_pages.py`), o `install` e
 `install` complete, o worker novo assume com ou sem bump.
 
 O que o bump faz é apagar o **conteúdo**: o `activate` só apaga cache de nome DIFERENTE
-do atual. Sem bumpar, a lista nova de precache só impede gravação NOVA, e o que a versão
-anterior guardou — inclusive dado privado — continua no aparelho.
+do atual. Sem bumpar, a regra nova só alcança gravação NOVA — e quem decide o que entra é
+a allowlist do `podeCachear`, não o `PRECACHE`: item tirado do precache que a allowlist
+ainda aceita volta a ser cacheado em runtime, e é o caso do Chart.js. O que a versão
+anterior já guardou — inclusive dado privado — continua no aparelho.
 
 ### `pending_actions`: uma linha por usuário, ~100 lugares mexendo nela
 

--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -153,8 +153,17 @@ outro módulo não pode receber `immutable` enquanto não tiver hash no nome.
 HTML e auth nunca são cacheados, assets são network-first com fallback de cache,
 API e WebSocket passam direto. O `manifest.json` tem `start_url: "/login"` — e a
 `index.html` tem um guard no topo que manda a PWA instalada para `/login`, com saída
-por `?site=1`. Mexeu na estratégia de cache? Bumpe o `CACHE_NAME`, senão o aparelho
-que já instalou continua com o SW velho.
+por `?site=1`. Mexeu na estratégia de cache? Bumpe o `CACHE_NAME` — e o CI reprova quem esquecer,
+desde o #197.
+
+**Não é para entregar o código novo.** Isso já acontece sozinho: a rota serve o arquivo
+com `Cache-Control: no-cache` (`frontend/routes/static_pages.py`), o `install` encadeia
+`skipWaiting()` depois do `addAll` e o `activate` chama `clients.claim()`. Desde que o
+`install` complete, o worker novo assume com ou sem bump.
+
+O que o bump faz é apagar o **conteúdo**: o `activate` só apaga cache de nome DIFERENTE
+do atual. Sem bumpar, a lista nova de precache só impede gravação NOVA, e o que a versão
+anterior guardou — inclusive dado privado — continua no aparelho.
 
 ### `pending_actions`: uma linha por usuário, ~100 lugares mexendo nela
 


### PR DESCRIPTION
Fecha #200. Um arquivo, um commit, só prosa.

O \`docs/armadilhas.md\` afirmava que sem bumpar o \`CACHE_NAME\` "o aparelho que já instalou continua com o SW velho". Não é o que acontece — o worker novo assume com ou sem bump:

- a rota serve o arquivo com \`Cache-Control: no-cache\` (\`frontend/routes/static_pages.py\`);
- o \`install\` encadeia \`skipWaiting()\` depois do \`addAll\`;
- o \`activate\` chama \`clients.claim()\`.

O que **sobrevive** sem o bump é o CONTEÚDO cacheado sob o mesmo nome, porque o \`activate\` só apaga cache de nome diferente do atual.

A distinção importa: é a diferença entre "o usuário não recebe a correção" (falso) e "o dado privado que a versão anterior guardou continua no aparelho" (verdadeiro, e é o motivo do gate mergeado no #197).

O \`CLAUDE.md\` §5 já tinha virado ponteiro e não carregava mais a frase; sobrou no \`docs/armadilhas.md\`.

**Verificado:** nada a rodar — é documentação. O comportamento afirmado no texto novo é o mesmo que o #197 mediu e que está no comentário do step do gate.