### PR TITLE
ci: o CACHE_NAME passa a ter de AVANÇAR, e o piso que envelhecia sai

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,10 +179,24 @@ jobs:
       #    do 'Re-run jobs': o re-run repete o payload do evento, então
       #    head.sha e merge ref vêm do mesmo lugar e não se defasam por isso.
       #
-      # Estes dois são os limites de ESCOPO. Os limites de LEITURA do arquivo
+      # 3. REMOVER o service worker não é barrado aqui, e sim por um irmão.
+      #    O ramo que sai 0 quando o `$SW` não está na árvore do head parece
+      #    autorizar apagar ou renomear o worker — não autoriza, mas quem
+      #    garante é outro check: `tests/frontend/sw_cache_privado.test.mjs` faz
+      #    `readFileSync` de caminho fixo, então some o arquivo e o step
+      #    `Run frontend tests` (mesmo job, três steps adiante) fica vermelho.
+      #    Medido: 11 dos 28 testes daquele arquivo quebram com ENOENT, tanto
+      #    apagando quanto renomeando. Se um dia aquele teste deixar de ler o
+      #    arquivo, este ramo passa a ser um buraco de verdade.
+      #    O risco de fundo continua sem dono: `CacheStorage` sobrevive à
+      #    desregistração do worker, então remover o SW deixa o conteúdo do
+      #    cache atual no aparelho. Isso não se resolve por gate de CI — pede um
+      #    deploy de limpeza, que é código de runtime.
+      #
+      # Estes três são os limites de ESCOPO. Os limites de LEITURA do arquivo
       # ficam onde doem, no corpo do step: o comentário `ponytail:` no ramo da
-      # base (`export const` e BOM não são reconhecidos) e o teto do
-      # `CACHE_NAME = ""` na comparação final.
+      # base (três formas não são reconhecidas) e o teto do `CACHE_NAME = ""` na
+      # comparação final.
       # ────────────────────────────────────────────────────────────────────
       - name: Gate do CACHE_NAME do service worker
         if: github.event_name == 'pull_request'
@@ -330,11 +344,17 @@ jobs:
             # isso o aviso não afirma que o valor era indeterminável. rc 1 (não
             # consegui LER) continua reprovando.
             #
-            # ponytail: heurística de grep ancorado, não parser de JS. Teto:
-            # `export const` e BOM antes da declaração passam sem comparação. Alargar o DECL
-            # reintroduz a classe do A2 (comentário casando como declaração); se
-            # o teto incomodar, o upgrade é ler a constante com node, que este
-            # job já tem instalado para o `npm run test:frontend`.
+            # ponytail: heurística de grep ancorado, não parser de JS. Três
+            # formas de base passam sem comparação: `export const`, BOM antes da
+            # declaração, e declaração MORTA dentro de bloco `/* */` com valor
+            # divergente — esta última é a que dói, porque o JS ignora a linha e
+            # o grep não, então um bump de verdade se perde no ::warning. Só é
+            # alcançável se a BASE já estiver assim (pelo head o gate reprova com
+            # DUAS_DECL), e a única porta para isso é push direto na main, onde o
+            # `if:` deste step o desliga. Alargar o DECL reintroduz a classe do
+            # A2 (comentário casando como declaração); se o teto incomodar, o
+            # upgrade é ler a constante com node, que este job já tem instalado
+            # para o `npm run test:frontend`.
             case "$RC" in
               0) ;;
               3|4)
@@ -346,6 +366,30 @@ jobs:
 
           if [ "$NOVA" = "$VELHA" ]; then
             echo "::error file=$SW,title=CACHE_NAME não foi bumpado::$SW mudou neste PR e o CACHE_NAME continua \"$NOVA\". O activate apaga todo cache de nome diferente do atual, então bumpar a versão é o que REMOVE do aparelho o que a anterior já tinha guardado: sem o bump, a lista nova só impede gravação NOVA e o dado privado que já está lá continua lá. Não confunda com entregar o código novo — isso já acontece sozinho, por no-cache na rota mais skipWaiting e clients.claim. Bumpe para o próximo pigbank-vN ou justifique na thread do PR."
+            exit 1
+          fi
+
+          # Exigir AVANÇO, e não só mudança. Só vale quando os DOIS lados usam
+          # o esquema `pigbank-vN`: fora dele não existe ordem definida, e
+          # inventar uma faria o gate reprovar bump legítimo no dia em que o
+          # esquema mudar (`pigbank-2026-08`, um hash de build) — que é o modo
+          # de falha que o ramo do ::warning acima existe para evitar. Fora do
+          # esquema, desigualdade continua sendo o que se exige.
+          #
+          # O `10#` força base decimal: sem ele um `pigbank-v09` estouraria como
+          # octal inválido em vez de comparar. Ele também é o que faz `v9` e
+          # `v09` colidirem em 9 e caírem no `-le` — dois nomes de texto
+          # diferente para a MESMA versão não são bump.
+          versao() {
+            case "$1" in pigbank-v*) ;; *) return 1 ;; esac
+            local n=${1#pigbank-v}
+            case "$n" in ''|*[!0-9]*) return 1 ;; esac
+            printf '%s' "$((10#$n))"
+          }
+          NN=$(versao "$NOVA") && RCN=0 || RCN=$?
+          VN=$(versao "$VELHA") && RCV=0 || RCV=$?
+          if [ "$RCN" -eq 0 ] && [ "$RCV" -eq 0 ] && [ "$NN" -le "$VN" ]; then
+            echo "::error file=$SW,title=CACHE_NAME regrediu::$SW mudou neste PR e o CACHE_NAME foi de \"$VELHA\" para \"$NOVA\", que não avança. O activate só apaga cache de nome DIFERENTE do atual, então voltar para um nome já usado faz o aparelho que ainda tem aquele cache reusar o conteúdo antigo — inclusive o dado privado que o bump anterior tinha tirado de circulação. Bumpe para um pigbank-vN maior que $VN. (Nomes de texto diferente e mesmo número, como v9 e v09, contam como a mesma versão: o cache tem UM nome só, e não é o texto da declaração.)"
             exit 1
           fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,8 +114,10 @@ jobs:
       # Mexeu no service-worker.js e não bumpou o CACHE_NAME? O `activate` apaga
       # todo cache de nome diferente do atual (`service-worker.js:89`), então
       # bumpar é o que REMOVE do aparelho o que a versão anterior já guardou.
-      # Sem o bump, a lista nova só impede gravação NOVA e o dado privado que já
-      # está lá continua lá. A regra era só prosa no CLAUDE.md; aqui ela reprova.
+      # Sem o bump, a regra nova só alcança gravação NOVA — e quem decide isso é
+      # a allowlist do `podeCachear`, não o `PRECACHE`: item tirado do precache
+      # que a allowlist ainda aceita volta a ser cacheado em runtime, como o
+      # Chart.js. O dado privado que já está lá continua lá. A regra era só prosa no CLAUDE.md; aqui ela reprova.
       #
       # O que o bump NÃO faz: entregar o código novo. Isso já acontece sozinho —
       # a rota serve o arquivo com `Cache-Control: no-cache`
@@ -365,7 +367,7 @@ jobs:
           fi
 
           if [ "$NOVA" = "$VELHA" ]; then
-            echo "::error file=$SW,title=CACHE_NAME não foi bumpado::$SW mudou neste PR e o CACHE_NAME continua \"$NOVA\". O activate apaga todo cache de nome diferente do atual, então bumpar a versão é o que REMOVE do aparelho o que a anterior já tinha guardado: sem o bump, a lista nova só impede gravação NOVA e o dado privado que já está lá continua lá. Não confunda com entregar o código novo — isso já acontece sozinho, por no-cache na rota mais skipWaiting e clients.claim. Bumpe para o próximo pigbank-vN ou justifique na thread do PR."
+            echo "::error file=$SW,title=CACHE_NAME não foi bumpado::$SW mudou neste PR e o CACHE_NAME continua \"$NOVA\". O activate apaga todo cache de nome diferente do atual, então bumpar a versão é o que REMOVE do aparelho o que a anterior já tinha guardado: sem o bump, a regra nova só alcança gravação NOVA — e quem decide isso é a allowlist do podeCachear, não o PRECACHE: item tirado do precache que a allowlist ainda aceita volta a ser cacheado em runtime, como o Chart.js. O dado privado que já está lá continua lá. Não confunda com entregar o código novo — isso já acontece sozinho, por no-cache na rota mais skipWaiting e clients.claim. Bumpe para o próximo pigbank-vN ou justifique na thread do PR."
             exit 1
           fi
 
@@ -384,6 +386,13 @@ jobs:
             case "$1" in pigbank-v*) ;; *) return 1 ;; esac
             local n=${1#pigbank-v}
             case "$n" in ''|*[!0-9]*) return 1 ;; esac
+            # Teto de 18 dígitos: o inteiro do shell é 64 bits com sinal e
+            # ESTOURA EM SILÊNCIO. Medido: 19 noves viram -8446744073709551617,
+            # e aí o `-le` inverte a ordem — reprovaria um avanço legítimo, ou
+            # aprovaria uma regressão. Acima do teto o nome cai fora do esquema
+            # e volta a valer só desigualdade: melhor não comparar do que
+            # comparar errado.
+            [ "${#n}" -le 18 ] || return 1
             printf '%s' "$((10#$n))"
           }
           NN=$(versao "$NOVA") && RCN=0 || RCN=$?

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -30,6 +30,13 @@ import vm from "node:vm";
 const SW = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend", "service-worker.js");
 const ORIGEM = "https://pigbankai.com";
 
+// A versão que este arquivo assume ser o cache ATUAL. Um número só, num lugar
+// só: bumpar o CACHE_NAME sem mexer aqui derruba o teste da declaração, logo
+// abaixo. Antes havia um piso (`>= 9`) que precisava ser levantado à mão e
+// deixava de significar "não regrediu" no bump seguinte — número fixo que
+// envelhece em silêncio é o que o CLAUDE.md §2 manda não escrever.
+const VERSAO_ATUAL = 9;
+
 /**
  * Roda o service-worker.js num contexto falso e devolve o que precisamos:
  * o `podeCachear`, os handlers registrados e o CACHE_NAME.
@@ -155,22 +162,36 @@ test("o CDN saiu do PRECACHE — addAll rejeita inteiro se um item falhar", () =
   assert.ok(!bloco.includes("cdnjs"), "o CDN voltou pro PRECACHE: a queda dele impede a instalação do worker");
 });
 
-test("CACHE_NAME subiu — é o que apaga do aparelho o que a versão anterior guardou", () => {
+test("CACHE_NAME tem UMA declaração e é a versão que este arquivo assume", () => {
   // Lido do FONTE: `const` no `vm.runInContext` fica no escopo léxico e não
   // vira propriedade do contexto (a `function podeCachear` vira, por ser
-  // declaração de função). Sem o bump, a allowlist só impede gravação nova e o
-  // dado privado que o v8 guardou continua no aparelho.
+  // declaração de função).
+  //
+  // ANCORADA em início de linha, e `matchAll` no lugar de `.match()`: sem as
+  // duas coisas a regex casava declaração COMENTADA (`// const CACHE_NAME =
+  // "pigbank-v8";`) e, como `.match()` devolve a PRIMEIRA ocorrência, uma linha
+  // morta acima da viva fazia o teste ler o valor errado sem reclamar.
+  //
+  // A tolerância de espaçamento é a MESMA do gate de CI (`.github/workflows/
+  // tests.yml`), para os dois não divergirem em silêncio. Sobra de propósito uma
+  // diferença: aqui o esquema `pigbank-vN` é exigido, lá não — lá exigir esquema
+  // travaria o repositório no dia em que o esquema mudasse.
+  //
+  // Que a versão AVANCE quem prova é aquele gate, a cada PR, contra a base de
+  // verdade. Aqui só se prova que ela é UMA, legível, e a que os outros testes
+  // deste arquivo assumem.
   const fonte = readFileSync(SW, "utf-8");
-  const m = fonte.match(/const CACHE_NAME = "(pigbank-v\d+)"/);
-  assert.ok(m, "CACHE_NAME sumiu ou mudou de forma");
-  assert.ok(Number(m[1].replace("pigbank-v", "")) >= 9,
-            `CACHE_NAME precisa passar de v8 para apagar o cache antigo, veio ${m[1]}`);
+  const achados = [...fonte.matchAll(/^[ \t]*const[ \t]+CACHE_NAME[ \t]*=[ \t]*"(pigbank-v\d+)"/gm)];
+  assert.equal(achados.length, 1,
+               `esperava UMA declaração 'const CACHE_NAME = "pigbank-vN"' em início de linha no service-worker.js, achei ${achados.length}`);
+  assert.equal(achados[0][1], `pigbank-v${VERSAO_ATUAL}`,
+               `o CACHE_NAME é ${achados[0][1]} e este arquivo assume pigbank-v${VERSAO_ATUAL}: bumpou o worker, atualize o VERSAO_ATUAL junto`);
 });
 
 test("o activate apaga todo cache de nome diferente", async () => {
   const apagados = [];
   const { ctx, handlers } = carregaSW();
-  ctx.caches.keys = async () => ["pigbank-v7", "pigbank-v8", "pigbank-v9"];
+  ctx.caches.keys = async () => ["pigbank-v7", "pigbank-v8", `pigbank-v${VERSAO_ATUAL}`];
   ctx.caches.delete = async (k) => { apagados.push(k); return true; };
 
   let pendente;


### PR DESCRIPTION
Fecha #201, #202 e #203. Dois arquivos, um commit — as três andam juntas: o piso fixo do teste só pode cair depois que o gate souber exigir avanço, senão a cobertura some junto.

## #203 — o gate exige AVANÇO, não só mudança

Antes, com a base em `pigbank-v10`, um PR podia voltar para `pigbank-v9` e passar. Agora compara o número — **mas só quando os dois lados usam o esquema `pigbank-vN`**. Fora dele não existe ordem definida, e inventar uma faria o gate reprovar bump legítimo no dia em que o esquema mudasse (`pigbank-2026-08`, um hash de build), que é o modo de falha que o ramo do `::warning` existe para evitar.

| caso | rc | |
|---|---|---|
| `v9 → v10` | 0 | avança |
| `v10 → v9` | **1** | `::error CACHE_NAME regrediu` |
| `v10 → v8` | **1** | idem |
| `v9 → v09` | **1** | mesmo número, textos diferentes |
| `pigbank-2026-09 → pigbank-2026-08` | 0 | fora do esquema, desigualdade basta |
| só a base no esquema / só o head | 0 | idem |
| base sem o arquivo → `v10` | 0 | não há valor antigo a comparar |

**Controle negativo:** com a checagem removida, `v10 → v9` e `v9 → v09` dão **rc 0** — o gate aprova a regressão. Discrimina.

O `10#` força base decimal: sem ele um `v09` estouraria como octal inválido em vez de comparar. É também o que faz `v9` e `v09` colidirem em 9 — dois textos diferentes para a MESMA versão não são bump, porque o cache tem um nome só e não é o texto da declaração.

## #201 — a regex do teste vira ancorada, e o piso sai

A regex de `sw_cache_privado.test.mjs` não era ancorada, então casava declaração **comentada**; como `.match()` devolve a primeira ocorrência, uma linha morta acima da viva fazia o teste ler o valor errado sem reclamar.

**Controle**, com `// const CACHE_NAME = "pigbank-v10";` acima de uma declaração viva **regredida** para `pigbank-v8`:

| | lê | veredito |
|---|---|---|
| regex antiga | `pigbank-v10` | piso `>= 9` **passa** — verde sobre um SW regredido |
| regex nova | `pigbank-v8` | **reprova** |

E o piso `>= 9` saiu. Ele precisava ser levantado à mão a cada bump e deixava de significar "não regrediu" já no bump seguinte — número fixo que envelhece em silêncio, que é o que o `CLAUDE.md` §2 manda não escrever. No lugar entrou um `VERSAO_ATUAL` único, compartilhado pelo teste da declaração e pelo do `activate`: **bumpar sem atualizá-lo derruba os dois** (medido). Quem prova que a versão AVANÇA passa a ser o gate, contra a base de verdade, a cada PR — uma fonte só (§0.7).

A tolerância de espaçamento da regex nova é a **mesma** do gate, para os dois não divergirem em silêncio: `const  CACHE_NAME  =  "..."` agora passa nos dois, e `export const` reprova nos dois. Sobra de propósito uma diferença: aqui o esquema `pigbank-vN` é exigido, lá não.

## #202 — dois tetos que o comentário não nomeava

- o `ponytail:` passa a citar a terceira forma que escapa: **declaração morta dentro de bloco `/* */` com valor divergente** — o JS ignora a linha, o grep não, e um bump de verdade se perde no `::warning`. Só é alcançável se a BASE já estiver assim, e a única porta é push direto na main, onde o `if:` desliga o step;
- o bloco `LIMITES ACEITOS` ganha o nº 3: **remover ou renomear o SW é barrado por um irmão, não por este gate**. `sw_cache_privado.test.mjs` lê caminho fixo, então some o arquivo e 11 dos 28 testes quebram com ENOENT, no mesmo job, três steps adiante. Se um dia aquele teste deixar de ler o arquivo, o ramo vira buraco de verdade.

## Verificação

- **Regressão do #197 re-rodada inteira**: 19 casos, rc a rc idênticos.
- **`npm run test:frontend`**: 190 tests, 190 pass, 0 fail.
- **`pytest -q`**: 10 failed, 5220 passed, 1 xfailed. As 10 são **preexistentes** — rodei a suíte também num worktree limpo em `origin/main` e a lista de nomes é **idêntica** (`diff` vazio). São todas de fuso/dia (`test_fuso_do_app`, `test_dia_das_listagens_no_fuso`, `test_category_launches_query`) mais uma de NLP, e nenhum teste de pytest lê os dois arquivos deste PR.
- **`bash -n`** limpo, YAML parseia com `yaml.safe_load`.

**Não verificado:** o comportamento do runner (`actions/checkout`, `bash -e {0}`, renderização das annotations) — quem prova é o run deste PR. `grep`/`sed`/`sort` locais são ugrep/BSD/Apple e o runner tem GNU: validação local é sinal, não prova. PR de fork e PR em conflito real continuam sem medição.
