### PR TITLE
test: os nomes antigos do teste do activate saem do VERSAO_ATUAL

### DIFF
--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -191,14 +191,19 @@ test("CACHE_NAME tem UMA declaração e é a versão que este arquivo assume", (
 test("o activate apaga todo cache de nome diferente", async () => {
   const apagados = [];
   const { ctx, handlers } = carregaSW();
-  ctx.caches.keys = async () => ["pigbank-v7", "pigbank-v8", `pigbank-v${VERSAO_ATUAL}`];
+  // Os nomes antigos saem do VERSAO_ATUAL, não fixos: com "pigbank-v7" e
+  // "pigbank-v8" escritos à mão ao lado de um atual derivado, VERSAO_ATUAL em 7
+  // ou 8 COLIDIA — o cache atual aparecia duas vezes na lista, o activate não o
+  // apagava, e o teste ficava vermelho sem ter nada a ver com o que ele mede.
+  const ANTIGOS = [`pigbank-v${VERSAO_ATUAL - 2}`, `pigbank-v${VERSAO_ATUAL - 1}`];
+  ctx.caches.keys = async () => [...ANTIGOS, `pigbank-v${VERSAO_ATUAL}`];
   ctx.caches.delete = async (k) => { apagados.push(k); return true; };
 
   let pendente;
   await handlers.activate({ waitUntil: (p) => { pendente = p; } });
   await pendente;
 
-  assert.deepEqual(apagados.sort(), ["pigbank-v7", "pigbank-v8"]);
+  assert.deepEqual(apagados.sort(), [...ANTIGOS].sort());
 });
 
 // ── A limpeza no logout ──────────────────────────────────────────────────


### PR DESCRIPTION
Defeito que **entrou no #205** e que a prova do gate (#206) expôs. Um arquivo, um commit.

Ao derivar o cache ATUAL do `VERSAO_ATUAL`, os antigos ficaram fixos em `pigbank-v7` e `pigbank-v8` ao lado dele. Com `VERSAO_ATUAL` em 7 ou 8, o mesmo nome entrava duas vezes na lista, o `activate` não o apagava (é o cache atual), e o teste quebrava por motivo que não tem nada a ver com o que ele mede.

Não é hipotético: no #206 a prova da regressão teve de ir para `pigbank-v6` em vez de `v8` por causa disso.

**Controle**, com o `CACHE_NAME` acompanhando o `VERSAO_ATUAL`:

| valor | antes (main) | depois |
|---|---|---|
| v7 | **rc=1** | rc=0 |
| v8 | **rc=1** | rc=0 |
| v9 | rc=0 | rc=0 |
| v10 | rc=0 | rc=0 |
| v11 | rc=0 | rc=0 |

**E o teste continua medindo** — controle de mutação no `service-worker.js`, trocando o `.filter(k => k !== CACHE_NAME)` do `activate`:

| mutante | resultado |
|---|---|
| `k => true` (apaga tudo, inclusive o atual) | teste **vermelho** |
| `k => false` (não apaga nada) | teste **vermelho** |

**Verificado:** `node --test tests/frontend/sw_cache_privado.test.mjs` → 28 tests, 28 pass, 0 fail. Um arquivo de teste; `pytest` não o lê.