### PR TITLE
[NÃO MERGEAR — substituído pelo #219] Gate: handler inline resolve no escopo global

### DIFF
--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -128,13 +128,22 @@ escrito aqui: `wc -l frontend/dashboard.js`.
 
 Três fatos que decidem qualquer mexida ali:
 
-- **`dashboard.html` tem 139 handlers inline** (`onclick="abrirX()"`) chamando **86
-  nomes** distintos. Eles funcionam porque o arquivo é script clássico e tudo no topo
-  é global. `settings.html` tem 61 handlers inline e `home.html` tem 11.
-- **Trocar por `<script type="module">` sem mais nada quebra os 139** — módulo tem
-  escopo próprio, os nomes somem do `window`, o botão para de funcionar **sem erro
-  visível**. Enquanto os handlers inline existirem, qualquer divisão precisa devolver
-  os 86 nomes ao `window` e ter teste que compare a lista com o HTML.
+- **O `dashboard.html` é quase todo handler inline** (`onclick="abrirX()"`), e o
+  `settings.html`, o `admin-dashboard.html` e o `home.html` também têm. Eles funcionam
+  porque os arquivos são script clássico e tudo no topo é global. Quantos são sai de
+  `grep -oE 'on[a-z]+="' frontend/<pagina>.html | wc -l`; os números que estavam
+  escritos aqui diziam 139 e 61 quando o real era 144 e 55.
+- **Trocar por `<script type="module">` sem mais nada quebra todos eles** — módulo tem
+  escopo próprio, os nomes somem do escopo global, e o botão para de funcionar **sem
+  erro visível**: nada no console, só o clique que não faz nada. Um IIFE em volta do
+  arquivo faz o mesmo.
+
+  **Esse teste agora existe**: `tests/frontend/handlers_inline.test.mjs` sobe cada
+  página no Chromium e pergunta ao motor se cada nome resolve. Duas armadilhas de
+  medição estão pagas lá dentro, e valem para quem for mexer: `typeof window[nome]`
+  dá falso negativo (`const` no topo não vira propriedade de `window`, mas o handler
+  o enxerga), e página que redireciona sem backend mede zero — o teste reprova nos
+  dois casos em vez de aprovar calado.
 - **Esses handlers inline são também o que segura o `'unsafe-inline'`** no
   `script-src` da CSP. A Fase 1 já tirou o `<script>` inline; matar os handlers é o
   que falta para fechar o `script-src`.

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -74,10 +74,22 @@ const NATIVO = new Set([
  */
 const semStrings = (s) => s.replace(/'[^']*'/g, "''").replace(/&quot;[^&]*&quot;/g, "");
 
+/**
+ * Tira as interpolações `${...}`: o que está DENTRO delas roda na GERAÇÃO do
+ * markup, no escopo de quem gera, e não no clique.
+ *
+ * Em `onclick="openCardEditModal(${escapeHtmlSafe(JSON.stringify(c))})"` só
+ * `openCardEditModal` precisa existir no escopo global; o `escapeHtmlSafe` é
+ * ajudante do gerador. Sem tirar, o dia em que o `dashboard.js` virar módulo com os
+ * pontos de entrada exportados, o teste reprovaria por causa dos ajudantes — que é
+ * falso positivo, e falso positivo trava PR legítimo.
+ */
+const semInterpolacao = (s) => s.replace(/\$\{[^}]*\}/g, "");
+
 function nomesDe(trechos) {
   const nomes = new Set();
   for (const t of trechos) {
-    for (const c of semStrings(t).matchAll(CHAMADA)) {
+    for (const c of semInterpolacao(semStrings(t)).matchAll(CHAMADA)) {
       if (!NATIVO.has(c[1])) nomes.add(c[1]);
     }
   }

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * Handler inline só funciona se o nome existir no escopo global.
+ *
+ * `onclick="abrirX()"` não enxerga escopo de módulo nem de IIFE: o navegador
+ * resolve `abrirX` pelo escopo global. Trocar um `<script>` clássico por
+ * `<script type="module">`, ou embrulhar o arquivo num IIFE, faz **o botão parar
+ * de funcionar sem erro nenhum** — nada no console, nada vermelho, só o clique
+ * que não faz nada. É a armadilha que o `docs/armadilhas.md` já descrevia e
+ * pedia teste: "qualquer divisão precisa devolver os nomes ao `window` e ter
+ * teste que compare a lista com o HTML".
+ *
+ * Este é esse teste, e ele NÃO lê o JS: sobe a página no Chromium e pergunta ao
+ * próprio motor se o nome resolve. Duas armadilhas de medição, as duas pagas na
+ * construção:
+ *
+ * 1. **`typeof window[nome]` está errado.** `const $id = ...` no topo de um
+ *    script clássico NÃO vira propriedade de `window`, mas o handler inline o
+ *    enxerga pelo escopo global léxico. A pergunta certa é `typeof <nome>`.
+ * 2. **Página que redireciona mede nada.** Sem backend, `settings.html` saía
+ *    para o login antes de carregar os scripts, e as 31 funções "sumiam". Por
+ *    isso o teste REPROVA se a página navegou ou se não carregou script nenhum,
+ *    em vez de aprovar em silêncio.
+ *
+ * Rodar:  npm run test:frontend
+ *         (ou: node --test tests/frontend/handlers_inline.test.mjs)
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+// Porta PRÓPRIA: `node --test tests/frontend/*.test.mjs` roda os arquivos em
+// paralelo, e o padrão daqui é uma porta ímpar por teste (8899, 8901 … 8909, todas
+// tomadas). Reusar uma derruba o OUTRO teste com "http.server morreu" — foi o que
+// aconteceu quando este arquivo nasceu com a 8907, a mesma do onboarding_visibility.
+const PORT = Number(process.env.PB_HANDLERS_TEST_PORT || 8911);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Páginas públicas: fingir sessão VÁLIDA manda o login embora para /home. */
+const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos.html"]);
+
+const HANDLER = /\bon[a-z]+\s*=\s*"([^"]*)"/gi;
+const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g;
+
+/** Nome que o navegador já traz, ou que não é chamada de função do autor. */
+const NATIVO = new Set([
+  "if", "for", "while", "switch", "catch", "return", "typeof", "new", "function",
+  "alert", "confirm", "prompt", "parseInt", "parseFloat", "Number", "String",
+  "Boolean", "Array", "Object", "JSON", "Math", "Date", "setTimeout",
+  "setInterval", "encodeURIComponent", "decodeURIComponent", "console", "event",
+  "this", "void", "delete", "require",
+]);
+
+/**
+ * Esvazia as strings do handler ANTES de procurar chamada.
+ *
+ * Sem isto, `'Use exatamente 4 números (ou deixe vazio).'` rendia o
+ * "identificador" `meros`: o `\w` do JavaScript é ASCII, então o `ú` corta o
+ * nome e o `(` logo depois completa o engano.
+ */
+const semStrings = (s) => s.replace(/'[^']*'/g, "''").replace(/&quot;[^&]*&quot;/g, "");
+
+function nomesChamados(html) {
+  const nomes = new Set();
+  for (const m of html.matchAll(HANDLER)) {
+    for (const c of semStrings(m[1]).matchAll(CHAMADA)) {
+      if (!NATIVO.has(c[1])) nomes.add(c[1]);
+    }
+  }
+  return [...nomes].sort();
+}
+
+async function startServer() {
+  const proc = spawn(
+    "python3",
+    ["-m", "http.server", String(PORT), "--bind", "127.0.0.1", "--directory", FRONTEND],
+    { stdio: "ignore" },
+  );
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    if (proc.exitCode !== null) throw new Error(`http.server morreu (porta ${PORT} ocupada?)`);
+    try { if ((await fetch(`${ORIGIN}/index.html`)).ok) return proc; } catch { /* subindo */ }
+  }
+  proc.kill();
+  throw new Error(`http.server não subiu em ${ORIGIN}`);
+}
+
+let server, browser;
+before(async () => { server = await startServer(); browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/** Só as páginas que TÊM handler inline; as outras não têm o que provar. */
+const PAGINAS = readdirSync(FRONTEND)
+  .filter((f) => f.endsWith(".html"))
+  .map((f) => [f, nomesChamados(readFileSync(join(FRONTEND, f), "utf-8"))])
+  .filter(([, nomes]) => nomes.length);
+
+test("há páginas com handler inline para verificar", () => {
+  // Se o extrator quebrar, os testes abaixo passariam medindo lista vazia.
+  assert.ok(PAGINAS.length >= 5, `esperava várias páginas com handler inline, achei ${PAGINAS.length}`);
+});
+
+for (const [pagina, nomes] of PAGINAS) {
+  test(`${pagina}: os ${nomes.length} nomes dos handlers inline existem no escopo global`, async () => {
+    const page = await browser.newPage();
+    const autenticado = !SEM_SESSAO.has(pagina);
+    // O alvo é o ESCOPO, não a autenticação nem a rede: sem estes stubs a página
+    // navega para o login e o teste mediria uma página que nem carregou.
+    await page.route("**/auth/**", (r) => r.fulfill({
+      status: autenticado ? 200 : 401,
+      contentType: "application/json",
+      body: JSON.stringify(autenticado
+        ? { ok: true, valid: true, authenticated: true, user_id: 1, user: { id: 1, name: "t", email: "t@t" } }
+        : { detail: "sem sessão" }),
+    }));
+    await page.route("**/cdn.pluggy.ai/**", (r) => r.fulfill({
+      status: 200, contentType: "application/javascript", body: "window.PluggyConnect=function(){};",
+    }));
+    await page.route("**/api/**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: "{}" }));
+
+    try {
+      await page.goto(`${ORIGIN}/${pagina}`, { waitUntil: "load" }).catch(() => {});
+      await sleep(700);
+
+      // Premissa antes da medição: página que saiu daqui, ou que não rodou script
+      // nenhum, não prova nada sobre escopo — e aprovaria em silêncio.
+      const url = page.url();
+      assert.ok(url.includes(pagina), `a página navegou para ${url.replace(ORIGIN, "")} — o teste mediria outra coisa`);
+      const scripts = await page.evaluate(() => document.scripts.length);
+      assert.ok(scripts > 0, `${pagina} carregou 0 scripts — nada a medir`);
+
+      // `typeof <nome>`, e não `window[nome]`: const/let no topo de script
+      // clássico não viram propriedade de window, mas o handler inline os vê.
+      const faltando = await page.evaluate(
+        (ns) => ns.filter((n) => {
+          try { return new Function(`return typeof ${n}`)() !== "function"; } catch { return true; }
+        }),
+        nomes,
+      );
+      assert.deepEqual(faltando, [],
+        `handler inline de ${pagina} chama nome que não existe no escopo global: ${faltando.join(", ")}. ` +
+        "O clique falha em silêncio. Se o script virou módulo ou ganhou IIFE, devolva os nomes ao escopo global.");
+    } finally {
+      await page.close();
+    }
+  });
+}

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -88,13 +88,39 @@ function valorDoHandler(texto, i) {
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
 // forma literal específica, e o modo de falha é deixar de achar, nunca inventar.
 const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*["'`]([^"'`]+)["'`]/gi;
-// POSIÇÃO DE CHAMADA: início do handler, ou depois de `;` — o que o clique de fato
-// invoca. Pegar todo identificador seguido de `(` cobrava também o ajudante aninhado
-// num argumento (`entry(${ajuda(x)})`), que roda na geração. Medido: restringir NÃO
-// perde nada — 150, 16, 31 e 8 nomes continuam iguais — e torna inofensiva qualquer
-// imperfeição do `semInterpolacao`, porque o que está dentro de argumento nunca
-// chega a ser cobrado.
-const CHAMADA = /(?:^|;)\s*(?:await\s+)?([A-Za-z_$][\w$]*)\s*\(/g;
+const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/y;
+
+/**
+ * As funções que o CLIQUE invoca: identificador seguido de `(` em profundidade ZERO
+ * de parênteses.
+ *
+ * Pegar todo identificador seguido de `(` cobrava o ajudante aninhado num argumento
+ * (`entry(${ajuda(x)})`), que roda na geração — falso positivo. Exigir início de
+ * comando ou `;` corrigia isso mas perdia a chamada GUARDADA, que é comum aqui:
+ * `onclick="if(event.key==='Enter') quickAddBoleto()"`.
+ *
+ * Profundidade de parênteses resolve os dois: o `if(...)` abre e fecha antes do
+ * `quickAddBoleto`, que fica no nível zero; o `ajuda` de dentro do argumento está no
+ * nível um. Medido nas duas trocas: nenhuma mudou o conjunto de nomes — 150, 31, 16,
+ * 8 e 3 nas cinco páginas —, então isto é robustez, não cobertura nova.
+ */
+function funcoesInvocadas(handler) {
+  const achadas = new Set();
+  let d = 0, i = 0;
+  while (i < handler.length) {
+    CHAMADA.lastIndex = i;
+    const m = CHAMADA.exec(handler);
+    if (m && m.index === i) {
+      if (d === 0 && !NATIVO.has(m[1])) achadas.add(m[1]);
+      i = CHAMADA.lastIndex; d++;
+      continue;
+    }
+    if (handler[i] === "(") d++;
+    else if (handler[i] === ")") d = Math.max(0, d - 1);
+    i++;
+  }
+  return achadas;
+}
 
 /**
  * Identificador NU passado como argumento: `startCheckout(currentCycle, this, 'x')`.
@@ -142,7 +168,7 @@ function nomesDe(trechos) {
   const variaveis = new Set();
   for (const t of trechos) {
     const limpo = semInterpolacao(semStrings(t));
-    for (const c of limpo.matchAll(CHAMADA)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
+    for (const n of funcoesInvocadas(limpo)) funcoes.add(n);
     for (const a of limpo.matchAll(ARGUMENTO)) {
       for (const tok of a[1].split(",")) {
         const n = tok.trim();

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -48,7 +48,7 @@ const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos
 
 // Onde um handler COMEÇA. O valor não sai daqui — sai do `valorDoHandler`, que
 // varre até o delimitador de fechamento tratando `${...}` como opaco.
-const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`])/gi;
+const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`]|(?=[A-Za-z_$]))/gi;
 
 /**
  * O valor do handler que começa em `i`, **sem** as interpolações.
@@ -77,10 +77,13 @@ const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`])/gi;
  * filtrar por posição: uma versão anterior filtrava por profundidade de parênteses e
  * perdia exatamente esse caso.
  */
-function valorDoHandler(texto, i) {
-  const escapado = texto[i] === "\\";
-  const delim = texto[escapado ? i + 1 : i];
-  let j = escapado ? i + 2 : i + 1;
+function valorDoHandler(texto, i, semAspas = false) {
+  const escapado = !semAspas && texto[i] === "\\";
+  // HTML aceita valor sem aspas (`onclick=doLogin(event)`), e o navegador executa
+  // igual. Sem este ramo, trocar a forma citada pela não-citada tirava o handler da
+  // extração sem uma linha vermelha. Aí o fim do valor é espaço em branco ou `>`.
+  const delim = semAspas ? null : texto[escapado ? i + 1 : i];
+  let j = semAspas ? i : escapado ? i + 2 : i + 1;
   let prof = 0, aspa = null, out = "";
   while (j < texto.length) {
     const c = texto[j];
@@ -94,7 +97,7 @@ function valorDoHandler(texto, i) {
       continue;                       // conteúdo da interpolação NÃO entra
     }
     if (c === "$" && texto[j + 1] === "{") { prof = 1; j += 2; continue; }
-    if (c === delim) break;
+    if (delim === null ? /[\s>]/.test(c) : c === delim) break;
     out += c; j++;
   }
   return out;
@@ -106,6 +109,17 @@ function valorDoHandler(texto, i) {
 // forma literal específica, e o modo de falha é deixar de achar, nunca inventar.
 const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*["'`]([^"'`]+)["'`]/gi;
 const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g;
+
+/**
+ * `window.algumaCoisa()` num handler É um global, e o `CHAMADA` o descartava junto com
+ * `event.stopPropagation()` — o lookbehind não distingue receptor nativo de `window`.
+ *
+ * Só `window.`, de propósito: cobrar toda chamada de membro acusaria
+ * `this.setCustomValidity()`, `parcelas.find()` e `document.getElementById()`, que são
+ * 22 dos 24 membros chamados nos handlers de hoje e não são globais nenhum. O ganho
+ * está em `window.X`, onde o `X` é exatamente o que some quando o script vira módulo.
+ */
+const CHAMADA_WINDOW = /\bwindow\.([A-Za-z_$][\w$]*)\s*\(/g;
 
 /**
  * Identificador NU passado como argumento: `startCheckout(currentCycle, this, 'x')`.
@@ -143,7 +157,7 @@ const NATIVO = new Set([
  * `\\.` cobre o delimitador escapado dentro da própria string.
  */
 const semStrings = (s) => s
-  .replace(/&quot;[^&]*&quot;/g, "")
+  .replace(/&quot;(?:(?!&quot;)[\s\S])*&quot;/g, "")
   .replace(/'(?:\\.|[^'\\])*'/g, "''")
   .replace(/"(?:\\.|[^"\\])*"/g, '""')
   .replace(/`(?:\\.|[^`\\])*`/g, "``");
@@ -155,6 +169,7 @@ function nomesDe(trechos) {
   for (const t of trechos) {
     const limpo = semStrings(t);
     for (const c of limpo.matchAll(CHAMADA)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
+    for (const c of limpo.matchAll(CHAMADA_WINDOW)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
     for (const a of limpo.matchAll(ARGUMENTO)) {
       for (const tok of a[1].split(",")) {
         const n = tok.trim();
@@ -166,7 +181,8 @@ function nomesDe(trechos) {
 }
 
 const trechosDe = (texto) => [
-  ...[...texto.matchAll(INICIO_HANDLER)].map((m) => valorDoHandler(texto, m.index + m[0].length - m[1].length)),
+  ...[...texto.matchAll(INICIO_HANDLER)].map((m) =>
+    valorDoHandler(texto, m.index + m[0].length - m[1].length, m[1] === "")),
   ...[...texto.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
 ];
 
@@ -175,7 +191,7 @@ function scriptsDaPagina(html) {
   // As DUAS aspas: `src='...'` é HTML equivalente, e reconhecer só a dupla deixaria
   // uma troca neutra de marcação desligar o teste em silêncio — some a cobertura dos
   // nomes que só existem no .js, e a página continua verde.
-  return [...html.matchAll(/<script[^>]+src=(["'])\/?([^"'?]+\.js)/gi)]
+  return [...html.matchAll(/<script[^>]+src\s*=\s*(["'])\/?([^"'?]+\.js)/gi)]
     .map((m) => join(FRONTEND, m[2]))
     .filter((f) => existsSync(f));
 }
@@ -226,8 +242,13 @@ function semComentarios(txt) {
 }
 
 function nomesChamados(html) {
-  const trechos = [...trechosDe(semComentarios(html))];
-  for (const js of scriptsDaPagina(html)) trechos.push(...trechosDe(semComentarios(readFileSync(js, "utf-8"))));
+  const limpo = semComentarios(html);
+  const trechos = [...trechosDe(limpo)];
+  // `scriptsDaPagina(limpo)`, não `(html)`: um `<script src>` dentro de comentário HTML
+  // o navegador NÃO carrega, e ler o arquivo mesmo assim cobraria nomes que a página
+  // não tem — falso positivo. Era regressão minha, introduzida junto com o próprio
+  // `semComentarios`.
+  for (const js of scriptsDaPagina(limpo)) trechos.push(...trechosDe(semComentarios(readFileSync(js, "utf-8"))));
   const { funcoes, variaveis } = nomesDe(trechos);
   return { funcoes: [...funcoes].sort(), variaveis: [...variaveis].sort() };
 }

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -107,7 +107,7 @@ function valorDoHandler(texto, i, semAspas = false) {
 // no admin-dashboard.html e `el.onclick = "..."`. São 10 nomes hoje, todos em
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
 // forma literal específica, e o modo de falha é deixar de achar, nunca inventar.
-const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*["'`]([^"'`]+)["'`]/gi;
+const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/gi;
 const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g;
 
 /**
@@ -128,7 +128,34 @@ const CHAMADA_WINDOW = /\bwindow\.([A-Za-z_$][\w$]*)\s*\(/g;
  * caminho que as funções. Uma instância hoje, no `precos.html`. Só precisa EXISTIR,
  * não ser função, então a verificação é `typeof !== "undefined"`.
  */
-const ARGUMENTO = /\(([^()]*)\)/g;
+/**
+ * Percorre TODA lista de argumento, em todo nível de aninhamento, e devolve os
+ * trechos separados por vírgula do nível de cada uma.
+ *
+ * Era um regex `/\(([^()]*)\)/g`, que só casa a lista mais interna: em
+ * `outer(currentCycle, inner())` ele achava o `()` do `inner` e perdia o
+ * `currentCycle` — justamente o argumento nu que o teste existe para cobrar.
+ * Aninhamento não se resolve com expressão regular; resolve-se com uma pilha.
+ */
+function argumentosDe(t) {
+  const fora = [];
+  const pilha = [];
+  let seg = "";
+  for (const c of t) {
+    if (c === "(") { pilha.push([]); seg = ""; continue; }
+    if (c === ")") {
+      if (!pilha.length) { seg = ""; continue; }
+      const lista = pilha.pop();
+      lista.push(seg);
+      fora.push(...lista);
+      seg = "";
+      continue;
+    }
+    if (c === "," && pilha.length) { pilha[pilha.length - 1].push(seg); seg = ""; continue; }
+    seg += c;
+  }
+  return fora;
+}
 const SO_NOME = /^[A-Za-z_$][\w$]*$/;
 const NAO_E_NOME = new Set(["this", "event", "true", "false", "null", "undefined"]);
 
@@ -156,18 +183,27 @@ const NATIVO = new Set([
  *
  * `\\.` cobre o delimitador escapado dentro da própria string.
  *
- * ENTIDADE VIRA ASPA ANTES DE TUDO. O navegador decodifica `&quot;`, `&#34;`,
- * `&#x22;`, `&apos;`, `&#39;` e `&#x27;` para aspa comum antes de executar o handler,
- * e reconhecer só uma dessas formas rendia nome inventado nas outras — `&#39;` sozinho
- * aparece 9× neste frontend. Decodificar primeiro fecha a categoria inteira, em vez de
- * um padrão por entidade: depois disso existe só o caso das três aspas literais.
+ * ENTIDADE VIRA DELIMITADOR ANTES DE TUDO. O navegador decodifica a referência de
+ * caractere antes de compilar o handler, então `&#39;` e `'` são a mesma coisa para
+ * ele — e reconhecer só algumas formas rendia nome inventado nas outras.
+ *
+ * ENUMERAR AS FORMAS FALHOU DUAS VEZES. Primeiro listei só `&quot;`; depois listei as
+ * seis de `"` e `'` e esqueci a CRASE, apesar de o código tratar três delimitadores.
+ * Então aqui não há lista: decodifica-se QUALQUER referência numérica e, se o
+ * resultado for um dos três delimitadores, ela vira o caractere. O resto fica intacto.
+ * É a regra, não a enumeração — e não tem como esquecer um membro dela.
  */
-const ENTIDADE_ASPA = /&(?:quot|#0*34|#[xX]0*22);/g;
-const ENTIDADE_APOS = /&(?:apos|#0*39|#[xX]0*27);/g;
+const DELIMITADORES = new Set(['"', "'", "`"]);
+const NOMEADAS = { quot: '"', apos: "'", DiacriticalGrave: "`" };
+const REFERENCIA = /&(?:([A-Za-z][A-Za-z0-9]*)|#(\d+)|#[xX]([0-9a-fA-F]+));/g;
 
-const semStrings = (s) => s
-  .replace(ENTIDADE_ASPA, '"')
-  .replace(ENTIDADE_APOS, "'")
+const decodificaDelimitador = (s) =>
+  s.replace(REFERENCIA, (inteira, nome, dec, hex) => {
+    const c = nome ? NOMEADAS[nome] : String.fromCharCode(parseInt(dec ?? hex, dec ? 10 : 16));
+    return c && DELIMITADORES.has(c) ? c : inteira;
+  });
+
+const semStrings = (s) => decodificaDelimitador(s)
   .replace(/'(?:\\.|[^'\\])*'/g, "''")
   .replace(/"(?:\\.|[^"\\])*"/g, '""')
   .replace(/`(?:\\.|[^`\\])*`/g, "``");
@@ -180,11 +216,9 @@ function nomesDe(trechos) {
     const limpo = semStrings(t);
     for (const c of limpo.matchAll(CHAMADA)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
     for (const c of limpo.matchAll(CHAMADA_WINDOW)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
-    for (const a of limpo.matchAll(ARGUMENTO)) {
-      for (const tok of a[1].split(",")) {
-        const n = tok.trim();
-        if (SO_NOME.test(n) && !NAO_E_NOME.has(n) && !NATIVO.has(n)) variaveis.add(n);
-      }
+    for (const tok of argumentosDe(limpo)) {
+      const n = tok.trim();
+      if (SO_NOME.test(n) && !NAO_E_NOME.has(n) && !NATIVO.has(n)) variaveis.add(n);
     }
   }
   return { funcoes, variaveis };
@@ -193,7 +227,7 @@ function nomesDe(trechos) {
 const trechosDe = (texto) => [
   ...[...texto.matchAll(INICIO_HANDLER)].map((m) =>
     valorDoHandler(texto, m.index + m[0].length - m[1].length, m[1] === "")),
-  ...[...texto.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
+  ...[...texto.matchAll(HANDLER_MONTADO)].map((m) => m[2]),
 ];
 
 /** `<script src="/x.js">` -> os arquivos de `frontend/` que a página carrega. */
@@ -205,7 +239,7 @@ function scriptsDaPagina(html) {
   // aspas —, as mesmas que o INICIO_HANDLER reconhece. Faltar qualquer uma deixa uma
   // edição de formatação neutra desligar a cobertura em silêncio, e foi assim que a
   // aspa simples e o espaço em volta do `=` chegaram aqui, um apontamento por vez.
-  return [...html.matchAll(/<script[^>]+src\s*=\s*(?:"\/?([^"?]+\.js)|'\/?([^'?]+\.js)|\/?([^\s"'>?]+\.js))/gi)]
+  return [...html.matchAll(/<script[^>]*\ssrc\s*=\s*(?:"\/?([^"?]+\.js)|'\/?([^'?]+\.js)|\/?([^\s"'>?]+\.js))/gi)]
     .map((m) => join(FRONTEND, m[1] ?? m[2] ?? m[3]))
     .filter((f) => existsSync(f));
 }

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -48,7 +48,7 @@ const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos
 
 // Onde um handler COMEÇA. O valor não sai daqui — sai do `valorDoHandler`, que
 // varre até o delimitador de fechamento tratando `${...}` como opaco.
-const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`]|(?=[A-Za-z_$]))/gi;
+const INICIO_HANDLER = /(?<![-\w$.])on[a-z]+\s*=\s*(\\?["'`]|(?=[A-Za-z_$]))/gi;
 
 /**
  * O valor do handler que começa em `i`, **sem** as interpolações.
@@ -210,8 +210,13 @@ const NOMEADAS = {
   // não-delimitadores comuns, para o guarda do `nomesDe` não descartar trecho legítimo
   amp: "&", lt: "<", gt: ">", nbsp: "\u00a0",
 };
-const REFERENCIA = /&(?:([A-Za-z][A-Za-z0-9]*)|#(\d+)|#[xX]([0-9a-fA-F]+));/g;
-const NOMEADA_DESCONHECIDA = /&([A-Za-z][A-Za-z0-9]*);/g;
+// O `;` é OPCIONAL na numérica — medido no Chromium: `entry(&#39Press (Y)&#39)`
+// chega ao handler como `entry('Press (Y)')`. Na NOMEADA sem `;` a regra do HTML é
+// condicional (`&quotPress` não decodifica, `&quot` no fim decodifica), e regra
+// condicional é exatamente onde minhas listas erram — então ela cai no guarda de
+// desconhecida em vez de eu adivinhar.
+const REFERENCIA = /&(?:([A-Za-z][A-Za-z0-9]*);|#(\d+);?|#[xX]([0-9a-fA-F]+);?)/g;
+const NOMEADA_DESCONHECIDA = /&([A-Za-z][A-Za-z0-9]*);?/g;
 
 const decodificaDelimitador = (s) =>
   s.replace(REFERENCIA, (inteira, nome, dec, hex) => {
@@ -221,7 +226,7 @@ const decodificaDelimitador = (s) =>
 
 /** Sobrou nome que não está no mapa? Então não sei separar string de código aqui. */
 const temReferenciaDesconhecida = (s) =>
-  [...s.matchAll(NOMEADA_DESCONHECIDA)].some((m) => !(m[1] in NOMEADAS));
+  [...s.matchAll(NOMEADA_DESCONHECIDA)].some((m) => !m[0].endsWith(";") || !(m[1] in NOMEADAS));
 
 const semStrings = (s) => decodificaDelimitador(s)
   .replace(/'(?:\\.|[^'\\])*'/g, "''")

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -172,8 +172,11 @@ const trechosDe = (texto) => [
 
 /** `<script src="/x.js">` -> os arquivos de `frontend/` que a página carrega. */
 function scriptsDaPagina(html) {
-  return [...html.matchAll(/<script[^>]+src="\/?([^"?]+\.js)/gi)]
-    .map((m) => join(FRONTEND, m[1]))
+  // As DUAS aspas: `src='...'` é HTML equivalente, e reconhecer só a dupla deixaria
+  // uma troca neutra de marcação desligar o teste em silêncio — some a cobertura dos
+  // nomes que só existem no .js, e a página continua verde.
+  return [...html.matchAll(/<script[^>]+src=(["'])\/?([^"'?]+\.js)/gi)]
+    .map((m) => join(FRONTEND, m[2]))
     .filter((f) => existsSync(f));
 }
 
@@ -185,9 +188,46 @@ function scriptsDaPagina(html) {
  * não mostra e que o DOM também não, porque sem dados aquilo não renderiza. Era o
  * maior ponto cego do teste, maior que o próprio HTML da página.
  */
+/**
+ * Remove COMENTÁRIO antes de procurar handler.
+ *
+ * `trechosDe` varre o .js inteiro, e não sabe distinguir markup gerado de prosa: o
+ * `comecar.js:6` já tem `` `onclick=` `` num comentário de bloco, e um exemplo de
+ * documentação como `onclick="privateHelper()"` faria o teste exigir `privateHelper`
+ * no escopo global sem que exista handler nenhum. É falso positivo — a classe que
+ * reprova código correto.
+ *
+ * A armadilha aqui, e a razão de isto ser um scanner: **o markup gerado mora dentro
+ * de template literal**. Tratar a crase como string a ser descartada apagaria os 72
+ * nomes que o `dashboard.js` emite. Então o scanner só usa o estado de string para
+ * decidir se um `/` inicia comentário — nunca para descartar o conteúdo.
+ *
+ * TETO: literal de expressão regular contendo aspa (`/["']/g`) confunde o estado de
+ * string, e comentário dentro de `${...}` de um template não é visto. Os dois são
+ * raros, e o conjunto de nomes das 7 páginas é idêntico com e sem esta função —
+ * medido, não suposto.
+ */
+function semComentarios(txt) {
+  let out = "", i = 0, aspa = null;
+  while (i < txt.length) {
+    const c = txt[i], d = txt[i + 1];
+    if (aspa) {
+      if (c === "\\") { out += c + (d ?? ""); i += 2; continue; }
+      if (c === aspa) aspa = null;
+      out += c; i++; continue;
+    }
+    if (c === "'" || c === '"' || c === "`") { aspa = c; out += c; i++; continue; }
+    if (c === "/" && d === "*") { i = txt.indexOf("*/", i + 2); i = i < 0 ? txt.length : i + 2; continue; }
+    if (c === "/" && d === "/") { const n = txt.indexOf("\n", i); i = n < 0 ? txt.length : n; continue; }
+    if (txt.startsWith("<!--", i)) { const n = txt.indexOf("-->", i); i = n < 0 ? txt.length : n + 3; continue; }
+    out += c; i++;
+  }
+  return out;
+}
+
 function nomesChamados(html) {
-  const trechos = [...trechosDe(html)];
-  for (const js of scriptsDaPagina(html)) trechos.push(...trechosDe(readFileSync(js, "utf-8")));
+  const trechos = [...trechosDe(semComentarios(html))];
+  for (const js of scriptsDaPagina(html)) trechos.push(...trechosDe(semComentarios(readFileSync(js, "utf-8"))));
   const { funcoes, variaveis } = nomesDe(trechos);
   return { funcoes: [...funcoes].sort(), variaveis: [...variaveis].sort() };
 }

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -46,15 +46,43 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 /** Páginas públicas: fingir sessão VÁLIDA manda o login embora para /home. */
 const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos.html"]);
 
-// Um grupo POR DELIMITADOR — aspa dupla, simples, crase, e a ESCAPADA
-// (`onclick=\\"x()\\"`, que é como um .js escreve handler dentro de string).
-//
-// Uma classe única com os três cortaria o handler na primeira aspa DE DENTRO:
-// `onclick="foo(${bar('x')})"` viraria `foo(${bar(`, e aí o
-// `semInterpolacao` não teria mais o `}` para casar — a interpolação ficaria, e o
-// `bar` seria cobrado como se fosse ponto de entrada. É o mesmo erro que o extrator
-// de URL do gate de rotas cometeu, pela mesma razão.
-const HANDLER = /\bon[a-z]+\s*=\s*(?:\\"((?:[^"\\]|\\[^"])*)\\"|"([^"]*)"|'([^']*)'|`([^`]*)`)/gi;
+// Onde um handler COMEÇA. O valor não sai daqui — sai do `valorDoHandler`, que
+// varre até o delimitador de fechamento tratando `${...}` como opaco.
+const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`])/gi;
+
+/**
+ * O valor do handler que começa em `i`, indo até o delimitador que o fecha.
+ *
+ * Isto é um scanner e não um regex, e a razão está medida: regex por classe de
+ * aspas cortava na primeira aspa de dentro; regex por delimitador cortava quando a
+ * aspa de dentro era IGUAL à de fora — que é o caso de
+ * `onclick="... openCardDeleteModal(${escapeHtmlSafe(JSON.stringify(c.name || ""))})"`
+ * no dashboard.js. Cada versão de regex fechou uma borda e abriu a seguinte; foram
+ * cinco rodadas de revisão até ficar claro que a forma certa é varrer.
+ *
+ * `${...}` é opaco: conta profundidade de chave e não olha aspas lá dentro. Quem
+ * remove o conteúdo é o `semInterpolacao`, depois — aqui só importa não terminar o
+ * handler no meio dele.
+ */
+function valorDoHandler(texto, i) {
+  const escapado = texto[i] === "\\";
+  const delim = texto[escapado ? i + 1 : i];
+  let j = (escapado ? i + 2 : i + 1), prof = 0, out = "";
+  while (j < texto.length) {
+    const c = texto[j];
+    if (prof === 0 && c === "$" && texto[j + 1] === "{") { prof = 1; out += "${"; j += 2; continue; }
+    if (prof > 0) {
+      if (c === "{") prof++;
+      else if (c === "}") prof--;
+      out += c; j++; continue;
+    }
+    if (c === "\\" && escapado && texto[j + 1] === delim) break;
+    if (c === delim) break;
+    out += c; j++;
+  }
+  return out;
+}
+
 // Handler MONTADO, fora de atributo literal: `{ click: "openUsersModal(event)" }`
 // no admin-dashboard.html e `el.onclick = "..."`. São 10 nomes hoje, todos em
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
@@ -103,9 +131,7 @@ function nomesDe(trechos) {
 }
 
 const trechosDe = (texto) => [
-  // `m.slice(1).find(Boolean)`: só um dos quatro grupos casa; os outros vêm
-  // undefined, e um `m[1]` cego pegaria sempre o da aspa escapada.
-  ...[...texto.matchAll(HANDLER)].map((m) => m.slice(1).find(Boolean) || ""),
+  ...[...texto.matchAll(INICIO_HANDLER)].map((m) => valorDoHandler(texto, m.index + m[0].length - m[1].length)),
   ...[...texto.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
 ];
 

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -88,7 +88,24 @@ function valorDoHandler(texto, i) {
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
 // forma literal específica, e o modo de falha é deixar de achar, nunca inventar.
 const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*["'`]([^"'`]+)["'`]/gi;
-const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g;
+// POSIÇÃO DE CHAMADA: início do handler, ou depois de `;` — o que o clique de fato
+// invoca. Pegar todo identificador seguido de `(` cobrava também o ajudante aninhado
+// num argumento (`entry(${ajuda(x)})`), que roda na geração. Medido: restringir NÃO
+// perde nada — 150, 16, 31 e 8 nomes continuam iguais — e torna inofensiva qualquer
+// imperfeição do `semInterpolacao`, porque o que está dentro de argumento nunca
+// chega a ser cobrado.
+const CHAMADA = /(?:^|;)\s*(?:await\s+)?([A-Za-z_$][\w$]*)\s*\(/g;
+
+/**
+ * Identificador NU passado como argumento: `startCheckout(currentCycle, this, 'x')`.
+ *
+ * Ele não é chamado, mas é lido no clique — e some do escopo global pelo mesmo
+ * caminho que as funções. Uma instância hoje, no `precos.html`. Só precisa EXISTIR,
+ * não ser função, então a verificação é `typeof !== "undefined"`.
+ */
+const ARGUMENTO = /\(([^()]*)\)/g;
+const SO_NOME = /^[A-Za-z_$][\w$]*$/;
+const NAO_E_NOME = new Set(["this", "event", "true", "false", "null", "undefined"]);
 
 /** Nome que o navegador já traz, ou que não é chamada de função do autor. */
 const NATIVO = new Set([
@@ -121,13 +138,19 @@ const semStrings = (s) => s.replace(/'[^']*'/g, "''").replace(/&quot;[^&]*&quot;
 const semInterpolacao = (s) => s.replace(/\$\{[^}]*\}/g, "");
 
 function nomesDe(trechos) {
-  const nomes = new Set();
+  const funcoes = new Set();
+  const variaveis = new Set();
   for (const t of trechos) {
-    for (const c of semInterpolacao(semStrings(t)).matchAll(CHAMADA)) {
-      if (!NATIVO.has(c[1])) nomes.add(c[1]);
+    const limpo = semInterpolacao(semStrings(t));
+    for (const c of limpo.matchAll(CHAMADA)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
+    for (const a of limpo.matchAll(ARGUMENTO)) {
+      for (const tok of a[1].split(",")) {
+        const n = tok.trim();
+        if (SO_NOME.test(n) && !NAO_E_NOME.has(n) && !NATIVO.has(n)) variaveis.add(n);
+      }
     }
   }
-  return nomes;
+  return { funcoes, variaveis };
 }
 
 const trechosDe = (texto) => [
@@ -153,7 +176,8 @@ function scriptsDaPagina(html) {
 function nomesChamados(html) {
   const trechos = [...trechosDe(html)];
   for (const js of scriptsDaPagina(html)) trechos.push(...trechosDe(readFileSync(js, "utf-8")));
-  return [...nomesDe(trechos)].sort();
+  const { funcoes, variaveis } = nomesDe(trechos);
+  return { funcoes: [...funcoes].sort(), variaveis: [...variaveis].sort() };
 }
 
 async function startServer() {
@@ -179,14 +203,14 @@ after(async () => { await browser?.close(); server?.kill(); });
 const PAGINAS = readdirSync(FRONTEND)
   .filter((f) => f.endsWith(".html"))
   .map((f) => [f, nomesChamados(readFileSync(join(FRONTEND, f), "utf-8"))])
-  .filter(([, nomes]) => nomes.length);
+  .filter(([, { funcoes, variaveis }]) => funcoes.length || variaveis.length);
 
 test("há páginas com handler inline para verificar", () => {
   // Se o extrator quebrar, os testes abaixo passariam medindo lista vazia.
   assert.ok(PAGINAS.length >= 5, `esperava várias páginas com handler inline, achei ${PAGINAS.length}`);
 });
 
-for (const [pagina, nomes] of PAGINAS) {
+for (const [pagina, { funcoes, variaveis }] of PAGINAS) {
   test(`${pagina}: todo handler inline resolve no escopo global`, async () => {
     const page = await browser.newPage();
     const autenticado = !SEM_SESSAO.has(pagina);
@@ -233,19 +257,32 @@ for (const [pagina, nomes] of PAGINAS) {
         }
         return out;
       });
-      const todos = [...new Set([...nomes, ...nomesDe(doDom)])].sort();
+      const doDomNomes = nomesDe(doDom);
+      const todasFuncoes = [...new Set([...funcoes, ...doDomNomes.funcoes])].sort();
+      const todasVariaveis = [...new Set([...variaveis, ...doDomNomes.variaveis])]
+        .filter((v) => !todasFuncoes.includes(v)).sort();
 
       // `typeof <nome>`, e não `window[nome]`: const/let no topo de script
       // clássico não viram propriedade de window, mas o handler inline os vê.
       const faltando = await page.evaluate(
-        (ns) => ns.filter((n) => {
-          try { return new Function(`return typeof ${n}`)() !== "function"; } catch { return true; }
-        }),
-        todos,
+        ([fns, vars]) => {
+          const resolve = (n, tipo) => {
+            try {
+              const t = new Function(`return typeof ${n}`)();
+              return tipo === "function" ? t === "function" : t !== "undefined";
+            } catch { return false; }
+          };
+          return [
+            ...fns.filter((n) => !resolve(n, "function")),
+            // Argumento nu só precisa EXISTIR — é lido, não chamado.
+            ...vars.filter((n) => !resolve(n, "qualquer")).map((n) => `${n} (argumento)`),
+          ];
+        },
+        [todasFuncoes, todasVariaveis],
       );
       assert.deepEqual(faltando, [],
-        `${pagina}: dos ${todos.length} nomes verificados (${nomes.length} do fonte, ` +
-        `${todos.length - nomes.length} só no DOM), estes não existem no escopo global: ` +
+        `${pagina}: de ${todasFuncoes.length} funções e ${todasVariaveis.length} ` +
+        `argumentos verificados, estes não existem no escopo global: ` +
         `${faltando.join(", ")}. ` +
         "O clique falha em silêncio. Se o script virou módulo ou ganhou IIFE, devolva os nomes ao escopo global.");
     } finally {

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -47,6 +47,11 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos.html"]);
 
 const HANDLER = /\bon[a-z]+\s*=\s*"([^"]*)"/gi;
+// Handler MONTADO, fora de atributo literal: `{ click: "openUsersModal(event)" }`
+// no admin-dashboard.html e `el.onclick = "..."`. São 10 nomes hoje, todos em
+// código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
+// forma literal específica, e o modo de falha é deixar de achar, nunca inventar.
+const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*["'`]([^"'`]+)["'`]/gi;
 const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g;
 
 /** Nome que o navegador já traz, ou que não é chamada de função do autor. */
@@ -67,14 +72,23 @@ const NATIVO = new Set([
  */
 const semStrings = (s) => s.replace(/'[^']*'/g, "''").replace(/&quot;[^&]*&quot;/g, "");
 
-function nomesChamados(html) {
+function nomesDe(trechos) {
   const nomes = new Set();
-  for (const m of html.matchAll(HANDLER)) {
-    for (const c of semStrings(m[1]).matchAll(CHAMADA)) {
+  for (const t of trechos) {
+    for (const c of semStrings(t).matchAll(CHAMADA)) {
       if (!NATIVO.has(c[1])) nomes.add(c[1]);
     }
   }
-  return [...nomes].sort();
+  return nomes;
+}
+
+/** Do FONTE: atributo literal (inclusive dentro de template string) e handler montado. */
+function nomesChamados(html) {
+  const trechos = [
+    ...[...html.matchAll(HANDLER)].map((m) => m[1]),
+    ...[...html.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
+  ];
+  return [...nomesDe(trechos)].sort();
 }
 
 async function startServer() {
@@ -108,11 +122,19 @@ test("há páginas com handler inline para verificar", () => {
 });
 
 for (const [pagina, nomes] of PAGINAS) {
-  test(`${pagina}: os ${nomes.length} nomes dos handlers inline existem no escopo global`, async () => {
+  test(`${pagina}: todo handler inline resolve no escopo global`, async () => {
     const page = await browser.newPage();
     const autenticado = !SEM_SESSAO.has(pagina);
     // O alvo é o ESCOPO, não a autenticação nem a rede: sem estes stubs a página
     // navega para o login e o teste mediria uma página que nem carregou.
+    //
+    // Os stubs são MÍNIMOS de propósito, e o teto disso está medido: com `{}` em
+    // toda API, o `admin-dashboard.html` renderiza 3 handlers no DOM contra os 27
+    // que o fonte tem — quase tudo dele é gerado a partir de dados. Isso não
+    // enfraquece o teste, porque a lista principal vem do FONTE; a leitura do DOM
+    // é adição. Devolver dados plausíveis por página seria fixture por página, e o
+    // que ela compraria é só a parte que já está coberta pelo outro lado.
+    // (Medido também: com estes stubs, zero erro de página nas três maiores.)
     await page.route("**/auth/**", (r) => r.fulfill({
       status: autenticado ? 200 : 401,
       contentType: "application/json",
@@ -136,16 +158,30 @@ for (const [pagina, nomes] of PAGINAS) {
       const scripts = await page.evaluate(() => document.scripts.length);
       assert.ok(scripts > 0, `${pagina} carregou 0 scripts — nada a medir`);
 
+      // E o que o DOM tiver DEPOIS de renderizar, que o fonte não mostra: handler
+      // posto por script em elemento criado na hora. Só soma — o que não renderizou
+      // com estes stubs mínimos continua coberto pela leitura do fonte.
+      const doDom = await page.evaluate(() => {
+        const out = [];
+        for (const el of document.querySelectorAll("*")) {
+          for (const a of el.attributes) if (/^on[a-z]+$/i.test(a.name)) out.push(a.value);
+        }
+        return out;
+      });
+      const todos = [...new Set([...nomes, ...nomesDe(doDom)])].sort();
+
       // `typeof <nome>`, e não `window[nome]`: const/let no topo de script
       // clássico não viram propriedade de window, mas o handler inline os vê.
       const faltando = await page.evaluate(
         (ns) => ns.filter((n) => {
           try { return new Function(`return typeof ${n}`)() !== "function"; } catch { return true; }
         }),
-        nomes,
+        todos,
       );
       assert.deepEqual(faltando, [],
-        `handler inline de ${pagina} chama nome que não existe no escopo global: ${faltando.join(", ")}. ` +
+        `${pagina}: dos ${todos.length} nomes verificados (${nomes.length} do fonte, ` +
+        `${todos.length - nomes.length} só no DOM), estes não existem no escopo global: ` +
+        `${faltando.join(", ")}. ` +
         "O clique falha em silêncio. Se o script virou módulo ou ganhou IIFE, devolva os nomes ao escopo global.");
     } finally {
       await page.close();

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -133,8 +133,20 @@ const NATIVO = new Set([
  * Sem isto, `'Use exatamente 4 números (ou deixe vazio).'` rendia o
  * "identificador" `meros`: o `\w` do JavaScript é ASCII, então o `ú` corta o
  * nome e o `(` logo depois completa o engano.
+ *
+ * As TRÊS aspas, não só a simples: um handler delimitado por `'` pode conter `"`
+ * à vontade, e `onclick='alert("Press (Y)")'` rendia a função `Press` e a variável
+ * `Y`. Esse é o modo de falha que importa — nome INVENTADO reprova handler correto,
+ * enquanto nome perdido só reduz cobertura. O `dashboard.js` já usa handler de aspa
+ * simples com `"` dentro (linhas 1464 e 1863).
+ *
+ * `\\.` cobre o delimitador escapado dentro da própria string.
  */
-const semStrings = (s) => s.replace(/'[^']*'/g, "''").replace(/&quot;[^&]*&quot;/g, "");
+const semStrings = (s) => s
+  .replace(/&quot;[^&]*&quot;/g, "")
+  .replace(/'(?:\\.|[^'\\])*'/g, "''")
+  .replace(/"(?:\\.|[^"\\])*"/g, '""')
+  .replace(/`(?:\\.|[^`\\])*`/g, "``");
 
 
 function nomesDe(trechos) {

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -51,32 +51,40 @@ const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos
 const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`])/gi;
 
 /**
- * O valor do handler que começa em `i`, indo até o delimitador que o fecha.
+ * O valor do handler que começa em `i`, **sem** as interpolações.
  *
- * Isto é um scanner e não um regex, e a razão está medida: regex por classe de
- * aspas cortava na primeira aspa de dentro; regex por delimitador cortava quando a
- * aspa de dentro era IGUAL à de fora — que é o caso de
- * `onclick="... openCardDeleteModal(${escapeHtmlSafe(JSON.stringify(c.name || ""))})"`
- * no dashboard.js. Cada versão de regex fechou uma borda e abriu a seguinte; foram
- * cinco rodadas de revisão até ficar claro que a forma certa é varrer.
+ * Um scanner, não regex, e cada detalhe aqui foi pago numa rodada de revisão:
  *
- * `${...}` é opaco: conta profundidade de chave e não olha aspas lá dentro. Quem
- * remove o conteúdo é o `semInterpolacao`, depois — aqui só importa não terminar o
- * handler no meio dele.
+ * - varrer até o delimitador de fechamento, porque regex por classe de aspas cortava
+ *   na primeira aspa de dentro, e regex por delimitador cortava quando a aspa de
+ *   dentro era igual à de fora — o caso real é
+ *   `openCardDeleteModal(${escapeHtmlSafe(JSON.stringify(c.name || ""))})`;
+ * - DESCARTAR `${...}`: o que está lá dentro roda na GERAÇÃO do markup, no escopo de
+ *   quem gera, e não no clique. Cobrar isso é falso positivo;
+ * - contar chave respeitando STRING dentro da interpolação, senão um `{` de dentro de
+ *   uma string desequilibra a conta e a interpolação "vaza" para o texto do handler.
+ *
+ * Depois disto o que sobra é literal, e TUDO que sobra roda no clique — inclusive o
+ * `inner` de `outer(inner())`. Por isso a extração seguinte não precisa (e não deve)
+ * filtrar por posição: uma versão anterior filtrava por profundidade de parênteses e
+ * perdia exatamente esse caso.
  */
 function valorDoHandler(texto, i) {
   const escapado = texto[i] === "\\";
   const delim = texto[escapado ? i + 1 : i];
-  let j = (escapado ? i + 2 : i + 1), prof = 0, out = "";
+  let j = escapado ? i + 2 : i + 1;
+  let prof = 0, aspa = null, out = "";
   while (j < texto.length) {
     const c = texto[j];
-    if (prof === 0 && c === "$" && texto[j + 1] === "{") { prof = 1; out += "${"; j += 2; continue; }
     if (prof > 0) {
-      if (c === "{") prof++;
+      if (aspa) { if (c === aspa) aspa = null; }
+      else if (c === '"' || c === "'" || c === "`") aspa = c;
+      else if (c === "{") prof++;
       else if (c === "}") prof--;
-      out += c; j++; continue;
+      j++;
+      continue;                       // conteúdo da interpolação NÃO entra
     }
-    if (c === "\\" && escapado && texto[j + 1] === delim) break;
+    if (c === "$" && texto[j + 1] === "{") { prof = 1; j += 2; continue; }
     if (c === delim) break;
     out += c; j++;
   }
@@ -88,39 +96,7 @@ function valorDoHandler(texto, i) {
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
 // forma literal específica, e o modo de falha é deixar de achar, nunca inventar.
 const HANDLER_MONTADO = /(?:\bclick|\.on[a-z]+)\s*[:=]\s*["'`]([^"'`]+)["'`]/gi;
-const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/y;
-
-/**
- * As funções que o CLIQUE invoca: identificador seguido de `(` em profundidade ZERO
- * de parênteses.
- *
- * Pegar todo identificador seguido de `(` cobrava o ajudante aninhado num argumento
- * (`entry(${ajuda(x)})`), que roda na geração — falso positivo. Exigir início de
- * comando ou `;` corrigia isso mas perdia a chamada GUARDADA, que é comum aqui:
- * `onclick="if(event.key==='Enter') quickAddBoleto()"`.
- *
- * Profundidade de parênteses resolve os dois: o `if(...)` abre e fecha antes do
- * `quickAddBoleto`, que fica no nível zero; o `ajuda` de dentro do argumento está no
- * nível um. Medido nas duas trocas: nenhuma mudou o conjunto de nomes — 150, 31, 16,
- * 8 e 3 nas cinco páginas —, então isto é robustez, não cobertura nova.
- */
-function funcoesInvocadas(handler) {
-  const achadas = new Set();
-  let d = 0, i = 0;
-  while (i < handler.length) {
-    CHAMADA.lastIndex = i;
-    const m = CHAMADA.exec(handler);
-    if (m && m.index === i) {
-      if (d === 0 && !NATIVO.has(m[1])) achadas.add(m[1]);
-      i = CHAMADA.lastIndex; d++;
-      continue;
-    }
-    if (handler[i] === "(") d++;
-    else if (handler[i] === ")") d = Math.max(0, d - 1);
-    i++;
-  }
-  return achadas;
-}
+const CHAMADA = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*\(/g;
 
 /**
  * Identificador NU passado como argumento: `startCheckout(currentCycle, this, 'x')`.
@@ -151,24 +127,13 @@ const NATIVO = new Set([
  */
 const semStrings = (s) => s.replace(/'[^']*'/g, "''").replace(/&quot;[^&]*&quot;/g, "");
 
-/**
- * Tira as interpolações `${...}`: o que está DENTRO delas roda na GERAÇÃO do
- * markup, no escopo de quem gera, e não no clique.
- *
- * Em `onclick="openCardEditModal(${escapeHtmlSafe(JSON.stringify(c))})"` só
- * `openCardEditModal` precisa existir no escopo global; o `escapeHtmlSafe` é
- * ajudante do gerador. Sem tirar, o dia em que o `dashboard.js` virar módulo com os
- * pontos de entrada exportados, o teste reprovaria por causa dos ajudantes — que é
- * falso positivo, e falso positivo trava PR legítimo.
- */
-const semInterpolacao = (s) => s.replace(/\$\{[^}]*\}/g, "");
 
 function nomesDe(trechos) {
   const funcoes = new Set();
   const variaveis = new Set();
   for (const t of trechos) {
-    const limpo = semInterpolacao(semStrings(t));
-    for (const n of funcoesInvocadas(limpo)) funcoes.add(n);
+    const limpo = semStrings(t);
+    for (const c of limpo.matchAll(CHAMADA)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
     for (const a of limpo.matchAll(ARGUMENTO)) {
       for (const tok of a[1].split(",")) {
         const n = tok.trim();

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -27,7 +27,7 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { chromium } from "playwright";
@@ -46,7 +46,9 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 /** Páginas públicas: fingir sessão VÁLIDA manda o login embora para /home. */
 const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos.html"]);
 
-const HANDLER = /\bon[a-z]+\s*=\s*"([^"]*)"/gi;
+// Aspa dupla, simples, crase — e a ESCAPADA (`onclick=\\"x()\\"`), que é como um .js
+// escreve handler dentro de string ao gerar markup.
+const HANDLER = /\bon[a-z]+\s*=\s*(?:\\?["'`])([^"'`\\]*)/gi;
 // Handler MONTADO, fora de atributo literal: `{ click: "openUsersModal(event)" }`
 // no admin-dashboard.html e `el.onclick = "..."`. São 10 nomes hoje, todos em
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
@@ -82,12 +84,29 @@ function nomesDe(trechos) {
   return nomes;
 }
 
-/** Do FONTE: atributo literal (inclusive dentro de template string) e handler montado. */
+const trechosDe = (texto) => [
+  ...[...texto.matchAll(HANDLER)].map((m) => m[1]),
+  ...[...texto.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
+];
+
+/** `<script src="/x.js">` -> os arquivos de `frontend/` que a página carrega. */
+function scriptsDaPagina(html) {
+  return [...html.matchAll(/<script[^>]+src="\/?([^"?]+\.js)/gi)]
+    .map((m) => join(FRONTEND, m[1]))
+    .filter((f) => existsSync(f));
+}
+
+/**
+ * Do FONTE: o HTML **e os .js que ele carrega**.
+ *
+ * Ler só o HTML deixava de fora a maior lista de todas: o `dashboard.js` EMITE 72
+ * nomes em markup gerado a partir de dados (`onclick=\"payBill(...)\"`), que o HTML
+ * não mostra e que o DOM também não, porque sem dados aquilo não renderiza. Era o
+ * maior ponto cego do teste, maior que o próprio HTML da página.
+ */
 function nomesChamados(html) {
-  const trechos = [
-    ...[...html.matchAll(HANDLER)].map((m) => m[1]),
-    ...[...html.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
-  ];
+  const trechos = [...trechosDe(html)];
+  for (const js of scriptsDaPagina(html)) trechos.push(...trechosDe(readFileSync(js, "utf-8")));
   return [...nomesDe(trechos)].sort();
 }
 

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -62,7 +62,15 @@ const INICIO_HANDLER = /\bon[a-z]+\s*=\s*(\\?["'`])/gi;
  * - DESCARTAR `${...}`: o que está lá dentro roda na GERAÇÃO do markup, no escopo de
  *   quem gera, e não no clique. Cobrar isso é falso positivo;
  * - contar chave respeitando STRING dentro da interpolação, senão um `{` de dentro de
- *   uma string desequilibra a conta e a interpolação "vaza" para o texto do handler.
+ *   uma string desequilibra a conta e a interpolação "vaza" para o texto do handler;
+ * - e respeitar a BARRA INVERTIDA dentro dessa string, senão `\"` fecha a string cedo,
+ *   o `}` seguinte zera a profundidade e o resto do handler é perdido.
+ *
+ * TETO DECLARADO: isto é um scanner de uma forma literal, não um lexer de JavaScript.
+ * Ele trata escape um nível fundo, dentro de string dentro de interpolação — o que
+ * cobre o que um gerador de markup escreve. Interpolação aninhada dentro de template
+ * literal dentro de interpolação está fora, e o modo de falha nesse caso é DEIXAR DE
+ * COBRAR um nome, nunca inventar um: o teste não trava PR legítimo por este caminho.
  *
  * Depois disto o que sobra é literal, e TUDO que sobra roda no clique — inclusive o
  * `inner` de `outer(inner())`. Por isso a extração seguinte não precisa (e não deve)
@@ -77,6 +85,7 @@ function valorDoHandler(texto, i) {
   while (j < texto.length) {
     const c = texto[j];
     if (prof > 0) {
+      if (aspa && c === "\\") { j += 2; continue; }   // \" não fecha a string
       if (aspa) { if (c === aspa) aspa = null; }
       else if (c === '"' || c === "'" || c === "`") aspa = c;
       else if (c === "{") prof++;

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -46,9 +46,15 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 /** Páginas públicas: fingir sessão VÁLIDA manda o login embora para /home. */
 const SEM_SESSAO = new Set(["login.html", "cadastro.html", "index.html", "precos.html"]);
 
-// Aspa dupla, simples, crase — e a ESCAPADA (`onclick=\\"x()\\"`), que é como um .js
-// escreve handler dentro de string ao gerar markup.
-const HANDLER = /\bon[a-z]+\s*=\s*(?:\\?["'`])([^"'`\\]*)/gi;
+// Um grupo POR DELIMITADOR — aspa dupla, simples, crase, e a ESCAPADA
+// (`onclick=\\"x()\\"`, que é como um .js escreve handler dentro de string).
+//
+// Uma classe única com os três cortaria o handler na primeira aspa DE DENTRO:
+// `onclick="foo(${bar('x')})"` viraria `foo(${bar(`, e aí o
+// `semInterpolacao` não teria mais o `}` para casar — a interpolação ficaria, e o
+// `bar` seria cobrado como se fosse ponto de entrada. É o mesmo erro que o extrator
+// de URL do gate de rotas cometeu, pela mesma razão.
+const HANDLER = /\bon[a-z]+\s*=\s*(?:\\"((?:[^"\\]|\\[^"])*)\\"|"([^"]*)"|'([^']*)'|`([^`]*)`)/gi;
 // Handler MONTADO, fora de atributo literal: `{ click: "openUsersModal(event)" }`
 // no admin-dashboard.html e `el.onclick = "..."`. São 10 nomes hoje, todos em
 // código que gera markup a partir de dados. Isto NÃO é parsear JS — é casar uma
@@ -97,7 +103,9 @@ function nomesDe(trechos) {
 }
 
 const trechosDe = (texto) => [
-  ...[...texto.matchAll(HANDLER)].map((m) => m[1]),
+  // `m.slice(1).find(Boolean)`: só um dos quatro grupos casa; os outros vêm
+  // undefined, e um `m[1]` cego pegaria sempre o da aspa escapada.
+  ...[...texto.matchAll(HANDLER)].map((m) => m.slice(1).find(Boolean) || ""),
   ...[...texto.matchAll(HANDLER_MONTADO)].map((m) => m[1]),
 ];
 

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -187,21 +187,41 @@ const NATIVO = new Set([
  * caractere antes de compilar o handler, então `&#39;` e `'` são a mesma coisa para
  * ele — e reconhecer só algumas formas rendia nome inventado nas outras.
  *
- * ENUMERAR AS FORMAS FALHOU DUAS VEZES. Primeiro listei só `&quot;`; depois listei as
- * seis de `"` e `'` e esqueci a CRASE, apesar de o código tratar três delimitadores.
- * Então aqui não há lista: decodifica-se QUALQUER referência numérica e, se o
- * resultado for um dos três delimitadores, ela vira o caractere. O resto fica intacto.
- * É a regra, não a enumeração — e não tem como esquecer um membro dela.
+ * ENUMERAR AS FORMAS FALHOU TRÊS VEZES: `&quot;` sozinho; depois as seis de `"` e `'`
+ * sem a CRASE; depois sem os aliases `&QUOT;` e `&grave;`. A lição não é "a lista está
+ * certa agora" — é que uma lista minha não é confiável aqui. Então há DUAS defesas:
+ *
+ * 1. NUMÉRICA é regra, não lista: qualquer `&#N;`/`&#xN;` decodifica de verdade.
+ * 2. NOMEADA é lista MEDIDA NO NAVEGADOR (não de memória) — ver o teste
+ *    "o mapa de referências nomeadas casa com o navegador", que falha se um alias
+ *    novo aparecer ou se um destes deixar de valer.
+ *
+ * E se mesmo assim sobrar uma referência nomeada que eu não conheça, o `nomesDe`
+ * DESCARTA o trecho inteiro em vez de adivinhar (ver lá). O modo de falha vira perder
+ * cobertura, nunca inventar nome — é o lado seguro de errar.
  */
 const DELIMITADORES = new Set(['"', "'", "`"]);
-const NOMEADAS = { quot: '"', apos: "'", DiacriticalGrave: "`" };
+
+/** Medido no Chromium: `&APOS;` e `&GRAVE;` NÃO existem; estes cinco decodificam. */
+const NOMEADAS = {
+  quot: '"', QUOT: '"',
+  apos: "'",
+  grave: "`", DiacriticalGrave: "`",
+  // não-delimitadores comuns, para o guarda do `nomesDe` não descartar trecho legítimo
+  amp: "&", lt: "<", gt: ">", nbsp: "\u00a0",
+};
 const REFERENCIA = /&(?:([A-Za-z][A-Za-z0-9]*)|#(\d+)|#[xX]([0-9a-fA-F]+));/g;
+const NOMEADA_DESCONHECIDA = /&([A-Za-z][A-Za-z0-9]*);/g;
 
 const decodificaDelimitador = (s) =>
   s.replace(REFERENCIA, (inteira, nome, dec, hex) => {
     const c = nome ? NOMEADAS[nome] : String.fromCharCode(parseInt(dec ?? hex, dec ? 10 : 16));
     return c && DELIMITADORES.has(c) ? c : inteira;
   });
+
+/** Sobrou nome que não está no mapa? Então não sei separar string de código aqui. */
+const temReferenciaDesconhecida = (s) =>
+  [...s.matchAll(NOMEADA_DESCONHECIDA)].some((m) => !(m[1] in NOMEADAS));
 
 const semStrings = (s) => decodificaDelimitador(s)
   .replace(/'(?:\\.|[^'\\])*'/g, "''")
@@ -214,6 +234,10 @@ function nomesDe(trechos) {
   const variaveis = new Set();
   for (const t of trechos) {
     const limpo = semStrings(t);
+    // Referência nomeada que o mapa não conhece pode ser um delimitador não
+    // decodificado, e aí o que parece chamada é texto. Descartar o trecho perde
+    // cobertura; adivinhar reprova handler correto. Escolho perder.
+    if (temReferenciaDesconhecida(limpo)) continue;
     for (const c of limpo.matchAll(CHAMADA)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
     for (const c of limpo.matchAll(CHAMADA_WINDOW)) if (!NATIVO.has(c[1])) funcoes.add(c[1]);
     for (const tok of argumentosDe(limpo)) {
@@ -329,6 +353,53 @@ const PAGINAS = readdirSync(FRONTEND)
 test("há páginas com handler inline para verificar", () => {
   // Se o extrator quebrar, os testes abaixo passariam medindo lista vazia.
   assert.ok(PAGINAS.length >= 5, `esperava várias páginas com handler inline, achei ${PAGINAS.length}`);
+});
+
+/**
+ * O `NOMEADAS` duplica um pedaço da tabela de referências do HTML, e o §0.7 do
+ * CLAUDE.md diz que duplicação inevitável precisa de um teste comparando as duas.
+ *
+ * Este é ele — e ele existe porque a lista escrita de memória já saiu errada TRÊS
+ * vezes neste mesmo arquivo. Se um alias novo passar a decodificar para delimitador,
+ * ou se um destes deixar de valer, aqui fica vermelho em vez de virar falso positivo
+ * no gate.
+ */
+test("o mapa de referências nomeadas casa com o navegador", async () => {
+  const page = await browser.newPage();
+  try {
+    await page.setContent("<div></div>");
+    const real = await page.evaluate((nomes) => {
+      const out = {};
+      for (const n of nomes) {
+        const d = document.createElement("div");
+        d.innerHTML = `&${n};`;
+        out[n] = d.textContent;
+      }
+      return out;
+    }, Object.keys(NOMEADAS));
+
+    for (const [nome, esperado] of Object.entries(NOMEADAS)) {
+      assert.equal(real[nome], esperado, `&${nome}; decodifica para ${JSON.stringify(real[nome])}, não ${JSON.stringify(esperado)}`);
+    }
+
+    // E o outro lado: nomes que eu NÃO tenho não podem ser delimitador.
+    const foraDoMapa = ["APOS", "GRAVE", "Quot", "acute", "prime", "lsquo", "rsquo", "ldquo", "rdquo", "sol", "num", "commat"];
+    const deFora = await page.evaluate((nomes) => {
+      const out = {};
+      for (const n of nomes) {
+        const d = document.createElement("div");
+        d.innerHTML = `&${n};`;
+        out[n] = d.textContent;
+      }
+      return out;
+    }, foraDoMapa);
+    for (const [nome, valor] of Object.entries(deFora)) {
+      assert.ok(!DELIMITADORES.has(valor),
+        `&${nome}; decodifica para o delimitador ${JSON.stringify(valor)} e não está no NOMEADAS`);
+    }
+  } finally {
+    await page.close();
+  }
 });
 
 for (const [pagina, { funcoes, variaveis }] of PAGINAS) {

--- a/tests/frontend/handlers_inline.test.mjs
+++ b/tests/frontend/handlers_inline.test.mjs
@@ -155,9 +155,19 @@ const NATIVO = new Set([
  * simples com `"` dentro (linhas 1464 e 1863).
  *
  * `\\.` cobre o delimitador escapado dentro da própria string.
+ *
+ * ENTIDADE VIRA ASPA ANTES DE TUDO. O navegador decodifica `&quot;`, `&#34;`,
+ * `&#x22;`, `&apos;`, `&#39;` e `&#x27;` para aspa comum antes de executar o handler,
+ * e reconhecer só uma dessas formas rendia nome inventado nas outras — `&#39;` sozinho
+ * aparece 9× neste frontend. Decodificar primeiro fecha a categoria inteira, em vez de
+ * um padrão por entidade: depois disso existe só o caso das três aspas literais.
  */
+const ENTIDADE_ASPA = /&(?:quot|#0*34|#[xX]0*22);/g;
+const ENTIDADE_APOS = /&(?:apos|#0*39|#[xX]0*27);/g;
+
 const semStrings = (s) => s
-  .replace(/&quot;(?:(?!&quot;)[\s\S])*&quot;/g, "")
+  .replace(ENTIDADE_ASPA, '"')
+  .replace(ENTIDADE_APOS, "'")
   .replace(/'(?:\\.|[^'\\])*'/g, "''")
   .replace(/"(?:\\.|[^"\\])*"/g, '""')
   .replace(/`(?:\\.|[^`\\])*`/g, "``");
@@ -191,8 +201,12 @@ function scriptsDaPagina(html) {
   // As DUAS aspas: `src='...'` é HTML equivalente, e reconhecer só a dupla deixaria
   // uma troca neutra de marcação desligar o teste em silêncio — some a cobertura dos
   // nomes que só existem no .js, e a página continua verde.
-  return [...html.matchAll(/<script[^>]+src\s*=\s*(["'])\/?([^"'?]+\.js)/gi)]
-    .map((m) => join(FRONTEND, m[2]))
+  // As TRÊS formas de valor de atributo que o HTML aceita — dupla, simples e SEM
+  // aspas —, as mesmas que o INICIO_HANDLER reconhece. Faltar qualquer uma deixa uma
+  // edição de formatação neutra desligar a cobertura em silêncio, e foi assim que a
+  // aspa simples e o espaço em volta do `=` chegaram aqui, um apontamento por vez.
+  return [...html.matchAll(/<script[^>]+src\s*=\s*(?:"\/?([^"?]+\.js)|'\/?([^'?]+\.js)|\/?([^\s"'>?]+\.js))/gi)]
+    .map((m) => join(FRONTEND, m[1] ?? m[2] ?? m[3]))
     .filter((f) => existsSync(f));
 }
 


### PR DESCRIPTION
Etapa 8 do plano do orquestrador. Dois arquivos, um commit.

## O que o teste prova

`onclick="abrirX()"` **não enxerga escopo de módulo nem de IIFE** — o navegador resolve `abrirX` pelo escopo global. Trocar um `<script>` clássico por `<script type="module">`, ou embrulhar o arquivo, faz o botão **parar de funcionar sem erro nenhum**: nada no console, nada vermelho, só o clique que não faz nada.

O `docs/armadilhas.md` já descrevia isso e pedia o teste, com estas palavras: *"qualquer divisão precisa devolver os nomes ao `window` e ter teste que compare a lista com o HTML"*.

**Ele não lê o JS.** Sobe cada página no Chromium e pergunta ao próprio motor se o nome resolve — 150 nomes em 7 páginas, e hoje todos resolvem.

## Controles

Seis, todos discriminando:

| mutante | resultado |
|---|---|
| baseline | 8 passed |
| `<script>` inline do `precos.html` vira `type="module"` — **o caso exato do doc** | 1 failed |
| `dashboard.js` embrulhado em IIFE | 1 failed |
| função do `home.html` renomeada | 1 failed |
| página navega (stub de sessão retirado) | 1 failed — *"a página navegou para /?logout=1"* |
| página sem script nenhum | 1 failed — *"carregou 0 scripts, nada a medir"* |
| extrator quebrado (asserção de sanidade) | 1 failed — *"esperava várias páginas, achei 0"* |

As três últimas são **guardas de premissa**: sem elas o teste aprovaria medindo nada, que é o pior modo de falha possível aqui.

## Três armadilhas de medição, pagas na construção

Todas viraram comentário no arquivo, porque quem for mexer vai tropeçar nelas de novo:

1. **`typeof window[nome]` dá falso negativo.** `const $id = ...` no topo de um script clássico **não** vira propriedade de `window`, mas o handler inline o enxerga pelo escopo global léxico. Minha primeira medição acusou o `$id` do `admin-dashboard.html`, que funciona perfeitamente. A pergunta certa é `typeof <nome>`.
2. **Página que redireciona mede zero.** Sem backend o `settings.html` saía para o login antes de carregar os scripts, e as 31 funções "sumiam". Virou guarda.
3. **O extrator inventava identificador.** `'Use exatamente 4 números (ou deixe vazio).'` rendia `meros` — o `\w` do JavaScript é ASCII, o `ú` corta o nome e o `(` seguinte completa o engano. As strings são esvaziadas antes da busca.

## Porta 8911

O padrão daqui é uma porta ímpar por teste, e 8899–8909 estão tomadas. Este arquivo **nasceu com a 8907** e derrubou o `onboarding_visibility` com `http.server morreu (porta ocupada?)` — os arquivos rodam em paralelo. Está medido e comentado no código.

## `docs/armadilhas.md`

Dizia **139** handlers no dashboard e **61** no settings; o real é **144** e **55**. As contagens saem e entra o comando que as produz (`CLAUDE.md` §2), mais o ponteiro para este teste.

## Verificação

- `npm run test:frontend` → **198 tests, 198 pass, 0 fail** (a `origin/main` dá 190/190; os +8 são estes).
- `pytest -q` → 10 failed, 5222 passed — **preexistentes**, este PR não toca Python.
