### PR TITLE
Trial grátis de 30 para 15 dias

### DIFF
--- a/core/handle_incoming.py
+++ b/core/handle_incoming.py
@@ -503,7 +503,7 @@ def _paywall_gate(msg: IncomingMessage, platform: str) -> list[OutgoingMessage] 
     return [OutgoingMessage(text=(
         "🐷 Oi! Que bom te ver por aqui.\n\n"
         "Pra eu poder cuidar do seu dinheiro, sua conta precisa estar ativa — e "
-        f"dá pra começar com {_bold('30 dias grátis', platform)}, sem cobrança "
+        f"dá pra começar com {_bold('15 dias grátis', platform)}, sem cobrança "
         "agora e cancelando quando quiser.\n\n"
         f"👉 {link}\n\n"
         "Assim que ativar, é só me mandar uma mensagem que eu já começo a anotar "

--- a/core/services/billing_commands.py
+++ b/core/services/billing_commands.py
@@ -96,7 +96,7 @@ def _handle_assinar(user_id: int, platform: str) -> str:
         )
     b = lambda s: _bold(s, platform)
     offer_text = (
-        f"Aqui ó, link pra assinar com {b('30 dias grátis')} "
+        f"Aqui ó, link pra assinar com {b('15 dias grátis')} "
         "(cancela quando quiser, sem cobrança no trial):"
     )
     try:
@@ -181,7 +181,7 @@ def _handle_plano(user_id: int, platform: str) -> str:
                 f"Manda {b('assinar plano')} 🐷✨"
             )
 
-        # Nota: o trial de 30 dias hoje é uma assinatura Stripe do plano escolhido
+        # Nota: o trial de 15 dias hoje é uma assinatura Stripe do plano escolhido
         # (status trialing) — cai no ramo pago abaixo com status_label "Período
         # grátis em andamento" e "Primeira cobrança" na data. Não há mais o
         # estado "Plus sem assinatura" (trial sem cartão).
@@ -242,7 +242,7 @@ def _handle_plano(user_id: int, platform: str) -> str:
         next_label = "Renovação"
     else:
         status_label = {
-            "trialing": "Trial em andamento (30 dias grátis)",
+            "trialing": "Trial em andamento (15 dias grátis)",
             "active": "Ativo",
             "past_due": "Pagamento em atraso",
             "canceled": "Cancelado",

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -181,14 +181,14 @@ def send_plan_change_scheduled_email(to: str, new_plan_name: str, effective_date
 
 
 def send_trial_downsell_email(to: str, dashboard_url: str = "") -> bool:
-    """Fim do trial de 30 dias sem assinatura → downsell pro Essencial.
+    """Fim do trial de 15 dias sem assinatura → downsell pro Essencial.
 
     Parte da escada v2: o teste dá o Plus completo; quem não assina cai pro
     Grátis (banco pausa, agentes silenciam) e este e-mail oferece a saída de
     R$ 9,90 antes do churn. Enviado UMA vez (trial_downsell_sent_at)."""
     base = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
-      <p>Oi! Seus <strong>30 dias de teste do PigBank</strong> chegaram ao fim. 🐷</p>
+      <p>Oi! Seus <strong>15 dias de teste do PigBank</strong> chegaram ao fim. 🐷</p>
       <p>Sua conta continua no plano Grátis: seus dados estão todos guardados,
       mas o banco conectado ficou <strong>pausado</strong> e a Piggy voltou pro modo básico.</p>
       <p>Pra continuar de onde parou:</p>
@@ -631,7 +631,7 @@ def send_reengagement_email(to: str, user_id: int | None = None) -> bool:
 
 def send_free_upgrade_nudge_email(to: str, user_id: int | None = None, dashboard_url: str = "") -> bool:
     """Nudge de conversão (B2) pro usuário Grátis ativo: mostra o que o Plus
-    destrava e convida pros 30 dias de teste. Piggy: entusiasmado, sem pressão."""
+    destrava e convida pros 15 dias de teste. Piggy: entusiasmado, sem pressão."""
     unsub = make_unsub_url(user_id, to) if user_id else ""
     base = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
@@ -643,21 +643,21 @@ def send_free_upgrade_nudge_email(to: str, user_id: int | None = None, dashboard
         <li><strong>Agentes do Piggy</strong> — Xerife, Repórter e Carteiro trabalhando por você</li>
         <li><strong>Histórico ilimitado</strong>, caixinhas e cartões sem limite</li>
       </ul>
-      <p>Dá pra <strong>testar 30 dias grátis</strong> — se não curtir, é só cancelar antes do
+      <p>Dá pra <strong>testar 15 dias grátis</strong> — se não curtir, é só cancelar antes do
          fim e você não paga nada.</p>
       <p style="text-align:center;margin:24px 0"><a class="btn" href="{base}/precos">Testar o Plus grátis</a></p>
       <p class="sig">Te espero lá,<br/><strong>Piggy 🐷</strong></p>
     """
-    html = _piggy_html("Destrave o Plus — 30 dias grátis", content, unsub)
+    html = _piggy_html("Destrave o Plus — 15 dias grátis", content, unsub)
     text = (
         "Oi! Piggy aqui.\n\n"
         "No Plus você destrava Open Finance, os agentes do Piggy e histórico ilimitado. "
-        f"Dá pra testar 30 dias grátis: {base}/precos\n\nTe espero lá, Piggy"
+        f"Dá pra testar 15 dias grátis: {base}/precos\n\nTe espero lá, Piggy"
     )
     headers = unsub_headers(unsub) if unsub else {}
     return send_email(
         to=to,
-        subject="🐷 Destrave o Plus — 30 dias grátis",
+        subject="🐷 Destrave o Plus — 15 dias grátis",
         html_body=html,
         text_body=text,
         from_addr=EMAIL_FROM_PIGGY,
@@ -979,7 +979,7 @@ def send_pro_welcome_email(to: str, trial_end_at, dashboard_url: str = "") -> bo
     cta = f'<p style="text-align:center;margin:24px 0"><a class="btn" href="{dash}/app">🐷 Abrir meu dashboard</a></p>'
     content = f"""
       <p>🐷✨ <strong>Tá dentro do PigBank+!</strong></p>
-      <p>Sua assinatura começou agora. Os <strong>30 dias grátis</strong> vão até <strong>{trial_end}</strong> —
+      <p>Sua assinatura começou agora. Os <strong>15 dias grátis</strong> vão até <strong>{trial_end}</strong> —
       só tem cobrança depois disso, e você pode cancelar quando quiser sem ser cobrado.</p>
       <p>Agora você desbloqueou:</p>
       <ul>
@@ -995,7 +995,7 @@ def send_pro_welcome_email(to: str, trial_end_at, dashboard_url: str = "") -> bo
     html = _base_html("Bem-vindo ao PigBank+", content)
     text = (
         f"PigBank+ ativado!\n\n"
-        f"Sua assinatura começou. 30 dias grátis até {trial_end} — só tem cobrança depois.\n\n"
+        f"Sua assinatura começou. 15 dias grátis até {trial_end} — só tem cobrança depois.\n\n"
         f"Abra o dashboard: {dash}/app\n"
         f"Pra cancelar antes: mande 'cancelar plano' no bot ou acesse {dash}/conta"
     )

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -10,8 +10,8 @@ Dois mundos atrás do flag PLANS_V2_ENABLED (lido dinâmico, sem redeploy):
     banco é ALIAS LEGADO do tier plus (R$ 19,90 — antigo "Pro", hoje "Plus");
     o tier pro novo (R$ 39,90) usa o valor 'pro_max'. Grátis entra no app
     (has_app_access sempre True) e os gates viram por-feature/por-tier.
-    Trial (2026-08-06): 30 dias do PLANO ESCOLHIDO, via Stripe COM CARTÃO
-    (subscription trialing → cobra no dia 31). Escolheu Pro? 30 dias de Pro.
+    Trial (2026-08-06): 15 dias do PLANO ESCOLHIDO, via Stripe COM CARTÃO
+    (subscription trialing → cobra no dia 16). Escolheu Pro? 15 dias de Pro.
     Nasce no checkout, não no cadastro; 1 por telefone na vida (plan_trials).
     Durante o trial o tier vem da coluna `plan` (assinatura vigente), com os
     limites cheios do plano assinado — cadastro novo sem assinatura = Grátis.
@@ -45,7 +45,7 @@ _STORED_PLAN_TO_TIER = {
     "pro_max": "pro",    # tier novo de R$ 39,90 (ainda não vendido)
 }
 
-TRIAL_DAYS_DEFAULT = 30
+TRIAL_DAYS_DEFAULT = 15
 
 
 def plans_v2_enabled() -> bool:
@@ -82,7 +82,7 @@ def get_trial_status(user_id: int, user: dict | None = None) -> dict:
     """{"active": bool, "days_left": int, "started_at": datetime|None}.
 
     Fonte: auth_accounts.trial_started_at (ancorado por telefone via
-    db.plans.claim_trial_for_user — 30 dias únicos por phone_hash, na vida;
+    db.plans.claim_trial_for_user — 15 dias únicos por phone_hash, na vida;
     cartão não zera nem estica)."""
     started = None
     if user is not None and "trial_started_at" in user:

--- a/core/services/trial_downsell.py
+++ b/core/services/trial_downsell.py
@@ -1,7 +1,7 @@
 """
 Downsell do fim do trial (escada v2).
 
-Trial de 30 dias venceu sem virar assinatura → um único e-mail oferecendo o
+Trial de 15 dias venceu sem virar assinatura → um único e-mail oferecendo o
 Essencial (R$ 9,90) antes do churn. Roda junto do tick de expiração de trial
 (mesmo loop do of_trial_expiry). Inerte com PLANS_V2_ENABLED off.
 

--- a/db/plans.py
+++ b/db/plans.py
@@ -1,7 +1,7 @@
 """
 Camada de banco do sistema de planos v2 (escada Grátis/Essencial/Plus/Pro).
 
-Trial de 30 dias do plano escolhido, via Stripe COM CARTÃO (2026-08-06), com
+Trial de 15 dias do plano escolhido, via Stripe COM CARTÃO (2026-08-06), com
 trava de 1 trial por TELEFONE na vida: `plan_trials` é keyed por phone_hash e
 sobrevive à deleção da conta — recriar conta com o mesmo número herda o
 started_at original (trial já queimado). A elegibilidade é checada na criação
@@ -30,7 +30,7 @@ class TrialClaimError(RuntimeError):
 def claim_trial_for_user(user_id: int) -> datetime | None:
     """Ancora o trial do usuário no telefone dele (idempotente).
 
-    Regra fechada: o contador é UM SÓ — 30 dias por telefone, na vida.
+    Regra fechada: o contador é UM SÓ — 15 dias por telefone, na vida.
     - Telefone nunca usou trial → registra now() em plan_trials e ancora a conta.
     - Telefone JÁ usou trial (nesta ou noutra conta, mesmo deletada) → a conta
       herda o started_at ORIGINAL; se o trial já venceu, days_left = 0.
@@ -91,7 +91,7 @@ def claim_trial_for_user(user_id: int) -> datetime | None:
 
 
 def is_trial_eligible_for_user(user_id: int) -> bool:
-    """O telefone deste usuário ainda tem direito ao trial de 30 dias?
+    """O telefone deste usuário ainda tem direito ao trial de 15 dias?
 
     Regra: 1 trial por telefone na vida. Elegível = o phone_hash NUNCA apareceu
     em plan_trials (nesta conta ou em outra, mesmo deletada). Usado na criação

--- a/db/privacy.py
+++ b/db/privacy.py
@@ -538,7 +538,7 @@ def delete_user_data(user_id: int) -> dict:
                     cur.execute("delete from credit_bills where user_id = %s", (user_id,))
 
             # `plan_trials` não aparece em `user_owned_tables` de propósito: a
-            # linha é keyed por phone_hash e segura a trava de 30 dias de teste
+            # linha é keyed por phone_hash e segura a trava de 15 dias de teste
             # por telefone, na vida — apagar devolveria um trial novo a cada
             # conta recriada com o mesmo número. O `user_id` dela é desvinculado
             # pela FK `on delete set null` (db/schema_repairs.py), e não por um

--- a/db/schema.py
+++ b/db/schema.py
@@ -1692,11 +1692,11 @@ def init_db():
         """,
 
         # ── Planos v2 (escada Grátis/Essencial/Plus/Pro) ─────────────────────
-        # Trial de 30 dias do plano escolhido, via Stripe COM CARTÃO (2026-08-06):
+        # Trial de 15 dias do plano escolhido, via Stripe COM CARTÃO (2026-08-06):
         # plan_trials registra a queima do trial por telefone. É keyed por
         # phone_hash e NÃO tem FK pra users de propósito: sobrevive à deleção da
         # conta — recriar conta com o mesmo número herda o started_at original
-        # (trial já queimado). Regra: 30 dias únicos por telefone, na vida.
+        # (trial já queimado). Regra: 15 dias únicos por telefone, na vida.
         """alter table auth_accounts add column if not exists trial_started_at timestamptz""",
         # Downsell do fim do trial: 1 e-mail por conta, na vida.
         """alter table auth_accounts add column if not exists trial_downsell_sent_at timestamptz""",

--- a/db/schema_repairs.py
+++ b/db/schema_repairs.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 _USER_FK_SET_NULL_TABLES: frozenset[str] = frozenset({
     "auth_login_events",
     # Trava de 1 trial por telefone, na vida. A linha é keyed por phone_hash e
-    # PRECISA sobreviver à deleção da conta — cascatear devolveria 30 dias novos
+    # PRECISA sobreviver à deleção da conta — cascatear devolveria 15 dias novos
     # a cada conta recriada com o mesmo número. Estar nesta lista não é detalhe:
     # sem ela, o `repair_user_fk_cascades` abaixo converteria a FK nova para
     # CASCADE na primeira subida e apagaria a trava em silêncio.

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -176,7 +176,7 @@
     <div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap">
       <span style="flex-shrink:0;width:46px;height:46px;border-radius:14px;background:rgba(255,45,142,.16);color:#FF2D8E;display:inline-flex;align-items:center;justify-content:center;font-size:24px"><i class="ph ph-sparkle" aria-hidden="true"></i></span>
       <div style="flex:1;min-width:220px">
-        <div style="color:var(--text);font-weight:600;font-size:1rem;line-height:1.3">Experimente o Plus por 30 dias grátis</div>
+        <div style="color:var(--text);font-weight:600;font-size:1rem;line-height:1.3">Experimente o Plus por 15 dias grátis</div>
         <div style="color:var(--text-2);font-size:.82rem;line-height:1.45;margin-top:3px">Conecte seu banco, ative os agentes e veja seu dinheiro trabalhar. Cancele quando quiser.</div>
         <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:11px">
           <span style="display:inline-flex;align-items:center;gap:5px;font-size:.75rem;color:var(--text);background:rgba(255,255,255,.05);border:1px solid var(--div);padding:4px 9px;border-radius:999px"><i class="ph ph-bank" style="color:var(--neon-ink)" aria-hidden="true"></i> Open Finance</span>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10789,7 +10789,7 @@ function _showAccessError(title, msg) {
         // Paywall/escolha de plano: mesmo veredito da revalidação por WS
         // rejeitado (applyAccessVerdict já limpa snapshot e para o retry).
         if (!applyAccessVerdict(me)) return false;
-        // Banner de trial (B1): oferta dos 30d de Plus pro Grátis sem trial ativo.
+        // Banner de trial (B1): oferta dos 15d de Plus pro Grátis sem trial ativo.
         // Nunca no app iOS (CTA de compra externa fere a diretriz 3.1.1 da Apple).
         if (me && me.plan_tier === "free" && !(me.trial && me.trial.active) && !window.PB_IN_APP) {
           maybeShowTrialBanner();

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -3954,7 +3954,7 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             )
         trial_days = trial_days_total() if eligible else 0
     else:
-        trial_days = int(os.getenv("PRO_TRIAL_DAYS", "30"))
+        trial_days = int(os.getenv("PRO_TRIAL_DAYS", "15"))
 
     # Cota mensal da IA do plano comprado. Plus e Pro têm `ai_monthly_messages:
     # None` em plan_limits.py, o que NÃO é ilimitado: cai no teto global

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -566,7 +566,7 @@ footer a:hover { color:var(--text); }
     <div class="free-banner" id="free-banner">
       <div class="fb-text">
         <span class="fb-emoji"><i class="ph ph-piggy-bank" aria-hidden="true"></i></span>
-        <span>Você está no <b>Free</b>. Suba pro <b>PigBank+</b> e libere <b>conversar com a IA</b>, OFX, investimentos, export e caixinhas ilimitadas. 30 dias grátis.</span>
+        <span>Você está no <b>Free</b>. Suba pro <b>PigBank+</b> e libere <b>conversar com a IA</b>, OFX, investimentos, export e caixinhas ilimitadas. 15 dias grátis.</span>
       </div>
       <a class="fb-cta" href="/precos">Fazer upgrade</a>
     </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -482,12 +482,12 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       <div class="section-head" data-reveal>
         <div class="eyebrow">Planos</div>
         <h2>Escolha seu <span class="grad">PigBank+</span></h2>
-        <p>30 dias grátis pra testar. Cancele quando quiser, sem letras miúdas.</p>
+        <p>15 dias grátis pra testar. Cancele quando quiser, sem letras miúdas.</p>
       </div>
 
       <div class="plan-solo-wrap" data-reveal>
         <article class="plan-solo">
-          <span class="plan-solo-trial">30 dias grátis</span>
+          <span class="plan-solo-trial">15 dias grátis</span>
           <div class="plan-solo-from">Acesse o PigBank por apenas</div>
           <div class="plan-solo-amount">R$ 9,90<span>/mês</span></div>
           <ul class="plan-solo-feats">
@@ -501,7 +501,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         </article>
       </div>
 
-      <p class="plans-note"><i class="ph ph-confetti" aria-hidden="true"></i> 30 dias grátis com cartão; a primeira cobrança só acontece depois do trial. Cancele quando quiser pelo dashboard antes do fim do trial, sem ser cobrado. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
+      <p class="plans-note"><i class="ph ph-confetti" aria-hidden="true"></i> 15 dias grátis com cartão; a primeira cobrança só acontece depois do trial. Cancele quando quiser pelo dashboard antes do fim do trial, sem ser cobrado. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
     </section>
 
     <div class="sec-sep"></div>
@@ -533,7 +533,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">Tem período grátis? <span class="chev">+</span></button>
-          <div class="faq-a"><p>Tem 30 dias grátis pra testar tudo. A primeira cobrança só acontece depois do trial, e você pode cancelar antes sem pagar nada.</p></div>
+          <div class="faq-a"><p>Tem 15 dias grátis pra testar tudo. A primeira cobrança só acontece depois do trial, e você pode cancelar antes sem pagar nada.</p></div>
         </div>
         <div class="faq-item">
           <button class="faq-q" type="button" aria-expanded="false">Como funciona o pagamento? <span class="chev">+</span></button>

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Planos · PigBank</title>
-<meta name="description" content="Planos PigBank: Grátis, Essencial R$ 9,90, Plus R$ 19,90 e Pro R$ 49,90. 30 dias grátis pra testar o plano que você escolher." />
+<meta name="description" content="Planos PigBank: Grátis, Essencial R$ 9,90, Plus R$ 19,90 e Pro R$ 49,90. 15 dias grátis pra testar o plano que você escolher." />
 <link rel="canonical" href="https://pigbankai.com/precos" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -205,7 +205,7 @@
         <img src="/brand/mascot.webp" alt="" style="width:132px;height:auto;display:block;margin:0 auto 18px;filter:drop-shadow(0 10px 26px rgba(0,0,0,.5))" />
         <div class="eyebrow" id="precos-eyebrow">Planos</div>
         <h2 id="precos-title">Escolha seu <span class="grad">PigBank</span></h2>
-        <p id="precos-sub">30 dias grátis pra testar o plano que você escolher. Cancele antes do fim e não paga nada.</p>
+        <p id="precos-sub">15 dias grátis pra testar o plano que você escolher. Cancele antes do fim e não paga nada.</p>
       </div>
 
       <!-- Escada de planos (Grátis/Essencial/Plus/Pro/Premium) — conteúdo ÚNICO
@@ -315,7 +315,7 @@
 
         <p class="plans-note"><i class="ph ph-piggy-bank" aria-hidden="true"></i> <strong>Preço de fundador:</strong> assinando agora, seu valor fica congelado pra sempre: enquanto a assinatura estiver ativa, ele nunca sobe.</p>
       </div>
-      <p class="plans-note" id="plans-note-v2"><i class="ph ph-confetti" aria-hidden="true"></i> Todo plano vem com <strong>30 dias grátis pra testar</strong> (um teste por número). A primeira cobrança só acontece depois do trial. Cancele antes pelo dashboard e não paga nada. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
+      <p class="plans-note" id="plans-note-v2"><i class="ph ph-confetti" aria-hidden="true"></i> Todo plano vem com <strong>15 dias grátis pra testar</strong> (um teste por número). A primeira cobrança só acontece depois do trial. Cancele antes pelo dashboard e não paga nada. Pagamentos processados pela Stripe. A PigBank nunca vê os dados do seu cartão.</p>
       <p class="plans-cta"><a href="#comparar">Ver a comparação completa, recurso por recurso <i class="ph ph-caret-right" aria-hidden="true"></i></a></p>
     </section>
 
@@ -843,7 +843,7 @@ async function applyOnboardingChoice() {
   if (me && me.needs_plan_selection) {
     // Guia visual: deixa claro que precisa escolher um plano pra começar.
     const sub = document.getElementById("precos-sub");
-    if (sub) sub.textContent = "Escolha um plano pra começar: dá pra seguir no Grátis ou testar um plano pago 30 dias de graça.";
+    if (sub) sub.textContent = "Escolha um plano pra começar: dá pra seguir no Grátis ou testar um plano pago 15 dias de graça.";
     ctas.forEach(cta => {
       cta.removeAttribute("href");
       cta.style.cursor = "pointer";

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -627,7 +627,7 @@ async def _enforce_bank_limit(user_id: int, new_item_id: str | None = None) -> N
                     "code": "OF_BANK_LIMIT",
                     "limit": 0,
                     "message": "Conectar banco faz parte dos planos pagos — no Grátis a conexão "
-                               "vale durante os 30 dias de teste. Assine pra reativar: /precos",
+                               "vale durante os 15 dias de teste. Assine pra reativar: /precos",
                 },
             )
         count = await asyncio.to_thread(count_open_finance_connections, user_id)
@@ -684,7 +684,7 @@ async def _ensure_of_access_allowed(user_id: int) -> None:
                     "code": "OF_BANK_LIMIT",
                     "limit": 0,
                     "message": "Conectar banco faz parte dos planos pagos — no Grátis a conexão "
-                               "vale durante os 30 dias de teste. Assine pra reativar: /precos",
+                               "vale durante os 15 dias de teste. Assine pra reativar: /precos",
                 },
             )
         return

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -114,10 +114,10 @@
       </section>
 
       <section>
-        <h2>4. Trial de 30 dias</h2>
+        <h2>4. Trial de 15 dias</h2>
         <p>
           Ao assinar um plano pago pela primeira vez, você tem acesso a um período de avaliação
-          gratuita de <strong>30 dias</strong>, com necessidade de cadastro de cartão no início.
+          gratuita de <strong>15 dias</strong>, com necessidade de cadastro de cartão no início.
           Durante o trial ficam liberadas, sem cobrança, as funcionalidades do
           <strong>plano que você escolheu</strong> — assinou Essencial, o trial é de Essencial;
           assinou Pro, é de Pro. O período gratuito é de <strong>um por número de telefone</strong>,
@@ -164,7 +164,7 @@
       <section>
         <h2>7. Reembolso</h2>
         <p>
-          O período de trial gratuito de 30 dias com cartão funciona como avaliação prática do
+          O período de trial gratuito de 15 dias com cartão funciona como avaliação prática do
           serviço. Cancelamentos efetuados <strong>durante o trial</strong> não geram cobrança e,
           portanto, não exigem reembolso.
         </p>

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -161,7 +161,7 @@ def test_checkout_default_uses_monthly_price(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "price_anual_xyz")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", "")
-    # Trial lido de PRO_TRIAL_DAYS em runtime (default do código = 30). Fixa pra
+    # Trial lido de PRO_TRIAL_DAYS em runtime (default do código = 15). Fixa pra
     # o teste ficar deterministico independente do ambiente.
     monkeypatch.setenv("PRO_TRIAL_DAYS", "7")
     fake = _patch_stripe(monkeypatch)
@@ -190,7 +190,7 @@ def test_checkout_annual_uses_annual_price(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "price_anual_xyz")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", "")
-    # Trial lido de PRO_TRIAL_DAYS em runtime (default do código = 30). Fixa pra
+    # Trial lido de PRO_TRIAL_DAYS em runtime (default do código = 15). Fixa pra
     # o teste ficar deterministico independente do ambiente.
     monkeypatch.setenv("PRO_TRIAL_DAYS", "7")
     fake = _patch_stripe(monkeypatch)

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -265,7 +265,7 @@ def test_assinar_v2_inelegivel_nao_promete_trial(patches):
 
     out = mod.handle_billing_command(99, "assinar plano", platform="whatsapp")
 
-    assert "30 dias grátis" not in out
+    assert "15 dias grátis" not in out
     assert "cobrança imediata" in out
 
 
@@ -275,5 +275,5 @@ def test_assinar_v2_com_consulta_indisponivel_delega_confirmacao_ao_checkout(pat
 
     out = mod.handle_billing_command(99, "assinar plano", platform="whatsapp")
 
-    assert "30 dias grátis" not in out
+    assert "15 dias grátis" not in out
     assert "checkout confirma" in out

--- a/tests/test_plan_tiers.py
+++ b/tests/test_plan_tiers.py
@@ -177,17 +177,17 @@ class TestTrialStatus:
         _patch_user(monkeypatch, _user("free", trial_started=NOW - timedelta(hours=1)))
         st = plan_service.get_trial_status(1, _user("free", trial_started=NOW - timedelta(hours=1)))
         assert st["active"] is True
-        assert st["days_left"] == 30
+        assert st["days_left"] == 15
 
     def test_days_left_ultimo_dia(self, v2):
         st = plan_service.get_trial_status(
-            1, _user("free", trial_started=NOW - timedelta(days=29, hours=12)))
+            1, _user("free", trial_started=NOW - timedelta(days=14, hours=12)))
         assert st["active"] is True
         assert st["days_left"] == 1
 
     def test_expirado(self, v2):
         st = plan_service.get_trial_status(
-            1, _user("free", trial_started=NOW - timedelta(days=30, minutes=1)))
+            1, _user("free", trial_started=NOW - timedelta(days=15, minutes=1)))
         assert st["active"] is False
         assert st["days_left"] == 0
 

--- a/tests/test_privacy_deletion.py
+++ b/tests/test_privacy_deletion.py
@@ -1,7 +1,7 @@
 """Exclusão de conta: o que some, e o resíduo que sobrava sem função.
 
 `plan_trials` sobrevive de propósito — é keyed por `phone_hash` e segura a
-regra de 30 dias de teste por telefone, na vida. Apagar devolveria um trial
+regra de 15 dias de teste por telefone, na vida. Apagar devolveria um trial
 novo a cada conta recriada com o mesmo número.
 
 O `user_id` da linha, porém, era resíduo: só é escrito no insert
@@ -79,7 +79,7 @@ def test_exclusao_desvincula_o_trial_da_conta_apagada(user_id):
 
 def test_exclusao_preserva_a_trava_de_um_trial_por_telefone(user_id):
     """Positivo: sem ele, apagar a linha inteira passaria neste grupo — e daria
-    um teste de 30 dias novo a cada conta recriada com o mesmo número."""
+    um teste de 15 dias novo a cada conta recriada com o mesmo número."""
     phone_hash = _trial_para(user_id)
     try:
         antes = _linha(phone_hash)["started_at"]
@@ -96,7 +96,7 @@ def test_exclusao_preserva_a_trava_de_um_trial_por_telefone(user_id):
 def test_fk_da_trava_e_set_null_e_nao_cascade():
     """A FK existe e é SET NULL.
 
-    CASCADE aqui apagaria a linha na exclusão da conta e devolveria 30 dias de
+    CASCADE aqui apagaria a linha na exclusão da conta e devolveria 15 dias de
     teste a cada conta recriada com o mesmo telefone. É o erro que o
     `repair_user_fk_cascades` cometeria sozinho se `plan_trials` não estivesse
     em `_USER_FK_SET_NULL_TABLES` — este teste é o que segura as duas pontas


### PR DESCRIPTION
## O que muda

O trial não é configurado no Stripe — sai do backend, como `trial_period_days` na `checkout.Session.create`. Um "free trial" setado no Price do dashboard do Stripe seria ignorado.

**Backend (o que de fato chega no Stripe):**
- `core/services/plan_service.py:48` — `TRIAL_DAYS_DEFAULT = 15` (lido por `trial_days_total()` via env `PLANS_TRIAL_DAYS`)
- `frontend/finance_bot_websocket_custom.py:3957` — fallback `PRO_TRIAL_DAYS` default `"15"` (caminho v2-off)

**Cópia de usuário:** `index.html`, `precos.html`, `termos.html`, `home.html`, `dashboard.html`, `email_service.py` (9 sites), `billing_commands.py`, `handle_incoming.py`, `routes/open_finance.py`.

**Não tocado** (mesma string, outro assunto): "Histórico dos últimos 30 dias", IOF dos primeiros 30 dias em investimentos, aviso prévio de 30 dias nos termos, retenção de cookie de indicação/afiliado.

## Quem já está em trial de 30 dias fica com 30 dias

Verificado nos três caminhos:

- **Cobrança** — o `trial_end` já está gravado na assinatura do Stripe. `trial_period_days` só vale para sessões novas.
- **Acesso** — o gate é `get_plan_tier` → `plan_expires_at`, gravado do `current_period_end` do webhook (`finance_bot_websocket_custom.py:4396`). Vem do Stripe, não do constante.
- **Contador** — `get_trial_status` recalcula com 15, mas `days_left` não é renderizado em lugar nenhum e `trial.active` tem um consumidor só: o banner de upsell em `dashboard.js:10794`, guardado por `plan_tier === "free"`. Quem está em trial não é `free` — ramo inalcançável.

## Testes

Suíte completa local: **5344 passed, 1 xfailed**.

`tests/test_plan_tiers.py::TestTrialStatus` tinha 30 chumbado (`days_left == 30`, último dia em 29d12h) e falhava com a mudança — ajustado para 15 / 14d12h. É o controle negativo: reverter `TRIAL_DAYS_DEFAULT` para 30 deixa esses casos vermelhos.

## Não verificado aqui

- A cópia do frontend só aparece **depois do deploy** (o app carrega o site ao vivo).
- `trial_period_days=15` chegando no Stripe só se prova num checkout real.
- **Ação de ambiente:** se `PLANS_TRIAL_DAYS` estiver setada em produção, ela ganha do código. Conferir e remover (ou setar `=15`) antes do deploy, senão nada muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)