### PR TITLE
/precos carrega o auth-refresh.js — clicar em Assinar pedia login

### DIFF
--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -178,6 +178,11 @@
   }
 </style>
 <script src="/safe-area.js?v=1"></script>
+<!-- Renova o access token em 401 e refaz a request. A /precos é logada
+     (checkout, troca de plano, /auth/me) e o cookie de access vale 15 min,
+     enquanto o dashboard_token do nav dura horas: sem isto o nav mostrava a
+     conta logada e o clique em "Assinar" caía em "Faça login". -->
+<script src="/static/auth-refresh.js?v=1"></script>
 </head>
 <body>
 <div class="glow"></div>

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -154,7 +154,7 @@ def test_auth_refresh_js_revalida_a_cada_load():
 
 
 def test_auth_refresh_js_sai_versionado_nas_paginas_autenticadas():
-    """As 4 páginas que o carregam pedem `?v=<hash>`, não a URL nua.
+    """As páginas que o carregam pedem `?v=<hash>`, não a URL nua.
 
     Três delas referenciavam sem `?v=` nenhum, e o `?v=1` da quarta era um
     cache-buster MORTO: o `_ASSET_VER_RE` não aceitava `/` no meio do caminho,
@@ -166,7 +166,7 @@ def test_auth_refresh_js_sai_versionado_nas_paginas_autenticadas():
         "static/auth-refresh.js",
         (FRONTEND_DIR / "static" / "auth-refresh.js").stat().st_mtime_ns,
     )
-    for page in ["/app", "/home", "/settings", "/onboarding"]:
+    for page in ["/app", "/home", "/settings", "/onboarding", "/precos"]:
         html = client.get(page).text
         assert "/static/auth-refresh.js" in html, page
         m = re.search(r"/static/auth-refresh\.js\?v=([0-9a-f]+)", html)


### PR DESCRIPTION
## O bug

Reportado em teste com conta real: usuário logado clica em **Assinar Plus** na `/precos` e recebe o toast *"Faça login pra continuar a assinatura."*

A `/precos` é a **única página logada que não carregava o `/static/auth-refresh.js`**.

A cadeia:

1. O cookie de access (`auth_token`) vale **15 minutos** — `finance_bot_websocket_custom.py:2150`, `AUTH_COOKIE_MAX_AGE = 15 * 60`.
2. O nav não usa esse cookie: `nav-auth.js` chama `/auth/validate`, que resolve pelo **`dashboard_token`**, de duração em horas. Por isso a tela mostra a conta logada.
3. `POST /billing/create-checkout` exige o `auth_token` (`Depends(_get_current_user)`) → passados 15 min, **401**.
4. O `auth-refresh.js` existe exatamente pra isso: intercepta qualquer 401 same-origin, chama `/auth/refresh` e refaz a request. `/app`, `/home`, `/settings` e `/onboarding` carregam. A `/precos` não.
5. Sem o interceptor, o 401 cai direto no `showToast(...)` de `precos.html:939`.

Efeito: quem abre a `/precos` e leva mais de 15 minutos pra decidir — ou chega nela de uma aba aberta há um tempo — não consegue assinar. Não é só o checkout: `/billing/subscription`, `/billing/change-plan` e `/auth/me` da mesma página caem igual, então "Seu plano atual" também some.

## A correção

Uma tag no `<head>` da `precos.html`, antes do script inline (o wrapper precisa estar instalado antes do primeiro `fetch`):

```html
<script src="/static/auth-refresh.js?v=1"></script>
```

## Varredura da classe

Todas as páginas HTML com `fetch` para endpoint autenticado, cruzadas com quem carrega o interceptor: a `/precos` era a única faltando. `admin-dashboard`/`admin-login` usam sessão de admin separada; `login`, `cadastro`, `completar-cadastro`, `reset-password` e `suporte` são pré-auth.

## Testes

`test_auth_refresh_js_sai_versionado_nas_paginas_autenticadas` já enumerava as páginas que carregam o interceptor — a `/precos` entrou na lista.

**Controle negativo:** removendo a tag do `precos.html`, o teste fica **vermelho** (`AssertionError` em `test_static_pages_routes.py:171`); com a tag, verde. Suíte completa: **5344 passed, 1 xfailed**.

## Não verificado aqui

O cenário real — esperar o cookie de 15 min vencer e clicar em Assinar — exige servidor de pé e sessão real; só se prova depois do deploy. E, como o app carrega o site ao vivo, a tag só passa a valer para os usuários no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)