### PR TITLE
401 do /auth/refresh precisa deslogar de verdade — conta ficava presa sem conseguir assinar

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2804,17 +2804,27 @@ async def auth_refresh(request: Request, response: Response):
     por `Authorization: Bearer` cai em 401 (é o comportamento de sempre; os dois
     clientes desta rota, `login.html` e o interceptor, são de cookie).
 
-    O `_clear_session_cookies` do ramo `invalid` NÃO chega ao cliente — o
-    `HTTPException` descarta os headers do sub-response (medido, #175). Está
-    fora do escopo deste conserto, mas não é para ser lido como funcionando.
+    Os dois ramos de 401 MONTAM a resposta em vez de dar `raise`: o
+    `HTTPException` descarta os headers do sub-response injetado (medido,
+    #175), então o `_clear_session_cookies` não chegava ao cliente e o
+    dashboard_token (12h) sobrevivia ao refresh morto. O usuário ficava preso —
+    ver o comentário no primeiro ramo.
     """
     refresh_in_cookie = (request.cookies.get(REFRESH_COOKIE_NAME) or "").strip()
     if not refresh_in_cookie:
         token = _get_auth_token_from_request(request, None)
         sessao_viva = bool(token) and (_decode_jwt(token) or {}).get("type") == "auth"
-        raise HTTPException(
-            status_code=400 if sessao_viva else 401, detail="missing_refresh_token",
-        )
+        if sessao_viva:
+            raise HTTPException(status_code=400, detail="missing_refresh_token")
+        # O Set-Cookie da limpeza precisa CHEGAR ao cliente: `raise
+        # HTTPException` descarta os headers do sub-response injetado (#175).
+        # Sem isto o dashboard_token (12h) sobrevivia ao refresh morto e o
+        # usuário ficava preso — o nav mostrava a conta logada, todo /billing
+        # dava 401, e o /login rebatia de volta pro app porque o /auth/validate
+        # olha o dashboard_token, não o access. Nem assinava, nem relogava.
+        resp = JSONResponse(status_code=401, content={"detail": "missing_refresh_token"})
+        _clear_session_cookies(resp)
+        return _no_store(resp)
 
     from core.refresh_tokens import consume_refresh_token
     ip = get_remote_address(request) or None
@@ -2823,9 +2833,11 @@ async def auth_refresh(request: Request, response: Response):
         consume_refresh_token, refresh_in_cookie, ip=ip, user_agent=ua,
     )
     if not result:
-        # Limpa cookies — qualquer motivo de falha vira deslogue.
-        _clear_session_cookies(response)
-        raise HTTPException(status_code=401, detail="invalid_refresh_token")
+        # Limpa cookies — qualquer motivo de falha vira deslogue. Mesmo motivo
+        # do ramo acima para montar a resposta em vez de dar raise (#175).
+        resp = JSONResponse(status_code=401, content={"detail": "invalid_refresh_token"})
+        _clear_session_cookies(resp)
+        return _no_store(resp)
 
     user_id = int(result["user_id"])
     session_jti = result["session_jti"]

--- a/tests/test_auth_cookie.py
+++ b/tests/test_auth_cookie.py
@@ -139,6 +139,21 @@ def _post_refresh(client: TestClient):
     return client.post("/auth/refresh", headers=_csrf_headers(client))
 
 
+def _cookies_expirados(response) -> set:
+    """Nomes de cookie que ESTA resposta manda o navegador apagar.
+
+    Só o Set-Cookie conta. O `_clear_session_cookies` era chamado num
+    sub-response e o `raise HTTPException` descartava os headers (#175): o
+    servidor "limpava" e nada chegava ao cliente.
+    """
+    apagados = set()
+    for header in response.headers.get_list("set-cookie"):
+        nome, _, resto = header.partition("=")
+        if "max-age=0" in resto.lower() or "01 jan 1970" in resto.lower():
+            apagados.add(nome.strip())
+    return apagados
+
+
 def test_refresh_sem_cookie_com_access_valido_nao_encerra_sessao():
     client = TestClient(dashboard.app)
     client.cookies.set(
@@ -180,6 +195,10 @@ def test_refresh_sem_cookie_com_access_expirado_encerra_sessao():
         "sessão irrecuperável: 400 aqui deixaria o estado privado no aparelho"
     )
     assert response.json()["detail"] == "missing_refresh_token"
+    # O dashboard_token dura 12h e sobrevive ao access de 15min. Se ele não for
+    # apagado AQUI, o /auth/validate continua passando: o nav mostra a conta
+    # logada, todo /billing dá 401 e o /login rebate de volta — preso.
+    assert dashboard.DASHBOARD_COOKIE_NAME in _cookies_expirados(response)
 
 
 def test_refresh_sem_cookie_nenhum_encerra_sessao():
@@ -202,6 +221,7 @@ def test_refresh_com_token_desconhecido_continua_encerrando_sessao():
 
     assert response.status_code == 401
     assert response.json()["detail"] == "invalid_refresh_token"
+    assert dashboard.DASHBOARD_COOKIE_NAME in _cookies_expirados(response)
 
 
 def test_dashboard_token_accepts_auth_cookie_without_authorization_header():


### PR DESCRIPTION
## O bug, medido no log de produção

Conta do dono, 2026-09-01 22:40:27 GMT-4 — **já com o `auth-refresh.js` da #223 no ar**:

```
GET  /auth/me                  401 Unauthorized
POST /auth/refresh             401 Unauthorized
POST /billing/create-checkout  401 Unauthorized
GET  /login?next=%2Fprecos     200 OK
GET  /auth/validate            200 OK      <- o nav segue "logado"
GET  /billing/subscription     401 Unauthorized
```

O interceptor da #223 funciona: ele dispara o `/auth/refresh`. Só que **o refresh também dá 401** — e aí a conta trava num loop fechado:

| cookie | duração | quem olha |
|---|---|---|
| `auth_token` | 15 min | `/billing/*`, `/auth/me` |
| `refresh_token` | 14d absoluto, 7d idle | `/auth/refresh` |
| `dashboard_token` | 12h | `/auth/validate` |

Com o refresh morto e o `dashboard_token` vivo: o nav mostra a conta logada, todo `/billing` dá 401, e o `/login` — que decide pelo `/auth/validate` — rebate direto pro app **sem nunca mostrar o formulário**. O usuário não assina e não consegue relogar. Confirmado pelo dono: *"Login joga direto logado? sim"*.

## A causa

A rota **já tentava** limpar os cookies nesse ramo:

```python
_clear_session_cookies(response)
raise HTTPException(status_code=401, detail="invalid_refresh_token")
```

Mas `raise HTTPException` descarta os headers do sub-response injetado — o `Set-Cookie` nunca chega ao cliente. Isso estava documentado no próprio docstring da rota como conhecido e fora de escopo (#175). O `dashboard_token` sobrevivia, e é ele que sustenta o loop.

## A correção

Os dois ramos de 401 (`missing_refresh_token` sem access válido e `invalid_refresh_token`) montam a resposta em vez de dar `raise`, então a limpeza chega ao navegador. Status e `detail` inalterados. O ramo 400 (sessão viva) não muda.

A limpeza fica **inline nos dois ramos, não num helper**: o gate do §0.7 (`test_rotas_que_encerram_sessao_estao_no_auth_refresh`) varre por chamada direta de `_clear_session_cookies` dentro da função de rota, e o helper escondia `/auth/refresh` da lista que o `auth-refresh.js` espelha. Tentei o helper primeiro e o gate reprovou — corretamente.

## Quem já está preso

Cura sozinho, sem intervenção: o interceptor dispara `/auth/refresh` no próximo 401, agora recebe o `Set-Cookie` de limpeza, e o `/login` passa a mostrar o formulário.

## Testes

`_cookies_expirados()` lê o `Set-Cookie` real da resposta (`max-age=0` / época) e os dois testes de 401 passam a exigir o `dashboard_token` entre os apagados.

**Controle negativo:** repondo o `raise`, `test_refresh_sem_cookie_com_access_expirado_encerra_sessao` e `test_refresh_com_token_desconhecido_continua_encerrando_sessao` ficam **vermelhos**. Suíte completa: **5365 passed, 1 xfailed**.

## O que este PR NÃO responde

**Por que o refresh daquela conta morreu** antes do `dashboard_token` de 12h, sendo que ele vale 14 dias. Candidatos: idle de 7d, revogação por reset de senha, replay detectado na rotação, ou o cookie nunca ter sido setado (o magic link tem um `fail-soft` que emite só o `dashboard_token` e loga `"sessão degradada"`). Isso é investigação separada — mas, com este PR, o sintoma deixa de ser conta travada e passa a ser um pedido de login normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)