### PR TITLE
URGENTE: 401 do /auth/refresh reemite o CSRF — o #224 quebrou o login em produção

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2824,6 +2824,13 @@ async def auth_refresh(request: Request, response: Response):
         # olha o dashboard_token, não o access. Nem assinava, nem relogava.
         resp = JSONResponse(status_code=401, content={"detail": "missing_refresh_token"})
         _clear_session_cookies(resp)
+        # ...e um CSRF NOVO junto, senão o login seguinte é impossível. O
+        # `_clear_session_cookies` apaga o csrf_token também, e o middleware só
+        # reemite em método seguro sem cookie — a /login já carregou, então o
+        # POST /auth/login sairia sem token e tomaria 403. Foi o que derrubou o
+        # smoke de produção do #224 ("HTTP 403 em /auth/login"): fim de sessão
+        # não pode levar junto a credencial de que o formulário precisa.
+        _set_csrf_cookie(resp, _make_csrf_token())
         return _no_store(resp)
 
     from core.refresh_tokens import consume_refresh_token
@@ -2837,6 +2844,13 @@ async def auth_refresh(request: Request, response: Response):
         # do ramo acima para montar a resposta em vez de dar raise (#175).
         resp = JSONResponse(status_code=401, content={"detail": "invalid_refresh_token"})
         _clear_session_cookies(resp)
+        # ...e um CSRF NOVO junto, senão o login seguinte é impossível. O
+        # `_clear_session_cookies` apaga o csrf_token também, e o middleware só
+        # reemite em método seguro sem cookie — a /login já carregou, então o
+        # POST /auth/login sairia sem token e tomaria 403. Foi o que derrubou o
+        # smoke de produção do #224 ("HTTP 403 em /auth/login"): fim de sessão
+        # não pode levar junto a credencial de que o formulário precisa.
+        _set_csrf_cookie(resp, _make_csrf_token())
         return _no_store(resp)
 
     user_id = int(result["user_id"])

--- a/tests/test_auth_cookie.py
+++ b/tests/test_auth_cookie.py
@@ -139,6 +139,15 @@ def _post_refresh(client: TestClient):
     return client.post("/auth/refresh", headers=_csrf_headers(client))
 
 
+def _csrf_do_jar(client: TestClient) -> str:
+    """O csrf_token que o navegador mandaria. O jar guarda uma entrada por
+    domínio (a limpeza escreve para host e .host), então `cookies.get` estoura
+    com CookieConflict — aqui vale a que tem valor."""
+    valores = {c.value for c in client.cookies.jar
+               if c.name == dashboard.CSRF_COOKIE_NAME and c.value}
+    return valores.pop() if len(valores) == 1 else ""
+
+
 def _cookies_expirados(response) -> set:
     """Nomes de cookie que ESTA resposta manda o navegador apagar.
 
@@ -721,3 +730,44 @@ def test_email_rate_limit_blocks_same_email_even_when_case_changes():
         asyncio.run(dashboard._check_persistent_rate_limit("login", other_identifier, 5, 60))
     finally:
         _clear_rate_limits(email_identifier, *ip_identifiers, locals().get("other_identifier", ""))
+
+
+def test_refresh_que_encerra_sessao_ainda_permite_logar_em_seguida():
+    """Fim de sessão não pode levar junto a credencial do formulário de login.
+
+    O caminho é o da /login com sessão morta: o boot chama /auth/refresh, leva
+    401, e o usuário digita e-mail e senha NA MESMA página — sem nenhum GET no
+    meio para o middleware reemitir o csrf_token. Sem o CSRF novo na resposta do
+    401, esse POST sai sem token e o middleware devolve 403: login impossível
+    para todo mundo, não só para quem tinha sessão degradada. Foi o que o smoke
+    de produção pegou no #224 ("HTTP 403 em /auth/login").
+    """
+    client = TestClient(dashboard.app)
+    client.get("/login")  # middleware emite o csrf da primeira visita
+    antigo = _csrf_do_jar(client)
+    assert antigo
+
+    # Sem _post_refresh de propósito: ele injeta um csrf fixo no jar, e aqui o
+    # que está em teste é justamente o que o jar carrega antes e depois.
+    encerrou = client.post(
+        "/auth/refresh", headers={dashboard.CSRF_HEADER_NAME: antigo},
+    )
+
+    assert encerrou.status_code == 401
+    assert dashboard.DASHBOARD_COOKIE_NAME in _cookies_expirados(encerrou)
+    # O jar é o que o navegador teria: o csrf antigo saiu e um novo entrou.
+    atual = _csrf_do_jar(client)
+    assert atual and atual != antigo, (
+        "sem csrf novo o formulário de login fica sem credencial"
+    )
+
+    # O POST que o formulário faz em seguida, sem nenhum GET no meio.
+    entrar = client.post(
+        "/auth/login",
+        json={"email": "naoexiste@example.com", "password": "seja-o-que-for"},
+        headers={dashboard.CSRF_HEADER_NAME: atual},
+    )
+
+    assert entrar.status_code != 403, (
+        "403 aqui é o CSRF barrando o login, não credencial errada"
+    )


### PR DESCRIPTION
## Regressão que este PR conserta

Smoke de produção do merge do #224 (`50ae836`) **falhou**:

```
FALHA: [/login] HTTP 403 em /auth/login
FALHA: [/login] page.waitForURL: Timeout 30000ms exceeded.
```

**Login quebrado para todo mundo**, não só para quem tinha sessão degradada.

## Como o #224 causou isso

O #224 fez a limpeza de cookies do 401 chegar de verdade ao cliente — era esse o conserto. Só que `_clear_session_cookies` apaga o **`csrf_token`** junto, e o middleware de CSRF só reemite o cookie em **método seguro sem cookie** (`GET` etc.).

Na `/login` não existe GET nenhum entre o boot e o submit:

1. `GET /login` → middleware emite o `csrf_token`.
2. Boot da página: `/auth/validate` 401 → `POST /auth/refresh`.
3. Esse refresh devolve 401 e **apaga o `csrf_token`** (o conserto do #224).
4. Usuário digita e-mail e senha → `POST /auth/login` sai **sem** token.
5. Middleware → **403**.

O passo 2 acontece em toda visita à `/login` sem sessão. Ou seja: qualquer login novo.

## A correção

Os dois ramos de 401 emitem um `csrf_token` novo junto da limpeza. Fim de sessão continua encerrando a sessão — só não leva junto a credencial de que o formulário de login precisa.

## Testes

`test_refresh_que_encerra_sessao_ainda_permite_logar_em_seguida` percorre o caminho real: `GET /login` → `POST /auth/refresh` (401) → `POST /auth/login` **sem nenhum GET no meio**, usando o token que o cookie jar carrega (o que o navegador mandaria).

**Controle negativo:** removendo o `_set_csrf_cookie`, o teste fica vermelho exatamente com o 403 do smoke.

`tests/test_auth_cookie.py`: **25 passed**. A suíte completa ainda não terminou de rodar neste branch — está rodando agora e eu reporto o resultado. Dado que produção está com o login quebrado, mandei o PR antes de esperar.

## O que eu errei

O #224 mexeu em fim de sessão sem inventariar **quem mais depende dos cookies que a limpeza apaga**. O `csrf_token` estava na lista de `_clear_session_cookies` desde sempre; o que mudou foi o Set-Cookie passar a chegar. O smoke de produção pegou — o meu teste não, porque exercitava a rota isolada e não a conversa `/login` → refresh → login (CLAUDE.md §3: "rode a conversa, não a função").

🤖 Generated with [Claude Code](https://claude.com/claude-code)