### PR TITLE
clearSessionSnapshots deixava o pb_home_ da aba (paywall negado não limpava nada da /home)

### DIFF
--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -398,13 +398,17 @@ function persistSnapshotToSession(data) {
   // vivo (ms) e não há replay — a reconexão re-GERA o snapshot no connect.
   try { sessionStorage.setItem(_snapSessionKey(data.year, data.month), JSON.stringify({ ...data, pb_saved_at: Date.now() })); } catch {}
 }
-// Limpa os snapshots pb_snap_* da aba. Chamada no logout e quando o paywall
-// NEGA (meGate): o restore pinta o snapshot que a PRÓPRIA aba gravou antes do
+// Limpa os snapshots da aba. Chamada no logout e quando o paywall NEGA
+// (meGate): o restore pinta o snapshot que a PRÓPRIA aba gravou antes do
 // veredito do /me — aceitável (o navegador do usuário já possui o dado, e
 // gatear o restore custaria ~1 RTT no caminho quente) — mas depois de um
 // veredito negativo um reload da aba não deve repintar saldo.
+// Os DOIS prefixos: pb_snap_ (esta tela) e pb_home_ (a /home, que a mesma aba
+// pinta). Mesmo par do clearHomeCache (home.html) e do reset (settings.html).
+// O paywall não chama /auth/logout, então a limpeza central do auth-refresh.js
+// não roda neste caminho — aqui é a única que limpa.
 function clearSessionSnapshots() {
-  try { Object.keys(sessionStorage).forEach(k => { if (k.startsWith("pb_snap_")) sessionStorage.removeItem(k); }); } catch {}
+  try { Object.keys(sessionStorage).forEach(k => { if (k.startsWith("pb_snap_") || k.startsWith("pb_home_")) sessionStorage.removeItem(k); }); } catch {}
 }
 function restoreSnapshotFromSession() {
   if (!USER_ID) return false;

--- a/tests/frontend/boot_paywall_async.test.mjs
+++ b/tests/frontend/boot_paywall_async.test.mjs
@@ -150,6 +150,15 @@ const snapKeys = (page) => page.evaluate(
   () => Object.keys(sessionStorage)
               .filter((k) => k.startsWith("pb_snap_") || k.startsWith("pb_home_")).sort());
 
+// As duas chaves do seed, por NOME. Contar (`length === 2`) passava com as duas
+// semeadas apagadas e duas outras no lugar — e isso é alcançável: qualquer
+// payload entregue pelo WS grava um pb_snap_ novo pelo persistSnapshotToSession.
+const SEED_KEYS = (() => {
+  const d = new Date();
+  return ["pb_home_42",
+          `pb_snap_42_${d.getFullYear()}_${String(d.getMonth() + 1).padStart(2, "0")}`];
+})();
+
 test("paywall NEGA: pb_snap_* E pb_home_* somem — reload da aba não repinta saldo", async () => {
   const { ctx, page } = await bootApp({ me: { app_access: false }, seedSnap: true });
   await page.waitForURL("**/precos?ativar=1", { timeout: 5000 });
@@ -162,7 +171,8 @@ test("paywall APROVA: restore intacto (nenhum gate novo no caminho quente)", asy
   const { ctx, page } = await bootApp({ me: { app_access: true }, seedSnap: true });
   await page.waitForFunction(() => !!window.PBRefresh, { timeout: 5000 });
   const chaves = await snapKeys(page);
-  assert.equal(chaves.length, 2, "snapshot de sessão não pode ser apagado no caminho aprovado");
+  assert.deepEqual(chaves, SEED_KEYS,
+                   "as chaves semeadas não podem ser apagadas no caminho aprovado");
   await ctx.close();
 });
 

--- a/tests/frontend/boot_paywall_async.test.mjs
+++ b/tests/frontend/boot_paywall_async.test.mjs
@@ -20,6 +20,13 @@ import { chromium } from "playwright";
 const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
 const DASHBOARD_JS = readFileSync(join(FRONTEND, "dashboard.js"), "utf8");
 
+// Mês do seed, lido UMA vez: o seed (dentro do navegador) e a expectativa
+// (aqui) têm de ser a mesma chave, ou uma suíte que começa segundos antes da
+// virada de mês semeia um mês e espera outro.
+const _SEED_D = new Date();
+const SEED_ANO = _SEED_D.getFullYear();
+const SEED_MES = String(_SEED_D.getMonth() + 1).padStart(2, "0");
+
 const IDS = [
   "grid", "bgt-overlay", "bgt-input", "investment-detail-overlay",
   "investment-help-overlay", "edit-launch-overlay", "launch-overlay",
@@ -62,16 +69,17 @@ async function bootApp({ me, meDelayMs = 400, meStatus = 200, wsMode = "silent",
     // o restoreSnapshotFromSession consome no boot. pb_home_42 é o par dele: a
     // MESMA aba pinta a /home com essa chave, e o clearSessionSnapshots limpava
     // só o pb_snap_.
-    await page.addInitScript(() => {
+    // O mês vem de FORA (SEED_ANO/SEED_MES): calculá-lo aqui dentro daria uma
+    // segunda `new Date()`, e uma suíte que começa segundos antes da virada de
+    // mês semearia um mês e esperaria outro (Codex, este PR).
+    await page.addInitScript(([ano, mes]) => {
       if (location.pathname !== "/app") return;
-      const d = new Date();
-      const key = `pb_snap_42_${d.getFullYear()}_${String(d.getMonth() + 1).padStart(2, "0")}`;
-      sessionStorage.setItem(key, JSON.stringify({
-        year: d.getFullYear(), month: d.getMonth() + 1, launches: [],
+      sessionStorage.setItem(`pb_snap_42_${ano}_${mes}`, JSON.stringify({
+        year: ano, month: Number(mes), launches: [],
         launches_pagination: { page: 1, filter_type: "all", query: "" },
       }));
       sessionStorage.setItem("pb_home_42", JSON.stringify({ userId: 42, snapshot: { total: 1 } }));
-    });
+    }, [SEED_ANO, SEED_MES]);
   }
   await page.addInitScript((mode) => {
     window._t0 = Date.now();
@@ -153,11 +161,8 @@ const snapKeys = (page) => page.evaluate(
 // As duas chaves do seed, por NOME. Contar (`length === 2`) passava com as duas
 // semeadas apagadas e duas outras no lugar — e isso é alcançável: qualquer
 // payload entregue pelo WS grava um pb_snap_ novo pelo persistSnapshotToSession.
-const SEED_KEYS = (() => {
-  const d = new Date();
-  return ["pb_home_42",
-          `pb_snap_42_${d.getFullYear()}_${String(d.getMonth() + 1).padStart(2, "0")}`];
-})();
+// Já ordenadas ("pb_home_" < "pb_snap_"), como o snapKeys devolve.
+const SEED_KEYS = ["pb_home_42", `pb_snap_42_${SEED_ANO}_${SEED_MES}`];
 
 test("paywall NEGA: pb_snap_* E pb_home_* somem — reload da aba não repinta saldo", async () => {
   const { ctx, page } = await bootApp({ me: { app_access: false }, seedSnap: true });

--- a/tests/frontend/boot_paywall_async.test.mjs
+++ b/tests/frontend/boot_paywall_async.test.mjs
@@ -59,7 +59,9 @@ async function bootApp({ me, meDelayMs = 400, meStatus = 200, wsMode = "silent",
   let meCalls = 0;
   if (seedSnap) {
     // Snapshot que a "aba anterior" gravou (USER_ID 42, mês corrente) — o que
-    // o restoreSnapshotFromSession consome no boot.
+    // o restoreSnapshotFromSession consome no boot. pb_home_42 é o par dele: a
+    // MESMA aba pinta a /home com essa chave, e o clearSessionSnapshots limpava
+    // só o pb_snap_.
     await page.addInitScript(() => {
       if (location.pathname !== "/app") return;
       const d = new Date();
@@ -68,6 +70,7 @@ async function bootApp({ me, meDelayMs = 400, meStatus = 200, wsMode = "silent",
         year: d.getFullYear(), month: d.getMonth() + 1, launches: [],
         launches_pagination: { page: 1, filter_type: "all", query: "" },
       }));
+      sessionStorage.setItem("pb_home_42", JSON.stringify({ userId: 42, snapshot: { total: 1 } }));
     });
   }
   await page.addInitScript((mode) => {
@@ -142,11 +145,15 @@ test("cadastro sem plano escolhido: cai em /precos?escolha=1", async () => {
   await ctx.close();
 });
 
-test("paywall NEGA: pb_snap_* some — reload da aba não repinta saldo", async () => {
+// Os dois prefixos que a aba usa para pintar dinheiro na hora.
+const snapKeys = (page) => page.evaluate(
+  () => Object.keys(sessionStorage)
+              .filter((k) => k.startsWith("pb_snap_") || k.startsWith("pb_home_")).sort());
+
+test("paywall NEGA: pb_snap_* E pb_home_* somem — reload da aba não repinta saldo", async () => {
   const { ctx, page } = await bootApp({ me: { app_access: false }, seedSnap: true });
   await page.waitForURL("**/precos?ativar=1", { timeout: 5000 });
-  const chaves = await page.evaluate(
-    () => Object.keys(sessionStorage).filter((k) => k.startsWith("pb_snap_")));
+  const chaves = await snapKeys(page);
   assert.deepEqual(chaves, [], `snapshot sobreviveu ao veredito negativo: ${chaves}`);
   await ctx.close();
 });
@@ -154,9 +161,8 @@ test("paywall NEGA: pb_snap_* some — reload da aba não repinta saldo", async 
 test("paywall APROVA: restore intacto (nenhum gate novo no caminho quente)", async () => {
   const { ctx, page } = await bootApp({ me: { app_access: true }, seedSnap: true });
   await page.waitForFunction(() => !!window.PBRefresh, { timeout: 5000 });
-  const chaves = await page.evaluate(
-    () => Object.keys(sessionStorage).filter((k) => k.startsWith("pb_snap_")));
-  assert.equal(chaves.length, 1, "snapshot de sessão não pode ser apagado no caminho aprovado");
+  const chaves = await snapKeys(page);
+  assert.equal(chaves.length, 2, "snapshot de sessão não pode ser apagado no caminho aprovado");
   await ctx.close();
 });
 


### PR DESCRIPTION
Bug irmão achado durante o #217, fora do escopo daquele PR.

## O que estava errado

O loop do `clearSessionSnapshots` ([dashboard.js:411](frontend/dashboard.js#L411)) removia só as chaves `pb_snap_*`, enquanto o `clearHomeCache` ([home.html:1461](frontend/home.html#L1461)) e o reset ([settings.html:2551](frontend/settings.html#L2551)) já removiam o par `pb_snap_` + `pb_home_`.

## O que já estava coberto (e por isso o diff é menor que o relato)

O **logout** do dashboard já não vazava: `dashboard.html` carrega o `auth-refresh.js`, cujo interceptor de `fetch` apaga o `sessionStorage` inteiro (menos a allowlist `_PRESERVA`) quando o `POST /auth/logout` responde ok — e a limpeza é **aguardada** antes de o `fetch` do `logoutDashboard` resolver. A tabela em [auth-refresh.js:158](frontend/static/auth-refresh.js#L158) documenta esse exato "dashboard.js — pb_home_*: DEIXA" como já enumerado e resolvido lá.

## O que sobrava de verdade

Os dois caminhos que **não** passam pelo interceptor:

1. **paywall NEGA** (`applyAccessVerdict`, os dois ramos): não existe request de logout nenhuma, então esta função é a única limpeza do caminho. O snapshot da /home sobrevivia ao veredito negativo e um reload da aba repintava saldo — exatamente o que o comentário da função promete evitar.
2. **logout com a request falhando** (offline): o interceptor não limpa, o `clearSessionSnapshots` limpa, e ele deixava o `pb_home_` para trás.

Conserto na função compartilhada e não no chamador: os três chamadores querem os dois prefixos, e o diff vira uma condição a mais.

## Teste

Em [tests/frontend/boot_paywall_async.test.mjs](tests/frontend/boot_paywall_async.test.mjs), que boota o `dashboard.js` **sem** o `auth-refresh.js` — isola a limpeza da página. O seed ganha `pb_home_42` ao lado do `pb_snap_`, e os dois casos que já existiam passam a olhar o par.

- **Controle negativo:** removendo o `pb_home_` do loop, o caso "paywall NEGA" fica vermelho e os outros 7 do arquivo seguem verdes (rodado).
- **Controle positivo:** "paywall APROVA" prova que o caminho aprovado continua com as duas chaves intactas.

`npm run test:frontend`: **229 passam, 0 falham.**

Não verificado aqui: nada. A mudança é JS de página, coberta pelo Playwright — mas, como toda mudança de frontend, ela só aparece no app **depois do deploy** (CLAUDE.md §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)