### PR TITLE
docs: o resíduo da virada de mês já estava fechado — a tabela mentia

### DIFF
--- a/tests/test_virada_de_mes.py
+++ b/tests/test_virada_de_mes.py
@@ -49,23 +49,41 @@ prende a tela (HIPÓTESE lida no código, sem navegador):
 Ou seja: "trava no spinner" vale para o snapshot do WebSocket, NÃO para o
 dashboard inteiro.
 
-RESÍDUO — o que este PR NÃO resolve, e que é a próxima issue. O conserto troca
-"servidor em UTC" por "servidor no fuso do APP": isso casa com o navegador de
-quem está NO fuso do app e com mais ninguém. Para os outros o descarte do
-`isCurrentViewData` continua idêntico (HIPÓTESE lida no código, sem navegador):
+RESÍDUO — FECHADO, e este parágrafo é o registro de que foi. Quando este
+arquivo nasceu, o conserto trocava "servidor em UTC" por "servidor no fuso do
+APP": casava com o navegador de quem está NO fuso do app e com mais ninguém, e
+para os outros o descarte do `isCurrentViewData` continuava idêntico:
 
-| usuário          | instante       | servidor (SP) | navegador | resultado      |
-|------------------|----------------|---------------|-----------|----------------|
-| São Paulo        | 31/08 21:13-03 | agosto        | agosto    | consertado     |
-| Manaus (−04)     | 31/08 23:30-04 | setembro      | agosto    | ainda descarta |
-| Rio Branco (−05) | 31/08 22:30-05 | setembro      | agosto    | ainda descarta |
-| Lisboa (+01)     | 01/09 01:00+01 | agosto        | setembro  | ainda descarta |
+| usuário          | instante       | servidor (SP) | navegador | era        | hoje   |
+|------------------|----------------|---------------|-----------|------------|--------|
+| São Paulo        | 31/08 21:13-03 | agosto        | agosto    | consertado | idem   |
+| Manaus (−04)     | 31/08 23:30-04 | setembro      | agosto    | descartava | adota  |
+| Rio Branco (−05) | 31/08 22:30-05 | setembro      | agosto    | descartava | adota  |
+| Lisboa (+01)     | 01/09 01:00+01 | agosto        | setembro  | descartava | adota  |
 
-Não é regressão: com o servidor em UTC esses três já divergiam. O conserto de
-raiz é no `isCurrentViewData` — não descartar antes do `stopSpin()` —, que é
-frontend e está FORA deste PR. Alívio parcial que já existe: o `_doRefresh`
-manda `year`/`month` explícitos, então quem aperta "atualizar" se recupera; o
-estrago é a carga inicial.
+O conserto do cliente entrou no `c8e3bbe` (Onda 1 de perf), integrado no merge
+`85ea2a4` — posterior ao `8ea113a` deste arquivo, e é por isso que a versão
+original desta tabela dizia "ainda descarta" para as três últimas linhas. Ele
+NÃO é o que este parágrafo previa ("não descartar antes do `stopSpin()`"): no
+branch `snapshot` do `ws.onmessage`, se o usuário ainda não navegou de mês à
+mão, o mês do snapshot é ADOTADO — o servidor é a fonte da verdade do mês —, e
+o teto do `btn-next` (`latestKnownMonth`) avança junto. `month_data` fica de
+fora: é resposta a `get_month` explícito e tem mesmo que ser descartado.
+
+Provado com navegador, não por leitura:
+`tests/frontend/snapshot_virada_de_mes.test.mjs` sintetiza a divergência num
+contexto `Asia/Tokyo` (não depende do dia real) e traz os dois controles — o
+negativo (`userNavigatedMonth` ligado volta a descartar) e o positivo (mês
+corrente segue o caminho de sempre). Rodar:
+
+    NODE_PATH=$(npm root -g) node --test tests/frontend/snapshot_virada_de_mes.test.mjs
+
+Sobra deste caminho, medido e deixado de fora de propósito: o
+`restoreSnapshotFromSession` roda ANTES do `connect()` e lê a chave da sessão
+por `viewYear/viewMonth` (relógio do DISPOSITIVO), enquanto o
+`persistSnapshotToSession` gravou com o mês do SERVIDOR. Na janela a chave não
+casa e a troca /home ↔ /app perde o paint instantâneo até o WS chegar. É
+otimização perdida por ~3 h/mês, não tela presa.
 
 RESÍDUO, 2ª parte — `is_current_month` tem um TERCEIRO consumidor. Além do
 `isCurrentViewData`, o render de frontend/dashboard.js deriva
@@ -78,8 +96,8 @@ condições têm de valer juntas para alcançá-lo:
   1. navegador À FRENTE do fuso do app (Lisboa +01 contra São Paulo −03), E
   2. dentro da janela de 3h do dia 1º, E
   3. navegando EXPLICITAMENTE para o mês do navegador — o `year`/`month` vai na
-     requisição. Sem eles o servidor responde o próprio mês e quem descarta é o
-     `isCurrentViewData` da tabela acima, não isto.
+     requisição. Sem eles o servidor responde o próprio mês e o cliente ADOTA
+     esse mês (tabela acima) em vez de cair aqui.
 
 Aí o servidor responde `is_current_month: false` onde antes respondia `true`, e
 o saldo dos bancos conectados SOME do consolidado. Não é dinheiro errado — nada


### PR DESCRIPTION
## O que aconteceu

O docstring de `tests/test_virada_de_mes.py` afirma que Manaus (−04), Rio Branco (−05) e Lisboa (+01) **"ainda descarta[m]"** o snapshot na janela de 3h do dia 1º, e aponta a próxima issue para o `isCurrentViewData`.

Não é mais verdade. E o custo não foi teórico: essa tabela me mandou abrir um PR para consertar um bug que não existe. É exatamente o modo de falha que o §2 do `CLAUDE.md` descreve — afirmação de estado que envelhece em silêncio e passa a mentir com cara de medição.

## Por que ficou velha

O conserto do cliente entrou no `c8e3bbe` (Onda 1 de perf) e foi integrado no merge `85ea2a4`, que é **posterior** ao `8ea113a` — o commit que escreveu essa tabela. Os dois nasceram em branches paralelos, e quem chegou depois não releu o docstring do outro.

E o conserto não é o que o parágrafo previa. Ele previa "não descartar antes do `stopSpin()`". O que existe é outra coisa: no branch `snapshot` do `ws.onmessage` ([dashboard.js:7611](https://github.com/JapaLcK/Bot_Financeiro/blob/main/frontend/dashboard.js#L7611)), se o usuário ainda não navegou de mês à mão, o mês do snapshot é **adotado** — o servidor é a fonte da verdade do mês —, e o teto do `btn-next` (`latestKnownMonth`) avança junto. `month_data` continua descartado de propósito: é resposta a um `get_month` explícito.

## O que mudou

| | |
|---|---|
| arquivos | 1 (`tests/test_virada_de_mes.py`) |
| linhas de produção | 0 |
| asserts tocados | 0 |
| skip / xfail adicionados | 0 |

Só o docstring. A tabela ganhou duas colunas (`era` × `hoje`) em vez de ser apagada — o histórico é o que explica por que ela mentiu.

## O que foi medido

Nada aqui precisa de conserto novo, então a medição é de que o estado documentado bate com o código:

```
NODE_PATH=$(npm root -g) node --test tests/frontend/snapshot_virada_de_mes.test.mjs
✔ snapshot do mês 'seguinte' é ADOTADO (antes: descartado, skeleton)
✔ depois de navegar de mês manualmente, snapshot divergente volta a ser descartado
✔ month_data divergente continua descartado (só snapshot adota)
✔ snapshot do mês corrente segue o caminho de sempre (positivo do caminho antigo)
4 pass, 0 fail
```

Esse teste é de **navegador** (Playwright, contexto `Asia/Tokyo`), não leitura de código — e traz os dois controles: o negativo (`userNavigatedMonth` ligado volta a descartar) e o positivo (mês corrente segue o caminho antigo).

Backend, na mesma árvore:

```
pytest tests/test_virada_de_mes.py tests/test_budget_category_accent.py -q
20 passed
```

Controle negativo do `#215`, para confirmar que o guard ainda discrimina: revertendo `now = now_tz()` para `datetime.now(timezone.utc)` em [finance_bot_websocket_custom.py:413](https://github.com/JapaLcK/Bot_Financeiro/blob/main/frontend/finance_bot_websocket_custom.py#L413) → **2 failed, 4 passed** em `tests/test_virada_de_mes.py`. Revertido em seguida.

A contagem "4 passed" **não** entrou no texto do docstring: pela mesma §2, ficou o comando que a produz.

## O resíduo que sobrou de verdade

Tomou o lugar do parágrafo velho, medido e deixado fora deste PR de propósito:

`restoreSnapshotFromSession()` roda **antes** do `connect()` ([dashboard.js:10833](https://github.com/JapaLcK/Bot_Financeiro/blob/main/frontend/dashboard.js#L10833)) e lê a chave da sessão por `viewYear/viewMonth` — relógio do **dispositivo** —, enquanto `persistSnapshotToSession` gravou com o mês do **servidor**. Na janela a chave não casa e a troca /home ↔ /app perde o paint instantâneo até o WS chegar.

É otimização perdida por ~3 h/mês, que se cura sozinha em 1 RTT — não é tela presa. Não vale o código; fica registrado.

A "2ª parte" do resíduo (`is_current_month` × `hist` × saldo do Open Finance) **continua aberta** e não foi tocada: ela exige navegação explícita para o mês do navegador, caminho que a adoção não alcança. Só ajustei a referência cruzada, que apontava para a tabela agora corrigida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Nota de percurso: dois commits de CI que foram descartados

O `frontend` reprovou este PR duas vezes. Não era regressão dele — o PR toca só um docstring Python, e a mesma falha estava no run `33583800081` da `main`. Cheguei a empurrar dois commits para desbloquear (`page.waitForURL` no lugar do `page.evaluate`, e o poll do `startServer` sem cliente `undici`).

Enquanto isso o [#229](https://github.com/JapaLcK/Bot_Financeiro/pull/229) entrou na `main` e cobriu os dois casos melhor:

- em vez de trocar por `waitForURL`, extraiu `avaliaTolerandoNavegacao` com catch **seletivo** (só contexto morto vira `false`; o resto sobe, senão bug real vira timeout mudo) e varreu a categoria nos 3 arquivos que têm `waitFor` caseiro;
- e atribuiu o `assert(!this.paused)` a outra causa que não a minha — fetch de boot da página em voo quando o `fechar()` derruba o contexto, não o `fetch` do `startServer`. A minha hipótese ali não tinha controle negativo (Node 22 no CI × 23.9 local) e não se sustenta contra essa.

**Os dois commits foram descartados** e este PR voltou a ser o que diz ser: 1 arquivo, só docstring. O que restou de conteúdo meu naquele diagnóstico está no PR #229, não aqui.
