### PR TITLE
waitFor engolia o sucesso: navegação destruía o contexto e a exceção subia

### DIFF
--- a/tests/frontend/reset_cache_multiaba.test.mjs
+++ b/tests/frontend/reset_cache_multiaba.test.mjs
@@ -57,6 +57,18 @@ async function waitFor(cond, what, timeoutMs = 15000) {
   throw new Error(`timeout esperando: ${what}`);
 }
 
+/** page.evaluate que devolve false quando a NAVEGAÇÃO destrói o contexto no
+ *  meio — reload/redirect em curso é o próprio sucesso que se está esperando,
+ *  e o waitFor não engole rejeição (a exceção subia e matava o teste no exato
+ *  instante do sucesso: flake do PR #226, run 33644738135). Só o erro de
+ *  contexto morto vira false: qualquer outro SOBE, senão bug real viraria
+ *  timeout mudo (§3) — é o que o teste "waitFor:" no fim do arquivo prova. */
+const avaliaTolerandoNavegacao = (page, fn) => page.evaluate(fn).catch((e) => {
+  if (/Execution context (was destroyed|is not available)|Cannot find context/.test(String(e)))
+    return false;
+  throw e;
+});
+
 let server, browser;
 before(async () => { server = await startServer(); browser = await chromium.launch(); });
 after(async () => { await browser?.close(); server?.kill(); });
@@ -227,12 +239,8 @@ async function abaRecarregaNoEvento(page, url, prontoQuando) {
   await page.evaluate(() => {
     window.dispatchEvent(new StorageEvent("storage", { key: "finbot_reset_at", newValue: "123" }));
   });
-  await waitFor(async () => {
-    // o reload destrói o contexto no meio do evaluate — é o próprio sucesso
-    // em curso; tenta de novo até o documento novo (sem __viva) responder.
-    try { return await page.evaluate(() => window.__viva === undefined); }
-    catch { return false; }
-  }, "reload da aba após o evento do reset");
+  await waitFor(() => avaliaTolerandoNavegacao(page, () => window.__viva === undefined),
+                "reload da aba após o evento do reset");
 }
 
 test("dashboard: storage event do finbot_reset_at recarrega a aba aberta", async () => {
@@ -265,7 +273,7 @@ test("settings: sucesso do reset grava o marker e limpa os snapshots da aba", as
       document.getElementById("reset-password").value = "senha";
       requestAccountReset();                    // POST stubado (200) → marker → /onboarding
     });
-    await waitFor(() => page.evaluate(() => location.pathname === "/onboarding"),
+    await waitFor(() => avaliaTolerandoNavegacao(page, () => location.pathname === "/onboarding"),
                   "redirect pro /onboarding");
     const estado = await page.evaluate(() => ({
       marker: localStorage.getItem("finbot_reset_at"),
@@ -275,5 +283,23 @@ test("settings: sucesso do reset grava o marker e limpa os snapshots da aba", as
     assert.ok(Number(estado.marker) > 0, "o reset tinha que gravar finbot_reset_at");
     assert.equal(estado.snap, null, "pb_snap_* da própria aba tinha que sumir");
     assert.equal(estado.home, null, "pb_home_* da própria aba tinha que sumir");
+  } finally { await fechar(page); }
+});
+
+test("waitFor: erro que não é navegação sobe; condição impossível estoura com a mensagem", async () => {
+  // Controle do conserto acima (§3): tolerar a destruição do contexto não pode
+  // virar "engole tudo". NEGATIVO — com `catch { return false }` no lugar do
+  // filtro, a 1ª rejeição vira timeout genérico e o /bug real/ fica vermelho.
+  const page = await newPage();
+  try {
+    await page.goto(`${ORIGIN}/home.html`);
+    await assert.rejects(
+      () => waitFor(() => avaliaTolerandoNavegacao(page, () => { throw new TypeError("bug real"); }),
+                    "nunca acontece", 300),
+      /bug real/, "erro real virou timeout mudo — o catch engoliu demais");
+    await assert.rejects(
+      () => waitFor(() => avaliaTolerandoNavegacao(page, () => false), "condição impossível", 300),
+      /timeout esperando: condição impossível/,
+      "a mensagem do timeout tem que dizer o que se esperava");
   } finally { await fechar(page); }
 });

--- a/tests/frontend/reset_cache_multiaba.test.mjs
+++ b/tests/frontend/reset_cache_multiaba.test.mjs
@@ -290,9 +290,12 @@ test("waitFor: erro que não é navegação sobe; condição impossível estoura
   // Controle do conserto acima (§3): tolerar a destruição do contexto não pode
   // virar "engole tudo". NEGATIVO — com `catch { return false }` no lugar do
   // filtro, a 1ª rejeição vira timeout genérico e o /bug real/ fica vermelho.
+  // about:blank de propósito: o helper e o waitFor não dependem de página
+  // nenhuma, e bootar a home deixaria fetch em voo quando o fechar() derruba o
+  // contexto — a "atividade assíncrona depois do teste" que o arquivo já
+  // combate (acaoSegura/fechar). Sem request, sem corrida.
   const page = await newPage();
   try {
-    await page.goto(`${ORIGIN}/home.html`);
     await assert.rejects(
       () => waitFor(() => avaliaTolerandoNavegacao(page, () => { throw new TypeError("bug real"); }),
                     "nunca acontece", 300),


### PR DESCRIPTION
## O flake

`tests/frontend/reset_cache_multiaba.test.mjs:254` (`settings: sucesso do reset...`) caiu no CI do #226 (run 33644738135, job `frontend`) com:

```
page.evaluate: Execution context was destroyed, most likely because of a navigation
```

Re-run do MESMO commit ficou verde nos 3 checks. Não é regressão.

**Causa:** o `waitFor` (linha 51) só reavalia enquanto a condição devolve **falso** — rejeição ele deixa subir. Na espera do redirect, o `requestAccountReset()` navega pro `/onboarding` exatamente entre o agendamento e a execução do `page.evaluate`. O teste morria no instante do próprio sucesso.

## O conserto

O arquivo já tratava essa classe à mão no irmão `abaRecarregaNoEvento` (`catch { return false }`). Extraí `avaliaTolerandoNavegacao` para os dois sites.

Ele **não engole tudo**: só erro de contexto morto vira `false`, o resto sobe. Catch cego transformaria bug real em timeout mudo — pior que o flake.

## Varredura da categoria (§2)

| onde | veredito |
|---|---|
| `reset_cache_multiaba` | 2 waits dependem de navegação (230 e 268) — **os 2 cobertos** |
| `settings_security_fanout` | tem o `waitFor` caseiro, mas nenhuma condição depende de navegação (contadores de request, `window.__done`) |
| `of_refresh_ui` | idem — `typeof window.X === "function"` em página já parada |
| demais 15 arquivos | usam `waitForFunction`/`waitForURL` do Playwright, já resilientes a navegação |

## Controles (§3)

**NEGATIVO A** — teste novo no grupo exige que erro não-navegação suba. Trocando o filtro por `return false`:

```
✖ waitFor: erro que não é navegação sobe; condição impossível estoura...
    actual: Error: timeout esperando: nunca acontece
    expected: /bug real/
```

**NEGATIVO B** — corrida forçada (evaluate de 800ms + `reload()` aos 100ms):

```
ANTES:  Error: page.evaluate: Execution context was destroyed, most likely because of a navigation.
DEPOIS: Error: timeout esperando: cond pós-navegação
```

O erro do CI reproduzido ao pé da letra sem o helper; com ele, nada estoura e a mensagem do timeout continua nomeando o que se esperava.

**POSITIVO** — os 8 testes originais do arquivo seguem verdes.

## Medido

- `node --test tests/frontend/reset_cache_multiaba.test.mjs` → **9/9**
- `npm run test:frontend` → **230/230**

Não verificado: só mexe em teste, não há caminho de aparelho/deploy envolvido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)