### PR TITLE
Logout deixava o aparelho sujo quando o POST não dava 200: sem rede, e com 403/429/500

### DIFF
--- a/frontend/nav-auth.js
+++ b/frontend/nav-auth.js
@@ -46,8 +46,14 @@
   var PRESERVA = ["pigbank_theme", "pigbank_hide_balance", "pbFabPos",
                   "pbDebug", "pbSpa", "finbot_logout_at", "finbot_reset_at"];
 
-  function apagaStorage(store) {
+  // Recebe o NOME, não o objeto: `window.localStorage` é um getter que LANÇA
+  // com dados do site bloqueados, e a avaliação do argumento ficava fora do
+  // `try`. Aqui o dano era maior que no auth-refresh — o `.finally` do
+  // `doLogout` rejeitava e o `location.reload()` nunca rodava, então nas
+  // páginas públicas o "Sair" não fazia nada visível.
+  function apagaStorage(nome) {
     try {
+      var store = window[nome];
       Object.keys(store).forEach(function (k) {
         if (PRESERVA.indexOf(k) === -1) store.removeItem(k);
       });
@@ -69,8 +75,8 @@
   }
 
   function limpaCacheNoLogout() {
-    apagaStorage(window.localStorage);
-    apagaStorage(window.sessionStorage);
+    apagaStorage("localStorage");
+    apagaStorage("sessionStorage");
     return desregistraWorkers()
       .then(function () {
         if (!window.caches) return;

--- a/frontend/static/auth-refresh.js
+++ b/frontend/static/auth-refresh.js
@@ -80,16 +80,28 @@
    * `_clear_session_cookies` (finance_bot_websocket_custom.py). São três, e o
    * critério de cada uma difere — por isso um mapa e não um array:
    *
-   *   POST   /auth/logout    encerra quando dá certo
-   *   DELETE /auth/account   idem — a exclusão agendada desloga na hora
-   *   POST   /auth/refresh   encerra quando dá 401, e SÓ 401. O status desta
-   *                          rota responde "a sessão acabou?", não classifica
-   *                          o erro: 400 é refresh ausente com access ainda
-   *                          válido (sessão de pé, nada a apagar), 401 é
-   *                          refresh invalidado/revogado ou ausente sem access
-   *                          válido. Tratar todo 401 como fim de sessão
-   *                          apagava o aparelho de quem só errou a senha
-   *                          noutra rota (#173).
+   *   POST   /auth/logout    encerra quando dá certo — E quando não houve
+   *                          resposta nenhuma (`resp === null`, o fetch
+   *                          REJEITOU: offline, DNS, captive portal). Sair
+   *                          sem rede é sair deste aparelho do mesmo jeito:
+   *                          todo chamador navega no `.finally`, o usuário vê
+   *                          a tela deslogada, e o que ficasse para trás é
+   *                          resíduo privado no aparelho compartilhado.
+   *   DELETE /auth/account   encerra quando dá certo, e SÓ com resposta. Numa
+   *                          rejeição a exclusão não aconteceu, o chamador
+   *                          (settings.html) mostra o toast e NÃO navega:
+   *                          apagar o aparelho de quem continua logado seria
+   *                          pior que o bug.
+   *   POST   /auth/refresh   encerra quando dá 401, e SÓ 401 — rejeição é
+   *                          rede fora, não fim de sessão: apagar aí destruía
+   *                          o aparelho de quem só entrou no metrô. O status
+   *                          desta rota responde "a sessão acabou?", não
+   *                          classifica o erro: 400 é refresh ausente com
+   *                          access ainda válido (sessão de pé, nada a
+   *                          apagar), 401 é refresh invalidado/revogado ou
+   *                          ausente sem access válido. Tratar todo 401 como
+   *                          fim de sessão apagava o aparelho de quem só
+   *                          errou a senha noutra rota (#173).
    *
    * Por que 401 aqui justifica apagar: o refresh token acabou, então não há
    * como renovar de novo — o que estiver no aparelho é lixo de uma sessão que
@@ -103,9 +115,9 @@
    * de conta ficou de fora: consertei a instância e não a classe (Codex, #170).
    */
   const _SESSAO_ENCERRADA = {
-    "/auth/logout":  function (resp) { return resp.ok; },
-    "/auth/account": function (resp) { return resp.ok; },
-    "/auth/refresh": function (resp) { return resp.status === 401; },
+    "/auth/logout":  function (resp) { return !resp || resp.ok; },
+    "/auth/account": function (resp) { return !!resp && resp.ok; },
+    "/auth/refresh": function (resp) { return !!resp && resp.status === 401; },
   };
 
   /**
@@ -239,6 +251,33 @@
     return resp;
   }
 
+  /**
+   * A request nossa, com a limpeza aplicada TAMBÉM quando não vem resposta.
+   *
+   * `await _origFetch(...)` estourava antes do `_comLimpeza`, então fetch que
+   * REJEITA (offline, DNS, captive portal, abort) saía por baixo da limpeza —
+   * e é o pior caso, não o mais raro: `logoutSettings` (settings.html) não tem
+   * limpeza própria nenhuma e navega no `.finally` mesmo com a rejeição, então
+   * sair do Ajustes em modo avião deixava `pigbank_menu_v1` (e-mail, nome,
+   * plano), `pb_home_<uid>` e o Cache Storage inteiro no aparelho, com cara de
+   * logout bem-sucedido. As limpezas locais de `dashboard.js` e `home.html`
+   * cobrem só parte disso; o Cache Storage não é coberto por nenhuma.
+   *
+   * QUAL rota limpa sem resposta é decidido pelo predicado de cada uma
+   * (`_SESSAO_ENCERRADA`), não aqui: só o logout. Rejeição no refresh e no
+   * DELETE de conta é rede fora com a sessão de pé.
+   */
+  async function _requestComLimpeza(caminho, input, init) {
+    let resp;
+    try {
+      resp = await _origFetch(input, init);
+    } catch (e) {
+      await _comLimpeza(caminho, null);
+      throw e;
+    }
+    return _comLimpeza(caminho, resp);
+  }
+
   window.fetch = async function(input, init) {
     // Requests pra fora da própria origem (Stripe, CDN, etc) seguem direto
     if (!_isOwnApi(input)) return _origFetch(input, init);
@@ -250,7 +289,7 @@
     // (`location.replace`/`reload`/`href`), e navegação descarta o documento:
     // uma limpeza disparada e esquecida não tem garantia de terminar, e o cache
     // privado sobrevive no aparelho compartilhado (Codex, #170).
-    let resp = await _comLimpeza(caminho, await _origFetch(input, init));
+    let resp = await _requestComLimpeza(caminho, input, init);
 
     if (resp.status !== 401) return resp;
 
@@ -260,7 +299,7 @@
     // Tenta renovar e refazer a request original
     const ok = await _doRefresh();
     if (!ok) return resp;
-    return _comLimpeza(caminho, await _origFetch(input, init));
+    return _requestComLimpeza(caminho, input, init);
   };
 
   // ── Modo app (iOS/Capacitor) ─────────────────────────────────────────────

--- a/frontend/static/auth-refresh.js
+++ b/frontend/static/auth-refresh.js
@@ -20,7 +20,12 @@
   function _isOwnApi(url) {
     if (typeof url !== "string") url = (url && url.url) || "";
     if (!url) return false;
-    if (url.startsWith("/")) return true;
+    // Sem fast-path por "começa com /". Ele aceitava como nossa qualquer URL
+    // com essa forma, e `//host/x` e `/\host/x` apontam para OUTRO host — a
+    // segunda porque a WHATWG normaliza `\` como `/`. Bastava uma delas
+    // terminando em `/auth/logout` para o pathname bater e a limpeza apagar
+    // este aparelho. O parse abaixo compara HOST, e cobre as duas formas, o
+    // caminho relativo comum e a URL absoluta com uma regra só.
     try {
       const u = new URL(url, window.location.origin);
       return u.host === window.location.host;
@@ -80,13 +85,29 @@
    * `_clear_session_cookies` (finance_bot_websocket_custom.py). São três, e o
    * critério de cada uma difere — por isso um mapa e não um array:
    *
-   *   POST   /auth/logout    encerra quando dá certo — E quando não houve
-   *                          resposta nenhuma (`resp === null`, o fetch
-   *                          REJEITOU: offline, DNS, captive portal). Sair
-   *                          sem rede é sair deste aparelho do mesmo jeito:
-   *                          todo chamador navega no `.finally`, o usuário vê
-   *                          a tela deslogada, e o que ficasse para trás é
-   *                          resíduo privado no aparelho compartilhado.
+   *   POST   /auth/logout    encerra SEMPRE — 2xx, erro, ou resposta nenhuma
+   *                          (`resp === null`, o fetch REJEITOU: offline, DNS,
+   *                          captive portal). O critério não é o servidor, é o
+   *                          chamador: os cinco donos de logout navegam para a
+   *                          tela deslogada no `.finally`, sem olhar o status.
+   *                          Se o estado ficasse, ele ficaria num aparelho que
+   *                          mostra "saí" — resíduo privado no aparelho
+   *                          compartilhado.
+   *
+   *                          Não é hipotético e não precisa de modo avião: o
+   *                          cookie `csrf_token` dura 24h e só é reemitido em
+   *                          método SEGURO quando falta, então uma aba aberta
+   *                          mais de um dia manda o POST sem header e leva
+   *                          403 do `csrf_middleware` — antes da rota. Prender
+   *                          a limpeza ao `resp.ok` deixava esse caso e o 429
+   *                          do `@limiter.limit("30/minute")` do lado errado.
+   *
+   *                          O que isto NÃO faz: os cookies de sessão são
+   *                          `httponly`, então JS nenhum os apaga, e num
+   *                          logout que não chegou ao servidor a sessão
+   *                          continua VIVA (`revoke_session` não rodou). O que
+   *                          se ganha é não deixar e-mail, nome, plano e
+   *                          snapshot na tela do próximo dono — não "deslogou".
    *   DELETE /auth/account   encerra quando dá certo, e SÓ com resposta. Numa
    *                          rejeição a exclusão não aconteceu, o chamador
    *                          (settings.html) mostra o toast e NÃO navega:
@@ -115,7 +136,7 @@
    * de conta ficou de fora: consertei a instância e não a classe (Codex, #170).
    */
   const _SESSAO_ENCERRADA = {
-    "/auth/logout":  function (resp) { return !resp || resp.ok; },
+    "/auth/logout":  function ()     { return true; },
     "/auth/account": function (resp) { return !!resp && resp.ok; },
     "/auth/refresh": function (resp) { return !!resp && resp.status === 401; },
   };
@@ -153,8 +174,18 @@
     "finbot_logout_at", "finbot_reset_at",
   ]);
 
-  function _apagaStorage(store) {
+  /**
+   * Recebe o NOME, não o objeto: `window.localStorage` é um getter que LANÇA
+   * quando o site está com dados bloqueados (Chrome), e a avaliação do
+   * argumento acontecia fora do `try`. O comentário prometia sobreviver a isso
+   * e não sobrevivia — o erro subia por `_limpaEstadoDoDispositivo`, o Cache
+   * Storage e o service worker ficavam intactos (o resíduo que esta limpeza
+   * existe para remover) e o chamador recebia `SecurityError` no lugar do erro
+   * de rede.
+   */
+  function _apagaStorage(nome) {
     try {
+      const store = window[nome];
       Object.keys(store).forEach(function (k) {
         if (!_PRESERVA.has(k)) store.removeItem(k);
       });
@@ -179,8 +210,8 @@
    * são inofensivas e tirá-las seria outro PR.
    */
   function _limpaEstadoDoDispositivo() {
-    _apagaStorage(window.localStorage);
-    _apagaStorage(window.sessionStorage);
+    _apagaStorage("localStorage");
+    _apagaStorage("sessionStorage");
     // ORDEM: desregistra ANTES de apagar. Um worker ANTIGO ainda no controle
     // tem `cache.put` assíncrono no handler de fetch dele, e uma request em voo
     // noutra aba podia recriar o cache DEPOIS do delete (Codex, #170). O
@@ -241,9 +272,13 @@
    * vez de remendados um a um — é a terceira rodada deste PR na mesma classe,
    * e o CLAUDE.md §4 manda parar de remendar e enumerar quando isso acontece.
    *
-   * Não limpa duas vezes no mesmo turno: cada ponto avalia o predicado da SUA
-   * resposta, e os caminhos são exclusivos (ou o inicial encerrou, ou o refresh
-   * falhou, ou o retry encerrou).
+   * Cada ponto avalia o predicado da SUA resposta, e a limpeza roda uma vez:
+   * ou o inicial encerrou, ou o refresh falhou, ou o retry encerrou. A cadeia
+   * `logout → 401 → refresh OK → retry` limparia duas vezes agora que o logout
+   * encerra em qualquer resposta, mas ela não existe — a rota não tem
+   * dependência de auth, é no-op sem token e nunca responde 401
+   * (`finance_bot_websocket_custom.py`). Se um dia responder, a limpeza é
+   * idempotente e a segunda passada é desperdício, não dano.
    */
   async function _comLimpeza(caminho, resp) {
     const fim = _SESSAO_ENCERRADA[caminho];
@@ -256,7 +291,7 @@
    *
    * `await _origFetch(...)` estourava antes do `_comLimpeza`, então fetch que
    * REJEITA (offline, DNS, captive portal, abort) saía por baixo da limpeza —
-   * e é o pior caso, não o mais raro: `logoutSettings` (settings.html) não tem
+   * e não é o caso raro: `logoutSettings` (settings.html) não tem
    * limpeza própria nenhuma e navega no `.finally` mesmo com a rejeição, então
    * sair do Ajustes em modo avião deixava `pigbank_menu_v1` (e-mail, nome,
    * plano), `pb_home_<uid>` e o Cache Storage inteiro no aparelho, com cara de
@@ -272,6 +307,11 @@
     try {
       resp = await _origFetch(input, init);
     } catch (e) {
+      // Sem `try` em volta de propósito. Um `catch` aqui engoliria também o
+      // erro de um predicado quebrado — a limpeza deixaria de acontecer sem
+      // ninguém ficar sabendo, falha ABERTA, e a guarda de `null` de cada
+      // predicado pararia de ser medida por teste nenhum. O que protege o erro
+      // do chamador são as guardas, que falham fechado.
       await _comLimpeza(caminho, null);
       throw e;
     }

--- a/frontend/static/auth-refresh.js
+++ b/frontend/static/auth-refresh.js
@@ -58,7 +58,7 @@
         // aqui. Só o 401 conta: o backend responde 400 quando o cookie de
         // refresh falta mas o access token ainda vale — sessão de pé, nada a
         // apagar (finance_bot_websocket_custom.py, #173).
-        await _comLimpeza("/auth/refresh", r);
+        await _comLimpeza("/auth/refresh", r, "POST");
         return r.ok;
       } catch (_) {
         return false;
@@ -102,6 +102,14 @@
    *                          a limpeza ao `resp.ok` deixava esse caso e o 429
    *                          do `@limiter.limit("30/minute")` do lado errado.
    *
+   *                          O MÉTODO entra na conta porque o predicado é
+   *                          incondicional: um GET nesse pathname leva 405 e
+   *                          não navega para lugar nenhum, então limpar ali
+   *                          apagaria o aparelho de quem continua na página,
+   *                          logado (Codex). Os outros dois não precisam da
+   *                          checagem — o status já os prende, e um 405 não é
+   *                          `ok` nem 401.
+   *
    *                          O que isto NÃO faz: os cookies de sessão são
    *                          `httponly`, então JS nenhum os apaga, e num
    *                          logout que não chegou ao servidor a sessão
@@ -136,7 +144,7 @@
    * de conta ficou de fora: consertei a instância e não a classe (Codex, #170).
    */
   const _SESSAO_ENCERRADA = {
-    "/auth/logout":  function ()     { return true; },
+    "/auth/logout":  function (resp, metodo) { return metodo === "POST"; },
     "/auth/account": function (resp) { return !!resp && resp.ok; },
     "/auth/refresh": function (resp) { return !!resp && resp.status === 401; },
   };
@@ -280,9 +288,17 @@
    * (`finance_bot_websocket_custom.py`). Se um dia responder, a limpeza é
    * idempotente e a segunda passada é desperdício, não dano.
    */
-  async function _comLimpeza(caminho, resp) {
+  /** O método desta request, como o navegador o veria. */
+  function _metodo(input, init) {
+    const m = (init && init.method)
+      || (input && typeof input !== "string" && input.method)
+      || "GET";
+    return String(m).toUpperCase();
+  }
+
+  async function _comLimpeza(caminho, resp, metodo) {
     const fim = _SESSAO_ENCERRADA[caminho];
-    if (fim && fim(resp)) await _limpaEstadoDoDispositivo();
+    if (fim && fim(resp, metodo)) await _limpaEstadoDoDispositivo();
     return resp;
   }
 
@@ -312,10 +328,10 @@
       // ninguém ficar sabendo, falha ABERTA, e a guarda de `null` de cada
       // predicado pararia de ser medida por teste nenhum. O que protege o erro
       // do chamador são as guardas, que falham fechado.
-      await _comLimpeza(caminho, null);
+      await _comLimpeza(caminho, null, _metodo(input, init));
       throw e;
     }
-    return _comLimpeza(caminho, resp);
+    return _comLimpeza(caminho, resp, _metodo(input, init));
   }
 
   window.fetch = async function(input, init) {

--- a/frontend/static/auth-refresh.js
+++ b/frontend/static/auth-refresh.js
@@ -24,11 +24,16 @@
     // com essa forma, e `//host/x` e `/\host/x` apontam para OUTRO host — a
     // segunda porque a WHATWG normaliza `\` como `/`. Bastava uma delas
     // terminando em `/auth/logout` para o pathname bater e a limpeza apagar
-    // este aparelho. O parse abaixo compara HOST, e cobre as duas formas, o
-    // caminho relativo comum e a URL absoluta com uma regra só.
+    // este aparelho. O parse abaixo cobre as duas formas, o caminho relativo
+    // comum e a URL absoluta com uma regra só.
+    //
+    // ORIGEM, não host: host ignora o esquema, então numa página HTTPS o
+    // `http://mesmo-host/auth/logout` passava por nosso. O navegador recusa
+    // essa request por conteúdo misto, ela REJEITA, e a rejeição virou fim de
+    // sessão — o aparelho seria apagado por um logout que nunca saiu (Codex).
+    // "Mesma origem" é a definição certa aqui e é a que o cookie de sessão usa.
     try {
-      const u = new URL(url, window.location.origin);
-      return u.host === window.location.host;
+      return new URL(url, window.location.origin).origin === window.location.origin;
     } catch (_) { return false; }
   }
 

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -1015,3 +1015,24 @@ test("metodo em minusculo ainda e' POST — `fetch(url, {method:\"post\"})` e' v
                    "o logout com o metodo em minusculo parou de limpar o cache");
   assert.equal(local.has("pigbank_menu_v1"), false, "o menu sobreviveu ao logout");
 });
+
+test("mesmo host, esquema diferente NAO e' a nossa origem", async () => {
+  // `host` ignora o esquema. Numa pagina HTTPS o `http://mesmo-host/auth/logout`
+  // passava por nosso; o navegador recusa por conteudo misto, a request REJEITA,
+  // e a rejeicao vira fim de sessao — o aparelho apagado por um logout que nunca
+  // saiu do navegador. Achado do Codex no #230.
+  const apagados = [];
+  const repassadas = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async (input) => { repassadas.push(input); throw new TypeError("Failed to fetch"); };
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  const inseguro = `${ORIGEM.replace("https:", "http:")}/auth/logout`;
+  await assert.rejects(() => ctx.window.fetch(inseguro, { method: "POST" }), TypeError);
+
+  assert.deepEqual(repassadas, [inseguro],
+                   "a request nem chegou ao fetch original — o teste nao mede o caminho certo");
+  assert.deepEqual(apagados, [], "conteudo misto apagou o Cache Storage deste aparelho");
+  assert.equal(local.has("pigbank_menu_v1"), true, "conteudo misto apagou o menu deste aparelho");
+});

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -951,3 +951,67 @@ test("caminho relativo comum continua sendo interceptado sem o fast-path", async
   assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
                    "tirar o fast-path derrubou a interceptacao do caminho relativo");
 });
+
+// ── O METODO importa quando o predicado e' incondicional ────────────────
+//
+// `_caminho()` guarda so' o pathname, entao com o logout limpando em qualquer
+// resposta um GET no mesmo caminho tambem limpava. O backend so' define
+// `POST /auth/logout`, entao um GET leva 405 — e, ao contrario dos cinco donos
+// de logout, ele NAO navega para lugar nenhum: o usuario fica na pagina, com a
+// sessao viva no servidor e o aparelho apagado. Achado do Codex no #230.
+//
+// Os outros dois nao precisam da checagem: o status ja os prende, e um 405 nao
+// e' `ok` nem 401.
+
+for (const metodo of ["GET", "HEAD", "PUT"]) {
+  test(`${metodo} em /auth/logout NAO limpa — 405 e o usuario fica na pagina`, async () => {
+    const apagados = [];
+    const { ctx, local, sessao } = comStorageCheio("static/auth-refresh.js", (c) => {
+      c.fetch = async () => ({ ok: false, status: 405 });
+      c.caches.delete = async (k) => { apagados.push(k); return true; };
+    });
+
+    const opcoes = metodo === "GET" ? undefined : { method: metodo };
+    const resp = await ctx.window.fetch("/auth/logout", opcoes);
+
+    assert.equal(resp.status, 405);
+    assert.deepEqual(apagados, [], `${metodo} apagou o Cache Storage de quem continua logado`);
+    for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+      assert.equal(local.has(k), true, `${k} foi apagado por um ${metodo} que levou 405`);
+    }
+    assert.equal(sessao.has("pb_home_42"), true, "pb_home_ foi apagado da sessao");
+  });
+}
+
+test("o metodo sai do objeto Request quando nao vem no init", async () => {
+  // `fetch(new Request(url, {method}))` nao passa `init`. Sem ler o `.method` do
+  // objeto o metodo cairia para o default GET e o logout legitimo pararia de
+  // limpar — regressao pior que o bug que a checagem conserta.
+  const apagados = [];
+  const { ctx } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async () => ({ ok: true, status: 200 });
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await ctx.window.fetch({ url: "/auth/logout", method: "POST" });
+
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                   "o metodo do objeto Request foi ignorado e o logout parou de limpar");
+});
+
+test("metodo em minusculo ainda e' POST — `fetch(url, {method:\"post\"})` e' valido", async () => {
+  // O navegador aceita o metodo em qualquer caixa. Sem normalizar, um chamador
+  // que escrevesse "post" faria o logout parar de limpar em silencio —
+  // regressao pior que o 405 que a checagem de metodo conserta.
+  const apagados = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async () => ({ ok: true, status: 200 });
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await ctx.window.fetch("/auth/logout", { method: "post" });
+
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                   "o logout com o metodo em minusculo parou de limpar o cache");
+  assert.equal(local.has("pigbank_menu_v1"), false, "o menu sobreviveu ao logout");
+});

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -654,3 +654,129 @@ test("o worker NAO tem listener de message — a limpeza e' da pagina", () => {
   assert.ok(!/addEventListener\(\s*["']message["']/.test(fonte),
             "a limpeza voltou para o worker: nao alcanca aparelho com worker antigo");
 });
+
+// ── Logout SEM RESPOSTA: o fetch rejeita (offline, DNS, captive portal) ──
+//
+// O quarto caminho do interceptor, e o unico que nao produzia resposta: o
+// `await _origFetch(...)` estourava ANTES do `_comLimpeza`, entao nada era
+// apagado. Alcancavel de verdade — modo aviao / wifi de aeroporto + "Sair" no
+// Ajustes —, e o pior dos cinco donos de logout: `logoutSettings`
+// (settings.html) nao tem limpeza local nenhuma, grava o `finbot_logout_at`
+// ANTES do fetch (as outras abas caem para /?logout=1) e navega no `.finally`
+// mesmo com a rejeicao. O logout PARECIA ter dado certo com tudo no aparelho.
+//
+// O par de controles: apagar sem resposta vale so' para o /auth/logout. Nas
+// outras duas rotas do mapa a rejeicao e' rede fora com a sessao DE PE, e
+// limpar ali seria pior que o bug.
+
+/** fetch falso que rejeita como o navegador rejeita: TypeError, sem resposta. */
+const fetchOffline = () => async () => { throw new TypeError("Failed to fetch"); };
+
+test("logout OFFLINE limpa o aparelho — e a rejeicao ainda chega ao chamador", async () => {
+  const apagados = [];
+  const { ctx, local, sessao } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = fetchOffline();
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await assert.rejects(() => ctx.window.fetch("/auth/logout", { method: "POST" }),
+                       TypeError,
+                       "a rejeicao foi engolida: o chamador perde o erro de rede");
+
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), false, `${k} sobreviveu ao logout offline`);
+  }
+  assert.equal(sessao.has("pb_home_42"), false, "pb_home_ sobreviveu na sessao");
+  assert.equal(sessao.has("pb_snap_42_2026_08"), false, "pb_snap_ sobreviveu na sessao");
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                   "o Cache Storage sobreviveu ao logout offline");
+  for (const k of Object.keys(PREFERENCIA_DO_APARELHO)) {
+    assert.equal(local.get(k), PREFERENCIA_DO_APARELHO[k],
+                 `${k} foi apagado — e' preferencia do aparelho, nao da conta`);
+  }
+});
+
+test("offline em rota comum NAO limpa — o interceptor renova e a sessao segue", async () => {
+  // Controle positivo: o caminho legitimo (perder a rede com a sessao viva)
+  // tem que continuar funcionando. Sem ele, apagar em TODA rejeicao passaria
+  // nos casos acima destruindo o aparelho de quem so' entrou no metro.
+  const apagados = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = fetchOffline();
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await assert.rejects(() => ctx.window.fetch("/data/42"), TypeError);
+
+  assert.deepEqual(apagados, [], "apagou o Cache Storage num GET que so' perdeu a rede");
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), true, `${k} foi apagado com a sessao viva`);
+  }
+});
+
+test("offline no /auth/refresh NAO limpa — rejeicao nao e' o 401 do fim de sessao", async () => {
+  // O refresh e' disparado por reflexo em qualquer 401 (#176). Se a rejeicao
+  // dele contasse como fim de sessao, bastava um 401 de aplicacao com a rede
+  // instavel para apagar o aparelho.
+  const apagados = [];
+  const chamadas = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async (input) => {
+      const caminho = new URL(typeof input === "string" ? input : input.url, ORIGEM).pathname;
+      chamadas.push(caminho);
+      if (caminho === "/auth/refresh") throw new TypeError("Failed to fetch");
+      return { ok: false, status: 401 };
+    };
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  const resp = await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+
+  assert.ok(chamadas.includes("/auth/refresh"),
+            "o interceptor nem tentou renovar — o teste nao mede o caminho certo");
+  assert.equal(resp.status, 401, "o 401 tem que chegar ao chamador");
+  assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao de pe");
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), true, `${k} foi apagado por uma renovacao sem rede`);
+  }
+});
+
+test("offline no DELETE /auth/account NAO limpa — a exclusao nao aconteceu", async () => {
+  // O chamador (settings.html, ~:2605) mostra o toast e NAO navega nessa
+  // falha: o usuario continua logado na propria pagina. Apagar o aparelho dele
+  // ali seria pior que o bug que este PR conserta.
+  const apagados = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = fetchOffline();
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await assert.rejects(() => ctx.window.fetch("/auth/account", { method: "DELETE" }), TypeError);
+
+  assert.deepEqual(apagados, [], "apagou o Cache Storage de quem continua logado");
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), true, `${k} foi apagado numa exclusao que falhou`);
+  }
+});
+
+test("offline no /auth/refresh chamado DIRETO nao limpa nem estoura no predicado", async () => {
+  // O refresh do `_doRefresh` e' interno e nao passa pelo wrapper, entao o
+  // predicado dele so' e' alcancado quando alguem chama a rota direto. Sem o
+  // `!!resp &&`, `resp.status` num `resp` null trocaria o TypeError de rede do
+  // navegador por um TypeError de leitura de null — erro diferente chegando ao
+  // chamador, no meio da limpeza.
+  const apagados = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = fetchOffline();
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await assert.rejects(() => ctx.window.fetch("/auth/refresh", { method: "POST" }),
+                       (e) => e instanceof TypeError && /Failed to fetch/.test(e.message),
+                       "o erro que chegou ao chamador nao e' o da rede");
+
+  assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao de pe");
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), true, `${k} foi apagado por um refresh sem rede`);
+  }
+});

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -228,7 +228,11 @@ function paginaComCache(arquivo, prepara) {
       delete: async (k) => { apagados.push(k); return true; },
     },
     localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
-    location: { origin: ORIGEM, pathname: "/", href: ORIGEM, reload: () => {}, replace: () => {} },
+    // `host` nao e' decoracao: `_isOwnApi` compara POR ELE. Sem o campo, toda
+    // URL absoluta batia contra `undefined` e o interceptor tratava a PROPRIA
+    // origem como terceiro — o harness ficava cego a metade do `_isOwnApi`.
+    location: { origin: ORIGEM, host: new URL(ORIGEM).host, pathname: "/", href: ORIGEM,
+                reload: () => {}, replace: () => {} },
     navigator: { serviceWorker: { controller: null, getRegistrations: async () => [] } },
     document: {
       cookie: "", readyState: "complete",
@@ -256,7 +260,10 @@ test("auth-refresh apaga o Cache Storage num logout bem-sucedido", async () => {
                    "o logout nao limpou o cache do aparelho");
 });
 
-test("auth-refresh nao apaga nada em request comum nem em logout que falhou", async () => {
+test("auth-refresh nao apaga nada numa request comum", async () => {
+  // O titulo antigo prometia "nem em logout que falhou" e o corpo so' chamava
+  // `/data/42` — nunca houve logout aqui. O logout que falha tem os seus casos
+  // proprios no fim do arquivo, e o comportamento e' o OPOSTO: ele limpa.
   const { ctx, apagados } = paginaComCache("static/auth-refresh.js");
   ctx.fetch = ctx.window.fetch;
 
@@ -714,33 +721,6 @@ test("offline em rota comum NAO limpa — o interceptor renova e a sessao segue"
   }
 });
 
-test("offline no /auth/refresh NAO limpa — rejeicao nao e' o 401 do fim de sessao", async () => {
-  // O refresh e' disparado por reflexo em qualquer 401 (#176). Se a rejeicao
-  // dele contasse como fim de sessao, bastava um 401 de aplicacao com a rede
-  // instavel para apagar o aparelho.
-  const apagados = [];
-  const chamadas = [];
-  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
-    c.fetch = async (input) => {
-      const caminho = new URL(typeof input === "string" ? input : input.url, ORIGEM).pathname;
-      chamadas.push(caminho);
-      if (caminho === "/auth/refresh") throw new TypeError("Failed to fetch");
-      return { ok: false, status: 401 };
-    };
-    c.caches.delete = async (k) => { apagados.push(k); return true; };
-  });
-
-  const resp = await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
-
-  assert.ok(chamadas.includes("/auth/refresh"),
-            "o interceptor nem tentou renovar — o teste nao mede o caminho certo");
-  assert.equal(resp.status, 401, "o 401 tem que chegar ao chamador");
-  assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao de pe");
-  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
-    assert.equal(local.has(k), true, `${k} foi apagado por uma renovacao sem rede`);
-  }
-});
-
 test("offline no DELETE /auth/account NAO limpa — a exclusao nao aconteceu", async () => {
   // O chamador (settings.html, ~:2605) mostra o toast e NAO navega nessa
   // falha: o usuario continua logado na propria pagina. Apagar o aparelho dele
@@ -779,4 +759,195 @@ test("offline no /auth/refresh chamado DIRETO nao limpa nem estoura no predicado
   for (const k of Object.keys(DERIVADO_DE_CONTA)) {
     assert.equal(local.has(k), true, `${k} foi apagado por um refresh sem rede`);
   }
+});
+
+// ── Logout que RESPONDE ERRO: a outra metade da mesma classe ─────────────
+//
+// O primeiro corte deste PR prendia a limpeza ao `resp.ok` e so' abria excecao
+// para a rejeicao. Era consertar a instancia: o argumento que justifica limpar
+// sem resposta ("o chamador navega para a tela deslogada de qualquer jeito")
+// nao depende de HAVER resposta — vale igual para 403, 429 e 500.
+//
+// E o 403 nao precisa de modo aviao: o cookie `csrf_token` dura 24h
+// (CSRF_COOKIE_MAX_AGE) e so' e' reemitido em metodo SEGURO quando falta, entao
+// uma aba deixada aberta mais de um dia manda o POST sem o header e leva 403 do
+// `csrf_middleware` — antes da rota, sem o backend limpar cookie nenhum. O 429
+// vem do `@limiter.limit("30/minute")` da propria rota.
+
+for (const status of [403, 429, 500]) {
+  test(`logout que responde ${status} limpa — o chamador navega igual`, async () => {
+    const apagados = [];
+    const { ctx, local, sessao } = comStorageCheio("static/auth-refresh.js", (c) => {
+      c.fetch = async () => ({ ok: false, status });
+      c.caches.delete = async (k) => { apagados.push(k); return true; };
+    });
+
+    const resp = await ctx.window.fetch("/auth/logout", { method: "POST" });
+
+    assert.equal(resp.status, status, "o status tem que chegar ao chamador");
+    assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                     `logout ${status} deixou o Cache Storage no aparelho`);
+    for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+      assert.equal(local.has(k), false, `${k} sobreviveu a um logout ${status}`);
+    }
+    assert.equal(sessao.has("pb_home_42"), false, "pb_home_ sobreviveu na sessao");
+  });
+}
+
+test("URL protocolo-relativa de terceiro NAO e' a nossa origem", async () => {
+  // `_isOwnApi` aceitava qualquer string comecando com "/", inclusive `//host/`,
+  // ANTES de tentar parsear — e ai `_caminho()` resolvia
+  // `//cdn-de-terceiro/auth/logout` para o pathname `/auth/logout`. Com a
+  // limpeza agora disparando tambem sem resposta, e fetch cross-origin sem CORS
+  // SEMPRE rejeitando, bastaria uma dessas URLs para apagar o aparelho.
+  const apagados = [];
+  const repassadas = [];
+  const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async (input) => { repassadas.push(input); throw new TypeError("Failed to fetch"); };
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await assert.rejects(() => ctx.window.fetch("//cdn-de-terceiro.example.com/auth/logout",
+                                              { method: "POST" }), TypeError);
+
+  assert.deepEqual(repassadas, ["//cdn-de-terceiro.example.com/auth/logout"],
+                   "a request nem chegou ao fetch original — o teste nao mede o caminho certo");
+  assert.deepEqual(apagados, [], "um host de terceiro apagou o Cache Storage deste aparelho");
+  for (const k of Object.keys(DERIVADO_DE_CONTA)) {
+    assert.equal(local.has(k), true, `${k} foi apagado por uma URL de terceiro`);
+  }
+});
+
+test("caminho absoluto da PROPRIA origem continua sendo interceptado", async () => {
+  // Controle positivo do caso acima: a guarda do `//` nao pode derrubar a
+  // deteccao por HOST, que e' o que faz `https://pigbankai.com/auth/logout`
+  // (URL absoluta, mesma origem) continuar passando pela limpeza.
+  const apagados = [];
+  const { ctx } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async () => ({ ok: true, status: 200 });
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await ctx.window.fetch(`${ORIGEM}/auth/logout`, { method: "POST" });
+
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                   "a guarda do // derrubou a interceptacao da propria origem");
+});
+
+// ── Storage BLOQUEADO: o getter que lanca antes de qualquer try ─────────
+//
+// `window.localStorage` nao e' um campo, e' um GETTER, e ele LANCA
+// `SecurityError` quando o site esta' com dados bloqueados (Chrome) ou o
+// WKWebView nega storage. O `try` do `apagaStorage` protegia o `forEach`, mas a
+// avaliacao do ARGUMENTO acontecia fora dele — entao o erro subia por
+// `_limpaEstadoDoDispositivo` e derrubava a limpeza inteira ANTES do Cache
+// Storage e do service worker, que sao justamente o residuo que ela existe para
+// remover. De quebra, o chamador recebia `SecurityError` no lugar do erro real.
+
+/**
+ * `paginaComCache` com um dos storages lancando no ACESSO, como o navegador.
+ *
+ * O getter TEM que morar num `window` separado do global do vm: definido no
+ * proprio global, o Node engole a excecao e devolve `undefined` — medido, e foi
+ * assim que a primeira versao destes tres casos passou sem medir nada.
+ */
+function comStorageBloqueado(qual, prepara) {
+  const apagados = [];
+  const { ctx } = paginaComCache("static/auth-refresh.js", (c) => {
+    const win = Object.create(c);
+    Object.defineProperty(win, qual, {
+      configurable: true,
+      get() { const e = new Error("Access is denied for this document."); e.name = "SecurityError"; throw e; },
+    });
+    c.window = win;
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+    if (prepara) prepara(c);
+  });
+  return { ctx, apagados };
+}
+
+for (const qual of ["localStorage", "sessionStorage"]) {
+  test(`${qual} bloqueado nao derruba a limpeza do cache no logout`, async () => {
+    const { ctx, apagados } = comStorageBloqueado(qual);
+
+    const resp = await ctx.window.fetch("/auth/logout", { method: "POST" });
+
+    assert.equal(resp.ok, true, "o logout nem devolveu resposta ao chamador");
+    assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                     `com ${qual} bloqueado o Cache Storage ficou no aparelho`);
+  });
+}
+
+test("storage bloqueado no logout OFFLINE: limpa o cache E devolve o erro DA REDE", async () => {
+  // Os dois danos de uma vez. Sem o conserto o chamador recebia o SecurityError
+  // do getter em vez do TypeError da rede, e nada era apagado.
+  const desregistrados = [];
+  const { ctx, apagados } = comStorageBloqueado("localStorage", (c) => {
+    c.fetch = async () => { throw new TypeError("Failed to fetch"); };
+    c.navigator.serviceWorker.getRegistrations = async () => [
+      { unregister: async () => { desregistrados.push(1); return true; } },
+    ];
+  });
+
+  await assert.rejects(() => ctx.window.fetch("/auth/logout", { method: "POST" }),
+                       (e) => e instanceof TypeError && /Failed to fetch/.test(e.message),
+                       "o chamador recebeu o erro do storage, nao o da rede");
+
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"], "o cache ficou no aparelho");
+  assert.equal(desregistrados.length, 1, "o service worker nao foi desregistrado");
+});
+
+test("nav-auth tem a mesma correcao — o Sair das publicas parava de recarregar", () => {
+  // §0.7 de novo: o `apagaStorage` do nav-auth e' a copia do outro e tinha o
+  // mesmo `try` no lugar errado. La o dano e' pior: o `.finally` do `doLogout`
+  // rejeitava e o `location.reload()` NUNCA rodava — o botao "Sair" das 12
+  // paginas publicas nao fazia nada visivel. O `doLogout` e' interno ao IIFE e
+  // so' e' alcancado por clique, entao o que se prende aqui e' a FORMA: nenhum
+  // dos dois pode avaliar o getter fora do try.
+  const dir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
+  for (const [nome, caminho] of [["nav-auth.js", ["nav-auth.js"]],
+                                 ["auth-refresh.js", ["static", "auth-refresh.js"]]]) {
+    const fonte = readFileSync(join(dir, ...caminho), "utf-8");
+    assert.ok(!/apagaStorage\(\s*window\./i.test(fonte),
+              `${nome} volta a avaliar o getter de storage FORA do try: com dados do site bloqueados a limpeza inteira morre antes do Cache Storage`);
+    assert.ok(/pagaStorage\("localStorage"\)/.test(fonte) && /pagaStorage\("sessionStorage"\)/.test(fonte),
+              `${nome} parou de limpar um dos dois storages`);
+  }
+});
+
+test("URL com barra invertida tambem aponta para outro host", async () => {
+  // `//host/x` era o caso obvio; `/\host/x` resolve para o MESMO lugar porque a
+  // WHATWG normaliza `\` como `/`, e nao comeca com `//`. Consertar so' o
+  // primeiro era consertar a instancia: por esta ainda dava para apagar o
+  // aparelho de quem carregasse a URL. O conserto foi tirar o fast-path e
+  // deixar a comparacao por HOST decidir.
+  for (const url of ["//evil.example.com/auth/logout",
+                     "/\\evil.example.com/auth/logout",
+                     "/\\/evil.example.com/auth/logout"]) {
+    const apagados = [];
+    const { ctx, local } = comStorageCheio("static/auth-refresh.js", (c) => {
+      c.fetch = async () => { throw new TypeError("Failed to fetch"); };
+      c.caches.delete = async (k) => { apagados.push(k); return true; };
+    });
+
+    await assert.rejects(() => ctx.window.fetch(url, { method: "POST" }), TypeError);
+
+    assert.deepEqual(apagados, [], `${url} apagou o Cache Storage deste aparelho`);
+    assert.equal(local.has("pigbank_menu_v1"), true, `${url} apagou o menu deste aparelho`);
+  }
+});
+
+test("caminho relativo comum continua sendo interceptado sem o fast-path", async () => {
+  // Controle positivo de tirar o fast-path: `/auth/logout` cru e' a forma que
+  // TODOS os cinco donos de logout usam, e ela nao pode deixar de ser nossa.
+  const apagados = [];
+  const { ctx } = comStorageCheio("static/auth-refresh.js", (c) => {
+    c.fetch = async () => ({ ok: true, status: 200 });
+    c.caches.delete = async (k) => { apagados.push(k); return true; };
+  });
+
+  await ctx.window.fetch("/auth/logout", { method: "POST" });
+
+  assert.deepEqual(apagados.sort(), ["pigbank-v8", "pigbank-v9"],
+                   "tirar o fast-path derrubou a interceptacao do caminho relativo");
 });


### PR DESCRIPTION
Bug **pré-existente**, medido durante o #226 e fora do escopo dele. Não foi introduzido lá.

## O defeito

`_comLimpeza` do `frontend/static/auth-refresh.js` só era alcançado quando existia **resposta**: o `await _origFetch(...)` estourava antes. Fetch que **rejeita** — offline, DNS, captive portal — passava inteiro por fora da limpeza, e `_limpaEstadoDoDispositivo()` nunca rodava.

O pior dono é o `logoutSettings` ([settings.html:1774](frontend/settings.html#L1774)): não tem limpeza local nenhuma, grava o `finbot_logout_at` **antes** do fetch (as outras abas caem para `/?logout=1`) e navega no `.finally` mesmo com a rejeição. **Sair do Ajustes em modo avião deixava tudo no aparelho com cara de logout bem-sucedido.**

E não é só sem rede. O ataque encontrou a outra metade: **403, 429 e 500 também deixavam tudo**, e o 403 não precisa de modo avião nenhum — o cookie `csrf_token` dura 24h (`CSRF_COOKIE_MAX_AGE`) e só é reemitido em método **seguro** quando falta, então uma aba deixada aberta mais de um dia manda o POST sem header e leva **403 do `csrf_middleware`, antes da rota**. `/auth/logout` não está em `CSRF_EXEMPT_PATHS`, e tem `@limiter.limit("30/minute")` para o 429.

## A classe é maior que o Ajustes

Antes deste PR, offline os cinco donos de logout ficavam assim — a limpeza completa mora num lugar só (`_limpaEstadoDoDispositivo`), e era exatamente esse que não rodava:

| offline (fetch rejeita) | `pigbank_menu_v1` | `pb_home_`/`pb_snap_` | Cache Storage |
|---|---|---|---|
| `dashboard.js:446` | limpa | limpa | **fica** |
| `home.html:872` | **fica** | limpa | **fica** |
| `settings.html:1774` | **fica** | **fica** | **fica** |
| `settings.html` (exclusão) | n/a — não navega em falha de rede | | |
| `nav-auth.js:97` | limpa | limpa | limpa |

**Impacto:** resíduo privado no aparelho compartilhado (a ameaça do #170). `pigbank_menu_v1` guarda e-mail, nome e plano; `pb_home_<uid>` guarda snapshot, histórico, e-mail e nome.

**Não há paint cruzado entre contas** — `restoreHomeCache` valida `userId` (home.html:1436), a chave `pb_snap_` carrega o `USER_ID` e `loadUserMenuState` descarta cache de outro usuário (dashboard.js:163).

## O conserto

No **interceptor**, não no chamador. `_requestComLimpeza` envolve o `_origFetch`, chama `_comLimpeza(caminho, null)` e re-lança o erro original. A alternativa era mover a limpeza para o `.finally` do `logoutSettings`, como o `nav-auth.js` faz; descartada porque conserta 1 dos 3 sites e obrigaria a duplicar a lista `_PRESERVA` dentro do `settings.html` (§0.7 e §0.1).

### Qual rota limpa sem resposta é decisão do predicado

```js
"/auth/logout":  function ()     { return true; },
"/auth/account": function (resp) { return !!resp && resp.ok; },
"/auth/refresh": function (resp) { return !!resp && resp.status === 401; },
```

Era o risco de "pior que o bug", e está fechado por escopo:

- **`/auth/refresh`** — o interceptor renova por reflexo em qualquer 401 (#176). Se a rejeição contasse como fim de sessão, um 401 de aplicação com a rede instável apagaria o aparelho de quem só entrou no metrô.
- **`DELETE /auth/account`** — em falha de rede o chamador mostra o toast e **não navega**: o usuário continua logado na própria página.
- **Abort** — nenhum chamador de logout ou de exclusão de conta usa `AbortController`. O `/admin/auth/logout` é outro caminho e não está no mapa.

### Mais dois consertos que o ataque forçou

**`_isOwnApi` aceitava URL de terceiro.** Qualquer string começando com `/` era tratada como nossa, inclusive `//host/x` — e `_caminho()` resolvia `//cdn-de-terceiro/auth/logout` para o pathname `/auth/logout`. Com a limpeza disparando também sem resposta, e fetch cross-origin sem CORS **sempre** rejeitando, bastava uma dessas URLs. A primeira tentativa emendou o fast-path com `!url.startsWith("//")` e **`/\host/x` burlava** (a WHATWG normaliza `\` como `/`). O conserto é **apagar o fast-path**: a comparação por host cobre caminho relativo, `//host`, `/\host` e absoluto com uma regra só.

**`_apagaStorage` tinha o `try` no lugar errado, nos dois arquivos.** `window.localStorage` é um *getter* que lança `SecurityError` com dados do site bloqueados, e era avaliado **fora** do `try`. O erro subia por `_limpaEstadoDoDispositivo` e derrubava a limpeza **antes** do Cache Storage e do service worker — o resíduo que ela existe para remover. Em `nav-auth.js` o dano era maior: o `.finally` do `doLogout` rejeitava e o `location.reload()` nunca rodava, então o "Sair" das 12 páginas públicas não fazia nada visível. As duas funções passam a receber o **nome**, não o objeto.

## Medido

**Suítes (esta árvore, `main` a 0 commits de distância):**
- `pytest -q` → **5366 passed, 1 xfailed, 0 failed**. Inclui `test_static_pages_routes.py`, que compara o mapa `_SESSAO_ENCERRADA` com as rotas do Python por `ast`.
- `npm run test:frontend` → **244/244 passed**.

> Três rodadas anteriores do frontend deram falhas em arquivos diferentes a cada vez. A causa foi identificada e é ambiente, não este diff: `Error: http.server morreu (porta 8901 ocupada?)` — servidor pendurado de rodada anterior. Cada arquivo afetado passa isolado, e a rodada com a porta livre fecha 244/244.

**43 casos** em `tests/frontend/sw_cache_privado.test.mjs`, carregando o `auth-refresh.js` real numa vm.

**Controles negativos — 12 mutações, cada uma mata ao menos um caso:**

| mutação | caso que fica vermelho |
|---|---|
| limpeza na rejeição desligada | `logout OFFLINE limpa o aparelho` |
| logout só com `resp.ok` (código da `main`) | `logout OFFLINE` + os três de 403/429/500 |
| logout sem resposta sim, erro não (1º corte deste PR) | os três de 403/429/500 |
| `account` sem a guarda de null | `offline no DELETE /auth/account` |
| `account` limpa em toda rejeição | `offline no DELETE /auth/account` |
| `refresh` sem a guarda de null | `offline no /auth/refresh chamado DIRETO` |
| fast-path de volta com a guarda do `//` | `URL com barra invertida` |
| fast-path cru de volta | `barra invertida` + `protocolo-relativa` |
| `_apagaStorage` volta a receber o objeto | os três de storage bloqueado + o de forma |
| idem em `nav-auth.js` | o caso de forma |
| harness sem `location.host` | `caminho absoluto da PRÓPRIA origem` |

**Controles positivos:** offline em rota comum e no `DELETE /auth/account` não limpa nada; caminho relativo comum e URL absoluta da própria origem continuam sendo interceptados.

**Três casos meus foram descartados por não medirem nada:** um tautológico (verde nos 7 cenários — o refresh interno não passa pelo wrapper) e três de storage bloqueado que passavam porque o `vm` do Node engole exceção de getter definido no objeto global (movidos para um `window` separado). O título de `"…nem em logout que falhou"` mentia desde antes deste PR: o corpo só chamava `/data/42`.

## Fora de escopo, registrado

`finance_bot_websocket_custom.py:2763` manda `Clear-Site-Data: "cookies", "storage"` no **200** do logout, o que apaga o `localStorage` inteiro — incluindo as 7 chaves que a lista `_PRESERVA` jura preservar. Duas fontes de verdade em conflito (§0.7), e uma consequência provável: `settings.html:1775` grava o `finbot_logout_at` **antes** do fetch, o header o apaga, e o `storage` event nunca dispara — **sair pelo Ajustes não desloga as outras abas**. Medido em Chromium 151; **não medido em WebKit**, então o comportamento no app iOS fica em aberto. Pré-existente e de decisão própria, não entra aqui.

Também levantados e não tocados, todos sem chamador hoje: base de resolução `location.origin` vs `document.baseURI`, `/auth/logout/` com barra final, e `fetch(new URL(...))` (objeto `URL` não tem `.url`, então não é interceptado).

## Não verificado aqui

Mudança de frontend só aparece **depois do deploy** — o app iOS carrega o site ao vivo (§5). O cenário real (modo avião no aparelho, ou aba de 24h + "Sair") não foi exercitado neste ambiente; o que está provado é o `auth-refresh.js` real rodando em vm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)