### PR TITLE
Os dois gates que a execução mostrou necessários — e as três que ela matou (Etapa 10)

### DIFF
--- a/.claude/commands/time-dev.md
+++ b/.claude/commands/time-dev.md
@@ -39,6 +39,26 @@ valem por cima deste fluxo genérico.
    apontou (não necessariamente o Coder) com o apontamento exato, e repita a
    partir do passo relevante.
 
+## Gates deste repositório
+
+- **Verde local não é verde no CI: o venv local não é o `requirements.txt`.** Em
+  2026-09-02, `fastapi` 0.115.6 aqui × 0.141.1 no `requirements.txt`; remeça, não reuse
+  (na raiz do repo, que é onde mora o `.venv` — worktree não tem o seu):
+  `.venv/bin/python -c "import fastapi; print(fastapi.__version__)"` × `grep -i '^fastapi' requirements.txt`.
+  Teste que toca a superfície de API passa aqui e falha lá. Mande o **Tester** comparar
+  as duas versões, com o interpretador que a skill `baseline-testes` manda usar.
+- **Diff toca `frontend/service-worker.js` → mande o Coder bumpar o `CACHE_NAME` E o par
+  dele**: `VERSAO_ATUAL`, em `tests/frontend/sw_cache_privado.test.mjs`, para o mesmo N.
+  Os dois números são um só — bumpar o `CACHE_NAME` sozinho derruba 2 de 28 em
+  `node --test tests/frontend/sw_cache_privado.test.mjs` (medido em 2026-09-02, v9→v10:
+  28/28 → 26/28; remeça, não reuse). O gatilho é QUALQUER diff no arquivo, typo em
+  comentário incluso; o gate compara a base com o PR inteiro
+  (`git diff --quiet HEAD^1 HEAD -- "$SW"`, `.github/workflows/tests.yml:309`), então
+  bump em commit posterior do mesmo PR passa. A suíte local participa pela metade, e o
+  step só roda em `pull_request`: quem ESQUECE o bump passa local e só o CI pega; quem
+  bumpa SEM o par fica vermelho local. Por que o bump importa: `docs/armadilhas.md`,
+  § "Service worker e PWA".
+
 ## Regras do orquestrador
 
 - Nunca pule uma etapa para economizar tempo — o valor do time é justamente

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -360,14 +360,14 @@ jobs:
             case "$RC" in
               0) ;;
               3|4)
-                echo "::warning file=$SW,title=O gate não reconheceu a declaração do CACHE_NAME na base::Na base deste PR (HEAD^1) o gate não reconheceu UMA declaração 'const CACHE_NAME = \"...\"' (motivo no log acima), então não comparou o valor e está aprovando SEM verificar o bump. ATENÇÃO: isto não significa que a base não tivesse um CACHE_NAME legível — significa que a forma dela está fora do que este grep casa. Caem aqui, entre outros, 'export const', BOM ou outro byte invisível antes da declaração, e declarações repetidas com valores divergentes. Se você mexeu na estratégia de cache, confirme na thread do PR que o CACHE_NAME foi bumpado."
+                echo "::warning file=$SW,title=O gate não reconheceu a declaração do CACHE_NAME na base::Na base deste PR (HEAD^1) o gate não reconheceu UMA declaração 'const CACHE_NAME = \"...\"' (motivo no log acima), então não comparou o valor e está aprovando SEM verificar o bump. ATENÇÃO: isto não significa que a base não tivesse um CACHE_NAME legível — significa que a forma dela está fora do que este grep casa. Caem aqui, entre outros, 'export const', BOM ou outro byte invisível antes da declaração, e declarações repetidas com valores divergentes. Este step só chegou aqui porque o $SW mudou neste PR — o gatilho é QUALQUER diff no arquivo, typo em comentário incluso, não só mudança na estratégia de cache. Confirme na thread do PR que o CACHE_NAME foi bumpado."
                 exit 0 ;;
               *) falhou "HEAD^1 (a base deste PR)" ;;
             esac
           fi
 
           if [ "$NOVA" = "$VELHA" ]; then
-            echo "::error file=$SW,title=CACHE_NAME não foi bumpado::$SW mudou neste PR e o CACHE_NAME continua \"$NOVA\". O activate apaga todo cache de nome diferente do atual, então bumpar a versão é o que REMOVE do aparelho o que a anterior já tinha guardado: sem o bump, a regra nova só alcança gravação NOVA — e quem decide isso é a allowlist do podeCachear, não o PRECACHE: item tirado do precache que a allowlist ainda aceita volta a ser cacheado em runtime, como o Chart.js. O dado privado que já está lá continua lá. Não confunda com entregar o código novo — isso já acontece sozinho, por no-cache na rota mais skipWaiting e clients.claim. Bumpe para o próximo pigbank-vN ou justifique na thread do PR."
+            echo "::error file=$SW,title=CACHE_NAME não foi bumpado::$SW mudou neste PR e o CACHE_NAME continua \"$NOVA\". O activate apaga todo cache de nome diferente do atual, então bumpar a versão é o que REMOVE do aparelho o que a anterior já tinha guardado: sem o bump, a regra nova só alcança gravação NOVA — e quem decide isso é a allowlist do podeCachear, não o PRECACHE: item tirado do precache que a allowlist ainda aceita volta a ser cacheado em runtime, como o Chart.js. O dado privado que já está lá continua lá. Não confunda com entregar o código novo — isso já acontece sozinho, por no-cache na rota mais skipWaiting e clients.claim. Bumpe para o próximo pigbank-vN — e ponha o mesmo N no VERSAO_ATUAL de tests/frontend/sw_cache_privado.test.mjs, senão o npm run test:frontend fica vermelho — ou justifique na thread do PR."
             exit 1
           fi
 
@@ -398,7 +398,7 @@ jobs:
           NN=$(versao "$NOVA") && RCN=0 || RCN=$?
           VN=$(versao "$VELHA") && RCV=0 || RCV=$?
           if [ "$RCN" -eq 0 ] && [ "$RCV" -eq 0 ] && [ "$NN" -le "$VN" ]; then
-            echo "::error file=$SW,title=CACHE_NAME regrediu::$SW mudou neste PR e o CACHE_NAME foi de \"$VELHA\" para \"$NOVA\", que não avança. O activate só apaga cache de nome DIFERENTE do atual, então voltar para um nome já usado faz o aparelho que ainda tem aquele cache reusar o conteúdo antigo — inclusive o dado privado que o bump anterior tinha tirado de circulação. Bumpe para um pigbank-vN maior que $VN. (Nomes de texto diferente e mesmo número, como v9 e v09, contam como a mesma versão: o cache tem UM nome só, e não é o texto da declaração.)"
+            echo "::error file=$SW,title=CACHE_NAME regrediu::$SW mudou neste PR e o CACHE_NAME foi de \"$VELHA\" para \"$NOVA\", que não avança. O activate só apaga cache de nome DIFERENTE do atual, então voltar para um nome já usado faz o aparelho que ainda tem aquele cache reusar o conteúdo antigo — inclusive o dado privado que o bump anterior tinha tirado de circulação. Bumpe para um pigbank-vN maior que $VN, e ponha o mesmo N no VERSAO_ATUAL de tests/frontend/sw_cache_privado.test.mjs, senão o npm run test:frontend fica vermelho. (Nomes de texto diferente e mesmo número, como v9 e v09, contam como a mesma versão: o cache tem UM nome só, e não é o texto da declaração.)"
             exit 1
           fi
 

--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -159,8 +159,11 @@ outro módulo não pode receber `immutable` enquanto não tiver hash no nome.
 HTML e auth nunca são cacheados, assets são network-first com fallback de cache,
 API e WebSocket passam direto. O `manifest.json` tem `start_url: "/login"` — e a
 `index.html` tem um guard no topo que manda a PWA instalada para `/login`, com saída
-por `?site=1`. Mexeu na estratégia de cache? Bumpe o `CACHE_NAME` — e o CI reprova quem esquecer,
-desde o #197.
+por `?site=1`. Mexeu no `frontend/service-worker.js` — QUALQUER diff, typo em comentário
+incluso? Bumpe o `CACHE_NAME` **e o `VERSAO_ATUAL` de
+`tests/frontend/sw_cache_privado.test.mjs`**, para o mesmo N — um sem o outro fica
+vermelho em `node --test tests/frontend/sw_cache_privado.test.mjs`. O CI normalmente reprova quem
+esquecer, desde o #197.
 
 **Não é para entregar o código novo.** Isso já acontece sozinho: a rota serve o arquivo
 com `Cache-Control: no-cache` (`frontend/routes/static_pages.py`), o `install` encadeia


### PR DESCRIPTION
Etapa 10 do orquestrador: ligar os gates do repositório no `/time-dev`, que mencionava **zero** deles (medido: `grep -icE "gate|CACHE_NAME|npm run|pytest|workflow"` = 0).

O critério do dono era **"só a regra que a execução mostrar necessária"**, e ele cortou mais do que aprovou: a seção começou com **4 regras / 25 linhas** e terminou com **2 / 12**.

## As três regras que a medição matou

| candidata | por que caiu |
|---|---|
| virada de mês em UTC | **o bug já estava consertado** pelo `8ea113a`, que este branch contém. A regra mandaria ignorar o que hoje seria regressão — inversão do propósito do gate |
| porta duplicada entre suítes | morreu contra o **#227**, aberto às 14:57 durante o ciclo, que elimina as `PB_*_TEST_PORT` e passa tudo para porta efêmera |
| rodar a suíte inteira | **nunca teve episódio próprio** — era o §3 do `CLAUDE.md` reescrito, e este arquivo já importa o `CLAUDE.md` nas linhas 13-15 |

A âncora que eu mesmo dei ao time para a segunda também caiu: eu disse que o `handlers_inline.test.mjs` colidiu na porta 8907 na Etapa 8, e o `git log --all --follow -p` mostra que ele nasceu com 8911. A colisão foi na minha árvore antes do commit; o histórico não a sustenta.

## As duas que ficaram

**Venv ≠ CI.** O `.venv` local está em `fastapi` 0.115.6 e o `requirements.txt` pina 0.141.1. Um teste que filtrava `app.routes` por `hasattr(r, "path_regex")` passou aqui e **descartou os 11 routers em silêncio** no CI. Com data, comando e "remeça, não reuse" — não com número solto.

**`CACHE_NAME` e o par dele.** O gate reprova quem mexe em `frontend/service-worker.js` sem bumpar, e o gatilho é QUALQUER diff, typo em comentário incluso. Mas **bumpar o `CACHE_NAME` sozinho derruba 2 de 28** em `sw_cache_privado.test.mjs`, porque o `VERSAO_ATUAL` é o mesmo número em outro arquivo. Medido três vezes por dois agentes: 28/28 → **26/28** → 28/28.

A assimetria está escrita, e é o que faltava: **quem ESQUECE o bump passa local e só o CI pega; quem bumpa SEM o par fica vermelho local.**

## Fora do `/time-dev`: três frases da mesma classe

O Manager nomeou a classe — **"imperativo incompleto"**, mandar mexer sem mandar mexer no par — e ela foi corrigida onde já se estava editando:

- `docs/armadilhas.md` dizia *"mexeu na estratégia de cache?"*, **gatilho mais estreito que o do gate** (que dispara com qualquer diff). É a fonte para onde o `CLAUDE.md` §5 manda o Coder.
- duas mensagens do próprio gate (`tests.yml:370` e `:401`), que mandam bumpar sem citar o par. A `:370` é lida no minuto em que alguém descobre que precisa bumpar.
- e a mensagem do ramo que **aprova sem comparar** (`:363`) dizia "se você mexeu na estratégia de cache" — o único momento em que a decisão volta para o humano, e o mais caro para ter o gatilho errado.

**A classe tem pelo menos 6 sites; 3 ficaram abertos por decisão.** O mais forte deles é `frontend/service-worker.js:14-17`, o comentário logo acima da declaração — e ele fica porque quem bumpa e esquece o par já recebe a mensagem exata em `sw_cache_privado.test.mjs:188`; uma 4ª cópia brigaria com o §0.7.

## O ciclo

Arquiteto 1, **Coder 6, Tester 3, Manager 2**. O Tester parou o ciclo na 3ª rodada e escalou, como o protocolo manda. Duas decisões foram ao dono (cortar o bullet da virada de mês; cortar os dois de porta).

Achados que mudaram o resultado, todos provados com artefato:

- o Tester derrubou o mecanismo da regra 1 servindo um `http.server` da árvore de outro branch e capturando **`hideResetConfirm`** — símbolo que não existe aqui — chegando no assert;
- o Tester provou com **os dois controles** que `PB_*_TEST_PORT` era falso para 1 dos 7 arquivos: nome do padrão → 6 falhas, nome real → 6 verdes;
- o Manager achou o #227 rodando `gh pr list`. **Nenhum dos três agentes tinha consultado o presente do repositório** — só `git log`, `git grep`, `git show main`. Documentar repositório vivo sem olhar o que está em voo produz documentação nascida velha, que é o defeito que o ciclo passou 3 rodadas caçando.

## Verificado × não verificado

**Verificado:** `npm run test:frontend` **221/221**. As 3 strings do `tests.yml` provadas linha a linha — `yaml.safe_load`, `bash -n`, renderização com as variáveis definidas: 1 linha cada, 2 `::`, aspas pares, sem vírgula no `title=` (que partiria a anotação). O experimento do bump reproduzido por dois agentes independentemente.

**NÃO verificado, e é o principal:** **não há como provar que este texto muda o comportamento de agente nenhum.** Nenhum dos 3 arquivos é executado por teste; não existe controle negativo para arquivo de prompt. O efeito só aparece na próxima rodada real de `/time-dev`.

**Também não:** o gate nunca rodou neste PR — o step só roda em `pull_request` e sai no `exit 0` de "`$SW` não mudou", porque este diff não toca o service worker. As anotações foram provadas como shell bem formado, nunca renderizadas pelo GitHub.

## Fica de fora, para issue

- `docs/ambiente.md` diz *"existe um `.venv` na raiz com TODOS os pacotes"* e é silencioso sobre a divergência de versão. O roteamento pertence ao command; o **fato** pertence ao `ambiente.md`.
- A cláusula do gatilho existe agora em 3 formatos (prosa, `::warning`, `::error`) sem teste amarrando. O contra-argumento do Coder: o drift que importa é prosa × comportamento do gate, e quem guarda isso é o `git diff --quiet` da linha 309.
