### PR TITLE
Conta só via Google não conseguia excluir, exportar nem ativar MFA — 6 endpoints davam 401 para sempre

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -421,6 +421,7 @@ from .privacy import (
     delete_user_data,
     process_due_account_deletions,
     verify_user_password,
+    PasswordNotSetError,
     get_user_email,
     create_data_export_token,
     consume_data_export_token,
@@ -569,7 +570,7 @@ __all__ = [
     "ensure_account_deletion_columns", "is_account_scheduled_for_deletion",
     "schedule_account_deletion", "build_user_export_zip", "delete_user_data",
     "process_due_account_deletions",
-    "verify_user_password", "get_user_email",
+    "verify_user_password", "PasswordNotSetError", "get_user_email",
     "create_data_export_token", "consume_data_export_token",
     "has_recent_export_request",
     # google login

--- a/db/privacy.py
+++ b/db/privacy.py
@@ -19,17 +19,49 @@ from .connection import get_conn
 from .users import _check_password
 
 
+# Conta criada só via Google não tem password_hash: NENHUMA senha funciona, e
+# devolver "Senha incorreta." mandava o usuário tentar de novo pra sempre. A
+# mensagem aqui é EXPLÍCITA de propósito — ao contrário da vagueza de
+# /auth/login ("E-mail ou senha incorretos.",
+# frontend/finance_bot_websocket_custom.py:2646-2659), que existe contra
+# enumeração de e-mails por chamador ANÔNIMO. Nos endpoints que re-autenticam,
+# o usuário já está logado como ele mesmo: não há e-mail alheio a enumerar.
+PASSWORD_NOT_SET_MSG = (
+    "Sua conta foi criada com o Google e ainda não tem senha. "
+    "Defina uma senha para continuar."
+)
+
+
+class PasswordNotSetError(PermissionError):
+    """Conta sem password_hash (login só via OAuth) — não é senha errada.
+
+    Herda de PermissionError de propósito: as rotas que já capturam
+    PermissionError continuam recusando a operação mesmo sem tratar este caso.
+    Quem quiser o 409 captura ANTES do except PermissionError.
+    """
+
+
 def verify_user_password(user_id: int, password: str) -> bool:
-    """Confirma que `password` corresponde ao hash atual da conta do usuário."""
-    if not password:
-        return False
+    """Confirma que `password` corresponde ao hash atual da conta do usuário.
+
+    Levanta PasswordNotSetError quando a conta não tem senha nenhuma. Senha
+    ERRADA continua devolvendo False (contrato preservado pelos chamadores).
+    """
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "select password_hash from auth_accounts where user_id = %s limit 1",
             (user_id,),
         )
         row = cur.fetchone()
-    if not row or not row.get("password_hash"):
+    if not row:
+        return False
+    if not row.get("password_hash"):
+        raise PasswordNotSetError(PASSWORD_NOT_SET_MSG)
+    # DEPOIS do estado da conta, de propósito: o que o cliente mandou não muda o
+    # fato de a conta não ter senha. Enquanto esta linha era a primeira do corpo,
+    # senha vazia numa conta só-Google voltava False e virava o 401 "Senha
+    # incorreta." que esta função existe pra parar de mentir.
+    if not password:
         return False
     return _check_password(password, row["password_hash"])
 
@@ -221,9 +253,6 @@ def is_account_scheduled_for_deletion(user_id: int) -> dict | None:
 
 
 def schedule_account_deletion(user_id: int, password: str, grace_days: int = 7) -> dict:
-    if not password:
-        raise ValueError("Informe sua senha para confirmar a exclusão.")
-
     now = datetime.now(timezone.utc)
     scheduled_for = now + timedelta(days=grace_days)
 
@@ -241,6 +270,17 @@ def schedule_account_deletion(user_id: int, password: str, grace_days: int = 7) 
             account = cur.fetchone()
             if not account:
                 raise LookupError("Conta de login não encontrada.")
+            # Este caminho NÃO passa por verify_user_password (select próprio):
+            # sem esta guarda, _check_password(password, None) estoura
+            # AttributeError, é engolido em db/users.py:350-354 e vira
+            # "Senha incorreta." — mesma raiz, segundo caminho de código.
+            if not account["password_hash"]:
+                raise PasswordNotSetError(PASSWORD_NOT_SET_MSG)
+            # O "informe a senha" vem DEPOIS do estado da conta (era a primeira
+            # linha da função): senha vazia numa conta só-Google devolvia 400
+            # "Informe sua senha", terceiro status para o mesmo estado.
+            if not password:
+                raise ValueError("Informe sua senha para confirmar a exclusão.")
             if not _check_password(password, account["password_hash"]):
                 raise PermissionError("Senha incorreta.")
 

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -88,6 +88,7 @@ from db import (
     get_auth_user,
     build_user_export_zip,
     verify_user_password,
+    PasswordNotSetError,
     get_user_email,
     create_data_export_token,
     consume_data_export_token,
@@ -2967,7 +2968,10 @@ async def auth_me(user_id: int = Depends(_get_current_user)):
     """Retorna dados do usuário autenticado."""
     import sys
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-    from db import get_auth_user, should_show_mfa_onboarding, get_mfa_status
+    from db import (
+        auth_account_has_password, get_auth_user, should_show_mfa_onboarding,
+        get_mfa_status,
+    )
 
     user = get_auth_user(user_id)
     if not user:
@@ -3006,6 +3010,10 @@ async def auth_me(user_id: int = Depends(_get_current_user)):
         "user_id": user_id,
         **safe_user,
         "show_mfa_onboarding": show_onboarding,
+        # False = conta criada só via Google (password_hash NULL): a UI manda
+        # DEFINIR senha em vez de mostrar campo de senha que nunca aceita nada.
+        # Lido do banco, não do cache do get_auth_user — uma fonte de verdade.
+        "has_password": await asyncio.to_thread(auth_account_has_password, user_id),
         "mfa_enabled": bool(mfa.get("enabled")),
         "app_access": has_app_access(user_id),
         "needs_plan_selection": needs_plan_selection(user_id, user_dict),
@@ -3018,6 +3026,20 @@ async def auth_me(user_id: int = Depends(_get_current_user)):
         "of_ui_enabled": of_ui_enabled,
         "agents_ui_enabled": agents_ui,
     }
+
+
+async def _reauth_password_ok(user_id: int, password: str) -> bool:
+    """Re-autenticação por senha nos endpoints já autenticados.
+
+    Devolve False para senha ERRADA (cada chamador mantém o próprio 401 e o
+    próprio log). Conta SEM senha (criada só via Google) vira 409 aqui: a
+    PasswordNotSetError atravessando o asyncio.to_thread viraria 500 no handler
+    global de Exception (:2138), não 401.
+    """
+    try:
+        return await asyncio.to_thread(verify_user_password, user_id, password)
+    except PasswordNotSetError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 # ── MFA (TOTP) ───────────────────────────────────────────────────────────────
@@ -3078,7 +3100,7 @@ async def auth_mfa_setup(request: Request, body: MFASetupBody, user_id: int = De
     """Inicia setup do MFA: pede senha, gera secret, retorna QR + URI."""
     _block_setup_if_unsupported_user(user_id)
 
-    password_ok = await asyncio.to_thread(verify_user_password, user_id, body.password)
+    password_ok = await _reauth_password_ok(user_id, body.password)
     if not password_ok:
         raise HTTPException(status_code=401, detail="Senha incorreta.")
 
@@ -3132,7 +3154,7 @@ async def auth_mfa_enable(request: Request, body: MFAEnableBody, user_id: int = 
 @limiter.limit("5/hour")
 async def auth_mfa_disable(request: Request, body: MFADisableBody, user_id: int = Depends(_get_current_user)):
     """Desativa MFA (pede senha + codigo TOTP atual ou backup code)."""
-    password_ok = await asyncio.to_thread(verify_user_password, user_id, body.password)
+    password_ok = await _reauth_password_ok(user_id, body.password)
     if not password_ok:
         raise HTTPException(status_code=401, detail="Senha incorreta.")
 
@@ -3169,7 +3191,7 @@ async def auth_mfa_disable(request: Request, body: MFADisableBody, user_id: int 
 @limiter.limit("3/hour")
 async def auth_mfa_regenerate(request: Request, body: MFADisableBody, user_id: int = Depends(_get_current_user)):
     """Gera novos backup codes (invalida os antigos). Pede senha + TOTP."""
-    password_ok = await asyncio.to_thread(verify_user_password, user_id, body.password)
+    password_ok = await _reauth_password_ok(user_id, body.password)
     if not password_ok:
         raise HTTPException(status_code=401, detail="Senha incorreta.")
 
@@ -3290,7 +3312,7 @@ async def auth_account_export_request(request: Request, body: DataExportBody):
     user_agent = (request.headers.get("user-agent") or "").strip() or None
 
     # 1) Re-auth por senha
-    password_ok = await asyncio.to_thread(verify_user_password, user_id, body.password)
+    password_ok = await _reauth_password_ok(user_id, body.password)
     if not password_ok:
         await log_system_event(
             "warning",
@@ -3453,6 +3475,10 @@ async def auth_delete_account(request: Request, response: Response, body: Delete
     email = (auth_user or {}).get("email")
     try:
         result = await asyncio.to_thread(schedule_account_deletion, user_id, body.password, 7)
+    except PasswordNotSetError as exc:
+        # ANTES do except PermissionError (é subclasse dele): invertido, o
+        # genérico engole e o 409 nunca acontece.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except PermissionError as exc:
         raise HTTPException(status_code=401, detail=str(exc)) from exc
     except LookupError as exc:

--- a/frontend/routes/settings.py
+++ b/frontend/routes/settings.py
@@ -144,7 +144,7 @@ async def account_reset_route(request: Request, payload: AccountResetPayload):
 
     # Imports na função (padrão do arquivo p/ dependências fora do caminho quente).
     from core.observability import log_system_event_sync
-    from db.privacy import ResetLockUnavailableError, reset_user_data
+    from db.privacy import PasswordNotSetError, ResetLockUnavailableError, reset_user_data
     from frontend.routes.open_finance import delete_pluggy_items_best_effort
 
     # O que a limpeza remota ENUMEROU — comparado adiante com o que o DELETE
@@ -172,6 +172,10 @@ async def account_reset_route(request: Request, payload: AccountResetPayload):
         result = await asyncio.to_thread(
             reset_user_data, user_id, payload.password, remote_cleanup=_limpeza_remota,
         )
+    except PasswordNotSetError as exc:
+        # ANTES do except PermissionError (é subclasse dele): invertido, o
+        # genérico engole e o 409 nunca acontece.
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except PermissionError as exc:
         raise HTTPException(status_code=401, detail=str(exc)) from exc
     except ResetLockUnavailableError as exc:

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1475,7 +1475,7 @@ body.balance-hidden .account-balance {
         <div class="card">
           <div class="card-head">
             <div>
-              <div class="card-title">Resetar senha por e-mail</div>
+              <div class="card-title" id="security-reset-title">Resetar senha por e-mail</div>
               <div class="card-sub" id="security-reset-copy">O link expira em 30 minutos e abre uma página segura para definir a nova senha</div>
             </div>
             <button class="btn-connect" type="button" id="security-reset-btn" onclick="sendPasswordResetEmail()" style="width:auto; min-width:190px; padding:0 18px">
@@ -1748,6 +1748,51 @@ body.balance-hidden .account-balance {
 const API = window.location.origin;
 const params = new URLSearchParams(window.location.search);
 let USER_ID = null;
+// Conta criada só via Google não tem senha: pedir senha é pedir o que não
+// existe. Só `has_password === false` bloqueia — ausente/undefined (falha do
+// /auth/me, stub de teste) degrada pro comportamento de sempre. A AUTORIDADE é
+// o servidor (409); isto aqui é advisory, pra o campo de senha nem aparecer.
+// Lido no boot E rebuscado no PBRefresh (a senha é definida FORA desta página).
+let HAS_PASSWORD = true;
+// Geração, mesmo padrão de _securityGen/_mfaGen — mas na ESCRITA, porque as três
+// buscas de has_password (o /auth/me do boot e os dois PBRefresh, security e
+// data) terminam nesta mesma função. Quem busca bumpa ANTES do fetch e passa o
+// myGen aqui: só a busca mais recente assenta. Sem isso, dois /auth/me em voo e
+// o VELHO chegando por último RE-TRANCAVA os 6 fluxos até o próximo PTR — não é
+// o repaint que se cura sozinho na pintura seguinte (app-mode.js:869-873).
+// A janela do boot é larga: window.PBRefresh já existe (é atribuído no parse)
+// enquanto o initSettings ainda espera o /auth/validate + /auth/me dele.
+let _hasPwGen = 0;
+function setHasPassword(me, myGen) {
+  if (myGen !== _hasPwGen) return;   // superado: preserva a busca mais nova
+  HAS_PASSWORD = !(me && me.has_password === false);
+}
+/* HAS_PASSWORD — estados × eventos, enumerados de uma vez (§4 do CLAUDE.md:
+   duas rodadas de revisão seguidas bateram neste subsistema, e é remendando
+   uma transição por vez que nasce a terceira). Está escrito para ninguém fechar
+   um quarto caso sem ver o mapa inteiro. As corridas de ESCRITA estão fechadas
+   (_hasPwGen cobre os três emissores); o que sobra é tudo da mesma família —
+   cobertura do rebusque por aba e por ciclo de vida —, e "teto aceito" é
+   decisão, não esquecimento: nenhum custa mais que um puxão de tela ou um toast.
+
+     boot com /auth/me ok .......... escreve, com geração: initSettings bumpa o
+       _hasPwGen antes do fetch e passa o meGen para o setHasPassword.
+     boot com /auth/me não-ok, ou exceção .... NÃO escreve, fica `true` — o lado
+       permissivo, por decisão; a autoridade é o 409 do servidor.
+     PTR na aba `security` ......... rebusca ANTES dos loaders, porque
+       applySecuritySettings lê HAS_PASSWORD para escolher a copy do card; falha
+       do /auth/me não pula os loaders, vira âmbar no fim.
+     PTR na aba `data` ............. rebusca; falha rejeita (PTR âmbar).
+     dois /auth/me sobrepostos (PTR×PTR, boot×PTR) .... sim, o _hasPwGen aí em
+       cima: só a busca mais nova assenta.
+     PTR em `notifications`, `open-finance` ou `legal` .... NÃO rebusca (teto).
+     troca de aba (showSettingsSection) ...... NÃO rebusca (teto).
+     volta do app ao foreground .... NÃO rebusca (teto), e é o caminho MAIS
+       provável no iPhone: o link do e-mail abre o Safari e a pessoa volta para
+       o app. Coberto pela copy, que manda puxar esta tela.
+     servidor devolve 409 num submit .... o toast mostra a mensagem certa, mas
+       HAS_PASSWORD não vira false (teto): a autoridade discorda do advisory e o
+       cliente não aprende. */
 
 /* ── Helpers ─────────────────────────────────── */
 function esc(v) {
@@ -2006,6 +2051,19 @@ function applySecuritySettings(data) {
   document.getElementById("security-reset-copy").textContent = hasEmail
     ? `O link será enviado para ${data.email} e expira em 30 minutos.`
     : "Vincule um e-mail à conta antes de solicitar reset de senha.";
+  // Conta só-Google: não é "resetar", é DEFINIR a primeira senha. Mesmo fluxo
+  // e mesmo endpoint — o token de reset já grava password_hash partindo de
+  // NULL. O flag vem do módulo, não do payload de /settings/{id}/security.
+  // Os DOIS lados são escritos sempre: o PBRefresh rebusca has_password, então
+  // este repaint tem de saber voltar quando a senha passa a existir.
+  document.getElementById("security-reset-title").textContent =
+    HAS_PASSWORD ? "Resetar senha por e-mail" : "Definir senha";
+  document.getElementById("security-reset-btn").textContent =
+    HAS_PASSWORD ? "Enviar e-mail de reset" : "Enviar e-mail";
+  if (!HAS_PASSWORD && hasEmail) {
+    document.getElementById("security-reset-copy").textContent =
+      `Sua conta foi criada com o Google e ainda não tem senha. O link vai para ${data.email} e expira em 30 minutos.`;
+  }
 }
 
 // propagate=true (pull-to-refresh): rejeita em falha pro indicador do PTR virar
@@ -2464,7 +2522,43 @@ async function updateNotificationSettings(patch) {
   }
 }
 
+/* A senha é definida FORA desta página (o link do e-mail abre outra aba, e no
+   app abre o navegador): sem rebuscar, quem voltava continuava barrado nos 6
+   fluxos. O PTR do app NÃO recarrega o documento (é esse o ponto do PBRefresh),
+   então "atualize a página" não existe como gesto ali. */
+async function refreshHasPassword() {
+  const myGen = ++_hasPwGen;
+  const resp = await fetch(`${API}/auth/me`, { credentials: "same-origin" });
+  if (!resp.ok) throw new Error("Não foi possível atualizar o estado da conta");
+  setHasPassword(await resp.json(), myGen);
+}
+
+/* Guarda dos 6 fluxos que re-autenticam por senha. Fica nos ABRIDORES pra o
+   campo de senha nem aparecer. Retorna true quando pode seguir; o diálogo é
+   disparado SEM await de propósito — os abridores são síncronos (chamados por
+   onclick) e só precisam abortar. */
+function requireSenhaDefinida() {
+  if (HAS_PASSWORD) return true;
+  confirmModal(
+    "Sua conta foi criada com o Google e ainda não tem senha, então nenhuma senha funciona aqui. "
+    + "Defina uma senha por e-mail e volte para concluir.\n\n"
+    // No app o gesto é puxar a tela (não há recarregar); na web é recarregar.
+    // O PBRefresh rebusca o has_password nas duas abas que têm ponto barrado.
+    + (window.PB_IN_APP
+       ? "Já definiu a senha em outra aba? Puxe esta tela para baixo para atualizar."
+       : "Já definiu a senha em outra aba? Atualize a página."),
+    { title: "Defina uma senha primeiro", confirmText: "Definir senha", cancelText: "Agora não" },
+  ).then(function (ok) {
+    if (!ok) return;
+    showSettingsSection("security");
+    const btn = document.getElementById("security-reset-btn");
+    if (btn) btn.focus();
+  });
+  return false;
+}
+
 function showExportConfirm() {
+  if (!requireSenhaDefinida()) return;
   document.getElementById("export-confirm").classList.add("show");
   document.getElementById("export-password").focus();
 }
@@ -2506,6 +2600,7 @@ async function requestDataExport() {
 }
 
 function showResetConfirm() {
+  if (!requireSenhaDefinida()) return;
   document.getElementById("reset-confirm").classList.add("show");
   document.getElementById("reset-password").focus();
 }
@@ -2562,6 +2657,7 @@ async function requestAccountReset() {
 }
 
 function showDeleteConfirm() {
+  if (!requireSenhaDefinida()) return;
   document.getElementById("delete-confirm").classList.add("show");
   document.getElementById("delete-password").focus();
 }
@@ -3215,6 +3311,9 @@ function onMfaToggleClick() {
 
 /* ── Modal: Setup ─────────────────────────────── */
 function openMfaSetupModal() {
+  // A guarda vive AQUI e não no onMfaToggleClick: a /home manda
+  // ?view=security&autoOpenMfa=1 e o initSettings chama este abridor direto.
+  if (!requireSenhaDefinida()) return;
   const overlay = document.getElementById("mfa-setup-overlay");
   document.getElementById("mfa-setup-step1").style.display = "";
   document.getElementById("mfa-setup-step2").style.display = "none";
@@ -3302,6 +3401,7 @@ function copyRegenBackupCodes() { copyCodesFromList("mfa-regen-codes-list"); }
 
 /* ── Modal: Disable ──────────────────────────── */
 function openMfaDisableModal() {
+  if (!requireSenhaDefinida()) return;
   document.getElementById("mfa-disable-password").value = "";
   document.getElementById("mfa-disable-code").value = "";
   document.getElementById("mfa-disable-overlay").classList.add("open");
@@ -3337,6 +3437,7 @@ async function mfaDisableSubmit() {
 
 /* ── Modal: Regenerate backup codes ──────────── */
 function openMfaRegenerateModal() {
+  if (!requireSenhaDefinida()) return;
   document.getElementById("mfa-regen-password").value = "";
   document.getElementById("mfa-regen-code").value = "";
   document.getElementById("mfa-regen-result").style.display = "none";
@@ -3391,10 +3492,12 @@ async function initSettings() {
   }
   // Paywall: sem assinatura ativa → vai pro paywall (settings é gated).
   let me = null;
+  const meGen = ++_hasPwGen;
   try {
     const meResp = await fetch(`${API}/auth/me`, { credentials: "same-origin" });
     if (meResp.ok) {
       me = await meResp.json();
+      setHasPassword(me, meGen);
       // Gate de escolha de plano: cadastro novo passa pela /precos antes de
       // acessar qualquer tela do app (só na web; app iOS fica de fora — 3.1.1).
       if (me && me.needs_plan_selection && !window.PB_IN_APP) {
@@ -3467,14 +3570,21 @@ window.PBRefresh = () => {
   // toda aba apagava OF numa view onde nem aparece). Cada loader propaga falha
   // (propagate:true) pro indicador do PTR virar âmbar em vez de fingir sucesso.
   const view = new URLSearchParams(location.search).get("view") || "security";
-  if (view === "security")
+  if (view === "security") {
     // Encadeia atrás de um save de contato em voo; espera TODAS as branches
     // (security + MFA, e dentro da security, atividade + sessões) antes de soltar.
+    // O /auth/me vem ANTES dos loaders porque applySecuritySettings lê
+    // HAS_PASSWORD pra decidir a copy do card ("Definir senha" × "Resetar").
+    // Falha dele NÃO pula os loaders: vira erro propagado no fim (PTR âmbar).
+    let meErr = null;
     return Promise.resolve(_securitySave).catch(function () {})
+      .then(function () { return refreshHasPassword().catch(function (e) { meErr = e; }); })
       .then(function () { return awaitAllPropagate([
         loadSecuritySettings({ propagate: true }),
         loadMfaStatus({ propagate: true }),
-      ]); });
+      ]); })
+      .then(function () { if (meErr) throw meErr; });
+  }
   if (view === "notifications")
     // Encadeia atrás de um save de notificação em voo: o GET só roda depois que
     // o PATCH assentar, então não repinta com estado pré-PATCH.
@@ -3485,7 +3595,12 @@ window.PBRefresh = () => {
     // snapshot. wait=8 porque o watchdog do indicador é 12s (app-mode.js) e o
     // default do servidor (18s) faria todo sucesso terminar em âmbar.
     return refreshOpenFinance({ propagate: true, wait: 8 });
-  return Promise.resolve();   // data / legal: nada dinâmico a atualizar
+  if (view === "data")
+    // Exportar, recomeçar do zero e excluir conta moram AQUI e são 3 dos 6
+    // pontos barrados por falta de senha — sem esta linha, quem definiu a senha
+    // e está nesta aba continuava trancado. Rejeita em falha (PTR âmbar).
+    return refreshHasPassword();
+  return Promise.resolve();   // legal: nada dinâmico a atualizar
 };
 </script>
 

--- a/tests/frontend/settings_conta_sem_senha.test.mjs
+++ b/tests/frontend/settings_conta_sem_senha.test.mjs
@@ -1,0 +1,284 @@
+/**
+ * Conta criada só via Google (/auth/me → has_password:false) em
+ * frontend/settings.html.
+ *
+ * INVARIANTE: os 6 fluxos que re-autenticam por senha não podem MOSTRAR campo
+ * de senha para quem não tem senha nenhuma — o abridor aborta e o diálogo manda
+ * DEFINIR a senha. A autoridade continua sendo o servidor (409); isto aqui é a
+ * camada advisory, e é o que evita a pessoa digitar num campo que nunca aceita.
+ *
+ * CONTROLES DO GRUPO (§3 do CLAUDE.md). Cada mutação foi APLICADA e este arquivo
+ * rodado inteiro — os números são a saída do `node --test`. Baseline: 9 pass.
+ *   negativo — desligando a guarda dos abridores (requireSenhaDefinida sempre
+ *     true, o mesmo efeito de trocar `if (!requireSenhaDefinida()) return;` por
+ *     `if (false) return;` nos 6): 5 vermelhos, 4 verdes. Caem os três `sem
+ *     senha:` (inclusive o `?view=data`, onde moram 3 dos 6 pontos) e os dois
+ *     `PBRefresh rebusca …`, que começam checando o bloqueio do boot. Se algum
+ *     deles continuasse verde, mediria o boot e não a guarda. Os dois testes de
+ *     corrida NÃO caem: eles medem outra coisa, e têm o controle próprio abaixo.
+ *   negativo B — tirando `refreshHasPassword()` do window.PBRefresh (as duas
+ *     abas): 3 vermelhos, 6 verdes. Os dois `PBRefresh rebusca has_password na
+ *     aba …` (o abridor continua preso depois do PTR — um por aba porque o
+ *     branch `data` era `return Promise.resolve()` e o `security` não) e também
+ *     o `PTR durante o boot`, que puxa a tela na aba `data`: sem o rebusque,
+ *     sobra só o /auth/me lento do boot e os 6 ficam trancados.
+ *   positivo — os dois últimos testes (/auth/me = {} e = {has_password:true})
+ *     provam que quem TEM senha continua abrindo os 6 como antes. Eles ficaram
+ *     verdes nas TRÊS mutações, que é o trabalho deles. Sem eles o grupo
+ *     passaria numa versão que bloqueia todo mundo, que é pior que o bug.
+ *     E o PBRefresh continua sendo aguardado sem catch: se ele rejeitasse (o
+ *     PTR ficaria âmbar), o teste da aba correspondente falharia.
+ *
+ * A espera de boot é `#section-<view>` deixar de ser hidden: quem tira o hidden
+ * é o showSettingsSection, chamado DEPOIS da leitura do /auth/me no
+ * initSettings. Esperar o texto de um card em vez disso mediria o HTML estático.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+// Porta própria: o node --test roda os arquivos em paralelo. 8899 fanout,
+// 8901 hiw_rail, 8903 modal_keys, 8905 of_refresh, 8907 onboarding,
+// 8909 of_connect, 8911 handlers_inline. Compartilhar porta faz a sonda adotar
+// o servidor alheio e o teste morrer com ERR_CONNECTION_REFUSED quando o dono
+// termina — foi o que aconteceu aqui com a 8903.
+const PORT = Number(process.env.PB_SEMSENHA_TEST_PORT || 8913);
+const ORIGIN = `http://127.0.0.1:${PORT}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const json = (body) => ({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+async function startServer() {
+  const proc = spawn("python3", ["-m", "http.server", String(PORT), "--bind", "127.0.0.1", "--directory", FRONTEND],
+    { stdio: "ignore" });
+  for (let i = 0; i < 100; i++) {
+    await sleep(100);
+    if (proc.exitCode !== null) throw new Error(`http.server morreu (porta ${PORT} ocupada?)`);
+    try { if ((await fetch(`${ORIGIN}/settings.html`)).ok) return proc; } catch { /* subindo */ }
+  }
+  proc.kill();
+  throw new Error(`http.server não subiu em ${ORIGIN}`);
+}
+
+async function waitFor(cond, what, timeoutMs = 10000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return;
+    await sleep(50);
+  }
+  throw new Error(`timeout esperando: ${what}`);
+}
+
+let server, browser;
+before(async () => { server = await startServer(); browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+const SECURITY_OK = { ok: true, user_id: 1, email: "a@b.com", plan: "pro", display_name: "Japa", identities: [] };
+
+/** `me` = corpo do /auth/me, ou função que o devolve (pra mudar entre um PTR e
+    outro — é assim que o teste do upgrade path simula a senha sendo definida em
+    outra aba). Catch-all primeiro (menor prioridade no Playwright). */
+async function newPage(me) {
+  const corpoMe = () => (typeof me === "function" ? me() : me);
+  const page = await browser.newPage();
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin !== ORIGIN) return route.abort();
+    if (/\.[a-z0-9]+$/i.test(url.pathname)) return route.continue();
+    return route.fulfill(json({}));
+  });
+  await page.route("**/static/auth-refresh.js", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript",
+                    body: readFileSync(join(FRONTEND, "static", "auth-refresh.js"), "utf8") }));
+  await page.route("**/auth/validate", (route) => route.fulfill(json({ user_id: 1 })));
+  await page.route("**/auth/me", (route) => route.fulfill(json(corpoMe())));
+  await page.route("**/settings/1/security", (route) => route.fulfill(json(SECURITY_OK)));
+  await page.route("**/auth/mfa/status", (route) => route.fulfill(json({ enabled: false })));
+  return page;
+}
+
+/** Abre a página e espera o initSettings passar do /auth/me. */
+async function abrePagina(me, query, secao) {
+  const page = await newPage(me);
+  await page.goto(`${ORIGIN}/settings.html?${query}`);
+  await waitFor(() => page.evaluate((s) => !document.getElementById("section-" + s).hidden, secao),
+                `a aba ${secao} aparecer (boot do initSettings)`);
+  return page;
+}
+
+const modalAberto = (page) => page.evaluate(() => !!document.querySelector(".pig-modal-overlay"));
+const temClasse = (page, id, c) => page.evaluate(([i, k]) => document.getElementById(i).classList.contains(k), [id, c]);
+const fechaModal = (page) => page.evaluate(() => document.querySelector(".pig-modal-overlay")?.remove());
+const tituloCard = (page) => page.evaluate(() => document.getElementById("security-reset-title").textContent);
+
+/** Chama o abridor e devolve se o painel de senha correspondente apareceu. */
+async function abre(page, fn, id, classe) {
+  await page.evaluate((f) => window[f](), fn);
+  await sleep(120);   // o diálogo entra num requestAnimationFrame
+  return temClasse(page, id, classe);
+}
+
+const OS_SEIS = [
+  ["showExportConfirm", "export-confirm", "show"],
+  ["showResetConfirm", "reset-confirm", "show"],
+  ["showDeleteConfirm", "delete-confirm", "show"],
+  ["openMfaSetupModal", "mfa-setup-overlay", "open"],
+  ["openMfaDisableModal", "mfa-disable-overlay", "open"],
+  ["openMfaRegenerateModal", "mfa-regen-overlay", "open"],
+];
+
+// ── negativo do produto: conta SEM senha ────────────────────────────────────
+
+test("sem senha: os 6 abridores não revelam campo de senha e abrem o diálogo", async () => {
+  // ?view=data é a armadilha: exportar/recomeçar/excluir moram nesta aba, não
+  // na security — um teste que só cobrisse a security passaria cego a ela.
+  const page = await abrePagina({ has_password: false }, "view=data", "data");
+  try {
+    for (const [fn, id, classe] of OS_SEIS) {
+      assert.equal(await abre(page, fn, id, classe), false, `${fn} revelou o campo de senha`);
+      assert.equal(await modalAberto(page), true, `${fn} não abriu o diálogo de definir senha`);
+      await fechaModal(page);
+    }
+  } finally { await page.close(); }
+});
+
+test("sem senha: o botão do diálogo leva para a aba de segurança, com a copy de DEFINIR", async () => {
+  const page = await abrePagina({ has_password: false }, "view=data", "data");
+  try {
+    await page.evaluate(() => showExportConfirm());
+    await waitFor(() => modalAberto(page), "o diálogo de definir senha");
+
+    await page.click(".pig-modal-btn-primary, .pig-modal-btn-destructive");
+    await waitFor(() => page.evaluate(() => !document.getElementById("section-security").hidden),
+                  "a aba de segurança ficar visível");
+    assert.equal(await page.evaluate(() => new URLSearchParams(location.search).get("view")), "security");
+
+    // Para quem nunca teve senha isso é DEFINIR, não "resetar".
+    await waitFor(async () => (await tituloCard(page)) === "Definir senha", "a copy do card virar 'Definir senha'");
+  } finally { await page.close(); }
+});
+
+test("sem senha: ?view=security&autoOpenMfa=1 (o caminho da /home) não abre o setup", async () => {
+  // A /home manda esta URL e o initSettings chama openMfaSetupModal() DIRETO,
+  // sem passar pelo onMfaToggleClick — por isso a guarda vive no abridor.
+  const page = await abrePagina({ has_password: false }, "view=security&autoOpenMfa=1", "security");
+  try {
+    await waitFor(() => modalAberto(page), "o diálogo de definir senha do autoOpenMfa");   // setTimeout 400ms
+    assert.equal(await temClasse(page, "mfa-setup-overlay", "open"), false,
+                 "o autoOpenMfa abriu o setup de MFA numa conta sem senha");
+  } finally { await page.close(); }
+});
+
+// ── upgrade path: definiu a senha fora daqui e puxou a tela ─────────────────
+
+for (const view of ["data", "security"]) {
+  test(`PBRefresh rebusca has_password na aba ${view}: os 6 destravam sem reload`, async () => {
+    // O PTR do app NÃO recarrega o documento (é o motivo do PBRefresh existir),
+    // então sem rebuscar o /auth/me quem definiu a senha ficava preso. A aba
+    // `data` é a armadilha: 3 dos 6 pontos moram nela e o branch dela era
+    // `return Promise.resolve()`.
+    let me = { has_password: false };
+    const page = await abrePagina(() => me, `view=${view}`, view);
+    try {
+      assert.equal(await abre(page, "showExportConfirm", "export-confirm", "show"), false,
+                   "boot com has_password:false devia bloquear");
+      await fechaModal(page);
+
+      me = { has_password: true };   // a senha acabou de ser definida em outra aba
+      await page.evaluate(() => window.PBRefresh());
+
+      for (const [fn, id, classe] of OS_SEIS) {
+        assert.equal(await abre(page, fn, id, classe), true, `${fn} continuou preso após o PBRefresh`);
+        assert.equal(await modalAberto(page), false, `${fn} ainda abriu o diálogo de definir senha`);
+        await page.evaluate(([i, c]) => document.getElementById(i).classList.remove(c), [id, classe]);
+      }
+      // Na security o /auth/me roda ANTES dos loaders de propósito:
+      // applySecuritySettings lê HAS_PASSWORD, e a copy tem de saber VOLTAR.
+      if (view === "security") assert.equal(await tituloCard(page), "Resetar senha por e-mail");
+    } finally { await page.close(); }
+  });
+}
+
+// ── corrida: o /auth/me VELHO não pode vencer o NOVO ────────────────────────
+//
+// Os dois casos abaixo são o buraco que o rebusque do PBRefresh abriu: um
+// segundo /auth/me em voo. HAS_PASSWORD não é pixel — a escrita velha tranca os
+// 6 fluxos até outro PTR. Controle negativo do PAR: removendo a guarda de
+// geração (o `if (myGen !== _hasPwGen) return;` de setHasPassword) e rodando o
+// arquivo, dá 2 vermelhos e 7 verdes — os DOIS daqui, e só eles.
+
+/** Sequencia as respostas do /auth/me: `[delayMs, corpo]` por chamada, a última
+    repete. Registrada DEPOIS do newPage, então tem prioridade (rota do
+    Playwright é LIFO). `vistos()` conta as requisições já recebidas. */
+async function sequenciaAuthMe(page, respostas) {
+  let vistos = 0;
+  await page.route("**/auth/me", async (route) => {
+    const [delay, corpo] = respostas[Math.min(vistos++, respostas.length - 1)];
+    if (delay) await sleep(delay);
+    await route.fulfill(json(corpo));
+  });
+  return () => vistos;
+}
+
+/** Nenhum dos 6 pode estar barrado. */
+async function osSeisDestravados(page, quando) {
+  for (const [fn, id, classe] of OS_SEIS) {
+    assert.equal(await abre(page, fn, id, classe), true, `${fn} ficou preso ${quando}`);
+    await page.evaluate(([i, c]) => document.getElementById(i).classList.remove(c), [id, classe]);
+  }
+}
+
+test("dois refreshHasPassword sobrepostos: a resposta VELHA não sobrescreve a NOVA", async () => {
+  const page = await abrePagina({ has_password: false }, "view=data", "data");
+  try {
+    // #1 lenta com o estado VELHO (sem senha), #2 rápida com o NOVO (a senha
+    // acabou de ser definida em outra aba). A VELHA assenta por último.
+    await sequenciaAuthMe(page, [[800, { has_password: false }], [0, { has_password: true }]]);
+    await page.evaluate(() => Promise.all([refreshHasPassword(), refreshHasPassword()]));
+    await osSeisDestravados(page, "depois da resposta velha assentar por último");
+  } finally { await page.close(); }
+});
+
+test("PTR durante o boot: o /auth/me do boot (emitido ANTES) não vence o do PTR", async () => {
+  // window.PBRefresh é atribuído no parse, enquanto o initSettings ainda espera
+  // o /auth/validate + /auth/me dele: puxar a tela nessa janela deixa dois
+  // /auth/me em voo, e o do boot é o mais velho dos dois.
+  const page = await newPage({});
+  try {
+    const vistos = await sequenciaAuthMe(page, [[900, { has_password: false }], [0, { has_password: true }]]);
+    await page.goto(`${ORIGIN}/settings.html?view=data`);
+    await waitFor(() => vistos() >= 1, "o /auth/me do boot ser emitido");
+    await page.evaluate(() => window.PBRefresh());
+    // O boot só chega no showSettingsSection depois do /auth/me dele: esperar a
+    // aba aparecer é esperar a escrita velha ter tido a chance de assentar.
+    await waitFor(() => page.evaluate(() => !document.getElementById("section-data").hidden),
+                  "o boot passar do /auth/me lento");
+    await osSeisDestravados(page, "depois do /auth/me do boot assentar por último");
+  } finally { await page.close(); }
+});
+
+// ── positivo do grupo: quem TEM senha abre os 6 como sempre ─────────────────
+
+for (const [rotulo, me] of [["{} (campo ausente)", {}], ["has_password:true", { has_password: true }]]) {
+  test(`com /auth/me = ${rotulo}: os 6 abridores abrem como hoje`, async () => {
+    const page = await abrePagina(me, "view=security", "security");
+    try {
+      for (const [fn, id, classe] of OS_SEIS) {
+        assert.equal(await abre(page, fn, id, classe), true, `${fn} foi bloqueado indevidamente`);
+        assert.equal(await modalAberto(page), false, `${fn} abriu o diálogo de definir senha à toa`);
+        await page.evaluate(([i, c]) => document.getElementById(i).classList.remove(c), [id, classe]);
+      }
+      // applySecuritySettings JÁ rodou nesta aba (o boot esperou a security):
+      // com senha, a copy do card não pode ter virado "Definir senha".
+      assert.equal(await tituloCard(page), "Resetar senha por e-mail");
+    } finally { await page.close(); }
+  });
+}

--- a/tests/test_conta_google_sem_senha.py
+++ b/tests/test_conta_google_sem_senha.py
@@ -1,0 +1,260 @@
+"""Conta criada só via Google (auth_accounts.password_hash NULL) nos 6 endpoints
+que re-autenticam por senha.
+
+Antes: todos devolviam 401 "Senha incorreta." — o usuário não tem senha nenhuma
+que funcione, então a orientação era tentar pra sempre. Agora: 409 + mensagem
+mandando DEFINIR a senha (o fluxo de reset por e-mail já grava password_hash
+partindo de NULL).
+
+Os 6: POST /auth/account/export, POST /auth/mfa/setup, POST /auth/mfa/disable,
+POST /auth/mfa/regenerate-backup-codes, POST /settings/reset, DELETE /auth/account.
+
+CONTROLES DO GRUPO (§3 do CLAUDE.md). Cada mutação abaixo foi APLICADA e a suíte
+deste arquivo rodada inteira — os números são a saída do pytest, não estimativa.
+Baseline sem mutação: 7 passed.
+
+  negativo A — em db/privacy.py, trocando o `raise PasswordNotSetError` de
+    verify_user_password de volta pelo `return False` antigo: 4 vermelhos, 3
+    verdes. Muda de status SÓ os 5 endpoints que passam por ela (409 → 401
+    "Senha incorreta."); `test_delete_account_...` continua VERDE, porque o
+    DELETE tem select próprio e nunca chama verify_user_password.
+  negativo B — removendo SÓ a guarda `if not account["password_hash"]` de
+    schedule_account_deletion (o segundo caminho de código): 4 vermelhos, 3
+    verdes — NÃO é um vermelho sozinho. O que B discrimina é o inverso de A:
+    só o DELETE muda de status (401 "Senha incorreta." quando o campo tem
+    conteúdo, 400 quando é ""), e os 5 de verify_user_password seguem em 409
+    nos três testes que os medem. A e B juntos são a prova de que os dois
+    caminhos de código são independentes: cada um deixa verde o teste que o
+    outro derruba.
+  negativo C — devolvendo o `if not password` para a PRIMEIRA linha de
+    verify_user_password (e o `raise ValueError` para a primeira de
+    schedule_account_deletion): 2 vermelhos, 5 verdes.
+    `test_campo_de_senha_vazio_...[""]` cai com 401 nos 5 e 400 no DELETE, e
+    `test_verify_user_password_...` cai no `pytest.raises` do campo vazio com
+    password_hash NULL. O param `["   "]` fica VERDE e não discrimina C:
+    `not "   "` é False em Python, então ele nunca chega na checagem de campo
+    vazio — contra C ele é uma repetição do negativo A. Fica no arquivo assim
+    mesmo, porque é ele que documenta que espaço em branco é truthy: o "campo
+    vazio" do usuário e o do Python não são o mesmo conjunto.
+  positivo — `test_conta_com_senha_...` e
+    `test_campo_de_senha_vazio_numa_conta_COM_senha_...` ficaram VERDES nas
+    TRÊS mutações, que é o trabalho deles: não medem o conserto, medem que ele
+    não fechou porta nenhuma. Com senha de verdade os 6 continuam aceitando a
+    certa e recusando a errada com 401 "Senha incorreta."; campo vazio em conta
+    COM senha continua 401/400, nunca 409 nem 2xx. Sem eles o grupo passaria num
+    código que recusasse todo mundo com 409.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MFA_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+import frontend.finance_bot_websocket_custom as dashboard  # noqa: E402
+from db.connection import get_conn  # noqa: E402
+from db.privacy import PASSWORD_NOT_SET_MSG, PasswordNotSetError, verify_user_password  # noqa: E402
+
+SENHA = "senha-certa-123"
+
+
+@pytest.fixture(autouse=True)
+def _zera_rate_limit():
+    """Os endpoints têm tetos baixos por IP (export 3/hora, regenerate 3/hora) e
+    o TestClient é sempre o mesmo IP: sem zerar entre testes, o 4º POST levaria
+    429 no lugar do status medido. Mesmo padrão de tests/test_account_reset.py."""
+    from frontend.routes import shared as routes_shared
+
+    routes_shared.limiter.reset()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _sem_email_de_verdade(monkeypatch):
+    """Os caminhos de SUCESSO do export e da exclusão disparam e-mail."""
+    import core.services.email_service as email_service
+
+    for nome in (
+        "send_data_export_link_email",
+        "send_data_export_completed_email",
+        "send_account_deletion_scheduled_email",
+    ):
+        monkeypatch.setattr(email_service, nome, lambda *a, **kw: True, raising=False)
+    yield
+
+
+def _semeia_conta(uid: int, senha: str | None) -> str:
+    """auth_accounts do usuário. senha=None → password_hash NULL (só Google)."""
+    from db.users import _hash_password
+
+    email = f"google-{uid}-{uuid.uuid4().hex[:6]}@t.local"
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "insert into auth_accounts (user_id, email, password_hash, plan) "
+                "values (%s, %s, %s, 'pro')",
+                (uid, email, _hash_password(senha) if senha else None),
+            )
+        conn.commit()
+    return email
+
+
+def _auth(client: TestClient, uid: int, email: str) -> dict:
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(uid, email))
+    client.cookies.set(dashboard.DASHBOARD_COOKIE_NAME, dashboard.make_dashboard_token(uid, hours=1))
+    token = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, token)
+    return {dashboard.CSRF_HEADER_NAME: token, "Content-Type": "application/json"}
+
+
+def _chamadas(client: TestClient, headers: dict, senha: str):
+    """Os 6 endpoints, com o DELETE por último (ele agenda exclusão e os outros
+    passam a devolver 403 depois disso)."""
+    corpo = {"password": senha, "code": "000000"}
+    return [
+        ("POST /auth/account/export",
+         lambda: client.post("/auth/account/export", json=corpo, headers=headers)),
+        ("POST /auth/mfa/setup",
+         lambda: client.post("/auth/mfa/setup", json=corpo, headers=headers)),
+        ("POST /auth/mfa/disable",
+         lambda: client.post("/auth/mfa/disable", json=corpo, headers=headers)),
+        ("POST /auth/mfa/regenerate-backup-codes",
+         lambda: client.post("/auth/mfa/regenerate-backup-codes", json=corpo, headers=headers)),
+        ("POST /settings/reset",
+         lambda: client.post("/settings/reset", json=corpo, headers=headers)),
+        ("DELETE /auth/account",
+         lambda: client.request("DELETE", "/auth/account", json=corpo, headers=headers)),
+    ]
+
+
+# ── negativo do produto: conta SEM senha ─────────────────────────────────────
+
+def test_seis_endpoints_sem_senha_devolvem_409_orientando_definir_senha(user_id):
+    email = _semeia_conta(user_id, None)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id, email)
+
+    for nome, chamada in _chamadas(client, headers, "qualquer-coisa"):
+        resp = chamada()
+        assert resp.status_code == 409, f"{nome} devolveu {resp.status_code}: {resp.text}"
+        detail = resp.json().get("detail", "")
+        # A mensagem tem de EXPLICAR (usuário já autenticado como ele mesmo, não
+        # há e-mail alheio a enumerar) e não pode repetir a mentira antiga.
+        assert "Senha incorreta." not in detail, f"{nome} ainda fala em senha incorreta: {detail}"
+        assert detail == PASSWORD_NOT_SET_MSG, f"{nome}: {detail}"
+
+
+def test_delete_account_sem_senha_e_o_segundo_caminho_de_codigo(user_id):
+    """schedule_account_deletion NÃO passa por verify_user_password: tem select
+    próprio e chamava _check_password(senha, None). Discrimina a guarda dele."""
+    email = _semeia_conta(user_id, None)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id, email)
+
+    resp = client.request("DELETE", "/auth/account", json={"password": "x"}, headers=headers)
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"] == PASSWORD_NOT_SET_MSG
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select deletion_status from auth_accounts where user_id = %s", (user_id,))
+            row = cur.fetchone()
+        conn.commit()
+    assert not row["deletion_status"] or row["deletion_status"] == "none", \
+        "recusa por falta de senha não podia ter agendado a exclusão"
+
+
+@pytest.mark.parametrize("campo_vazio", ["", "   "])
+def test_campo_de_senha_vazio_numa_conta_sem_senha_tambem_da_409(user_id, campo_vazio):
+    """O estado da conta não depende do que o cliente mandou.
+
+    Enquanto o `if not password` era a PRIMEIRA linha de verify_user_password e
+    de schedule_account_deletion, o mesmo estado (conta só-Google) devolvia TRÊS
+    status diferentes: 401 "Senha incorreta." nos 5 que passam por verify (a
+    mentira que este PR mata) e 400 "Informe sua senha" no DELETE. Alcançável
+    por chamada direta à API — os abridores do settings.html barram antes, mas
+    a API é pública e a mensagem enganava quem integra.
+    """
+    email = _semeia_conta(user_id, None)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id, email)
+
+    # Os 6 de uma vez: a falha mostra o MAPA inteiro (era {400, 401}), que é o
+    # que denuncia "três status para o mesmo estado".
+    respostas = [(nome, chamada()) for nome, chamada in _chamadas(client, headers, campo_vazio)]
+    assert {nome: r.status_code for nome, r in respostas} == {nome: 409 for nome, _ in respostas}
+    for nome, resp in respostas:
+        assert resp.json().get("detail") == PASSWORD_NOT_SET_MSG, f"{nome}: {resp.text}"
+
+
+def test_campo_de_senha_vazio_numa_conta_COM_senha_continua_recusando(user_id):
+    """Positivo do conserto acima: mover a checagem de campo vazio para depois
+    do estado da conta não pode ter aberto porta nenhuma. Quem TEM senha e manda
+    o campo vazio continua recusado — nunca 409 (não é falta de senha) e nunca
+    2xx. 401 nos 5 de verify_user_password, 400 no DELETE (o ValueError dele)."""
+    email = _semeia_conta(user_id, SENHA)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id, email)
+
+    esperado = {"DELETE /auth/account": 400}
+    for nome, chamada in _chamadas(client, headers, ""):
+        resp = chamada()
+        assert resp.status_code == esperado.get(nome, 401), \
+            f"{nome} devolveu {resp.status_code}: {resp.text}"
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select deletion_status from auth_accounts where user_id = %s", (user_id,))
+            row = cur.fetchone()
+        conn.commit()
+    assert not row["deletion_status"] or row["deletion_status"] == "none", \
+        "recusa por campo vazio não podia ter agendado a exclusão"
+
+
+def test_verify_user_password_separa_sem_senha_de_senha_errada(user_id):
+    _semeia_conta(user_id, SENHA)
+    assert verify_user_password(user_id, SENHA) is True
+    assert verify_user_password(user_id, "errada") is False   # contrato bool preservado
+    assert verify_user_password(user_id, "") is False         # campo vazio, conta COM senha
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("update auth_accounts set password_hash = null where user_id = %s", (user_id,))
+        conn.commit()
+    with pytest.raises(PasswordNotSetError):
+        verify_user_password(user_id, "qualquer")
+    with pytest.raises(PasswordNotSetError):
+        verify_user_password(user_id, "")   # o vazio não pode encobrir o estado da conta
+
+
+# ── positivo do grupo: conta COM senha continua como sempre ──────────────────
+
+def test_conta_com_senha_aceita_a_certa_e_recusa_a_errada_com_401(user_id):
+    email = _semeia_conta(user_id, SENHA)
+    client = TestClient(dashboard.app)
+    headers = _auth(client, user_id, email)
+
+    # Senha ERRADA → 401 "Senha incorreta." nos 6 (nunca 409: o 409 é só falta
+    # de senha). Sem este bloco o grupo passaria num código que recusa tudo.
+    for nome, chamada in _chamadas(client, headers, "senha-errada"):
+        resp = chamada()
+        assert resp.status_code == 401, f"{nome} devolveu {resp.status_code}: {resp.text}"
+        assert resp.json()["detail"] == "Senha incorreta.", nome
+
+    # Senha CERTA → passa da re-autenticação nos 6 (nem 401 nem 409 nem 500).
+    for nome, chamada in _chamadas(client, headers, SENHA):
+        resp = chamada()
+        assert resp.status_code not in (401, 409, 500), \
+            f"{nome} barrou a senha certa: {resp.status_code} {resp.text}"
+
+    # E a exclusão (última da lista) foi de fato agendada com a senha certa.
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select deletion_status from auth_accounts where user_id = %s", (user_id,))
+            row = cur.fetchone()
+        conn.commit()
+    assert row["deletion_status"] == "scheduled"


### PR DESCRIPTION
# Conta criada só via Google não conseguia excluir, exportar nem ativar MFA

Conta criada exclusivamente pelo login Google fica com `auth_accounts.password_hash` NULL.
`verify_user_password` devolvia `False` incondicionalmente sem hash, então **todo** endpoint que
re-autentica por senha respondia `401 "Senha incorreta."` — para um usuário que não tem senha
nenhuma que funcione. A UI mostrava os cards normalmente e pedia "Confirme sua senha".

O relato original citava dois cards (Excluir conta e Recomeçar do zero). São **seis** endpoints,
e dois deles são direito do titular pela LGPD:

| endpoint | o que estava quebrado |
|---|---|
| `DELETE /auth/account` | excluir conta (eliminação) |
| `POST /settings/reset` | recomeçar do zero |
| `POST /auth/account/export` | exportar dados (portabilidade) |
| `POST /auth/mfa/setup` | **não conseguia nem ativar 2FA** |
| `POST /auth/mfa/disable` | desativar 2FA |
| `POST /auth/mfa/regenerate-backup-codes` | regenerar códigos de backup |

E não era um caminho de código só: `schedule_account_deletion` **não passa** por
`verify_user_password` — faz o próprio `select` e chamava `_check_password(password, None)`, que
estoura `AttributeError`, é engolido em `db/users.py` e vira o mesmo 401. Consertar só a função
compartilhada deixaria o `DELETE` mentindo.

## A decisão

Direcionar para **definir uma senha primeiro**, não reautenticação OAuth pelo provedor. O motivo
é que o caminho já existia inteiro e ninguém o estava usando: o card "Resetar senha por e-mail"
emite token por `email_hash` — que o cadastro Google grava — e `consume_password_reset_token`
escreve `password_hash` mesmo partindo de NULL. Nenhuma linha nova de backend foi necessária para
o usuário ganhar uma senha; faltava a UI parar de mentir e apontar o caminho.

`auth_account_has_password` (`db/google_auth.py`) já existia, já estava exportada, e **não tinha
nenhum chamador**. Agora tem.

## O que mudou

- **`db/privacy.py`** — `PasswordNotSetError(PermissionError)` e `PASSWORD_NOT_SET_MSG` (fonte
  única da mensagem). `verify_user_password` levanta quando não há hash; senha **errada** continua
  devolvendo `False`, contrato preservado. `schedule_account_deletion` ganhou a guarda equivalente
  no seu próprio caminho.
- **Rotas** — `409` em vez de `401`, com o `except PasswordNotSetError` **antes** do
  `except PermissionError` (é subclasse dele; invertido, o genérico engole e o 409 nunca acontece).
  Helper único `_reauth_password_ok` para os 4 sites do monólito, preservando o 401 de senha errada
  e o `log_system_event` do export.
- **`/auth/me`** — passa a devolver `has_password`.
- **`frontend/settings.html`** — os 6 abridores consultam o flag e, sem senha, abrem um diálogo
  explicando e levando ao card de definir senha, em vez de revelar um campo que nunca aceita nada.
  Zero `onclick=` novo no HTML. `=== false` é a única condição que bloqueia: payload ausente ou
  `/auth/me` falhando degradam para o comportamento de hoje, para não trancar usuário legítimo.

### Por que 409 e não 401 com mensagem melhor

Medido: `frontend/static/auth-refresh.js` trata todo 401 da própria origem como access vencido,
dispara `/auth/refresh` e **refaz a request**. Numa conta sem senha o retry nunca pode dar certo, e
cada tentativa consumia **dois** slots de rate limit (5/hora no MFA, 3/hora no export e no regen) —
429 em cerca de duas tentativas. O 409 não é retentado. E `readApiError` já exibe o `detail` em
qualquer status, então a mensagem honesta aparece sem tocar nos 6 handlers de erro.

A mensagem aqui é explícita de propósito, ao contrário da vagueza de `/auth/login`: lá o chamador é
anônimo e a vagueza existe contra enumeração de e-mail; aqui o usuário já está autenticado como ele
mesmo, e não há e-mail alheio a enumerar. Está comentado no código para ninguém "corrigir" de volta.

## Custos assumidos, explícitos

1. **`/auth/me` faz +1 query ao banco, sem cache, em todo boot de toda página.** É o preço da
   decisão de não derivar do cache de 10s do `get_auth_user` — que criaria uma segunda fonte de
   verdade para "tem senha?" (§0.7). Medido: 0,19 ms de 6,2 ms da requisição (3%). **Não
   "otimize" de volta para o cache**: reintroduz estado velho depois de definir a senha.
2. **Pull-to-refresh da aba `security`: 2 → 3 round-trips** (2423 ms → 3630 ms medidos com 1200 ms
   injetados por request; o watchdog do indicador é 12000 ms). A aba `data` foi de **0 para 1** —
   nela o PTR era instantâneo e infalível, e agora um `/auth/me` lento ou offline pinta o indicador
   de âmbar numa aba sem nada dinâmico.

## Tetos aceitos (enumerados uma vez, não remendados)

As corridas de **escrita** do flag estão fechadas por um contador de geração (`_hasPwGen`), no
mesmo idioma do `_securityGen`/`_mfaGen` que o arquivo já usava — cobre boot, PTR×PTR e boot×PTR.
O que sobra, tudo da mesma família (cobertura do rebusque por aba e por ciclo de vida), está numa
tabela de estados × eventos comentada no próprio arquivo:

- PTR nas abas `notifications` / `open-finance` / `legal` não rebusca;
- troca de aba não rebusca;
- **volta do app ao foreground não rebusca** — é o caminho mais provável no iPhone, já que o link
  do e-mail abre o Safari e o usuário volta ao app. Coberto pela copy, que no app diz "puxe esta
  tela para baixo para atualizar" (e na web, "atualize a página");
- um 409 vindo do servidor num submit mostra a mensagem certa mas não realimenta o flag no cliente.

Nenhum custa mais que um puxão de tela ou um toast, e o servidor é a autoridade nos dois sentidos —
a guarda da UI é advisory. Por isso nenhum virou código nesta rodada.

## Achados registrados e deliberadamente não corrigidos

- Três taps seguidos no abridor bloqueado empilham três diálogos (cosmético).
- `DELETE /auth/account` com campo vazio e sem linha em `auth_accounts`: era 400, virou 404 — efeito
  de mover a checagem de campo vazio para depois da de estado da conta. Ambos recusam, e 404 é
  discutivelmente mais correto nesse estado.
- `/auth/account/export` não grava mais `data_export_password_failed` quando o caso é 409 (não houve
  tentativa de senha real). É o único dos seis com log; o rate limit de 3/hora segue valendo.
- **Costura de copy fora deste diff**: o card virou "Definir senha", mas o e-mail
  (`core/services/email_service.py`) e a página `frontend/reset-password.html` continuam dizendo
  "redefinir". Quem nunca teve senha lê uma frase falsa. Corrigir custa passar `has_password` ao
  e-mail — não entrou aqui, mas não pode ficar mudo.
- **`/home` continua convidando conta só-Google para o MFA** (`should_show_mfa_onboarding` não olha
  `has_password`), e o convite agora termina no diálogo "defina uma senha". Mesmo bug de classe num
  caminho irmão, fora dos seis escopados; o payload do `/auth/me` já carrega o dado para fechar.
- `handlers_inline.test.mjs` e `reset_cache_multiaba.test.mjs` usam a mesma porta 8911 — flake
  pré-existente na `main`, fora deste diff.

## Como isto foi testado

Cada mutação abaixo foi **aplicada e a suíte rodada**; os números são saída do pytest, não estimativa.

- **Negativo A** (`raise` de volta para `return False`): 4 vermelhos — mudam de status só os 5
  endpoints que passam por `verify_user_password`; o teste do `DELETE` fica **verde**.
- **Negativo B** (remover só a guarda de `schedule_account_deletion`): 4 vermelhos — muda de status
  só o `DELETE`; os outros 5 seguem em 409. **A e B juntos provam que os dois caminhos de código são
  independentes**: cada um deixa verde o teste que o outro derruba.
- **Negativo C** (checagem de campo vazio de volta para a frente): 2 vermelhos, e o param `["   "]`
  fica verde — `not "   "` é `False` em Python, então ele nunca chega nessa checagem. Fica no
  arquivo porque documenta que "campo vazio" do usuário e do Python não são o mesmo conjunto.
- **Frontend**: desligar a guarda dos abridores → 5 vermelhos; tirar o rebusque do `PBRefresh` → 3;
  remover a guarda de geração → exatamente os 2 testes de corrida.
- **Positivo**, em todas as mutações: conta **com** senha continua aceitando a certa e recusando a
  errada com `401 "Senha incorreta."` nos seis; campo vazio em conta com senha continua 401/400,
  nunca 409 nem 2xx. Sem ele o grupo passaria num código que recusasse todo mundo.

Suíte Python: 5373 passed, 1 xfailed, 0 failed (baseline da árvore sem o diff: 5366, 0 failed).
Frontend: 238 pass, 0 fail.

## O que NÃO foi verificado

Nada aqui foi provado no aparelho nem em produção — mudança de frontend só aparece depois do deploy.
Especificamente não exercitados neste ambiente: o gesto real de pull-to-refresh no iOS, o login
Google de produção gravando `password_hash` NULL, o envio real do e-mail e o clique no link de
definir senha (`send_password_reset_email` está mockado nos testes).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
