### PR TITLE
"QUALQUER diff" era falso para remoção — o gate sai antes (segue #231)

### DIFF
--- a/.claude/commands/time-dev.md
+++ b/.claude/commands/time-dev.md
@@ -51,10 +51,11 @@ valem por cima deste fluxo genérico.
   dele**: `VERSAO_ATUAL`, em `tests/frontend/sw_cache_privado.test.mjs`, para o mesmo N.
   Os dois números são um só — bumpar o `CACHE_NAME` sozinho derruba 2 de 28 em
   `node --test tests/frontend/sw_cache_privado.test.mjs` (medido em 2026-09-02, v9→v10:
-  28/28 → 26/28; remeça, não reuse). O gatilho é QUALQUER diff no arquivo, typo em
+  28/28 → 26/28; remeça, não reuse). O gatilho é qualquer diff que MANTENHA o arquivo, typo em
   comentário incluso; o gate compara a base com o PR inteiro
   (`git diff --quiet HEAD^1 HEAD -- "$SW"`, `.github/workflows/tests.yml:309`), então
-  bump em commit posterior do mesmo PR passa. A suíte local participa pela metade, e o
+  bump em commit posterior do mesmo PR passa. PR que APAGA ou renomeia o arquivo sai
+  antes disso (`tests.yml:297-300`, "não existe no head") — não há constante a bumpar. A suíte local participa pela metade, e o
   step só roda em `pull_request`: quem ESQUECE o bump passa local e só o CI pega; quem
   bumpa SEM o par fica vermelho local. Por que o bump importa: `docs/armadilhas.md`,
   § "Service worker e PWA".

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -360,7 +360,7 @@ jobs:
             case "$RC" in
               0) ;;
               3|4)
-                echo "::warning file=$SW,title=O gate não reconheceu a declaração do CACHE_NAME na base::Na base deste PR (HEAD^1) o gate não reconheceu UMA declaração 'const CACHE_NAME = \"...\"' (motivo no log acima), então não comparou o valor e está aprovando SEM verificar o bump. ATENÇÃO: isto não significa que a base não tivesse um CACHE_NAME legível — significa que a forma dela está fora do que este grep casa. Caem aqui, entre outros, 'export const', BOM ou outro byte invisível antes da declaração, e declarações repetidas com valores divergentes. Este step só chegou aqui porque o $SW mudou neste PR — o gatilho é QUALQUER diff no arquivo, typo em comentário incluso, não só mudança na estratégia de cache. Confirme na thread do PR que o CACHE_NAME foi bumpado."
+                echo "::warning file=$SW,title=O gate não reconheceu a declaração do CACHE_NAME na base::Na base deste PR (HEAD^1) o gate não reconheceu UMA declaração 'const CACHE_NAME = \"...\"' (motivo no log acima), então não comparou o valor e está aprovando SEM verificar o bump. ATENÇÃO: isto não significa que a base não tivesse um CACHE_NAME legível — significa que a forma dela está fora do que este grep casa. Caem aqui, entre outros, 'export const', BOM ou outro byte invisível antes da declaração, e declarações repetidas com valores divergentes. Este step só chegou aqui porque o $SW mudou neste PR — o gatilho é qualquer diff que mantenha o arquivo, typo em comentário incluso, não só mudança na estratégia de cache. Confirme na thread do PR que o CACHE_NAME foi bumpado."
                 exit 0 ;;
               *) falhou "HEAD^1 (a base deste PR)" ;;
             esac

--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -159,7 +159,7 @@ outro módulo não pode receber `immutable` enquanto não tiver hash no nome.
 HTML e auth nunca são cacheados, assets são network-first com fallback de cache,
 API e WebSocket passam direto. O `manifest.json` tem `start_url: "/login"` — e a
 `index.html` tem um guard no topo que manda a PWA instalada para `/login`, com saída
-por `?site=1`. Mexeu no `frontend/service-worker.js` — QUALQUER diff, typo em comentário
+por `?site=1`. Mexeu no `frontend/service-worker.js` sem apagá-lo — qualquer diff, typo em comentário
 incluso? Bumpe o `CACHE_NAME` **e o `VERSAO_ATUAL` de
 `tests/frontend/sw_cache_privado.test.mjs`**, para o mesmo N — um sem o outro fica
 vermelho em `node --test tests/frontend/sw_cache_privado.test.mjs`. O CI normalmente reprova quem


### PR DESCRIPTION
Apontamento do Codex no #231, deixado às **16:03** e que **eu não vi antes de mergear**. Procede.

## O achado

Num PR que **apaga ou renomeia** o `frontend/service-worker.js`, o arquivo não existe em `HEAD` e o step sai com `exit 0` em `tests.yml:297-300` — *"não existe no head deste PR"* — **antes** de chegar ao `git diff --quiet` da linha 309.

Então "QUALQUER diff no arquivo" é falso nesse caso, e mandar bumpar uma constante dentro de um arquivo removido é ordem impossível.

## O conserto

Qualificado nos **três** lugares onde a cláusula vive: `qualquer diff que MANTENHA o arquivo`. E a razão foi escrita onde a regra mora, com a âncora do ramo que sai antes.

Vale notar que essa duplicação em três formatos era **o ponto que o Manager marcou como o mais frágil do #231** — e ela cobrou já na primeira correção: um achado, três edições.

## Erro de processo meu

Mergeei o #231 sem conferir os comentários. Tomei "o Codex não vai responder" como fato em vez de rodar `gh api .../comments --paginate` — que é exatamente o que o §7 do `CLAUDE.md` proíbe: não afirmar estado sem consultar. O comentário estava lá havia mais de uma hora.

## Verificado

`yaml.safe_load` ok (3 jobs, step com `if: pull_request`); `bash -n` no `run:` rc=0; `npm run test:frontend` **230/230**.

**Não verificado:** o gate não roda neste PR (o diff não toca o service worker), então a mensagem alterada foi provada como shell bem formado, não renderizada pelo GitHub.