### PR TITLE
O teto do seletor de mês segue o servidor nas duas direções, não só pra cima

### DIFF
--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -7628,9 +7628,20 @@ function connect() {
           msg.data?.year && msg.data?.month && !isCurrentViewData(msg.data)) {
         viewYear = Number(msg.data.year);
         viewMonth = Number(msg.data.month);
-        // O servidor conhece um mês mais novo que o relógio local: o teto do
-        // btn-next avança junto (senão "próximo mês" abre um mês vazio).
-        latestKnownMonth = Math.max(latestKnownMonth, viewYear * 12 + viewMonth);
+        // O teto do btn-next passa a ser o mês do SERVIDOR — atribuição, não
+        // `Math.max`. O `max` só sabia SUBIR o teto, e resolvia meia divergência:
+        // servidor À FRENTE do relógio local (Manaus −04 contra São Paulo −03),
+        // onde sem subir o "próximo mês" abriria um mês vazio.
+        // Na metade oposta — navegador à frente do servidor (Lisboa +01) — o teto
+        // ficava no mês do NAVEGADOR e deixava o btn-next aberto para um mês que o
+        // servidor ainda não começou. Quem clicasse ia parar num pedido explícito
+        // (`year`/`month` na requisição) que volta com `is_current_month: false`,
+        // e aí o render trata como mês histórico: `ofBank = hist ? 0 : ...`, e o
+        // saldo dos bancos do Open Finance SOME do "Saldo consolidado" — dinheiro
+        // a menos na tela, sem explicação, nas 3h após a virada do dia 1º.
+        // Descer o teto junto é a mesma regra já declarada duas linhas acima ("o
+        // servidor é a fonte da verdade do mês"), agora nas duas direções.
+        latestKnownMonth = viewYear * 12 + viewMonth;
         updateMonthLabel();
       }
       if (!isCurrentViewData(msg.data)) return;

--- a/tests/frontend/snapshot_virada_de_mes.test.mjs
+++ b/tests/frontend/snapshot_virada_de_mes.test.mjs
@@ -112,6 +112,35 @@ test("snapshot do mês 'seguinte' é ADOTADO (antes: descartado, skeleton)", asy
   await ctx.close();
 });
 
+// Mês ANTERIOR ao do relógio do navegador = a metade oposta da divergência
+// (navegador à frente do servidor: Lisboa +01 contra São Paulo −03).
+function prevMonthOf(page) {
+  return page.evaluate(() => {
+    const y = viewYear, m = viewMonth;
+    return m === 1 ? { year: y - 1, month: 12 } : { year: y, month: m - 1 };
+  });
+}
+
+test("servidor ATRÁS do navegador: adota e BAIXA o teto do btn-next", async () => {
+  // A outra metade da divergência. O teto era `Math.max`, que só subia: ele
+  // ficava no mês do NAVEGADOR e deixava o btn-next aberto para um mês que o
+  // servidor ainda não começou. Clicar ali manda `year`/`month` explícitos, a
+  // resposta vem com `is_current_month: false`, o render trata como histórico
+  // (`ofBank = hist ? 0 : ...`) e o saldo dos bancos do Open Finance some do
+  // "Saldo consolidado".
+  //
+  // Controle NEGATIVO: repondo `Math.max(latestKnownMonth, ...)` em
+  // dashboard.js, `nextDisabled` volta a `false` e este teste fica vermelho.
+  const { ctx, page } = await bootPage();
+  const pm = await prevMonthOf(page);
+  const out = await send(page, { type: "snapshot", data: { year: pm.year, month: pm.month, launches: [] } });
+  assert.deepEqual(out.view, [pm.year, pm.month], "não adotou o mês (anterior) do servidor");
+  const nextDisabled = await page.evaluate(() => document.getElementById("btn-next").disabled);
+  assert.equal(nextDisabled, true,
+               "btn-next aberto para um mês que o servidor ainda não começou");
+  await ctx.close();
+});
+
 test("depois de navegar de mês manualmente, snapshot divergente volta a ser descartado", async () => {
   const { ctx, page } = await bootPage();
   const nm = await nextMonthOf(page);

--- a/tests/test_virada_de_mes.py
+++ b/tests/test_virada_de_mes.py
@@ -105,6 +105,24 @@ o saldo dos bancos conectados SOME do consolidado. Não é dinheiro errado — n
 quem está NO fuso do app o conserto MELHORA esse mesmo caminho, pelo mesmo
 mecanismo ao contrário.
 
+FECHADO pela condição 3, que era a única alcançável pela interface. O teto do
+`btn-next` (`latestKnownMonth`) era `Math.max`, e `Math.max` só sabe SUBIR: ele
+cobria a divergência em que o servidor está À FRENTE (Manaus −04) e deixava a
+metade oposta (Lisboa +01) com o teto no mês do NAVEGADOR — botão aberto para um
+mês que o servidor ainda não começou. Virou atribuição: o teto é o mês do
+servidor nas duas direções, que é a regra já declarada no próprio bloco de
+adoção ("o servidor é a fonte da verdade do mês"). Com o botão desabilitado, e
+sendo `changeMonth` chamado só por `btn-prev`/`btn-next` (os demais `fetchMonthHttp`
+usam `viewYear`/`viewMonth`), não há caminho de UI até o pedido explícito.
+Coberto por `tests/frontend/snapshot_virada_de_mes.test.mjs`, com o negativo
+(repondo o `Math.max`, o caso novo fica vermelho) e o positivo (o caso do mês
+SEGUINTE prova que o teto continua subindo quando é o servidor que está à frente).
+
+O que NÃO mudou: o `hist` continua derivado de `!is_current_month`, ou seja,
+segue confundindo "não é o mês corrente" com "é passado". Um mês FUTURO
+alcançado por outro caminho ainda renderizaria com os bancos zerados. Não há
+caminho assim hoje; se algum aparecer, o conserto é no `hist`, não no teto.
+
 EXCEÇÃO CONHECIDA E DELIBERADA — sobra 1 instância da classe em produção, não 0.
 `auth_account_export_download` (o monólito) monta o nome do ZIP com `%Y%m%d` de
 um `datetime.now(timezone.utc)`: export às 21:13 de São Paulo sai com o dia


### PR DESCRIPTION
Fecha a **"2ª parte" do resíduo** registrada no docstring de `tests/test_virada_de_mes.py` pelo #215 — o último item aberto daquela família.

## O defeito

O bloco de adoção do snapshot declara que *"o servidor é a fonte da verdade do mês"*. Mas o teto do `btn-next` era `Math.max(latestKnownMonth, ...)`, e `Math.max` só sabe **subir**.

Isso cobria metade da divergência — servidor à frente do relógio local (Manaus −04 contra São Paulo −03), onde sem subir o teto o "próximo mês" abriria um mês vazio.

A metade oposta ficava aberta:

| | navegador | servidor (SP) | teto do btn-next | btn-next |
|---|---|---|---|---|
| Manaus (−04) | agosto | setembro | setembro (subiu) | desabilitado ✓ |
| **Lisboa (+01)** | **setembro** | **agosto** | **setembro (não desceu)** | **habilitado ✗** |

Nas 3h após a virada do dia 1º, o usuário em Lisboa adota agosto (certo), mas o botão continua aberto para setembro — um mês que o servidor ainda não começou.

## O que acontece se clicar

O clique manda `year`/`month` explícitos, a resposta volta com `is_current_month: false`, e o render trata como mês histórico:

```js
const hist   = !d.is_current_month;
const ofBank = hist ? 0 : Number(d.of_bank_balance || 0);
const saldoAtual = carteira + ofBank;
```

O saldo dos bancos do Open Finance **some do "Saldo consolidado"**. Não corrompe dado — é exibição, e passa sozinho quando a janela fecha — mas é dinheiro a menos na tela, sem explicação.

## O conserto

`Math.max` virou atribuição. Uma expressão: a regra já estava escrita duas linhas acima, só não valia nas duas direções.

Com o botão desabilitado não existe caminho de UI até o pedido explícito: `changeMonth` só é chamado por `btn-prev`/`btn-next` (`dashboard.html:122,124`), e os demais `fetchMonthHttp` usam `viewYear`/`viewMonth`.

## Controles

| controle | resultado |
|---|---|
| **NEGATIVO** — repondo o `Math.max` | o caso novo fica vermelho (`actual: false, expected: true`) |
| **POSITIVO** — caso do mês SEGUINTE (servidor à frente) | verde nas duas colunas |

O negativo discrimina de verdade: o caso estava **verde** com o conserto e fica **vermelho** sem ele. O positivo prova que descer o teto não quebrou a direção que já funcionava.

## Medido

```
node --test tests/frontend/snapshot_virada_de_mes.test.mjs          5/5
node --test --test-concurrency=1 tests/frontend/*.test.mjs      240/240
pytest tests/test_virada_de_mes.py -q                               6/6
```

`--test-concurrency=1` porque em paralelo esta máquina colide nas portas dos `http.server` dos testes e dá 44 falhas de `ERR_CONNECTION_REFUSED` — ambiente local, não código. Em sequencial fica limpo.

## O que NÃO muda

`hist` continua sendo `!is_current_month` — ainda confunde *"não é o mês corrente"* com *"é passado"*. Um mês **futuro** alcançado por outro caminho renderizaria com os bancos zerados do mesmo jeito. Não há caminho assim hoje; se aparecer, o conserto é no `hist`, não no teto. Ficou registrado no docstring em vez de virar código especulativo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)