### PR TITLE
fix: Clear-Site-Data "storage" atropelava o _PRESERVA do logout

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2767,7 +2767,16 @@ async def auth_logout(request: Request, response: Response):
             )
 
     _clear_session_cookies(response)
-    response.headers["Clear-Site-Data"] = '"cookies", "storage"'
+    # SEM `"storage"`, e a ausência é a regra — não esquecimento. O diretivo é
+    # tudo-ou-nada (não tem granularidade por chave) e apagava localStorage,
+    # sessionStorage, Cache Storage e service workers INTEIROS, atropelando o
+    # `_PRESERVA` de `frontend/static/auth-refresh.js` (e o gêmeo do
+    # `nav-auth.js`), que é a fonte de verdade do que sobrevive ao fim de
+    # sessão. Medido em Chromium 151: `finbot_reset_at` sumia e reabria o flash
+    # de snapshot pré-reset na cadeia reset → logout → relogin; tema, esconder-
+    # saldo e posição do FAB sumiam junto. Quem apaga o estado do aparelho é o
+    # JS — todo chamador de POST /auth/logout carrega um dos dois arquivos.
+    response.headers["Clear-Site-Data"] = '"cookies"'
     _no_store(response)
     return {"ok": True}
 

--- a/tests/test_auth_cookie.py
+++ b/tests/test_auth_cookie.py
@@ -320,7 +320,10 @@ def test_logout_expires_auth_and_dashboard_cookies():
 
     assert response.status_code == 200
     assert response.headers["cache-control"] == "no-store"
-    assert response.headers["clear-site-data"] == '"cookies", "storage"'
+    # `"storage"` NÃO pode voltar: ele apaga o storage inteiro e atropela o
+    # `_PRESERVA` do auth-refresh.js/nav-auth.js (fonte de verdade do que
+    # sobrevive ao logout), levando junto o MECANISMO `finbot_reset_at`.
+    assert response.headers["clear-site-data"] == '"cookies"'
     set_cookie = response.headers.get_list("set-cookie")
     assert any(cookie.startswith("auth_token=") and "Max-Age=0" in cookie for cookie in set_cookie)
     assert any(cookie.startswith("dashboard_token=") and "Max-Age=0" in cookie for cookie in set_cookie)


### PR DESCRIPTION
## O bug

`POST /auth/logout` mandava `Clear-Site-Data: "cookies", "storage"` ([finance_bot_websocket_custom.py](https://github.com/JapaLcK/Bot_Financeiro/blob/main/frontend/finance_bot_websocket_custom.py#L2770)). O diretivo é **tudo-ou-nada** — não tem granularidade por chave —, então ele apagava `localStorage`, `sessionStorage`, Cache Storage e service workers **inteiros**, atropelando o `_PRESERVA` de `frontend/static/auth-refresh.js` (e o gêmeo do `nav-auth.js`), que enumera as 7 chaves que "sobrevivem ao fim de sessão".

Duas fontes de verdade contraditórias sobre a mesma regra (CLAUDE.md §0.7), e no caminho feliz quem ganhava era o header — o `_PRESERVA` era decorativo.

## Medição — duas colunas, Chromium 151.0.7922.34

Mesmo servidor, mesmo estado inicial (8 chaves em `localStorage` + `pbSpa` em `sessionStorage` + 1 cache), só o header muda:

```
"cookies", "storage"  -> sobrevivem: local=[]  sessao=[]  caches=[]
"cookies"             -> sobrevivem: local=[8 chaves]  sessao=["pbSpa"]  caches=["pigbank-v9"]
```

O que sumia:

- **`finbot_reset_at`** — é MECANISMO e é LIDO (`dashboard.js:422`, `home.html:1445`). Sem ele, a cadeia `reset → logout → relogin na mesma aba` reabre o flash de snapshot pré-reset, exatamente o que o comentário do `_PRESERVA` diz não poder acontecer.
- **`pigbank_theme`, `pigbank_hide_balance`, `pbFabPos`** — preferência do APARELHO. O teste `"preferencia do aparelho SOBREVIVE — apagar o tema seria hostil"` (`tests/frontend/sw_cache_privado.test.mjs`) roda em `vm`, que não implementa `Clear-Site-Data`: verde no teste, falso no navegador.

## A decisão

Fica o `_PRESERVA`, sai o `"storage"`. Não dava para conciliar os dois.

**Custo aceito:** se o JS de limpeza falhar inteiro, não há mais fallback do navegador no logout. Ele já não existia nos outros dois fins de sessão que o `_SESSAO_ENCERRADA` reconhece — `/auth/refresh` 401 e `DELETE /auth/account` —, que nunca mandaram o header; `grep -rn "Clear-Site-Data"` dá **1** ocorrência no repo inteiro. Todo chamador de `POST /auth/logout` carrega um dos dois arquivos de limpeza: `settings.html:1103`, `dashboard.html:27`, `home.html:455` (auth-refresh) e as 12 páginas públicas (nav-auth). `admin-dashboard.html` usa `/admin/auth/logout`, rota diferente.

## O que NÃO foi mexido

O relato original apontava que `settings.html` gravaria `finbot_logout_at` cedo demais e que por isso "sair pelo Ajustes não desloga as outras abas". **Não procede**: o `setItem` ([settings.html:1820](https://github.com/JapaLcK/Bot_Financeiro/blob/main/frontend/settings.html#L1820)) vem *antes* do `fetch` da linha seguinte, então o `storage` event dispara nas outras abas no instante do `setItem`, muito antes de qualquer header chegar. Depois deste fix a chave também sobrevive, então não sobrou nada para consertar ali.

## Verificação

**Verificado aqui:**

- Suíte Python inteira: `5370 passed`. As 10 falhas da primeira rodada foram causadas pelo meu próprio `TZ=UTC PGTZ=UTC` (testes de fuso de São Paulo); rodadas sem o override, `174 passed`.
- `node --test tests/frontend/sw_cache_privado.test.mjs`: 49/49.
- **Controle negativo:** repondo `"storage"` no header, `test_logout_expires_auth_and_dashboard_cookies` fica **vermelho**; tirando, **verde**. O assert atualizado é o pino contra a volta do diretivo.

**Não verificado:**

- WebKit/WKWebView — a pergunta virou moot: nenhum navegador recebe mais `"storage"`.
- Comportamento no aparelho, que só aparece depois do deploy (CLAUDE.md §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)