### PR TITLE
Tira o plano Grátis da escolha do usuário: assinar vira obrigatório na web

### DIFF
--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -270,9 +270,13 @@ def send_welcome_email(to: str, link_code: str, dashboard_url: str = "") -> bool
     depois mandar o oi no WhatsApp — prometer uso imediato era falso.
 
     O trial é 1 por telefone na vida (plan_trials, db/schema.py), e quem sabe a
-    resposta pra ESTE usuário é db.plans.is_trial_eligible_for_user; aqui
-    falamos com quem está chegando, então a oferta aparece com a ressalva de
-    que o checkout confirma antes de qualquer cobrança.
+    resposta pra ESTE usuário é db.plans.is_trial_eligible_for_user — que precisa
+    do user_id e de um telefone vinculado, e este e-mail não tem nenhum dos dois
+    (a assinatura recebe só o e-mail, e o cadastro por senha nem grava telefone).
+    Então a copy NÃO garante quando a primeira cobrança acontece: quem recria a
+    conta com um número já usado é cobrado na hora (_billing_checkout_for_user
+    manda trial_days=0). A oferta dos 15 dias aparece como o que o checkout vai
+    confirmar antes de cobrar, nunca como fato consumado.
 
     `link_code` e `dashboard_url` chegam dos chamadores e não são usados: os
     links saem do _public_base_url() e do _whatsapp_link(). A assinatura fica
@@ -283,12 +287,11 @@ def send_welcome_email(to: str, link_code: str, dashboard_url: str = "") -> bool
 
     content = f"""
       <p>Olá! 👋</p>
-      <p>Sua conta no <strong>PigBank</strong> foi criada com sucesso — e você tem
-         <strong>15 dias grátis</strong> pra testar tudo.</p>
+      <p>Sua conta no <strong>PigBank</strong> foi criada com sucesso — falta só
+         escolher o plano que você quer testar por <strong>15 dias grátis</strong>.</p>
       <p><strong>1. Ative o seu teste</strong>: escolha o plano que quer
-         experimentar. Nada é cobrado agora — a primeira cobrança só vem depois
-         dos 15 dias, e dá pra cancelar antes sem pagar nada. O checkout mostra
-         o que vai acontecer antes de você confirmar.</p>
+         experimentar. O checkout mostra o que vai ser cobrado, e quando, antes
+         de você confirmar — nada é cobrado sem essa confirmação.</p>
       <p style="text-align:center"><a class="btn" href="{base}/precos">🐷 Ativar meus 15 dias grátis</a></p>
       <p><strong>2. Mande um oi pro Piggy no WhatsApp</strong> — com o teste
          ativo, ele reconhece o seu número automaticamente e já começa a anotar.</p>
@@ -305,9 +308,9 @@ def send_welcome_email(to: str, link_code: str, dashboard_url: str = "") -> bool
     html = _base_html("Bem-vindo ao PigBank!", content)
     text = (
         "Bem-vindo ao PigBank!\n\n"
-        "Sua conta foi criada e você tem 15 dias grátis pra testar tudo.\n\n"
+        "Sua conta foi criada — falta escolher o plano que você quer testar por 15 dias grátis.\n\n"
         f"1) Ative o teste escolhendo um plano: {base}/precos\n"
-        "   Nada é cobrado agora; cancele antes do fim dos 15 dias e não paga nada.\n"
+        "   O checkout mostra o que vai ser cobrado, e quando, antes de você confirmar.\n"
         "2) Depois, mande um oi pro Piggy no WhatsApp — ele reconhece seu número automaticamente.\n\n"
         "Lá você vai poder mandar: gastei 50 mercado, recebi 1000 salário, saldo, ajuda.\n"
     )

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -262,21 +262,38 @@ def _whatsapp_link(greeting: str = "Oi! Quero ativar minha conta no PigBank 🐷
 
 
 def send_welcome_email(to: str, link_code: str, dashboard_url: str = "") -> bool:
-    """Envia e-mail de boas-vindas após o cadastro."""
+    """Envia e-mail de boas-vindas após o cadastro (web).
+
+    A conta recém-criada NÃO entra no bot direto: o gate manda pra /precos
+    (routes/shared.py). Então a ordem aqui é ativar o teste de 15 dias
+    (plan_service.TRIAL_DAYS_DEFAULT, exposto em /billing/plans-config) e só
+    depois mandar o oi no WhatsApp — prometer uso imediato era falso.
+
+    O trial é 1 por telefone na vida (plan_trials, db/schema.py), e quem sabe a
+    resposta pra ESTE usuário é db.plans.is_trial_eligible_for_user; aqui
+    falamos com quem está chegando, então a oferta aparece com a ressalva de
+    que o checkout confirma antes de qualquer cobrança.
+
+    `link_code` e `dashboard_url` chegam dos chamadores e não são usados: os
+    links saem do _public_base_url() e do _whatsapp_link(). A assinatura fica
+    como está — mexer nela são 3 chamadores fora do escopo desta mudança.
+    """
     vincular_wpp = _whatsapp_link()
-    dashboard_url = dashboard_url.rstrip("/") if dashboard_url else ""
-    dashboard_section = f"""<p>Acompanhe tudo no seu dashboard:</p>
-      <p style="text-align:center"><a class="btn" href="{dashboard_url}">📊 Abrir Dashboard</a></p>""" if dashboard_url else ""
+    base = _public_base_url()
 
     content = f"""
       <p>Olá! 👋</p>
-      <p>Sua conta no <strong>PigBank</strong> foi criada com sucesso!
-         Vamos conectar o Piggy ao seu WhatsApp pra você começar.</p>
-      <p><strong>É só abrir o chat e mandar um oi</strong> — o Piggy reconhece o
-         seu número automaticamente e já começa. Sem código, sem prazo. 🎉</p>
+      <p>Sua conta no <strong>PigBank</strong> foi criada com sucesso — e você tem
+         <strong>15 dias grátis</strong> pra testar tudo.</p>
+      <p><strong>1. Ative o seu teste</strong>: escolha o plano que quer
+         experimentar. Nada é cobrado agora — a primeira cobrança só vem depois
+         dos 15 dias, e dá pra cancelar antes sem pagar nada. O checkout mostra
+         o que vai acontecer antes de você confirmar.</p>
+      <p style="text-align:center"><a class="btn" href="{base}/precos">🐷 Ativar meus 15 dias grátis</a></p>
+      <p><strong>2. Mande um oi pro Piggy no WhatsApp</strong> — com o teste
+         ativo, ele reconhece o seu número automaticamente e já começa a anotar.</p>
       <p style="text-align:center"><a class="btn" href="{vincular_wpp}">📱 Abrir chat no WhatsApp</a></p>
-      {dashboard_section}
-      <p><strong>Primeiros comandos:</strong></p>
+      <p><strong>O que você vai poder fazer por lá:</strong></p>
       <ul>
         <li><code>gastei 50 mercado</code> — registrar despesa</li>
         <li><code>recebi 1000 salário</code> — registrar receita</li>
@@ -288,9 +305,13 @@ def send_welcome_email(to: str, link_code: str, dashboard_url: str = "") -> bool
     html = _base_html("Bem-vindo ao PigBank!", content)
     text = (
         "Bem-vindo ao PigBank!\n\n"
-        "Abra o chat com o bot no WhatsApp e mande um oi — reconhecemos seu número automaticamente.\n"
+        "Sua conta foi criada e você tem 15 dias grátis pra testar tudo.\n\n"
+        f"1) Ative o teste escolhendo um plano: {base}/precos\n"
+        "   Nada é cobrado agora; cancele antes do fim dos 15 dias e não paga nada.\n"
+        "2) Depois, mande um oi pro Piggy no WhatsApp — ele reconhece seu número automaticamente.\n\n"
+        "Lá você vai poder mandar: gastei 50 mercado, recebi 1000 salário, saldo, ajuda.\n"
     )
-    return send_email(to=to, subject="✅ Bem-vindo ao PigBank — vincule o bot e comece agora", html_body=html, text_body=text)
+    return send_email(to=to, subject="✅ Bem-vindo ao PigBank — ative seus 15 dias grátis", html_body=html, text_body=text)
 
 
 # ─── Unsubscribe helpers ──────────────────────────────────────────────────────

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -272,8 +272,10 @@ def needs_plan_selection(user_id: int, user: dict | None = None) -> bool:
     """True se o cadastro ainda NÃO escolheu um plano na /precos.
 
     Regra de produto (2026-08-11): depois de criar a conta, o usuário é obrigado
-    a passar pela /precos e escolher um plano — mesmo o Grátis — antes de entrar
-    no dashboard. `plan_selected_at` (auth_accounts) marca essa escolha.
+    a passar pela /precos e ASSINAR um plano pago antes de entrar no dashboard
+    (o Grátis saiu da /precos como escolha em 2026-09-02 — segue existindo como
+    ESTADO, no fallback após falha de cobrança). `plan_selected_at`
+    (auth_accounts) marca essa escolha.
 
     Nunca trava quem já tem assinatura paga/trial vigente (escolha implícita no
     checkout) nem contas antigas (backfill em schema.py). Com o v2 desligado

--- a/db/schema.py
+++ b/db/schema.py
@@ -1702,8 +1702,9 @@ def init_db():
         """alter table auth_accounts add column if not exists trial_downsell_sent_at timestamptz""",
         # Gate de escolha de plano no cadastro (2026-08-11): depois de criar a
         # conta o usuário é OBRIGADO a passar pela /precos e escolher um plano
-        # (mesmo o Grátis) antes de entrar no dashboard. plan_selected_at marca
-        # o momento dessa escolha — NULL = ainda não escolheu → cai na /precos.
+        # antes de entrar no dashboard — desde 2026-09-02 só planos PAGOS, o
+        # Grátis não é mais oferecido lá. plan_selected_at marca o momento dessa
+        # escolha — NULL = ainda não escolheu → cai na /precos.
         #
         # Backfill preciso pela fronteira REAL do rollout (sem cutoff por data
         # chutado): o ADD COLUMN com DEFAULT now() carimba TODAS as contas que já

--- a/db_support.py
+++ b/db_support.py
@@ -664,9 +664,10 @@ def update_user_plan_impl(get_conn, user_id: int, plan: str, expires_at=None) ->
 
 
 def mark_plan_selected_impl(get_conn, user_id: int) -> None:
-    """Marca que o usuário já escolheu um plano no cadastro (Grátis ou pago),
-    liberando o acesso ao dashboard. Idempotente: só grava na primeira vez
-    (where plan_selected_at is null) pra preservar o timestamp original."""
+    """Marca que o usuário já escolheu um plano no cadastro, liberando o acesso
+    ao dashboard. Hoje só o webhook checkout.session.completed chama isto (a
+    escolha do Grátis morreu em 2026-09-02). Idempotente: só grava na primeira
+    vez (where plan_selected_at is null) pra preservar o timestamp original."""
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/db_support.py
+++ b/db_support.py
@@ -665,9 +665,13 @@ def update_user_plan_impl(get_conn, user_id: int, plan: str, expires_at=None) ->
 
 def mark_plan_selected_impl(get_conn, user_id: int) -> None:
     """Marca que o usuário já escolheu um plano no cadastro, liberando o acesso
-    ao dashboard. Hoje só o webhook checkout.session.completed chama isto (a
-    escolha do Grátis morreu em 2026-09-02). Idempotente: só grava na primeira
-    vez (where plan_selected_at is null) pra preservar o timestamp original."""
+    ao dashboard. Hoje quem chama são os DOIS ramos pagos do webhook da Stripe
+    (`checkout.session.completed` e `invoice.paid`/`invoice.payment_succeeded`);
+    a escolha do Grátis morreu em 2026-09-02. Não são duas portas de entrada: o
+    `invoice.paid` pressupõe subscription, que pressupõe uma sessão de checkout
+    antes, então o funil de cadastro continua com uma saída só — pagar.
+    Idempotente: só grava na primeira vez (where plan_selected_at is null) pra
+    preservar o timestamp original."""
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -135,7 +135,9 @@ de mensagem? Os dois lados mudam junto — o consumidor está no `dashboard.js`.
 ### Pagamentos
 
 Stripe: `/billing/create-checkout`, `webhook`, `portal`, `subscription`,
-`change-plan`, `cancel-change`, `select-free`, `plans-config`.
+`change-plan`, `cancel-change`, `plans-config` e `select-free` (esta só RECUSA
+com 410: a escolha do plano Grátis saiu da /precos em 2026-09-02; a rota
+sobrevive pra devolver `detail.message` a cliente antigo em cache).
 
 A **escada de planos é `free < essencial < plus < pro`**, atrás do flag
 `PLANS_V2_ENABLED` (lido dinamicamente, sem redeploy; `0`/`false` é freio de

--- a/frontend/como-funciona.html
+++ b/frontend/como-funciona.html
@@ -45,7 +45,7 @@
         <div class="steps">
           <div class="step">
             <div class="step-num">1</div>
-            <div><h3>Crie sua conta</h3><p>Grátis e em segundos, entrando com o Google. Sem cadastro chato.</p></div>
+            <div><h3>Crie sua conta</h3><p>Em segundos, entrando com o Google. Depois você ativa 15 dias grátis pra testar tudo.</p></div>
           </div>
           <div class="step">
             <div class="step-num">2</div>

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -10808,9 +10808,10 @@ function _showAccessError(title, msg) {
         if (me && me.agents_ui_enabled === false) {
           document.querySelectorAll('[data-nav="agentes"]').forEach(el => { el.style.display = "none"; });
         }
-        // Gate de escolha de plano: cadastro novo passa pela /precos antes de
-        // acessar o app (mesmo escolhendo o Grátis). Só na web — no app iOS o gate
-        // fica de fora pra não forçar a tela de planos/compra (diretriz 3.1.1).
+        // Gate de escolha de plano: cadastro novo passa pela /precos e assina um
+        // plano pago antes de acessar o app (o Grátis não é mais uma escolha
+        // oferecida na /precos). Só na web — no app iOS o gate fica de fora pra
+        // não forçar a tela de planos/compra (diretriz 3.1.1).
         // Paywall/escolha de plano: mesmo veredito da revalidação por WS
         // rejeitado (applyAccessVerdict já limpa snapshot e para o retry).
         if (!applyAccessVerdict(me)) return false;

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4111,10 +4111,8 @@ async def billing_plans_config():
     return {
         "plans_v2_enabled": plans_v2_enabled(),
         "essencial_available": bool(STRIPE_PRICE_ID_ESSENCIAL_MENSAL),
-        # Plus segue o mesmo `or` do _resolve_price_id("plus", "monthly"): sem o
-        # fallback legado, um deploy configurado só com STRIPE_PRICE_ID_PRO
-        # mostraria "Indisponível" num plano cujo checkout funciona.
-        "plus_available": bool(STRIPE_PRICE_ID_PRO_MENSAL or STRIPE_PRICE_ID_PRO),
+        "plus_available": bool(_resolve_price_id("plus", "monthly")
+                               or _resolve_price_id("plus", "annual")),
         "pro_available": bool(STRIPE_PRICE_ID_PROMAX_MENSAL),
         "trial_days": trial_days_total(),
     }

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4183,11 +4183,25 @@ async def billing_select_free(
     devolveria 404/405 (HTML da página de erro, sem `detail`) a um cliente
     antigo em cache, e o front trata 4xx lendo `detail.message`.
 
-    Ninguém no frontend chama isto: o `[data-free-cta]` e o `selectFree` saíram
-    da precos.html no mesmo commit (`git grep -n select-free -- frontend/`), e
-    o único caminho que fecha o gate hoje é o `mark_plan_selected` do webhook
-    `checkout.session.completed`. Então a recusa não vira erro na tela de
-    ninguém — é rede de segurança contra chamada direta.
+    O front NOVO não chama mais: o `[data-free-cta]` e o `selectFree` saíram da
+    precos.html no mesmo commit (`git grep -n select-free -- frontend/`), e quem
+    fecha o gate hoje são os dois ramos pagos do webhook da Stripe
+    (`checkout.session.completed` e `invoice.paid`/`invoice.payment_succeeded`,
+    os dois chamando `mark_plan_selected`).
+
+    Sobra UM chamador real, e é ele que sustenta o parágrafo acima: a aba com a
+    /precos ANTIGA já carregada no instante do deploy, de usuário em
+    `needs_plan_selection`. O JS velho dessa aba já converteu o CTA em
+    "Continuar com o plano Grátis"; o clique faz o POST, leva 410, e o
+    `selectFree` antigo cai no `showToast(msg, "err")` — ou seja, a recusa VIRA
+    um toast vermelho com a mensagem daqui, que por isso é escrita pra ser lida
+    por humano. Não é beco sem saída: os CTAs pagos da mesma aba continuam
+    funcionando, e um reload traz a página nova.
+
+    Os outros vetores estão fechados: link salvo, e-mail, deep link e sitemap
+    não alcançam a rota (é `@app.post` só, atrás de `_get_current_user` e do
+    CSRF — um GET dá 405), e HTML velho servido por PWA ou por cache HTTP não
+    existe (o service worker não intercepta navegação e o HTML sai `no-store`).
 
     O tier `free` continua existindo como ESTADO (fallback após falha de
     cobrança); o que sumiu é a ESCOLHA."""

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4111,6 +4111,10 @@ async def billing_plans_config():
     return {
         "plans_v2_enabled": plans_v2_enabled(),
         "essencial_available": bool(STRIPE_PRICE_ID_ESSENCIAL_MENSAL),
+        # Plus segue o mesmo `or` do _resolve_price_id("plus", "monthly"): sem o
+        # fallback legado, um deploy configurado só com STRIPE_PRICE_ID_PRO
+        # mostraria "Indisponível" num plano cujo checkout funciona.
+        "plus_available": bool(STRIPE_PRICE_ID_PRO_MENSAL or STRIPE_PRICE_ID_PRO),
         "pro_available": bool(STRIPE_PRICE_ID_PROMAX_MENSAL),
         "trial_days": trial_days_total(),
     }

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4055,11 +4055,12 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
                 f"&ev={'trial' if trial_days > 0 else 'purchase'}"
                 f"&td={trial_days}&pl={plan}&ia={ia_quota}"
             ),
-            # Abandonou o checkout → volta pra /precos escolher um plano (pago
-            # ou Grátis). O escolha=1 já faz o applyOnboardingChoice mostrar
-            # "Escolha um plano pra começar" (needs_plan_selection segue true,
-            # pois o gate não fechou) — não anexo upgrade=cancelled porque
-            # /precos não consome esse marcador (o toast vive só na /home).
+            # Abandonou o checkout → volta pra /precos escolher um plano PAGO
+            # (o Grátis não é mais escolha). O escolha=1 é o que a precos.html
+            # lê pra trocar o subtítulo por "Escolha um plano pra continuar"
+            # (needs_plan_selection segue true, pois o gate não fechou) — não
+            # anexo upgrade=cancelled porque /precos não consome esse marcador
+            # (o toast vive só na /home).
             cancel_url=f"{DASHBOARD_URL}/precos?escolha=1",
             metadata=metadata,
             subscription_data=subscription_data,
@@ -4158,24 +4159,27 @@ async def billing_select_free(
     request: Request,
     user_id: int = Depends(_get_current_user),
 ):
-    """Escolha do plano Grátis no fim do cadastro.
+    """Escolha do plano Grátis no fim do cadastro — DESATIVADA.
 
-    Fecha o gate da /precos (plan_selected_at) e libera o dashboard sem passar
-    pelo Stripe. Recusa se o usuário já tem assinatura paga/trial vigente —
-    aí a troca é pela /precos normal, não por aqui."""
-    from db import mark_plan_selected
-    from core.services.plan_service import get_plan_tier
+    O Grátis morreu como porta de entrada: quem se cadastra pela web tem de
+    assinar pra entrar. A rota continua existindo só pra RECUSAR — apagá-la
+    devolveria 404/405 (HTML da página de erro, sem `detail`) a um cliente
+    antigo em cache, e o front trata 4xx lendo `detail.message`.
 
-    tier = await asyncio.to_thread(get_plan_tier, user_id)
-    if tier != "free":
-        raise HTTPException(
-            status_code=409,
-            detail={"error": "already_subscribed",
-                    "message": "Você já tem um plano pago ativo."},
-        )
+    Ninguém no frontend chama isto: o `[data-free-cta]` e o `selectFree` saíram
+    da precos.html no mesmo commit (`git grep -n select-free -- frontend/`), e
+    o único caminho que fecha o gate hoje é o `mark_plan_selected` do webhook
+    `checkout.session.completed`. Então a recusa não vira erro na tela de
+    ninguém — é rede de segurança contra chamada direta.
 
-    await asyncio.to_thread(mark_plan_selected, user_id)
-    return {"ok": True, "dashboard_url": _dashboard_url("/home")}
+    O tier `free` continua existindo como ESTADO (fallback após falha de
+    cobrança); o que sumiu é a ESCOLHA."""
+    raise HTTPException(
+        status_code=410,
+        detail={"error": "free_plan_discontinued",
+                "message": "O plano Grátis não está mais disponível. "
+                           "Escolha um plano pago pra continuar."},
+    )
 
 
 # ─── Troca de plano (upgrade/downgrade sem assinatura dupla) ─────────────────

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -6914,12 +6914,12 @@ async def websocket_endpoint(ws: WebSocket, user_id: int):
     # Espelho do _enforce_subscription_gate (frontend/routes/shared.py): o
     # backstop 402 das rotas de dados NÃO cobre o WS — sem este gate, o
     # snapshot pintava dados no boot antes do veredito do paywall. Mesmas
-    # primitivas e mesma isenção do app iOS (diretriz 3.1.1: o app não pode
-    # ser empurrado pra tela de compra; fica no acesso base).
+    # primitivas e, como ele, sem isenção de app: a que existia aqui era uma
+    # segunda cópia da checagem de UA (`"PigBankApp" in ws.headers`), e o header
+    # é escolhido pelo cliente — dava pra abrir o WS sem plano só pedindo.
     from core.services.plan_service import has_app_access, needs_plan_selection
-    in_app = "PigBankApp" in (ws.headers.get("user-agent") or "")
     sem_plano = await asyncio.to_thread(
-        lambda: (not in_app and needs_plan_selection(user_id)) or not has_app_access(user_id)
+        lambda: needs_plan_selection(user_id) or not has_app_access(user_id)
     )
     if sem_plano:
         await ws.close(code=4402, reason="subscription_required")

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2271,8 +2271,9 @@ def _post_login_url(user_id: int | None = None) -> str:
     O campo `dashboard_url` nas respostas de auth aponta para cá.
 
     Cadastro novo (ou quem ainda não escolheu plano) vai DIRETO pra /precos —
-    só entra no dashboard depois de escolher um plano (mesmo o Grátis) e, nos
-    pagos, concluir o pagamento. Sem assinatura ativa (paywall ligado), idem."""
+    só entra no dashboard depois de escolher um plano — que hoje é sempre pago,
+    o Grátis saiu da /precos — e concluir o pagamento. Sem assinatura ativa
+    (paywall ligado), idem."""
     if user_id is not None:
         from core.services.plan_service import has_app_access, needs_plan_selection
         if needs_plan_selection(int(user_id)):
@@ -4056,11 +4057,12 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
                 f"&td={trial_days}&pl={plan}&ia={ia_quota}"
             ),
             # Abandonou o checkout → volta pra /precos escolher um plano PAGO
-            # (o Grátis não é mais escolha). O escolha=1 é o que a precos.html
-            # lê pra trocar o subtítulo por "Escolha um plano pra continuar"
-            # (needs_plan_selection segue true, pois o gate não fechou) — não
-            # anexo upgrade=cancelled porque /precos não consome esse marcador
-            # (o toast vive só na /home).
+            # (o Grátis não é mais escolha). O escolha=1 fica como rastro de
+            # origem: a copy "Escolha um plano pra continuar" da precos.html é
+            # decidida pelo needs_plan_selection do /auth/me (que segue true,
+            # pois o gate não fechou), não por este marcador — ele se perde num
+            # clique no "Planos" do próprio nav. Não anexo upgrade=cancelled
+            # porque /precos não consome esse marcador (o toast vive só na /home).
             cancel_url=f"{DASHBOARD_URL}/precos?escolha=1",
             metadata=metadata,
             subscription_data=subscription_data,
@@ -4136,8 +4138,8 @@ async def billing_create_checkout(
         _session_id = result.pop("session_id", None)
         await asyncio.to_thread(record_checkout_started, user_id, _session_id)
         # NÃO fechamos o gate da /precos aqui. Abrir o checkout não é escolher um
-        # plano — quem abandona o Stripe tem de voltar pra /precos e escolher
-        # (pago ou Grátis). O gate só fecha quando o pagamento COMPLETA de fato,
+        # plano — quem abandona o Stripe tem de voltar pra /precos e assinar
+        # (só há plano pago lá). O gate só fecha quando o pagamento COMPLETA de fato,
         # no webhook checkout.session.completed (mark_plan_selected lá). O
         # retorno de sucesso (?upgrade=success) é tratado como "webhook em
         # trânsito" pelo gate e pela tela de confirmação, sem cair no 402.

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1529,7 +1529,8 @@ let _homeMe = null;   // /auth/me da abertura, reusado pelas recargas
   // fail-open. Fora desse caso, o fluxo normal (loadAuthMe sem timeout).
   let me = _justUpgraded ? await awaitCheckoutConfirmation() : await loadAuthMe();
   // Gate de escolha de plano: cadastro novo tem que passar pela /precos e
-  // escolher um plano (mesmo o Grátis) antes de entrar no dashboard.
+  // assinar um plano pago antes de entrar no dashboard (o Grátis não é mais
+  // uma escolha oferecida na /precos).
   if (me && me.needs_plan_selection && !_justUpgraded && !window.PB_IN_APP) {
     window.location.replace("/precos?escolha=1");
     return;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -337,7 +337,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       </div>
 
       <div class="hiw-cta" data-reveal>
-        <p>A conta leva alguns segundos, e você testa 15 dias grátis antes de escolher um plano.</p>
+        <p>A conta leva alguns segundos. Depois você escolhe um plano pra ativar seus 15 dias grátis — um teste por número de telefone, e o checkout mostra o que vai ser cobrado, e quando, antes de você confirmar.</p>
         <a class="btn btn-primary" href="/cadastro">Criar minha conta <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -337,7 +337,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
       </div>
 
       <div class="hiw-cta" data-reveal>
-        <p>A conta leva alguns segundos e é grátis pra testar.</p>
+        <p>A conta leva alguns segundos, e você testa 15 dias grátis antes de escolher um plano.</p>
         <a class="btn btn-primary" href="/cadastro">Criar minha conta <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
 

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -851,10 +851,11 @@ async function cancelChange(btn) {
     if (!r.ok) return;            // deslogado (401): a copy padrão está certa
     me = await r.json();
   } catch { return; }             // rede caiu: copy padrão, sem travar a página
-  // No app iOS o gate nem se aplica (_is_pigbank_app isenta, routes/shared.py),
-  // e a /precos é alcançável de lá pelo "Ver planos" .pb-keep-in-app do paywall:
-  // o mandato seria falso pra quem não está travado. Mesma guarda dos irmãos.
-  if (!me || !me.needs_plan_selection || window.PB_IN_APP) return;  // copy padrão
+  // Sem guarda de window.PB_IN_APP: o gate deixou de isentar o app iOS
+  // (routes/shared.py), então quem abre a /precos de dentro dele está travado
+  // como qualquer um. Esconder o mandato deixaria a tela sem explicar por que
+  // o dashboard não abre.
+  if (!me || !me.needs_plan_selection) return;  // copy padrão
   const sub = document.getElementById("precos-sub");
   if (sub) sub.textContent =
     "Escolha um plano pra continuar: 15 dias grátis pra testar (um teste por número). "

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -873,6 +873,7 @@ async function cancelChange(btn) {
         b.disabled = true; b.textContent = "Indisponível"; b.dataset.unavailable = "1";
       });
       if (!cfg.essencial_available) markUnavailable('[data-plan-btn="essencial"]');
+      if (!cfg.plus_available) markUnavailable('[data-plan-btn="plus"]');
       if (!cfg.pro_available) markUnavailable('[data-plan-btn="pro"]');
     }
     // Assinante logado: botões viram "Seu plano atual / Trocar / Agendado".

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Planos · PigBank</title>
-<meta name="description" content="Planos PigBank: Grátis, Essencial R$ 9,90, Plus R$ 19,90 e Pro R$ 49,90. 15 dias grátis pra testar o plano que você escolher." />
+<meta name="description" content="Planos PigBank: Essencial R$ 9,90, Plus R$ 19,90 e Pro R$ 49,90. 15 dias grátis pra testar o plano que você escolher." />
 <link rel="canonical" href="https://pigbankai.com/precos" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -42,12 +42,13 @@
   .cycle-save { background: rgba(198,241,26,.16); color: var(--neon); font-weight: 700; padding: 2px 8px; border-radius: 999px; font-size: .78em; }
   .cycle-btn.is-active .cycle-save { background: rgba(255,255,255,.22); color: #fff; }
 
-  /* ── Cards: as 5 listas têm de começar no mesmo Y ──────────────────────
+  /* ── Cards: as 4 listas têm de começar no mesmo Y ──────────────────────
      A regra é a categoria, não o caso: TUDO que fica acima da lista e tem
      altura variável precisa reservar a altura máxima, senão desalinha.
-       · subtítulo — abaixo de ~1330px o card cai pra 230px e "Organize tudo,
-         sem limites"/"Seu dinheiro no automático" viram duas linhas enquanto
-         os outros três ficam em uma (medido: 20px de desalinho);
+       · subtítulo — a 1080px de viewport o card cai pra 243px e "Seu dinheiro
+         no automático" vira duas linhas enquanto os outros três ficam em uma
+         (medido 2026-09-02 em Chromium headless, com min-height desligado:
+         41,3px contra 20,6px — 20,7px de desalinho; remeça antes de reusar);
        · bloco do preço — o Premium mostra "Aguarde" em 1.15rem contra 2.5rem
          dos pagos, e a linha de equivalência mensal só existe no ciclo anual
          (medido: 32px). */
@@ -56,16 +57,22 @@
   #plans-v2 .price-block .price { margin: 0; }
   #plans-v2 .price .per { font-size: .95rem; font-weight: 600; color: var(--ink-2); letter-spacing: 0; }
   #plans-v2 .price-eq { color: var(--ink-3); font-size: .78rem; font-weight: 500; margin-top: 6px; font-variant-numeric: tabular-nums; }
-  /* O CTA do Grátis é <a> e os pagos são <button>: o <a> herda line-height 1.5
-     do body e o <button> cai no "normal" da UA, o que deixava a fileira de
-     botões 7px fora de esquadro. Fixar o line-height iguala os dois. */
+  /* Nasceu do CTA do Grátis, que era <a> (line-height 1.5 herdado do body)
+     contra os <button> dos pagos (o "normal" da UA) — 7px fora de esquadro.
+     Com o card do Grátis fora, os quatro CTAs são <button> e já casam entre si;
+     a regra fica porque ainda define a ALTURA da fileira, e tirá-la encolheria
+     os quatro (medido 2026-09-02, Chromium headless: 44,2px com ela contra
+     41,0px sem, nos dois viewports). Isso é mudança visual fora deste escopo. */
   #plans-v2 .plan .btn { line-height: 1.4; }
   /* .btn-outline tem borda de 1px e .btn-primary não tem nenhuma: o CTA do Plus
-     nascia 2px mais baixo que os outros quatro. Borda transparente iguala. */
+     nascia 2px mais baixo que os outros três. Borda transparente iguala. */
   #plans-v2 .plan .btn-primary, .cmp-table tfoot .btn-primary { border: 1px solid transparent; }
   #plans-v2 .plan .btn:focus-visible { outline: 2px solid var(--pink); outline-offset: 2px; }
   /* O badge é absoluto com left:50%, então a largura disponível é metade do
-     card (131px em 5 colunas) e "Mais popular" quebrava em duas linhas. */
+     card e "Mais popular" quebrava em duas linhas. Com 4 colunas ainda quebra:
+     medido 2026-09-02 em Chromium headless, o badge pede 139,5px e a metade do
+     card dá 121,5px a 1080px de viewport (a 1560px sobra — 181,5px — mas a
+     regra vale a categoria, não o caso). Remeça antes de reusar os números. */
   #plans-v2 .plan-badge { white-space: nowrap; }
 
   /* ── Tabela comparativa ────────────────────────────────────────────────
@@ -213,11 +220,16 @@
         <p id="precos-sub">15 dias grátis pra testar o plano que você escolher. Cancele antes do fim e não paga nada.</p>
       </div>
 
-      <!-- Escada de planos (Grátis/Essencial/Plus/Pro/Premium) — conteúdo ÚNICO
+      <!-- Escada de planos (Essencial/Plus/Pro/Premium) — conteúdo ÚNICO
            e hardcoded da página (lançada 2026-08-06, sem flag: nada de flash
            de conteúdo antigo). Sem classes CSS novas de propósito: reusa
-           .plan/.price/.plan-badge + estilos inline. -->
-      <!-- width breakout: a escada de 5 cards precisa de mais que os 1200px do
+           .plan/.price/.plan-badge + estilos inline.
+           O card do Grátis SAIU: assinar virou obrigatório pra entrar pela web,
+           então ele não é mais uma escolha oferecida aqui. O tier `free`
+           continua existindo no backend como ESTADO (fallback após falha de
+           cobrança) e como COLUNA da tabela comparativa abaixo — o que morreu é
+           a escolha, não o plano. -->
+      <!-- width breakout: a escada de 4 cards precisa de mais que os 1200px do
            .wrap pra não ficar espremida; centraliza na página via translate. -->
       <div id="plans-v2-wrap" style="width:min(1560px,calc(100vw - 48px));margin-left:50%;transform:translateX(-50%)">
         <div class="cycle-wrap">
@@ -228,22 +240,6 @@
         </div>
 
         <div class="plans" id="plans-v2" style="grid-template-columns:repeat(auto-fit,minmax(220px,1fr))">
-          <article class="plan">
-            <h3>Grátis</h3>
-            <div class="plan-sub">Pra conhecer a Piggy</div>
-            <div class="price-block">
-              <div class="price">R$ 0 <span>/ sempre</span></div>
-            </div>
-            <ul>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Registro por texto no WhatsApp</li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard completo · 30 lançamentos/mês</li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Histórico do mês corrente</li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> 1 caixinha e 1 cartão</li>
-              <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Piggy IA · 20 mensagens/mês</li>
-            </ul>
-            <a class="btn btn-outline btn-block" id="free-cta" data-free-cta href="/cadastro">Criar conta grátis</a>
-          </article>
-
           <article class="plan">
             <h3>Essencial</h3>
             <div class="plan-sub">Organize tudo, sem limites</div>
@@ -576,7 +572,11 @@
               <tfoot>
                 <tr>
                   <td class="cmp-feat"></td>
-                  <td><a class="btn btn-outline" data-free-cta href="/cadastro">Criar conta grátis</a></td>
+                  <!-- Coluna Grátis sem CTA: a coluna FICA (é informação — o que
+                       você perde descendo o degrau), mas o Grátis não é mais
+                       escolhível. Célula vazia, não colspan: as 6 colunas do
+                       colgroup e do tbody continuam valendo. -->
+                  <td></td>
                   <td><button class="btn btn-outline" type="button" data-plan-btn="essencial" onclick="startCheckout(currentCycle, this, 'essencial')">Assinar Essencial</button></td>
                   <td class="is-hl"><button class="btn btn-primary" type="button" data-plan-btn="plus" onclick="startCheckout(currentCycle, this, 'plus')">Assinar Plus</button></td>
                   <td><button class="btn btn-outline" type="button" data-plan-btn="pro" onclick="startCheckout(currentCycle, this, 'pro')">Assinar Pro</button></td>
@@ -829,76 +829,19 @@ async function cancelChange(btn) {
   }
 }
 
-// ── Onboarding: escolha de plano pós-cadastro ────────────────────────────────
-// Cadastro novo é jogado pra cá antes do dashboard. O card Grátis vira
-// "Continuar com o plano Grátis" (fecha o gate via /billing/select-free e entra
-// no app); os pagos seguem no fluxo normal de checkout.
-async function applyOnboardingChoice() {
-  let me = null;
-  try {
-    const r = await fetch("/auth/me", { credentials: "same-origin" });
-    if (!r.ok) return; // deslogado: mantém "Criar conta grátis" → /cadastro
-    me = await r.json();
-  } catch { return; }
-
-  // São DOIS CTAs de Grátis desde a tabela comparativa (card + rodapé da
-  // tabela). Iterar em [data-free-cta] em vez de #free-cta — com getElementById
-  // só o do card mudava e o da tabela continuava mandando pro /cadastro.
-  const ctas = document.querySelectorAll("[data-free-cta]");
-  if (me && me.needs_plan_selection) {
-    // Guia visual: deixa claro que precisa escolher um plano pra começar.
-    const sub = document.getElementById("precos-sub");
-    if (sub) sub.textContent = "Escolha um plano pra começar: dá pra seguir no Grátis ou testar um plano pago 15 dias de graça.";
-    ctas.forEach(cta => {
-      cta.removeAttribute("href");
-      cta.style.cursor = "pointer";
-      cta.textContent = "Continuar com o plano Grátis";
-      cta.onclick = function (e) { e.preventDefault(); selectFree(cta); };
-    });
-  } else if (me) {
-    // Já logado e com plano escolhido: o card Grátis não leva pro /cadastro.
-    ctas.forEach(cta => {
-      cta.removeAttribute("href");
-      cta.textContent = "Seu cadastro está pronto";
-      cta.classList.add("btn-outline");
-      cta.style.opacity = ".7";
-      cta.style.cursor = "default";
-      cta.onclick = function (e) { e.preventDefault(); };
-    });
-  }
-}
-
-async function selectFree(btn) {
-  if (btn.classList.contains("loading")) return;
-  const orig = btn.textContent;
-  btn.classList.add("loading");
-  btn.textContent = "Ativando…";
-  try {
-    const r = await fetch("/billing/select-free", {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "x-csrf-token": getCsrfToken() },
-    });
-    if (r.status === 401) {
-      showToast("Faça login pra continuar.", "err");
-      setTimeout(() => { window.location.href = "/login?next=" + encodeURIComponent("/precos"); }, 900);
-      return;
-    }
-    const d = await r.json().catch(() => ({}));
-    if (!r.ok) {
-      const msg = (d.detail && d.detail.message) ||
-        (typeof d.detail === "string" ? d.detail : "Não consegui ativar o Grátis.");
-      showToast(msg, "err");
-      btn.classList.remove("loading");
-      btn.textContent = orig;
-      return;
-    }
-    window.location.href = d.dashboard_url || "/home";
-  } catch {
-    showToast("Erro de conexão. Tente novamente.", "err");
-    btn.classList.remove("loading");
-    btn.textContent = orig;
-  }
+// Voltou do gate de escolha de plano (/precos?escolha=1 — cadastro novo,
+// checkout abandonado): assinar é OBRIGATÓRIO pra entrar, e a copy padrão
+// ("15 dias grátis pra testar") não diz isso. O marcador vem na URL, posto por
+// todos os caminhos do gate (routes/shared.py, home.html, dashboard.js,
+// settings.html e o cancel_url do Stripe) — não precisa de /auth/me pra isso.
+// O `if (sub)` é o mesmo do applyOnboardingChoice que saiu daqui, e não é
+// paranoia: isto roda em escopo de módulo, então um TypeError aqui abortaria o
+// resto do <script> — inclusive o IIFE de estado dos botões logo abaixo, que é
+// caminho de dinheiro.
+if (new URLSearchParams(location.search).get("escolha") === "1") {
+  const sub = document.getElementById("precos-sub");
+  if (sub) sub.textContent =
+    "Escolha um plano pra continuar: 15 dias grátis pra testar, cancele antes do fim e não paga nada.";
 }
 
 (async function loadPlansState(){
@@ -919,8 +862,6 @@ async function selectFree(btn) {
     // Assinante logado: botões viram "Seu plano atual / Trocar / Agendado".
     await loadSubscription();
     refreshPlanButtons();
-    // Cadastro novo: card Grátis vira "Continuar com o plano Grátis".
-    await applyOnboardingChoice();
   } catch {}
 })();
 

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -829,20 +829,33 @@ async function cancelChange(btn) {
   }
 }
 
-// Voltou do gate de escolha de plano (/precos?escolha=1 — cadastro novo,
-// checkout abandonado): assinar é OBRIGATÓRIO pra entrar, e a copy padrão
-// ("15 dias grátis pra testar") não diz isso. O marcador vem na URL, posto por
-// todos os caminhos do gate (routes/shared.py, home.html, dashboard.js,
-// settings.html e o cancel_url do Stripe) — não precisa de /auth/me pra isso.
-// O `if (sub)` é o mesmo do applyOnboardingChoice que saiu daqui, e não é
-// paranoia: isto roda em escopo de módulo, então um TypeError aqui abortaria o
-// resto do <script> — inclusive o IIFE de estado dos botões logo abaixo, que é
-// caminho de dinheiro.
-if (new URLSearchParams(location.search).get("escolha") === "1") {
+// Copy do gate de escolha de plano (cadastro novo, checkout abandonado):
+// assinar é OBRIGATÓRIO pra entrar, e a copy padrão ("15 dias grátis pra
+// testar") não diz isso. Quem decide é o ESTADO do servidor —
+// needs_plan_selection do /auth/me, a fonte de verdade (§0.7) —, NUNCA o
+// ?escolha=1 da URL: o marcador se perde em três caminhos alcançáveis em
+// produção (o link "Planos" do nav e do rodapé DESTA página; o gate_pro_page
+// em routes/shared.py, que redireciona pra /precos sem marcador; e os dois
+// redirects de /conta), e aí quem está travado no gate lia a copy de
+// visitante, sem nenhuma indicação de que precisa assinar pra entrar.
+// Sem atalho pela URL de propósito: ele criaria uma 4ª célula (visitante com
+// link velho lendo a copy do gate) pra economizar um flash de subtítulo.
+// É o mesmo fetch que o applyOnboardingChoice fazia aqui antes do commit
+// anterior — nenhuma requisição nova na página —, mas em IIFE próprio em vez de
+// dentro do loadPlansState: lá ele ficava serializado atrás do
+// /billing/subscription, que fala com o Stripe. O `if (sub)` também vem de lá.
+(async function applyPlanGateCopy() {
+  let me = null;
+  try {
+    const r = await fetch("/auth/me", { credentials: "same-origin" });
+    if (!r.ok) return;            // deslogado (401): a copy padrão está certa
+    me = await r.json();
+  } catch { return; }             // rede caiu: copy padrão, sem travar a página
+  if (!me || !me.needs_plan_selection) return;  // já escolheu: copy padrão
   const sub = document.getElementById("precos-sub");
   if (sub) sub.textContent =
     "Escolha um plano pra continuar: 15 dias grátis pra testar, cancele antes do fim e não paga nada.";
-}
+})();
 
 (async function loadPlansState(){
   try {

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -857,7 +857,8 @@ async function cancelChange(btn) {
   if (!me || !me.needs_plan_selection || window.PB_IN_APP) return;  // copy padrão
   const sub = document.getElementById("precos-sub");
   if (sub) sub.textContent =
-    "Escolha um plano pra continuar: 15 dias grátis pra testar, cancele antes do fim e não paga nada.";
+    "Escolha um plano pra continuar: 15 dias grátis pra testar (um teste por número). "
+    + "O checkout mostra o que vai ser cobrado, e quando, antes de você confirmar.";
 })();
 
 (async function loadPlansState(){

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -851,7 +851,10 @@ async function cancelChange(btn) {
     if (!r.ok) return;            // deslogado (401): a copy padrão está certa
     me = await r.json();
   } catch { return; }             // rede caiu: copy padrão, sem travar a página
-  if (!me || !me.needs_plan_selection) return;  // já escolheu: copy padrão
+  // No app iOS o gate nem se aplica (_is_pigbank_app isenta, routes/shared.py),
+  // e a /precos é alcançável de lá pelo "Ver planos" .pb-keep-in-app do paywall:
+  // o mandato seria falso pra quem não está travado. Mesma guarda dos irmãos.
+  if (!me || !me.needs_plan_selection || window.PB_IN_APP) return;  // copy padrão
   const sub = document.getElementById("precos-sub");
   if (sub) sub.textContent =
     "Escolha um plano pra continuar: 15 dias grátis pra testar, cancele antes do fim e não paga nada.";

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -559,9 +559,14 @@ _GATE_EXEMPT_PREFIXES = ("/billing", "/auth", "/conta")
 
 
 def _is_pigbank_app(request: Request) -> bool:
-    """True se a requisição vem do WebView do app iOS (UA anexa "PigBankApp").
-    Usado pra isentar o app dos gates que forçariam a /precos — diretriz 3.1.1
-    da App Store proíbe empurrar tela de compra; o app fica no acesso base."""
+    """True se a requisição diz vir do WebView do app iOS (UA anexa "PigBankApp").
+
+    Só para TELEMETRIA (signup_source_from_request). NÃO usar para conceder nada:
+    o User-Agent é escolhido pelo cliente, então isto é a alegação do chamador,
+    não um fato verificado. Os gates isentavam o app com base nisto e qualquer
+    conta web entrava sem plano mandando a substring — a isenção saiu por isso.
+    Quando o app for lançado, a 3.1.1 da App Store volta a valer e a isenção
+    precisa de credencial que o servidor consiga verificar, não deste header."""
     return "PigBankApp" in (request.headers.get("user-agent") or "")
 
 
@@ -588,9 +593,9 @@ def _enforce_subscription_gate(request: Request, user_id: int) -> None:
     if any(path.startswith(p) for p in _GATE_EXEMPT_PREFIXES):
         return
     from core.services.plan_service import has_app_access, needs_plan_selection
-    # App iOS não passa pelo gate de escolha (não pode comprar/escolher via web);
-    # segue governado por has_app_access e pelos limites por-feature/tier.
-    if not _is_pigbank_app(request) and needs_plan_selection(user_id):
+    # Sem isenção de app aqui: ela era `not _is_pigbank_app(request) and`, e o UA
+    # é escolhido pelo cliente — bastava mandar "PigBankApp" pra pular o gate.
+    if needs_plan_selection(user_id):
         raise HTTPException(status_code=402, detail={"error": "plan_selection_required"})
     if not has_app_access(user_id):
         raise HTTPException(status_code=402, detail={"error": "subscription_required"})
@@ -677,12 +682,11 @@ def gate_plan_selection(request: Request):
     from fastapi.responses import RedirectResponse
     from core.services.plan_service import needs_plan_selection
 
-    # App iOS (WebView anexa "PigBankApp" ao UA): não redireciona pra tela de
-    # planos/compra — diretriz 3.1.1 da App Store. Espelha o !window.PB_IN_APP
-    # do cliente. O acesso segue governado pelos gates por-feature/tier.
-    if _is_pigbank_app(request):
-        return None
-
+    # Aqui havia `if _is_pigbank_app(request): return None`, pela diretriz 3.1.1
+    # da App Store. Saiu porque o UA é escolhido pelo cliente: a isenção liberava
+    # o gate pra qualquer um que mandasse "PigBankApp" no header. Quando o app for
+    # lançado ele precisa de credencial que o servidor consiga verificar.
+    #
     # Retorno do checkout com sucesso: o webhook checkout.session.completed
     # (que fecha o gate via mark_plan_selected) pode ainda estar em trânsito.
     # Não jogamos quem ACABOU de pagar de volta pra /precos — a tela de
@@ -721,12 +725,12 @@ def gate_onboarding(request: Request):
       2. /settings é pra onde um usuário travado vai consertar a conta. Nunca
          trancar a saída de emergência.
 
-    O app iOS NÃO é isento, ao contrário do gate de plano. A isenção de lá
-    (_is_pigbank_app) existe pela diretriz 3.1.1 da App Store, que é sobre TELA
-    DE COMPRA. O wizard não é: é saldo, cartão, WhatsApp e resumo. Isentar o app
-    significaria que nenhum usuário de iPhone jamais veria o onboarding. O
-    cuidado fica no conteúdo da página — os CTAs de upgrade são <a href="/precos">,
-    que o auth-refresh.js esconde sozinho dentro do app.
+    O app iOS NÃO é isento. Isentá-lo significaria que nenhum usuário de iPhone
+    jamais veria o onboarding, e o wizard não é tela de compra: é saldo, cartão,
+    WhatsApp e resumo. O gate de plano também não isenta mais o app — a isenção
+    que existia lá era por User-Agent, escolhido pelo cliente. O cuidado fica no
+    conteúdo da página: os CTAs de upgrade são <a href="/precos">, que o
+    auth-refresh.js esconde sozinho dentro do app.
 
     `?upgrade=success` É isento, espelhando o gate de plano, mas por um motivo
     mais caro: /home?upgrade=success roda handleUpgradeReturn(), que dispara a

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -583,7 +583,7 @@ def _enforce_subscription_gate(request: Request, user_id: int) -> None:
     ele, um cadastro novo poderia pular a /precos batendo direto numa API
     autenticada (ex.: /data/{id}) ou navegando pro /settings. Retorna 402 pro
     front mandar ao paywall/escolha. As rotas de /billing, /auth e /conta são
-    isentas (são elas que resolvem o gate — checkout, /auth/me, select-free)."""
+    isentas (são elas que resolvem o gate — checkout, /auth/me)."""
     path = request.url.path or ""
     if any(path.startswith(p) for p in _GATE_EXEMPT_PREFIXES):
         return

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -64,7 +64,8 @@
           cartões, investimentos e metas em linguagem natural via WhatsApp, Discord e dashboard
           web. O serviço é oferecido em planos pagos (<strong>Essencial</strong>,
           <strong>Plus</strong> e <strong>Pro</strong>), com limites e recursos diferentes em cada
-          um, e todo plano começa com <strong>15 dias de teste gratuito</strong> (seção 4).
+          um, e todo plano oferece <strong>15 dias de teste gratuito</strong>, limitado a um por
+          número de telefone (seção 4).
         </p>
         <p>
           Funcionalidades estão sujeitas a evoluir, ser modificadas ou descontinuadas a qualquer

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -62,9 +62,9 @@
         <p>
           O PigBank é um assistente financeiro pessoal que permite registrar despesas, receitas,
           cartões, investimentos e metas em linguagem natural via WhatsApp, Discord e dashboard
-          web. O serviço é oferecido num plano <strong>Grátis</strong> e em planos pagos
-          (<strong>Essencial</strong>, <strong>Plus</strong> e <strong>Pro</strong>), com limites e
-          recursos diferentes em cada um.
+          web. O serviço é oferecido em planos pagos (<strong>Essencial</strong>,
+          <strong>Plus</strong> e <strong>Pro</strong>), com limites e recursos diferentes em cada
+          um, e todo plano começa com <strong>15 dias de teste gratuito</strong> (seção 4).
         </p>
         <p>
           Funcionalidades estão sujeitas a evoluir, ser modificadas ou descontinuadas a qualquer
@@ -127,7 +127,7 @@
           Você pode cancelar a qualquer momento durante o trial pelo
           <a href="/conta">Portal de assinatura</a> ou pelos comandos do bot (Discord/WhatsApp).
           Nesse caso, nenhuma cobrança será feita. Se não cancelar antes do fim do prazo, a
-          cobrança da mensalidade ou anuidade é feita automaticamente no 31º dia, no mesmo cartão
+          cobrança da mensalidade ou anuidade é feita automaticamente no 16º dia, no mesmo cartão
           informado.
         </p>
       </section>

--- a/frontend/whatsapp.html
+++ b/frontend/whatsapp.html
@@ -42,8 +42,8 @@
         <p>O PigBank transforma mensagens simples em registros financeiros organizados. Você envia o que aconteceu, a Piggy entende, categoriza e atualiza seu saldo.</p>
       </div>
       <div class="hero-cta" style="justify-content:center;margin-bottom:8px">
-        <a class="btn btn-primary btn-lg" href="/wa"><i class="ph ph-chat-circle" aria-hidden="true"></i> Abrir conversa com a Piggy</a>
-        <a class="btn btn-outline btn-lg" href="/cadastro">Criar conta grátis</a>
+        <a class="btn btn-primary btn-lg" href="/cadastro">Criar conta e testar 15 dias grátis</a>
+        <a class="btn btn-outline btn-lg" href="/wa"><i class="ph ph-chat-circle" aria-hidden="true"></i> Abrir conversa com a Piggy</a>
       </div>
     </section>
 
@@ -51,7 +51,7 @@
     <section class="section" style="padding-bottom:44px">
       <div class="section-head" style="margin-bottom:30px">
         <div class="eyebrow">Como conectar</div>
-        <h2>Comece em <span class="grad">3 passos</span></h2>
+        <h2>Comece em <span class="grad">4 passos</span></h2>
         <p>Leva menos de um minuto. O segredo é usar o <b>mesmo número</b> de WhatsApp no cadastro: é ele que liga a conversa à sua conta.</p>
       </div>
 
@@ -60,21 +60,28 @@
           <div class="step-num">1</div>
           <div>
             <h3>Crie sua conta com o mesmo número</h3>
-            <p>No <a href="/cadastro" class="grad" style="text-decoration:none;font-weight:700">cadastro grátis</a>, informe o número de telefone do seu WhatsApp. É esse número que a Piggy reconhece.</p>
+            <p>No <a href="/cadastro" class="grad" style="text-decoration:none;font-weight:700">cadastro</a>, informe o número de telefone do seu WhatsApp. É esse número que a Piggy reconhece.</p>
           </div>
         </div>
         <div class="step">
           <div class="step-num">2</div>
+          <div>
+            <h3>Ative seus 15 dias grátis</h3>
+            <p>Escolha em <a href="/precos" class="grad" style="text-decoration:none;font-weight:700">Planos</a> qual plano você quer testar. Nada é cobrado agora: a primeira cobrança só vem depois dos 15 dias, e dá pra cancelar antes sem pagar nada.</p>
+          </div>
+        </div>
+        <div class="step">
+          <div class="step-num">3</div>
           <div>
             <h3>Abra a conversa com a Piggy</h3>
             <p>Toque em <b>"Abrir conversa com a Piggy"</b> aqui embaixo. Ele abre o WhatsApp já no chat certo, com uma mensagem pronta pra enviar.</p>
           </div>
         </div>
         <div class="step">
-          <div class="step-num">3</div>
+          <div class="step-num">4</div>
           <div>
             <h3>Mande "oi" e pronto</h3>
-            <p>Na primeira mensagem a Piggy vincula seu número à sua conta automaticamente e libera todos os comandos. A partir daí é só falar: <i>"gastei 50 no mercado"</i>.</p>
+            <p>Na primeira mensagem a Piggy vincula seu número à sua conta automaticamente. Com o teste ativo, é só falar: <i>"gastei 50 no mercado"</i>.</p>
           </div>
         </div>
       </div>

--- a/frontend/whatsapp.html
+++ b/frontend/whatsapp.html
@@ -67,7 +67,7 @@
           <div class="step-num">2</div>
           <div>
             <h3>Ative seus 15 dias grátis</h3>
-            <p>Escolha em <a href="/precos" class="grad" style="text-decoration:none;font-weight:700">Planos</a> qual plano você quer testar. Nada é cobrado agora: a primeira cobrança só vem depois dos 15 dias, e dá pra cancelar antes sem pagar nada.</p>
+            <p>Escolha em <a href="/precos" class="grad" style="text-decoration:none;font-weight:700">Planos</a> qual plano você quer testar — o teste é um por número de telefone. O checkout mostra o que vai ser cobrado, e quando, antes de você confirmar.</p>
           </div>
         </div>
         <div class="step">

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -10,6 +10,10 @@
  *   · asserção do conserto — nenhum CTA de Grátis, nenhum card "Grátis", e
  *     nenhuma requisição pro /billing/select-free em nenhum dos dois estados
  *     (deslogado e needs_plan_selection);
+ *   · copy do gate — as 6 células de {deslogado, logado sem gate, logado com
+ *     gate} × {com ?escolha=1, sem marcador}: quem decide é o
+ *     needs_plan_selection do /auth/me, não a URL (o marcador se perde num
+ *     clique no "Planos" do próprio nav);
  *   · controle POSITIVO — "Assinar Plus" ainda dispara EXATAMENTE 1
  *     POST /billing/create-checkout. Sem ele o grupo passaria numa página com
  *     todos os botões quebrados, que é pior que o bug.
@@ -124,18 +128,37 @@ test("a coluna Grátis da tabela comparativa fica: 6 colunas, tfoot sem CTA", as
   await page.close();
 });
 
-test("?escolha=1 diz que precisa escolher um plano pra continuar", async () => {
-  const { page } = await abrirPrecos({ me: { user_id: 42, needs_plan_selection: true }, query: "?escolha=1" });
-  const sub = await page.textContent("#precos-sub");
-  assert.match(sub, /Escolha um plano pra continuar/,
-    `quem abandonou o checkout não lê que assinar é obrigatório: "${sub}"`);
-  await page.close();
+// ── copy do subtítulo: as 6 células de estado × marcador ────────────────────
+// A copy do gate é decidida pelo needs_plan_selection do /auth/me, não pelo
+// ?escolha=1: o marcador se perde num clique no "Planos" do próprio nav, no
+// gate_pro_page (routes/shared.py) e nos redirects de /conta. Então as 6
+// células = 3 estados × {com marcador, sem marcador}, e a coluna do marcador
+// não muda NENHUMA linha — é isso que o teste fixa.
+//
+// A célula que discrimina é "logado com gate SEM marcador": com a decisão pela
+// URL ela mostrava a copy de visitante a quem está travado no gate. As duas
+// "sem gate + COM marcador" são o outro lado: marcador velho (bookmark, link
+// compartilhado) não pode inventar gate pra quem já pagou nem pra visitante.
+const COPY_PADRAO = /^15 dias grátis/;
+const COPY_GATE = /Escolha um plano pra continuar/;
 
-  // Par negativo da mesma copy: sem o marcador, o subtítulo padrão continua.
-  const { page: p2 } = await abrirPrecos();
-  assert.match(await p2.textContent("#precos-sub"), /^15 dias grátis/);
-  await p2.close();
-});
+for (const [estado, me] of [
+  ["deslogado", null],
+  ["logado sem gate", { user_id: 42, needs_plan_selection: false }],
+  ["logado com gate", { user_id: 42, needs_plan_selection: true }],
+]) {
+  for (const query of ["?escolha=1", ""]) {
+    const esperado = me && me.needs_plan_selection ? COPY_GATE : COPY_PADRAO;
+    const rotulo = query ? "com marcador" : "sem marcador";
+    test(`copy do subtítulo: ${estado}, ${rotulo}`, async () => {
+      const { page } = await abrirPrecos({ me, query });
+      const sub = await page.textContent("#precos-sub");
+      assert.match(sub, esperado,
+        `${estado} ${rotulo} devia bater ${esperado} e leu: "${sub}"`);
+      await page.close();
+    });
+  }
+}
 
 // ── controle POSITIVO: o caminho legítimo continua funcionando ───────────────
 

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -44,7 +44,9 @@ after(async () => { await browser?.close(); server?.kill(); });
  * (`null` = 401, o visitante deslogado). Devolve a página e os contadores de
  * requisição por rota — a contagem é por INTERCEPTAÇÃO, não por efeito visível.
  */
-async function abrirPrecos({ me = null, query = "", app = false } = {}) {
+async function abrirPrecos({ me = null, query = "", app = false,
+                             plansConfig = { essencial_available: true, plus_available: true, pro_available: true },
+                           } = {}) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 },
                                        ...(app ? { userAgent: APP_UA } : {}) });
   const chamadas = { selectFree: 0, checkout: 0 };
@@ -56,7 +58,7 @@ async function abrirPrecos({ me = null, query = "", app = false } = {}) {
 
   await page.route("**/billing/plans-config", (route) => route.fulfill({
     contentType: "application/json",
-    body: JSON.stringify({ essencial_available: true, pro_available: true }),
+    body: JSON.stringify(plansConfig),
   }));
 
   await page.route("**/billing/subscription", (route) => route.fulfill({
@@ -227,6 +229,32 @@ test("controle positivo: os 6 CTAs pagos continuam habilitados (card e tabela)",
     { plano: "pro",       onde: "card",   desabilitado: false, texto: "Assinar Pro" },
     { plano: "essencial", onde: "tabela", desabilitado: false, texto: "Assinar Essencial" },
     { plano: "plus",      onde: "tabela", desabilitado: false, texto: "Assinar Plus" },
+    { plano: "pro",       onde: "tabela", desabilitado: false, texto: "Assinar Pro" },
+  ]);
+  await page.close();
+});
+
+// ── degradação parcial do Stripe: só o Plus sem price configurado ───────────
+// Sem o Grátis na página, um botão do Plus clicável só produz um toast de erro
+// e nenhuma saída. O par positivo deste caso é o teste dos 6 CTAs habilitados
+// acima: lá o mesmo DOM, com plus_available:true, tem os 6 clicáveis.
+test("plus_available:false marca EXATAMENTE os 2 botões do Plus como indisponíveis", async () => {
+  const { page } = await abrirPrecos({
+    me: { user_id: 42, needs_plan_selection: true },
+    plansConfig: { essencial_available: true, plus_available: false, pro_available: true },
+  });
+  const estado = await page.$$eval("[data-plan-btn]", (els) => els.map((e) => ({
+    plano: e.dataset.planBtn,
+    onde: e.closest("#plans-v2") ? "card" : "tabela",
+    desabilitado: e.disabled === true,
+    texto: e.textContent.trim(),
+  })));
+  assert.deepEqual(estado, [
+    { plano: "essencial", onde: "card",   desabilitado: false, texto: "Assinar Essencial" },
+    { plano: "plus",      onde: "card",   desabilitado: true,  texto: "Indisponível" },
+    { plano: "pro",       onde: "card",   desabilitado: false, texto: "Assinar Pro" },
+    { plano: "essencial", onde: "tabela", desabilitado: false, texto: "Assinar Essencial" },
+    { plano: "plus",      onde: "tabela", desabilitado: true,  texto: "Indisponível" },
     { plano: "pro",       onde: "tabela", desabilitado: false, texto: "Assinar Pro" },
   ]);
   await page.close();

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -14,6 +14,9 @@
  *     gate} × {com ?escolha=1, sem marcador}: quem decide é o
  *     needs_plan_selection do /auth/me, não a URL (o marcador se perde num
  *     clique no "Planos" do próprio nav);
+ *   · app iOS — mais 2 células com a UA PigBankApp: lá o gate não existe
+ *     (routes/shared.py isenta o app), então o mandato "Escolha um plano pra
+ *     continuar" seria falso pra quem não está travado;
  *   · controle POSITIVO — "Assinar Plus" ainda dispara EXATAMENTE 1
  *     POST /billing/create-checkout. Sem ele o grupo passaria numa página com
  *     todos os botões quebrados, que é pior que o bug.
@@ -25,6 +28,11 @@ import assert from "node:assert/strict";
 import { startServer } from "./_server.mjs";
 import { chromium } from "playwright";
 
+// UA do WebView do app (auth-refresh.js:274 casa a SUBSTRING PigBankApp) — é o
+// mecanismo real que liga window.PB_IN_APP, e não injeção da variável.
+const APP_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+  + "AppleWebKit/605.1.15 Safari/604.1 PigBankApp/1.0";
+
 let ORIGIN, server, browser;
 before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
                      browser = await chromium.launch(); });
@@ -35,8 +43,9 @@ after(async () => { await browser?.close(); server?.kill(); });
  * (`null` = 401, o visitante deslogado). Devolve a página e os contadores de
  * requisição por rota — a contagem é por INTERCEPTAÇÃO, não por efeito visível.
  */
-async function abrirPrecos({ me = null, query = "" } = {}) {
-  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+async function abrirPrecos({ me = null, query = "", app = false } = {}) {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 },
+                                       ...(app ? { userAgent: APP_UA } : {}) });
   const chamadas = { selectFree: 0, checkout: 0 };
   const corposCheckout = [];
 
@@ -158,6 +167,29 @@ for (const [estado, me] of [
       await page.close();
     });
   }
+}
+
+// ── app iOS: o gate não se aplica, então a copy de mandato seria falsa ───────
+// routes/shared.py isenta o _is_pigbank_app do gate, e a /precos é alcançável de
+// dentro do app pelo "Ver planos" .pb-keep-in-app do paywall (dashboard.html:858)
+// — dizer "Escolha um plano pra continuar" a quem não está travado é errado.
+// 2 células, não 6: as 4 de {deslogado, logado sem gate} × marcador saem da
+// função pelo mesmo `!me.needs_plan_selection`, com e sem app — a guarda não
+// alcança nenhuma delas. A coluna do marcador fica porque é o mesmo invariante
+// das células web: a URL não decide nada.
+for (const query of ["?escolha=1", ""]) {
+  const rotulo = query ? "com marcador" : "sem marcador";
+  test(`copy do subtítulo: app iOS, logado com gate, ${rotulo}`, async () => {
+    const { page } = await abrirPrecos({
+      me: { user_id: 42, needs_plan_selection: true }, query, app: true,
+    });
+    assert.equal(await page.evaluate(() => window.PB_IN_APP === true), true,
+      "a UA do app não ligou window.PB_IN_APP — a célula não mediria o app");
+    const sub = await page.textContent("#precos-sub");
+    assert.match(sub, COPY_PADRAO,
+      `app iOS ${rotulo} devia ler a copy padrão e leu: "${sub}"`);
+    await page.close();
+  });
 }
 
 // ── controle POSITIVO: o caminho legítimo continua funcionando ───────────────

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -167,6 +167,20 @@ for (const [estado, me] of [
       const sub = await page.textContent("#precos-sub");
       assert.match(sub, esperado,
         `${estado} ${rotulo} devia bater ${esperado} e leu: "${sub}"`);
+      if (esperado === COPY_GATE) {
+        // A copy do gate é NOSSA (941ffc0) e não pode garantir quando a
+        // cobrança vem: quem recria a conta com um telefone já em plan_trials
+        // é inelegível e o checkout sai com trial_days=0 (Codex, #239). A
+        // oferta fica (o COPY_GATE acima + os "15 dias grátis" daqui são o
+        // controle positivo: sem eles o caso passaria num subtítulo esvaziado).
+        for (const garantia of ["não paga nada", "Nada é cobrado agora",
+                                "primeira cobrança só vem depois"]) {
+          assert.ok(!sub.includes(garantia),
+            `a copy do gate garante a cobrança (${garantia}): "${sub}"`);
+        }
+        assert.ok(sub.includes("15 dias grátis") && sub.includes("checkout"),
+          `a copy do gate perdeu a oferta ou a deferência ao checkout: "${sub}"`);
+      }
       await page.close();
     });
   }

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -1,0 +1,176 @@
+/**
+ * /precos não oferece mais o plano Grátis.
+ *
+ * Assinar virou obrigatório pra entrar pela web, então o card do Grátis e os
+ * dois CTAs `[data-free-cta]` saíram da página, junto com o `selectFree` que
+ * batia em POST /billing/select-free. A COLUNA Grátis da tabela comparativa
+ * FICA (é informação: o que você perde descendo o degrau) — só o CTA dela some.
+ *
+ * O grupo tem os dois controles do CLAUDE.md §3:
+ *   · asserção do conserto — nenhum CTA de Grátis, nenhum card "Grátis", e
+ *     nenhuma requisição pro /billing/select-free em nenhum dos dois estados
+ *     (deslogado e needs_plan_selection);
+ *   · controle POSITIVO — "Assinar Plus" ainda dispara EXATAMENTE 1
+ *     POST /billing/create-checkout. Sem ele o grupo passaria numa página com
+ *     todos os botões quebrados, que é pior que o bug.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/**
+ * Abre a /precos com o backend mockado. `me` vira o corpo do /auth/me
+ * (`null` = 401, o visitante deslogado). Devolve a página e os contadores de
+ * requisição por rota — a contagem é por INTERCEPTAÇÃO, não por efeito visível.
+ */
+async function abrirPrecos({ me = null, query = "" } = {}) {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const chamadas = { selectFree: 0, checkout: 0 };
+  const corposCheckout = [];
+
+  await page.route("**/auth/me", (route) => (me
+    ? route.fulfill({ contentType: "application/json", body: JSON.stringify(me) })
+    : route.fulfill({ status: 401, contentType: "application/json", body: "{}" })));
+
+  await page.route("**/billing/plans-config", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ essencial_available: true, pro_available: true }),
+  }));
+
+  await page.route("**/billing/subscription", (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ active: false }),
+  }));
+
+  await page.route("**/billing/select-free", (route) => {
+    chamadas.selectFree += 1;
+    // 410 é o que o backend passou a devolver; o corpo segue o formato que o
+    // front lê nas outras rotas de billing (detail.message).
+    return route.fulfill({
+      status: 410, contentType: "application/json",
+      body: JSON.stringify({ detail: { error: "free_plan_discontinued", message: "indisponível" } }),
+    });
+  });
+
+  await page.route("**/billing/create-checkout", (route) => {
+    chamadas.checkout += 1;
+    corposCheckout.push(JSON.parse(route.request().postData() || "{}"));
+    // checkout_url pra uma página do próprio servidor: o startCheckout navega
+    // no sucesso, e mandá-lo pra lugar nenhum deixaria o teste cego pro ramo
+    // "Resposta inesperada do servidor".
+    return route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ checkout_url: `${ORIGIN}/precos.html?stripe=1` }),
+    });
+  });
+
+  await page.goto(`${ORIGIN}/precos.html${query}`);
+  await page.waitForSelector("#plans-v2 .plan");
+  // O IIFE loadPlansState é assíncrono (plans-config + subscription) e o
+  // applyOnboardingChoice que ele chamava era quem reescrevia os CTAs do
+  // Grátis. Sem esperar, "não existe CTA" passaria antes de o JS rodar — e o
+  // teste ficaria verde por corrida, não pelo conserto.
+  await page.waitForTimeout(600);
+  return { page, chamadas, corposCheckout };
+}
+
+// ── asserção do conserto ────────────────────────────────────────────────────
+
+for (const [rotulo, ctx] of [
+  ["deslogado", {}],
+  ["needs_plan_selection", { me: { user_id: 42, needs_plan_selection: true }, query: "?escolha=1" }],
+]) {
+  test(`${rotulo}: nenhum CTA de Grátis e nenhum card Grátis na escada`, async () => {
+    const { page, chamadas } = await abrirPrecos(ctx);
+
+    assert.equal(await page.$$eval("[data-free-cta]", (e) => e.length), 0,
+      "sobrou [data-free-cta] na página");
+
+    const nomes = await page.$$eval("#plans-v2 .plan h3", (e) => e.map((h) => h.textContent.trim()));
+    assert.deepEqual(nomes, ["Essencial", "Plus", "Pro", "Premium"]);
+
+    // Qualquer clicável com a copy do Grátis, em QUALQUER lugar da página (a
+    // classe, não o caso: o card era um, o rodapé da tabela era outro).
+    const clicaveis = await page.$$eval("a, button", (els) =>
+      els.map((e) => e.textContent.trim()).filter(Boolean));
+    for (const proibido of ["Criar conta grátis", "Continuar com o plano Grátis", "Seu cadastro está pronto"]) {
+      assert.ok(!clicaveis.includes(proibido),
+        `clicável com a copy "${proibido}" ainda existe: ${JSON.stringify(clicaveis)}`);
+    }
+
+    assert.equal(chamadas.selectFree, 0, "alguém ainda bate no /billing/select-free");
+    await page.close();
+  });
+}
+
+test("a coluna Grátis da tabela comparativa fica: 6 colunas, tfoot sem CTA", async () => {
+  const { page } = await abrirPrecos();
+  // O cabeçalho continua com a coluna do Grátis (é informação, não oferta).
+  const cabecalho = await page.$$eval(".cmp-table thead tr th", (e) => e.map((t) => t.textContent.trim()));
+  assert.ok(cabecalho.some((t) => t.includes("Grátis")), `thead sem Grátis: ${JSON.stringify(cabecalho)}`);
+  // 6 colunas no tfoot (1 rótulo + 5 planos), e a do Grátis vazia.
+  const tfoot = await page.$$eval(".cmp-table tfoot tr td", (e) => e.map((t) => t.textContent.trim()));
+  assert.equal(tfoot.length, 6, `tfoot com ${tfoot.length} células: ${JSON.stringify(tfoot)}`);
+  assert.equal(tfoot[1], "", `a célula do Grátis não está vazia: ${JSON.stringify(tfoot)}`);
+  assert.deepEqual(tfoot.slice(2), ["Assinar Essencial", "Assinar Plus", "Assinar Pro", "Em breve"]);
+  await page.close();
+});
+
+test("?escolha=1 diz que precisa escolher um plano pra continuar", async () => {
+  const { page } = await abrirPrecos({ me: { user_id: 42, needs_plan_selection: true }, query: "?escolha=1" });
+  const sub = await page.textContent("#precos-sub");
+  assert.match(sub, /Escolha um plano pra continuar/,
+    `quem abandonou o checkout não lê que assinar é obrigatório: "${sub}"`);
+  await page.close();
+
+  // Par negativo da mesma copy: sem o marcador, o subtítulo padrão continua.
+  const { page: p2 } = await abrirPrecos();
+  assert.match(await p2.textContent("#precos-sub"), /^15 dias grátis/);
+  await p2.close();
+});
+
+// ── controle POSITIVO: o caminho legítimo continua funcionando ───────────────
+
+test("controle positivo: 'Assinar Plus' dispara exatamente 1 POST /billing/create-checkout", async () => {
+  const { page, chamadas, corposCheckout } = await abrirPrecos({
+    me: { user_id: 42, needs_plan_selection: true }, query: "?escolha=1",
+  });
+  await Promise.all([
+    page.waitForURL(/stripe=1/, { timeout: 5000 }),
+    page.click('#plans-v2 [data-plan-btn="plus"]'),
+  ]);
+  assert.equal(chamadas.checkout, 1, `foram ${chamadas.checkout} POSTs de checkout`);
+  assert.deepEqual(corposCheckout[0], { interval: "monthly", plan: "plus" });
+  await page.close();
+});
+
+test("controle positivo: os 6 CTAs pagos continuam habilitados (card e tabela)", async () => {
+  // Clicar nos seis não dá: o primeiro clique bem-sucedido NAVEGA pro Stripe.
+  // Então a prova de "não quebrei os outros" é o estado do DOM — o clique de
+  // verdade é o teste acima. Cada plano pago tem DOIS botões (card + rodapé da
+  // tabela) e o do rodapé já tinha ficado clicável rumo ao erro uma vez.
+  const { page } = await abrirPrecos({ me: { user_id: 42, needs_plan_selection: true } });
+  const estado = await page.$$eval("[data-plan-btn]", (els) => els.map((e) => ({
+    plano: e.dataset.planBtn,
+    onde: e.closest("#plans-v2") ? "card" : "tabela",
+    desabilitado: e.disabled === true,
+    texto: e.textContent.trim(),
+  })));
+  assert.deepEqual(estado, [
+    { plano: "essencial", onde: "card",   desabilitado: false, texto: "Assinar Essencial" },
+    { plano: "plus",      onde: "card",   desabilitado: false, texto: "Assinar Plus" },
+    { plano: "pro",       onde: "card",   desabilitado: false, texto: "Assinar Pro" },
+    { plano: "essencial", onde: "tabela", desabilitado: false, texto: "Assinar Essencial" },
+    { plano: "plus",      onde: "tabela", desabilitado: false, texto: "Assinar Plus" },
+    { plano: "pro",       onde: "tabela", desabilitado: false, texto: "Assinar Pro" },
+  ]);
+  await page.close();
+});

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -14,9 +14,9 @@
  *     gate} × {com ?escolha=1, sem marcador}: quem decide é o
  *     needs_plan_selection do /auth/me, não a URL (o marcador se perde num
  *     clique no "Planos" do próprio nav);
- *   · app iOS — mais 2 células com a UA PigBankApp: lá o gate não existe
- *     (routes/shared.py isenta o app), então o mandato "Escolha um plano pra
- *     continuar" seria falso pra quem não está travado;
+ *   · app iOS — mais 2 células com a UA PigBankApp: o gate vale lá também, e
+ *     o mandato tem de aparecer. A isenção que routes/shared.py tinha era por
+ *     substring de User-Agent, escolhida pelo cliente, e saiu;
  *   · controle POSITIVO — "Assinar Plus" ainda dispara EXATAMENTE 1
  *     POST /billing/create-checkout. Sem ele o grupo passaria numa página com
  *     todos os botões quebrados, que é pior que o bug.
@@ -186,15 +186,16 @@ for (const [estado, me] of [
   }
 }
 
-// ── app iOS: o gate não se aplica, então a copy de mandato seria falsa ───────
-// routes/shared.py isenta o _is_pigbank_app do gate, e a /precos é alcançável de
-// dentro do app pelo "Ver planos" .pb-keep-in-app do paywall (`#upg-cta` em
-// frontend/dashboard.html)
-// — dizer "Escolha um plano pra continuar" a quem não está travado é errado.
+// ── app iOS: o gate passou a valer lá também, então a copy de mandato é certa ─
+// A isenção de routes/shared.py era decidida por substring de User-Agent, que o
+// cliente escolhe: qualquer conta web entrava sem plano mandando "PigBankApp".
+// Ela saiu, e com ela a guarda `|| window.PB_IN_APP` desta página. Quem abre a
+// /precos de dentro do app (pelo "Ver planos" .pb-keep-in-app do paywall,
+// `#upg-cta` em frontend/dashboard.html) está travado como qualquer um, e
+// esconder o mandato deixaria a tela sem explicar por que o dashboard não abre.
 // 2 células, não 6: as 4 de {deslogado, logado sem gate} × marcador saem da
-// função pelo mesmo `!me.needs_plan_selection`, com e sem app — a guarda não
-// alcança nenhuma delas. A coluna do marcador fica porque é o mesmo invariante
-// das células web: a URL não decide nada.
+// função pelo mesmo `!me.needs_plan_selection`, com e sem app. A coluna do
+// marcador fica porque é o mesmo invariante das células web: a URL não decide.
 for (const query of ["?escolha=1", ""]) {
   const rotulo = query ? "com marcador" : "sem marcador";
   test(`copy do subtítulo: app iOS, logado com gate, ${rotulo}`, async () => {
@@ -204,8 +205,8 @@ for (const query of ["?escolha=1", ""]) {
     assert.equal(await page.evaluate(() => window.PB_IN_APP === true), true,
       "a UA do app não ligou window.PB_IN_APP — a célula não mediria o app");
     const sub = await page.textContent("#precos-sub");
-    assert.match(sub, COPY_PADRAO,
-      `app iOS ${rotulo} devia ler a copy padrão e leu: "${sub}"`);
+    assert.match(sub, COPY_GATE,
+      `app iOS ${rotulo} devia ler o mandato e leu: "${sub}"`);
     await page.close();
   });
 }

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -28,7 +28,8 @@ import assert from "node:assert/strict";
 import { startServer } from "./_server.mjs";
 import { chromium } from "playwright";
 
-// UA do WebView do app (auth-refresh.js:274 casa a SUBSTRING PigBankApp) — é o
+// UA do WebView do app (o `/PigBankApp/.test(navigator.userAgent)` de
+// frontend/static/auth-refresh.js casa a SUBSTRING PigBankApp) — é o
 // mecanismo real que liga window.PB_IN_APP, e não injeção da variável.
 const APP_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
   + "AppleWebKit/605.1.15 Safari/604.1 PigBankApp/1.0";
@@ -171,7 +172,8 @@ for (const [estado, me] of [
 
 // ── app iOS: o gate não se aplica, então a copy de mandato seria falsa ───────
 // routes/shared.py isenta o _is_pigbank_app do gate, e a /precos é alcançável de
-// dentro do app pelo "Ver planos" .pb-keep-in-app do paywall (dashboard.html:858)
+// dentro do app pelo "Ver planos" .pb-keep-in-app do paywall (`#upg-cta` em
+// frontend/dashboard.html)
 // — dizer "Escolha um plano pra continuar" a quem não está travado é errado.
 // 2 células, não 6: as 4 de {deslogado, logado sem gate} × marcador saem da
 // função pelo mesmo `!me.needs_plan_selection`, com e sem app — a guarda não

--- a/tests/test_billing_plans_config.py
+++ b/tests/test_billing_plans_config.py
@@ -1,0 +1,44 @@
+"""GET /billing/plans-config — os flags de disponibilidade por plano.
+
+A /precos usa `<plano>_available` pra decidir se o botão vira "Indisponível".
+O flag do Plus tem que seguir a MESMA resolução de price id do checkout
+(`_resolve_price_id("plus", "monthly")`, que aceita o fallback legado
+STRIPE_PRICE_ID_PRO): se os dois divergirem, a página mostra "Indisponível"
+num plano cujo checkout funciona — ou o contrário. Por isso cada caso compara
+o flag com o `_resolve_price_id`, e não com um literal (CLAUDE.md §0.7).
+
+A rota não tem auth e não toca banco: TestClient sem lifespan basta.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+
+client = TestClient(dashboard.app)
+
+
+def test_plus_available_existe_na_resposta():
+    body = client.get("/billing/plans-config").json()
+    assert "plus_available" in body, f"chave ausente: {sorted(body)}"
+    assert isinstance(body["plus_available"], bool)
+
+
+@pytest.mark.parametrize(
+    "mensal, legado, esperado",
+    [
+        ("price_plus_mensal", "", True),          # env nova
+        ("", "price_legacy_pro", True),           # SÓ a env legada: checkout funciona
+        ("price_plus_mensal", "price_legacy_pro", True),
+        ("", "", False),                          # nada configurado
+    ],
+)
+def test_plus_available_segue_a_resolucao_de_price_id(monkeypatch, mensal, legado, esperado):
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", mensal)
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", legado)
+
+    flag = client.get("/billing/plans-config").json()["plus_available"]
+    assert flag is esperado
+    # o flag não pode divergir de quem realmente decide se o checkout sai
+    assert flag == bool(dashboard._resolve_price_id("plus", "monthly"))

--- a/tests/test_billing_plans_config.py
+++ b/tests/test_billing_plans_config.py
@@ -2,10 +2,11 @@
 
 A /precos usa `<plano>_available` pra decidir se o botão vira "Indisponível".
 O flag do Plus tem que seguir a MESMA resolução de price id do checkout
-(`_resolve_price_id("plus", "monthly")`, que aceita o fallback legado
-STRIPE_PRICE_ID_PRO): se os dois divergirem, a página mostra "Indisponível"
-num plano cujo checkout funciona — ou o contrário. Por isso cada caso compara
-o flag com o `_resolve_price_id`, e não com um literal (CLAUDE.md §0.7).
+(`_resolve_price_id`, que aceita o fallback legado STRIPE_PRICE_ID_PRO): se os
+dois divergirem, a página mostra "Indisponível" num plano cujo checkout
+funciona — ou o contrário. Indisponível = NENHUM intervalo resolve, mensal ou
+anual. Por isso cada caso compara o flag com o `_resolve_price_id`, e não com
+um literal (CLAUDE.md §0.7).
 
 A rota não tem auth e não toca banco: TestClient sem lifespan basta.
 """
@@ -37,8 +38,27 @@ def test_plus_available_existe_na_resposta():
 def test_plus_available_segue_a_resolucao_de_price_id(monkeypatch, mensal, legado, esperado):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", mensal)
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", legado)
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "")  # casos só do mensal
 
     flag = client.get("/billing/plans-config").json()["plus_available"]
     assert flag is esperado
     # o flag não pode divergir de quem realmente decide se o checkout sai
     assert flag == bool(dashboard._resolve_price_id("plus", "monthly"))
+
+
+def test_plus_available_com_so_o_anual_configurado(monkeypatch):
+    """Deploy que configurou só STRIPE_PRICE_ID_PRO_ANUAL: o checkout anual sai
+    (`_resolve_price_id("plus", "annual")`), então o Plus NÃO pode aparecer como
+    indisponível — a /precos desabilitaria os dois botões antes de o cliente
+    poder trocar de ciclo. Achado do Codex no PR #239."""
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", "")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "price_plus_anual")
+
+    assert dashboard._resolve_price_id("plus", "monthly") == ""  # só o anual resolve
+    assert client.get("/billing/plans-config").json()["plus_available"] is True
+
+    # Controle positivo: sem NENHUM intervalo configurado o flag volta a ser
+    # False. Sem ele o grupo passaria numa implementação que devolve True sempre.
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "")
+    assert client.get("/billing/plans-config").json()["plus_available"] is False

--- a/tests/test_billing_select_free_recusa.py
+++ b/tests/test_billing_select_free_recusa.py
@@ -1,0 +1,83 @@
+"""POST /billing/select-free recusa: o Grátis morreu como porta de entrada.
+
+Regra de produto: quem se cadastra pela web tem de ASSINAR pra entrar. A rota
+continua existindo só pra recusar (apagá-la devolveria 404/405 em HTML a um
+cliente antigo em cache, e o front lê `detail.message`), e nenhum caminho do
+frontend a chama mais — o `[data-free-cta]`/`selectFree` saíram da precos.html
+no mesmo commit (`tests/frontend/precos_sem_plano_gratis.test.mjs`).
+
+O que discrimina o conserto é a 3ª asserção: o gate CONTINUA fechado depois da
+chamada. Com a guarda removida, o corpo antigo chamava `mark_plan_selected` e
+`needs_plan_selection` virava False — que é exatamente o buraco que se fechou.
+O `test_controle_positivo_*` é o par dela: prova que `needs_plan_selection` não
+é sempre True (senão a asserção passaria num sistema onde ninguém entra nunca).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("MFA_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+import db
+import core.services.plan_service as plan_service
+import frontend.finance_bot_websocket_custom as dashboard
+
+_CSRF_TOKEN = "test-csrf-token-select-free"
+_CSRF_HEADERS = {dashboard.CSRF_HEADER_NAME: _CSRF_TOKEN}
+
+
+@pytest.fixture(autouse=True)
+def _v2_e_rate_limit(monkeypatch):
+    """v2 ligado (o gate de escolha só existe nele) e limiter zerado por teste —
+    /billing/select-free tem 20/hora com storage em memória compartilhado."""
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:
+        pass
+
+
+def _cadastro_novo(sufixo: str):
+    """Usuário recém-criado: plan_selected_at NULL → needs_plan_selection True."""
+    email = f"selectfree-{sufixo}@t.com"
+    user = db.register_auth_user(email, "senha-forte-123")
+    user_id = int(user["user_id"])
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(user_id, email))
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, _CSRF_TOKEN)
+    return user_id, client
+
+
+def test_select_free_recusa_e_nao_fecha_o_gate():
+    user_id, client = _cadastro_novo("recusa")
+    assert plan_service.needs_plan_selection(user_id) is True, "pré-condição"
+
+    r = client.post("/billing/select-free", headers=_CSRF_HEADERS)
+
+    assert 400 <= r.status_code < 500, f"devolveu {r.status_code}, esperava 4xx"
+    corpo = r.json()
+    # Mesmo formato das outras rotas de billing: detail.error + detail.message.
+    assert corpo["detail"]["error"] == "free_plan_discontinued"
+    assert corpo["detail"]["message"], "sem mensagem legível pro usuário"
+    # A que discrimina: o gate NÃO fechou. É o que vira False se a guarda sair.
+    assert plan_service.needs_plan_selection(user_id) is True, \
+        "a rota fechou o gate — a guarda não está valendo"
+
+
+def test_controle_positivo_o_gate_ainda_fecha_pelo_caminho_do_checkout():
+    """Par positivo: `mark_plan_selected` (o que o webhook
+    checkout.session.completed chama) continua liberando o usuário.
+
+    Sem este caso, a asserção de cima passaria num sistema onde
+    needs_plan_selection é True para sempre e ninguém entra nunca.
+    """
+    user_id, _ = _cadastro_novo("positivo")
+    assert plan_service.needs_plan_selection(user_id) is True
+
+    db.mark_plan_selected(user_id)
+
+    assert plan_service.needs_plan_selection(user_id) is False

--- a/tests/test_billing_select_free_recusa.py
+++ b/tests/test_billing_select_free_recusa.py
@@ -74,6 +74,12 @@ def test_controle_positivo_o_gate_ainda_fecha_pelo_caminho_do_checkout():
 
     Sem este caso, a asserção de cima passaria num sistema onde
     needs_plan_selection é True para sempre e ninguém entra nunca.
+
+    Chama a função de banco direto de propósito — o que este caso prova é só
+    que `needs_plan_selection` sabe virar False. Quem prova que a ÚNICA saída
+    do funil funciona pelo caminho real (POST /billing/webhook) é o
+    `test_checkout_completed_fecha_o_gate_de_escolha`, em
+    tests/test_billing_webhook_lifecycle.py.
     """
     user_id, _ = _cadastro_novo("positivo")
     assert plan_service.needs_plan_selection(user_id) is True

--- a/tests/test_billing_webhook_lifecycle.py
+++ b/tests/test_billing_webhook_lifecycle.py
@@ -210,6 +210,65 @@ def test_assinatura_invalida_da_400(user_id, monkeypatch):
     assert r.status_code == 400
 
 
+def test_checkout_completed_fecha_o_gate_de_escolha(user_id, monkeypatch):
+    """A ÚNICA saída do funil de cadastro: só o checkout concluído fecha o gate.
+
+    Depois de o Grátis sair da /precos (2026-09-02), `mark_plan_selected` tem um
+    chamador de verdade — o webhook `checkout.session.completed` (o
+    /billing/select-free só recusa com 410). Se este caminho não fechar o gate,
+    o cadastro novo paga e continua sendo devolvido pra /precos.
+
+    O que DISCRIMINA é a 2ª metade. Logo depois do checkout,
+    `needs_plan_selection` já é False de graça: o webhook grava plan='pro' com
+    validade futura, e a função nunca trava assinante pago vigente — a asserção
+    ali seria verde COM ou SEM o mark_plan_selected (tautológica). Quem separa
+    os dois mundos é o `plan_selected_at`, que sobrevive ao fim da assinatura:
+    depois do `customer.subscription.deleted` o plano volta pra 'free' e só o
+    carimbo mantém o gate fechado. Sem ele, quem já pagou uma vez e cancelou
+    cairia no gate de ESCOLHA (que não tem mais o que escolher) em vez do
+    paywall. Controle negativo: desligue o `mark_plan_selected` do ramo
+    checkout.session.completed do webhook
+    (`git grep -n "mark_plan_selected, user_id" -- frontend/`) e este teste fica
+    vermelho — os outros 5 do arquivo continuam verdes.
+    """
+    uid, client, fake = _setup(monkeypatch, f"gate-{user_id}")
+    # O gate de escolha só existe sob a escada v2 (o conftest fixa 0 pra suíte).
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    from core.services.plan_service import needs_plan_selection
+    try:
+        assert needs_plan_selection(uid) is True, \
+            "pré-condição: cadastro novo tem plan_selected_at NULL"
+
+        r = _post(
+            client, fake,
+            {"type": "checkout.session.completed",
+             "data": {"object": {"id": "cs_test_gate",
+                                  "metadata": {"finbot_user_id": str(uid)},
+                                  "subscription": "sub_gate"}}},
+            subs={"sub_gate": _fake_sub("trialing")},
+        )
+        assert r.status_code == 200, r.text
+        assert needs_plan_selection(uid) is False, "o gate não abriu pra quem pagou"
+
+        # Assinatura cancelada depois → plano volta pra 'free'. O gate de escolha
+        # tem de continuar FECHADO (quem barra agora é o paywall).
+        r = _post(
+            client, fake,
+            {"type": "customer.subscription.deleted",
+             "data": {"object": {"metadata": {"finbot_user_id": str(uid)}}}},
+        )
+        assert r.status_code == 200, r.text
+        assert db.get_auth_user(uid)["plan"] == "free", "pré-condição da 2ª metade"
+        assert needs_plan_selection(uid) is False, \
+            "o checkout não carimbou plan_selected_at: cancelou e caiu no gate de escolha"
+    finally:
+        _cleanup_trial(uid)
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("delete from checkout_funnel_events where user_id = %s", (uid,))
+            conn.commit()
+
+
 def test_checkout_completed_grava_funil(user_id, monkeypatch):
     """checkout.session.completed grava um 'completed' na tabela do funil, com
     o session_id do evento — é o par do 'started' do endpoint, correlacionado

--- a/tests/test_billing_webhook_lifecycle.py
+++ b/tests/test_billing_webhook_lifecycle.py
@@ -211,12 +211,15 @@ def test_assinatura_invalida_da_400(user_id, monkeypatch):
 
 
 def test_checkout_completed_fecha_o_gate_de_escolha(user_id, monkeypatch):
-    """A ÚNICA saída do funil de cadastro: só o checkout concluído fecha o gate.
+    """A saída do funil de cadastro é pagar: só o checkout concluído fecha o gate.
 
-    Depois de o Grátis sair da /precos (2026-09-02), `mark_plan_selected` tem um
-    chamador de verdade — o webhook `checkout.session.completed` (o
-    /billing/select-free só recusa com 410). Se este caminho não fechar o gate,
-    o cadastro novo paga e continua sendo devolvido pra /precos.
+    Depois de o Grátis sair da /precos (2026-09-02), `mark_plan_selected` tem
+    DOIS chamadores — os ramos `checkout.session.completed` e
+    `invoice.paid`/`invoice.payment_succeeded` do webhook (o /billing/select-free
+    só recusa com 410). Não são duas saídas do funil: o `invoice.paid` pressupõe
+    subscription, que pressupõe uma sessão de checkout antes, então quem sai do
+    cadastro passa pelo ramo testado aqui. Se este caminho não fechar o gate, o
+    cadastro novo paga e continua sendo devolvido pra /precos.
 
     O que DISCRIMINA é a 2ª metade. Logo depois do checkout,
     `needs_plan_selection` já é False de graça: o webhook grava plan='pro' com
@@ -226,10 +229,14 @@ def test_checkout_completed_fecha_o_gate_de_escolha(user_id, monkeypatch):
     depois do `customer.subscription.deleted` o plano volta pra 'free' e só o
     carimbo mantém o gate fechado. Sem ele, quem já pagou uma vez e cancelou
     cairia no gate de ESCOLHA (que não tem mais o que escolher) em vez do
-    paywall. Controle negativo: desligue o `mark_plan_selected` do ramo
-    checkout.session.completed do webhook
-    (`git grep -n "mark_plan_selected, user_id" -- frontend/`) e este teste fica
-    vermelho — os outros 5 do arquivo continuam verdes.
+    paywall.
+
+    Controle negativo: `git grep -n "mark_plan_selected, user_id" -- frontend/`
+    devolve DUAS linhas (um ramo cada). Mute a do ramo
+    `checkout.session.completed` — a primeira das duas, logo abaixo do
+    comentário "Checkout concluído = plano escolhido" — e este teste fica
+    vermelho na 2ª metade; os outros 5 do arquivo continuam verdes. Mutar a do
+    ramo `invoice.paid` não discrimina nada: este teste não emite invoice.
     """
     uid, client, fake = _setup(monkeypatch, f"gate-{user_id}")
     # O gate de escolha só existe sob a escada v2 (o conftest fixa 0 pra suíte).

--- a/tests/test_gate_plan_selection.py
+++ b/tests/test_gate_plan_selection.py
@@ -76,9 +76,27 @@ def test_retorno_cancelado_ainda_forca_precos(monkeypatch):
     assert out.headers["location"] == "/precos?escolha=1"
 
 
-def test_app_ios_e_isento(monkeypatch):
-    # UA do WebView do app: nunca redireciona pra tela de compra (3.1.1).
+def test_ua_de_app_nao_isenta_o_gate(monkeypatch):
+    """Mandar "PigBankApp" no User-Agent NÃO pula o gate de escolha de plano.
+
+    A isenção existia pela diretriz 3.1.1 da App Store e era decidida por
+    substring de header — escolhido pelo cliente. Qualquer conta web entrava no
+    dashboard sem plano só forjando o UA, e depois que o Grátis saiu da /precos
+    isso passou a valer dinheiro. Controle negativo: repor
+    `if _is_pigbank_app(request): return None` no topo de gate_plan_selection
+    faz este caso voltar a receber None.
+    """
     _patch(monkeypatch, payload={"type": "auth", "sub": "7"}, needs=True)
+    out = shared.gate_plan_selection(_Req(ua="Mozilla/5.0 PigBankApp/1.2"))
+    assert isinstance(out, RedirectResponse)
+    assert out.headers["location"] == "/precos?escolha=1"
+
+
+def test_ua_de_app_nao_impede_quem_ja_escolheu(monkeypatch):
+    # Controle positivo do par acima: sem o gate pendente, o UA de app segue
+    # entrando normalmente. Sem isto, o teste anterior passaria num gate que
+    # recusa todo mundo.
+    _patch(monkeypatch, payload={"type": "auth", "sub": "7"}, needs=False)
     assert shared.gate_plan_selection(_Req(ua="Mozilla/5.0 PigBankApp/1.2")) is None
 
 
@@ -166,3 +184,50 @@ class TestJanelaEntreEscritasDoWebhook:
         """Assinatura vencida não é escolha implícita: volta a barrar."""
         u = self._user("plus", plan_selected_at=None, expires="2020-01-01T00:00:00+00:00")
         assert plan_service.needs_plan_selection(1, u) is True
+
+
+class _DataReq:
+    """Request falso pro _enforce_subscription_gate: ele lê url.path e o UA."""
+    def __init__(self, ua="", path="/data/7"):
+        self.headers = {"user-agent": ua}
+
+        class _U:
+            pass
+        self.url = _U()
+        self.url.path = path
+
+
+@pytest.mark.parametrize("ua", ["Mozilla/5.0", "Mozilla/5.0 PigBankApp/1.2"])
+def test_backstop_402_nao_isenta_ua_de_app(monkeypatch, ua):
+    """O 402 das rotas de dados nega com e sem UA de app.
+
+    Era o terceiro ponto que isentava o app por header (`not
+    _is_pigbank_app(request) and needs_plan_selection(...)`): sem o gate de
+    página, uma conta sem plano batia direto em /data/{id} forjando o UA e lia
+    os dados. Controle negativo: repor o `not _is_pigbank_app(request) and`
+    faz o caso do UA de app parar de levantar.
+    """
+    monkeypatch.setattr(plan_service, "needs_plan_selection", lambda uid: True)
+    monkeypatch.setattr(plan_service, "has_app_access", lambda uid: True)
+    with pytest.raises(HTTPException) as exc:
+        shared._enforce_subscription_gate(_DataReq(ua=ua), 7)
+    assert exc.value.status_code == 402
+    assert exc.value.detail["error"] == "plan_selection_required"
+
+
+@pytest.mark.parametrize("ua", ["Mozilla/5.0", "Mozilla/5.0 PigBankApp/1.2"])
+def test_backstop_402_libera_quem_ja_escolheu(monkeypatch, ua):
+    # Controle positivo do par acima, nos dois UAs: sem gate pendente e com
+    # acesso, a rota passa. Sem isto o par passaria num backstop que nega tudo.
+    monkeypatch.setattr(plan_service, "needs_plan_selection", lambda uid: False)
+    monkeypatch.setattr(plan_service, "has_app_access", lambda uid: True)
+    assert shared._enforce_subscription_gate(_DataReq(ua=ua), 7) is None
+
+
+def test_backstop_402_ainda_isenta_as_rotas_que_resolvem_o_gate(monkeypatch):
+    # /billing e /auth continuam isentos por PREFIXO (não por UA): são eles que
+    # fecham o gate. Gatear isto trancaria a saída.
+    monkeypatch.setattr(plan_service, "needs_plan_selection", lambda uid: True)
+    monkeypatch.setattr(plan_service, "has_app_access", lambda uid: True)
+    assert shared._enforce_subscription_gate(
+        _DataReq(path="/billing/create-checkout"), 7) is None

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -42,6 +42,83 @@ def test_html_pages_respondem_com_no_store():
         assert resp.headers["cache-control"] == "no-store", path
 
 
+def test_whatsapp_nao_garante_quando_a_primeira_cobranca_vem():
+    """A trilha de passos da /whatsapp é NOSSA (1ca0c44) e não pode prometer a data.
+
+    Mesmo defeito que o `tests/test_welcome_email_copy.py` já proíbe no e-mail:
+    quem recria a conta com um telefone que já está em `plan_trials` é
+    inelegível (`db.plans.is_trial_eligible_for_user`), o checkout sai com
+    `trial_days=0` e o Stripe cobra na hora. Achado do Codex no PR #239 — o
+    e-mail foi corrigido e esta página ficou.
+
+    Controle positivo junto: a oferta dos 15 dias continua na página (senão o
+    caso passaria numa /whatsapp que apagou o trial, que é pior que a garantia)
+    e a ressalva "um por número" da /precos aparece.
+
+    Só a /whatsapp: na /precos as mesmas frases existem em copy PREEXISTENTE
+    (linhas 220, 319 e 773, anteriores ao PR), então a asserção de página
+    inteira ficaria vermelha por código que não é deste PR. A copy do gate de
+    lá, que é nossa, é medida em tests/frontend/precos_sem_plano_gratis.test.mjs.
+    """
+    html = " ".join(client.get("/whatsapp").text.split())
+
+    for garantia in (
+        "Nada é cobrado agora",
+        "primeira cobrança só vem depois",
+        "cancelar antes sem pagar nada",
+    ):
+        assert garantia not in html, (
+            f"a /whatsapp garante a data da cobrança, que a página não conhece: {garantia!r}"
+        )
+
+    assert "15 dias grátis" in html, "a /whatsapp deixou de oferecer o teste"
+    assert "um por número de telefone" in html, (
+        "a /whatsapp perdeu a ressalva de que o teste é um por número"
+    )
+    assert "checkout" in html.lower(), (
+        "a /whatsapp não defere ao checkout quem confirma a cobrança"
+    )
+
+
+def test_index_nao_inverte_o_fluxo_do_trial():
+    """O CTA do "como funciona" da / é NOSSO (1ca0c44) e dizia o fluxo ao contrário.
+
+    O texto era "você testa 15 dias grátis antes de escolher um plano", mas o
+    gate deste PR faz o oposto: escolher o plano é o que ATIVA o trial
+    (`needs_plan_selection` bloqueia o app até a assinatura). O mesmo commit
+    escreveu a ordem certa na /whatsapp e na /como-funciona e a inversa aqui.
+
+    A asserção é presa ao bloco `.hiw-cta` de propósito: as garantias de data
+    ("primeira cobrança", "sem pagar nada") também existem nas linhas 504 e
+    536 desta página, mas são PREEXISTENTES (d5e299f, anterior à merge-base
+    c779837) e não são deste PR. Guarda de página inteira, como o da
+    /whatsapp, é impossível aqui — ficaria vermelho por código de terceiro.
+
+    Controle positivo dentro do próprio bloco: ele continua oferecendo o teste
+    e deferindo ao checkout, senão o caso passaria num CTA que apagou a oferta.
+    """
+    html = " ".join(client.get("/").text.split())
+    bloco = re.search(r'class="hiw-cta".*?</div>', html)
+    assert bloco, "o bloco .hiw-cta sumiu da / — a asserção abaixo ficou cega"
+    cta = bloco.group(0)
+
+    assert not re.search(
+        r"test\w*[^.]{0,60}antes de (?:escolher|assinar|pegar|pagar)[^.]{0,25}plano",
+        cta,
+        re.I,
+    ), f"o CTA da / diz que se testa antes de escolher o plano: {cta!r}"
+
+    for garantia in ("primeira cobrança", "sem pagar nada", "não paga nada"):
+        assert garantia not in cta, (
+            f"o CTA da / garante a data/ausência da cobrança: {garantia!r}"
+        )
+
+    assert "15 dias grátis" in cta, "o CTA da / deixou de oferecer o teste"
+    assert "checkout" in cta.lower(), (
+        "o CTA da / não defere ao checkout quem confirma a cobrança"
+    )
+
+
 def test_stamp_asset_versions_usa_hash_de_conteudo():
     # Número hardcoded no HTML é ignorado e trocado pelo hash do arquivo real.
     mtime = (FRONTEND_DIR / "app-mode.css").stat().st_mtime_ns

--- a/tests/test_welcome_email_copy.py
+++ b/tests/test_welcome_email_copy.py
@@ -1,0 +1,72 @@
+"""E-mail de boas-vindas (send_welcome_email): a copy não pode prometer o bot
+antes do plano.
+
+Cadastro web novo cai no gate (/precos), então "abra o chat e mande um oi — o
+Piggy já começa" era falso: o passo 1 é ativar o teste de 15 dias, o passo 2 é
+o oi no WhatsApp. Os dois controles do CLAUDE.md §3:
+
+  · asserção do conserto — os dois corpos (HTML e texto) levam ao /precos, e o
+    CTA do plano vem ANTES do CTA do WhatsApp;
+  · controle POSITIVO — o CTA do WhatsApp continua no e-mail e o trial de 15
+    dias continua dito. Sem ele o grupo passaria num e-mail que só sabe cobrar,
+    que é o oposto do que o produto oferece.
+
+Não exercita o envio real (Resend está bloqueado no conftest, CLAUDE.md §6):
+o assunto aqui é o texto, e é isso que ele mede.
+"""
+from __future__ import annotations
+
+import core.services.email_service as email_service
+
+
+def _capturar(monkeypatch) -> dict:
+    """Chama o e-mail com o send_email capturado (o conftest já bloqueia rede)."""
+    capturado: dict = {}
+
+    def fake_send_email(**kwargs):
+        capturado.update(kwargs)
+        return True
+
+    monkeypatch.setattr(email_service, "send_email", fake_send_email)
+    assert email_service.send_welcome_email(
+        "novo@example.com", "123456", "https://pigbankai.com"
+    ) is True
+    return capturado
+
+
+def test_boas_vindas_leva_ao_precos_antes_do_whatsapp(monkeypatch):
+    enviado = _capturar(monkeypatch)
+    base = email_service._public_base_url()
+    link_wpp = email_service._whatsapp_link()
+
+    for campo in ("html_body", "text_body"):
+        corpo = enviado[campo]
+        assert f"{base}/precos" in corpo, f"{campo} não leva ao /precos"
+        assert "15 dias grátis" in corpo, f"{campo} não diz que dá pra testar de graça"
+
+    html = enviado["html_body"]
+    assert html.index(f"{base}/precos") < html.index(link_wpp), (
+        "o CTA do WhatsApp aparece antes do de ativar o teste — a ordem do "
+        "e-mail é justamente o conserto"
+    )
+
+
+def test_boas_vindas_nao_promete_bot_liberado_no_cadastro(monkeypatch):
+    enviado = _capturar(monkeypatch)
+    corpos = enviado["html_body"] + "\n" + enviado["text_body"] + "\n" + enviado["subject"]
+
+    for proibido in (
+        "Sem código, sem prazo",          # dizia que não havia nada entre o cadastro e o bot
+        "reconhecemos seu número automaticamente.",  # text_body antigo, sem passar pelo plano
+        "Abrir Dashboard",                # o gate redireciona o dashboard pro /precos
+        "Primeiros comandos",             # comandos como se já funcionassem
+        "vincule o bot e comece agora",   # assunto antigo
+    ):
+        assert proibido not in corpos, f"a copy órfã ainda está no e-mail: {proibido!r}"
+
+
+def test_controle_positivo_o_caminho_do_whatsapp_continua_no_email(monkeypatch):
+    enviado = _capturar(monkeypatch)
+    assert email_service._whatsapp_link() in enviado["html_body"]
+    assert "WhatsApp" in enviado["text_body"]
+    assert "gastei 50 mercado" in enviado["html_body"]

--- a/tests/test_welcome_email_copy.py
+++ b/tests/test_welcome_email_copy.py
@@ -70,3 +70,30 @@ def test_controle_positivo_o_caminho_do_whatsapp_continua_no_email(monkeypatch):
     assert email_service._whatsapp_link() in enviado["html_body"]
     assert "WhatsApp" in enviado["text_body"]
     assert "gastei 50 mercado" in enviado["html_body"]
+
+
+def test_boas_vindas_nao_garante_quando_a_primeira_cobranca_vem(monkeypatch):
+    """A copy não pode prometer que a 1ª cobrança só vem depois dos 15 dias.
+
+    Quem recria a conta com um telefone que já está em plan_trials é inelegível
+    (db.plans.is_trial_eligible_for_user), o checkout sai com trial_days=0 e o
+    Stripe cobra na hora. O e-mail não tem como saber: não recebe user_id, e no
+    cadastro por senha a conta ainda nem tem telefone. Achado do Codex no PR
+    #239. A oferta continua (controle positivo nos testes acima: "15 dias
+    grátis" nos dois corpos), mas quem confirma a cobrança é o checkout.
+    """
+    enviado = _capturar(monkeypatch)
+
+    for campo in ("html_body", "text_body"):
+        corpo = " ".join(enviado[campo].split())  # a copy quebra linha no meio da frase
+        for garantia in (
+            "primeira cobrança só vem depois",       # HTML antigo
+            "Nada é cobrado agora",                  # os dois corpos antigos
+            "cancele antes do fim dos 15 dias",      # texto antigo
+        ):
+            assert garantia not in corpo, (
+                f"{campo} garante a data da cobrança, que o e-mail não conhece: {garantia!r}"
+            )
+        assert "checkout" in corpo.lower(), (
+            f"{campo} não diz que o checkout mostra a cobrança antes de confirmar"
+        )

--- a/tests/test_ws_subscription_gate.py
+++ b/tests/test_ws_subscription_gate.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
+import db
 import frontend.finance_bot_websocket_custom as dashboard
 from token_utils import make_dashboard_token
 from tests.conftest import promote_to_pro
@@ -48,10 +49,15 @@ def test_paywall_desligado_segue_liberado(user_id, monkeypatch):
     assert msg["type"] == "snapshot"
 
 
-def test_isencao_ios_da_escolha_de_plano(user_id, monkeypatch):
-    """A perna needs_plan_selection do gate: cadastro sem plano escolhido é
-    negado na web, mas o app iOS (UA PigBankApp) passa — diretriz 3.1.1, a
-    mesma isenção do _enforce_subscription_gate das rotas de dados."""
+def test_ua_de_app_nao_abre_o_ws_sem_plano(user_id, monkeypatch):
+    """A perna needs_plan_selection do gate nega igual com e sem UA de app.
+
+    Havia isenção aqui pela diretriz 3.1.1, decidida por `"PigBankApp" in
+    ws.headers` — uma segunda cópia da checagem que o shared.py fazia. Como o
+    header é escolhido pelo cliente, bastava pedir para abrir o WS sem plano e
+    receber o snapshot com os dados. Controle negativo: repor o `not in_app and`
+    no lambda do gate faz a segunda perna deste teste voltar a receber snapshot.
+    """
     monkeypatch.setenv("PLANS_V2_ENABLED", "1")  # gate de escolha ativo (v2)
     from db.connection import get_conn
     with get_conn() as conn:
@@ -68,13 +74,25 @@ def test_isencao_ios_da_escolha_de_plano(user_id, monkeypatch):
         with pytest.raises(WebSocketDisconnect):
             with _connect(client, user_id) as ws:
                 ws.receive_json()
-        # iOS: mesma conta, UA do app ⇒ aceita e snapshot chega
+        # mesma conta, UA do app: negado igual — o header não concede nada
         client.cookies.set("dashboard_token", make_dashboard_token(user_id, hours=1))
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect(
+                f"/ws/{user_id}", headers={"user-agent": "Mozilla/5.0 PigBankApp"}
+            ) as ws:
+                ws.receive_json()
+        # Controle positivo: carimbado o plano, o MESMO UA de app conecta. Sem
+        # isto o caso acima passaria num gate que recusa todo mundo.
+        #
+        # Pelo db.mark_plan_selected, não por UPDATE cru: get_auth_user tem
+        # cache com TTL (db_support._auth_user_cache) e é a escrita oficial que
+        # o invalida. Um UPDATE em SQL deixa o cache quente e o gate segue
+        # negando — foi o que aconteceu na primeira versão deste teste.
+        db.mark_plan_selected(user_id)
         with client.websocket_connect(
             f"/ws/{user_id}", headers={"user-agent": "Mozilla/5.0 PigBankApp"}
         ) as ws:
-            msg = ws.receive_json()
-        assert msg["type"] == "snapshot"
+            assert ws.receive_json()["type"] == "snapshot"
     finally:
         with get_conn() as conn:
             with conn.cursor() as cur:


### PR DESCRIPTION
## O que muda

O plano Grátis deixa de ser **escolhível**. Ele continua existindo como **estado** no backend (fallback após falha de cobrança ou cancelamento) e como coluna informativa na tabela comparativa, mas ninguém mais entra nele por opção. Na web, assinar passa a ser obrigatório.

Decisões do dono do repositório que definiram o escopo:

1. Quem se cadastra pela web e não assina **fica sem entrar**.
2. Sai o **card inteiro** do Grátis; a **coluna** da tabela comparativa fica como informação; o CTA do `tfoot` sai.
3. O backend recusa de vez, **sem produzir erro no site**.
4. Vale para logado e deslogado.

## Commits, e por que cada um existe

**`941ffc0` — a remoção em si.** Card fora, os dois `[data-free-cta]` fora, `selectFree()` e `applyOnboardingChoice()` removidos, `POST /billing/select-free` passa a devolver 410 com `detail` estruturado. A rota não foi apagada de propósito: 404/405 devolveria o HTML da página de erro, sem `detail`, para um cliente antigo em cache. A remoção é de HTML estático, então vale com JavaScript desligado e para o visitante deslogado.

**`3498355` — corrige um bug que o commit anterior introduziu.** A copy do gate tinha passado a ser decidida por `?escolha=1`, e o marcador cai num clique: o nav e o rodapé da própria `/precos` linkam para `/precos` sem ele, e `gate_pro_page` e `/conta` também redirecionam sem. O usuário travado no gate lia a copy de visitante, agora sem o card do Grátis para lhe dar um degrau. Voltou a decidir por `needs_plan_selection` do `/auth/me`, que fecha as seis células de {deslogado, logado sem gate, logado com gate} × {com marcador, sem marcador} de uma vez.

O mesmo commit fecha uma lacuna de cobertura: com o Grátis fora, o webhook `checkout.session.completed` virou o único caminho que fecha o gate, e nenhum teste do repo asseria que ele fecha.

**`a7b6397` — isenta o app iOS.** O IIFE novo era o único consumidor de `needs_plan_selection` no frontend sem a guarda de app; `home.html`, `dashboard.js`, `settings.html` e `routes/shared.py` todos isentam. No app o usuário não está travado, e a `/precos` é alcançável de lá pelo "Ver planos" `.pb-keep-in-app`.

**`8414cc5` — corrige o que as docstrings deste PR passaram a afirmar errado**, incluindo três lugares que diziam "chamador único" de `mark_plan_selected` quando são dois (`checkout.session.completed` e `invoice.paid`).

**`1ca0c44` — protege o botão do Plus e tira a promessa de acesso sem plano.** Com o Grátis fora, uma queda do Stripe deixou de ter válvula de escape. O `/billing/plans-config` publicava só `essencial_available` e `pro_available`, então numa degradação parcial o botão do Plus continuava clicável e só produzia um toast de erro.

Junto, a copy de aquisição que prometia o que a tela não entrega mais: o e-mail de boas-vindas (disparado em todo cadastro web, dizia "sem código, sem prazo" e mandava abrir o chat direto), `como-funciona.html`, `index.html` e a landing `whatsapp.html`.

**`969040f` — termos.** O §1 não oferece mais o Grátis. E o §4, intitulado "Trial de 15 dias", dizia seis linhas abaixo que a cobrança sai "no 31º dia": resíduo de um trial de 30 dias. O Stripe recebe `trial_period_days = trial_days_total() = 15`, então a primeira fatura cai no 16º.

## Rodada de revisão do Codex

**`a74a331`** responde dois apontamentos.

O e-mail de boas-vindas garantia que a primeira cobrança só vem depois dos 15 dias. O trial é **um por número de telefone na vida** e o registro em `plan_trials` sobrevive à deleção da conta de propósito, então quem recria conta com um número já usado recebe `trial_days=0` e é cobrado na hora. Condicionar por elegibilidade não era possível: `send_welcome_email` não recebe `user_id`, e no cadastro por senha não há telefone nenhum, onde a resposta seria sempre "inelegível". A oferta passou a aparecer como o que o checkout confirma antes de cobrar.

E o `plus_available` copiava à mão a lógica de env do `_resolve_price_id`. Num deploy com só a env anual configurada, o checkout anual funcionava e a página desabilitava os dois botões do Plus mesmo assim. Passou a delegar à função que já resolve o price id, o que cobre os dois intervalos e tira a duplicação.

**`9875bd7`** responde o terceiro, e ele expôs um erro de classificação meu. Eu havia registrado a linha apontada como copy anterior ao PR; ela tinha sido **escrita por este PR**, em `1ca0c44`. Varrendo a categoria em vez da instância, contra a merge-base, este PR havia introduzido a mesma promessa em **quatro** lugares:

| linha | commit | o que era |
|---|---|---|
| `frontend/whatsapp.html:70` | `1ca0c44` | o que o Codex apontou |
| `frontend/precos.html:860` | `941ffc0` | copy do gate, "cancele antes do fim e não paga nada" |
| `frontend/index.html:340` | `1ca0c44` | inversão do fluxo, abaixo |
| `frontend/termos.html:67` | `969040f` | "todo plano **começa com** 15 dias" |

O da `index.html` era o pior e ninguém tinha visto: dizia que se testa 15 dias grátis "antes de escolher um plano", **invertendo o fluxo que este PR criou** — o gate exige escolher o plano para ativar o teste. O mesmo commit descreveu o fluxo certo em duas páginas e o inverso numa terceira.

A fraseologia usada é a que já existia no repo: a ressalva "um por número" vem de `precos.html:319` e a deferência ao checkout vem do próprio e-mail. Nada de quarta variante.

## Como foi verificado

Suíte frontend 275/275. pytest comparado **por nome** contra a árvore anterior em worktree: 247 falhas idênticas nos dois lados, `comm` vazio nos dois sentidos, e os passes a mais são exatamente os testes novos. As 247 são preexistentes e nenhuma toca billing ou `/precos`.

Os controles negativos foram feitos por mutação, não por leitura: desligar cada conserto deixa vermelho o caso que o discrimina, e os controles positivos ficam verdes nas duas rodadas. O teste do webhook não assere `needs_plan_selection` logo após o checkout, que seria tautológico (assinante pago vigente devolve `False` independente do carimbo): dispara `customer.subscription.deleted` pelo caminho real e só então mede.

Layout medido em 390×844: o CTA da `/` foi de 2 para 5 linhas, o subtítulo do gate de 3 para 4, e o passo da `/whatsapp` ficou nas mesmas 5 apesar de 15% mais caracteres. Nenhum estoura o container nem gera scroll horizontal.

## O que não foi verificado

Nada disso aparece no app antes do deploy: o app carrega o site ao vivo. O Stripe real nunca foi exercitado, os webhooks são sintéticos. O envio do e-mail via Resend não roda no ambiente, então o que foi verificado é o texto, não a entrega nem a renderização.

## Fica para decisão, fora deste PR

**Seis ocorrências preexistentes** da mesma promessa de cobrança ficaram intactas: `index.html:504` e `:536`, `precos.html:220`, `:319` e `:773`, `home.html:2030`. Não são deste PR. A mais exposta é `precos.html:220`, o subtítulo padrão que todo visitante deslogado da página de preços lê, e a única sem a ressalva por número que a mesma página traz noventa linhas abaixo.

**O e-mail de boas-vindas para cadastro vindo do app iOS** segue na thread aberta. O mecanismo é real, mas o app não foi lançado e nenhuma conta com essa origem existe hoje. Foi adiado para ser decidido junto com a isenção do `PB_IN_APP` e com o gate do bot, que respondem à mesma pergunta.

**O gate de assinatura no bot do WhatsApp** vai em PR próprio: o teste importa `core.handle_incoming` → `ofxparse`, ausente no ambiente de desenvolvimento, e só é provável no CI. Anexá-lo aqui tornaria metade deste PR não-medível.

**Efeitos colaterais aceitos pelo dono:** uma aba com a `/precos` antiga aberta no instante do deploy mostra um toast vermelho ao clicar no botão velho do Grátis (não é beco sem saída, os CTAs pagos da mesma aba funcionam, e é por isso que o 410 carrega `detail.message` legível). E uma queda do Stripe passa a trancar 100% dos cadastros novos, porque o Grátis era a válvula de escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF