### PR TITLE
A copy mentia nos dois passos seguintes ao "Definir senha"

### DIFF
--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -780,20 +780,37 @@ def send_new_login_alert(
     )
 
 
-def send_password_reset_email(to: str, reset_url: str) -> bool:
-    """Envia e-mail com link de recuperação de senha."""
+def send_password_reset_email(to: str, reset_url: str, has_password: bool = True) -> bool:
+    """Envia e-mail com link de senha.
+
+    `has_password=False` (conta criada só via Google, sem `password_hash`) troca a
+    copy de "redefinir" para "definir" — ela nunca teve senha para redefinir.
+    """
+    if has_password:
+        intro = "Recebemos uma solicitação para redefinir a senha da sua conta no <strong>PigBank</strong>."
+        button = "🔑 Redefinir minha senha"
+        title = "Redefinição de senha — PigBank"
+        subject = "🔑 Redefinir senha — PigBank"
+    else:
+        intro = (
+            "Sua conta no <strong>PigBank</strong> foi criada com o Google e ainda não tem senha. "
+            "Use o link abaixo para definir uma."
+        )
+        button = "🔑 Definir minha senha"
+        title = "Definir senha — PigBank"
+        subject = "🔑 Definir sua senha — PigBank"
     content = f"""
       <p>Olá!</p>
-      <p>Recebemos uma solicitação para redefinir a senha da sua conta no <strong>PigBank</strong>.</p>
-      <p style="text-align:center"><a class="btn" href="{reset_url}">🔑 Redefinir minha senha</a></p>
+      <p>{intro}</p>
+      <p style="text-align:center"><a class="btn" href="{reset_url}">{button}</a></p>
       <p class="warn">⚠️ Este link expira em <strong>30 minutos</strong> e só pode ser usado uma vez.<br/>
         Se você não solicitou isso, ignore este e-mail.</p>
       <p style="font-size:12px;color:rgba(255,255,255,.25);word-break:break-all;text-align:center;margin-top:20px;">
         Link: {reset_url}</p>
     """
-    html = _base_html("Redefinição de senha — PigBank", content)
-    text = f"Redefinição de senha — PigBank\n\nLink (expira em 30 min):\n{reset_url}"
-    return send_email(to=to, subject="🔑 Redefinir senha — PigBank", html_body=html, text_body=text)
+    html = _base_html(title, content)
+    text = f"{title}\n\nLink (expira em 30 min):\n{reset_url}"
+    return send_email(to=to, subject=subject, html_body=html, text_body=text)
 
 
 def send_account_exists_notice(to: str, login_url: str = "", reset_url: str = "") -> bool:

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2899,7 +2899,7 @@ async def auth_forgot_password(request: Request, body: EmailBody):
     """
     import sys
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
-    from db import create_password_reset_token
+    from db import create_password_reset_token, email_has_password
     from core.services.email_service import send_password_reset_email
 
     await _check_auth_rate_limits("forgot-password", request, body.email)
@@ -2907,7 +2907,11 @@ async def auth_forgot_password(request: Request, body: EmailBody):
     token = create_password_reset_token(body.email)
     if token:
         reset_url = f"{DASHBOARD_URL}/reset-password#token={token}"
-        send_password_reset_email(body.email.strip().lower(), reset_url)
+        # a consulta fica DENTRO do if: o ramo "e-mail não existe" continua
+        # instrução por instrução igual, e a resposta abaixo nunca muda
+        send_password_reset_email(
+            body.email.strip().lower(), reset_url, email_has_password(body.email)
+        )
 
     # sempre retorna 200 — não revela se o e-mail existe ou não
     return {"message": "Se este e-mail estiver cadastrado, você receberá as instruções em breve."}

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -144,7 +144,7 @@
     var email=document.getElementById('email').value.trim();
     if(!email){document.getElementById('email').focus();return err('login-error','Digite seu e-mail acima primeiro.')}
     try{await fetch('/auth/forgot-password',{method:'POST',credentials:'same-origin',headers:csrfHeaders({'Content-Type':'application/json'}),body:JSON.stringify({email:email})})}catch(e){}
-    err('login-error','Se o e-mail existir, enviamos um link pra redefinir a senha.',true);
+    err('login-error','Se o e-mail existir, enviamos um link por e-mail.',true);
   }
 </script>
 </body>

--- a/frontend/reset-password.html
+++ b/frontend/reset-password.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>Redefinir senha · PigBank</title>
+<title>Escolha sua senha · PigBank</title>
 <meta name="robots" content="noindex" />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
@@ -39,12 +39,12 @@
 
       <!-- Formulário -->
       <div id="form-state">
-        <h1>Nova senha</h1>
-        <p class="auth-sub">Digite sua nova senha. O link expira em 30 minutos.</p>
+        <h1>Escolha sua senha</h1>
+        <p class="auth-sub">Ela vale para entrar no PigBank. O link expira em 30 minutos.</p>
         <div class="auth-error" id="msg-error"></div>
         <form id="reset-form" novalidate>
           <div class="field">
-            <label for="password">Nova senha</label>
+            <label for="password">Senha</label>
             <input type="password" id="password" placeholder="Mínimo 8 caracteres" autocomplete="new-password" required />
             <div class="strength">
               <div class="strength-bar"><div class="strength-fill" id="strength-fill"></div></div>
@@ -52,10 +52,10 @@
             </div>
           </div>
           <div class="field">
-            <label for="password2">Confirmar nova senha</label>
+            <label for="password2">Confirmar senha</label>
             <input type="password" id="password2" placeholder="Repita a senha" autocomplete="new-password" required />
           </div>
-          <button type="submit" class="btn btn-primary btn-block btn-lg" id="submit-btn">Redefinir senha</button>
+          <button type="submit" class="btn btn-primary btn-block btn-lg" id="submit-btn">Salvar senha</button>
         </form>
         <a href="/login" class="back">← Voltar para o login</a>
       </div>
@@ -63,8 +63,8 @@
       <!-- Sucesso -->
       <div class="success-state" id="success-state">
         <div class="success-icon"><i class="ph ph-check-circle" aria-hidden="true"></i></div>
-        <h1>Senha redefinida!</h1>
-        <p class="auth-sub">Sua senha foi alterada com sucesso. Agora você pode entrar com a nova senha.</p>
+        <h1>Senha salva!</h1>
+        <p class="auth-sub">Sua senha foi salva. Entre com ela para continuar.</p>
         <a href="/login" class="btn btn-primary btn-block btn-lg" style="margin-top:10px">Ir para o login</a>
       </div>
     </div>
@@ -80,6 +80,7 @@
   var successState = document.getElementById("success-state");
   var msgError = document.getElementById("msg-error");
   var submitBtn = document.getElementById("submit-btn");
+  var originalBtnText = submitBtn.textContent;
   var pwInput = document.getElementById("password");
   var pw2Input = document.getElementById("password2");
   var strengthFill = document.getElementById("strength-fill");
@@ -116,7 +117,7 @@
     var pw = pwInput.value.trim(), pw2 = pw2Input.value.trim();
     if (pw.length < 8) return showError("A senha deve ter pelo menos 8 caracteres.");
     if (pw !== pw2) return showError("As senhas não coincidem.");
-    submitBtn.disabled = true; submitBtn.textContent = "Redefinindo…";
+    submitBtn.disabled = true; submitBtn.textContent = "Salvando…";
     try {
       var res = await fetch("/auth/reset-password", {
         method: "POST", credentials: "same-origin",
@@ -124,11 +125,11 @@
         body: JSON.stringify({ token: token, new_password: pw }),
       });
       var data = await res.json().catch(function(){ return {}; });
-      if (!res.ok) throw new Error(data.detail || "Erro ao redefinir senha.");
+      if (!res.ok) throw new Error(data.detail || "Erro ao salvar a senha.");
       formState.style.display = "none";
       successState.style.display = "block";
     } catch (err) {
-      showError(err.message); submitBtn.disabled = false; submitBtn.textContent = "Redefinir senha";
+      showError(err.message); submitBtn.disabled = false; submitBtn.textContent = originalBtnText;
     }
   });
 </script>

--- a/frontend/routes/settings.py
+++ b/frontend/routes/settings.py
@@ -359,17 +359,23 @@ async def security_password_reset_route(request: Request, user_id: int):
     if not email:
         raise HTTPException(status_code=400, detail="Adicione um e-mail antes de resetar a senha.")
 
-    from db import create_password_reset_token
+    from db import auth_account_has_password, create_password_reset_token
     from core.services.email_service import send_password_reset_email
 
     token = await asyncio.to_thread(create_password_reset_token, email)
     if not token:
         raise HTTPException(status_code=404, detail="Conta de e-mail não encontrada.")
+    has_password = await asyncio.to_thread(auth_account_has_password, user_id)
     reset_url = f"{shared.DASHBOARD_URL}/reset-password#token={token}"
-    sent = await asyncio.to_thread(send_password_reset_email, email.strip().lower(), reset_url)
+    sent = await asyncio.to_thread(send_password_reset_email, email.strip().lower(), reset_url, has_password)
     if not sent:
         raise HTTPException(status_code=500, detail="Não foi possível enviar o e-mail de reset.")
-    return {"ok": True, "message": "Enviamos um link de redefinição de senha para o seu e-mail."}
+    message = (
+        "Enviamos um link de redefinição de senha para o seu e-mail."
+        if has_password
+        else "Enviamos um link para você definir sua senha. Confira seu e-mail."
+    )
+    return {"ok": True, "message": message}
 
 
 @router.get("/settings/{user_id}/activity")

--- a/tests/test_copy_definir_senha.py
+++ b/tests/test_copy_definir_senha.py
@@ -1,0 +1,267 @@
+"""
+Copy de "definir senha" — conta criada só via Google tem
+`auth_accounts.password_hash IS NULL` e NUNCA teve senha. O e-mail e a página de
+destino não podem dizer "redefinir" para ela.
+
+Espia `core.services.email_service.send_email` (a ORIGEM), não
+`send_password_reset_email`: os dois chamadores importam a função dentro do corpo,
+então o patch na origem pega os dois *e* o texto real é construído pelo código sob
+teste.
+
+`"redefin"` é usado como raiz nas asserções — cobre redefinir/redefinição/redefinida
+de uma vez. Atenção: `"definir" in "redefinir"` é **True**, então `"definir" in ...`
+sozinho NÃO discrimina — quem discrimina é sempre o `"redefin" not in ...` ao lado.
+
+CONTROLES NEGATIVOS DO GRUPO (os cinco MEDIDOS — 1-3 na rodada 1, 4-5 na rodada 2):
+1. `has_password = True` no topo de `send_password_reset_email` → 3 vermelhos:
+   `test_email_sem_senha_diz_definir` (no html e no texto puro), `test_password_reset_route_conta_google`
+   e `test_forgot_password_conta_google` (nos dois, no assunto).
+2. `settings.py` voltando à string única de `message` → 1 vermelho:
+   `test_password_reset_route_conta_google` (na asserção do `message`).
+3. `git checkout origin/main -- frontend/reset-password.html` → 1 vermelho:
+   `test_pagina_reset_nao_promete_redefinicao` (no `<title>`; e, mutando SÓ o `<h1>`
+   de sucesso com o `<title>` já correto, no `h1` — a asserção não para no primeiro
+   elemento).
+4. `email_has_password(body.email)` → `False` fixo no monólito (todo mundo passa a
+   receber "definir") → 1 vermelho: `test_forgot_password_conta_com_senha`. Esta
+   mutação passava VERDE na rodada 1 — era o buraco do Grupo C.
+5. `git checkout origin/main -- frontend/login.html` → 1 vermelho:
+   `test_pagina_login_nao_promete_redefinicao` (o toast é a ÚNICA linha diferente
+   dentro do corpo de `doForgot`, que é o trecho que a asserção lê).
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.shared as shared
+from core.services.email_service import send_password_reset_email
+from db.connection import get_conn
+from tests._helpers_pii import insert_auth_account_pii
+
+RESET_URL = "https://pigbankai.com/reset-password#token=abc123"
+
+# A invariante anti-enumeração do /auth/forgot-password: mesmo corpo, exista ou não
+# a conta. Escrita como IGUALDADE, não como `in`.
+CORPO_ANONIMO = {"message": "Se este e-mail estiver cadastrado, você receberá as instruções em breve."}
+
+
+@pytest.fixture
+def spy_email(monkeypatch):
+    """Captura o e-mail em vez de enviar. Devolve True de propósito: com False a
+    rota do settings responde 500 (RESEND_API_KEY ausente aqui — CLAUDE.md §6)."""
+    import core.services.email_service as es
+
+    captured: dict = {}
+
+    def fake_send(to, subject, html_body, text_body=None, from_addr=None, headers=None, attachments=None):
+        captured.update(to=to, subject=subject, html=html_body, text=text_body)
+        return True
+
+    monkeypatch.setattr(es, "send_email", fake_send)
+    return captured
+
+
+@pytest.fixture
+def sem_rate_limit(monkeypatch):
+    """3/minute na rota do settings, 3/hour no forgot-password."""
+    monkeypatch.setattr(shared.limiter, "enabled", False)
+    monkeypatch.setattr(dashboard.limiter, "enabled", False)
+
+
+def _cria_conta(user_id: int, *, com_senha: bool) -> str:
+    """Conta via helper PII — insert SQL cru sem `email_hash` vira órfão invisível
+    para os dois lookups (`email_has_password` e `create_password_reset_token`)."""
+    email = f"copy-senha-{uuid.uuid4().hex[:10]}@test.local"
+    with get_conn() as conn, conn.cursor() as cur:
+        insert_auth_account_pii(cur, user_id, email, password_hash="hash" if com_senha else None)
+        conn.commit()
+    return email
+
+
+def _client_for(user_id: int, email: str) -> tuple[TestClient, dict]:
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(user_id, email))
+    client.cookies.set(dashboard.DASHBOARD_COOKIE_NAME, dashboard.make_dashboard_token(user_id, hours=1))
+    csrf = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, csrf)
+    return client, {dashboard.CSRF_HEADER_NAME: csrf}
+
+
+def _limpa_rate_limits(*identifiers: str) -> None:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("delete from auth_rate_limits where identifier = any(%s)", (list(identifiers),))
+        conn.commit()
+
+
+# ── Grupo A — a função, até o send_email ──────────────────────────────────────
+
+def test_email_sem_senha_diz_definir(spy_email):
+    assert send_password_reset_email("alguem@test.local", RESET_URL, False) is True
+
+    assert "definir" in spy_email["subject"].lower()
+    assert "redefin" not in spy_email["html"].lower()
+    assert "redefin" not in spy_email["text"].lower()  # preview do cliente e notificação do celular
+    assert "redefin" not in spy_email["subject"].lower()
+    assert RESET_URL in spy_email["html"]
+
+
+def test_email_com_senha_mantem_redefinir(spy_email):
+    """POSITIVO: o caminho legítimo não mudou — nem explícito, nem por default.
+    Assunto, html E texto puro: só o assunto deixava o CORPO do caso comum (a
+    maioria dos usuários) virar a copy de conta Google sem uma linha vermelha."""
+    send_password_reset_email("alguem@test.local", RESET_URL, True)
+    explicito = (spy_email["subject"], spy_email["html"], spy_email["text"])
+
+    send_password_reset_email("alguem@test.local", RESET_URL)  # argumento omitido
+    default = (spy_email["subject"], spy_email["html"], spy_email["text"])
+
+    assert all("redefin" in parte.lower() for parte in explicito), explicito
+    assert default == explicito
+
+
+# ── Grupo B — rota autenticada, ponta a ponta com banco ───────────────────────
+
+def test_password_reset_route_conta_google(user_id, spy_email, sem_rate_limit):
+    email = _cria_conta(user_id, com_senha=False)
+    client, headers = _client_for(user_id, email)
+
+    resp = client.post(f"/settings/{user_id}/password-reset", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert "definir" in resp.json()["message"].lower()
+    assert "redefin" not in resp.json()["message"].lower()
+    assert "redefin" not in spy_email["subject"].lower()
+
+
+def test_password_reset_route_conta_com_senha(user_id, spy_email, sem_rate_limit):
+    """POSITIVO: quem TEM senha continua lendo "redefinir" nos dois pontos."""
+    email = _cria_conta(user_id, com_senha=True)
+    client, headers = _client_for(user_id, email)
+
+    resp = client.post(f"/settings/{user_id}/password-reset", headers=headers)
+
+    assert resp.status_code == 200, resp.text
+    assert "redefin" in resp.json()["message"].lower()
+    assert "redefin" in spy_email["subject"].lower()
+
+
+# ── Grupo C — anônimo. A resposta é invariante; só o e-mail muda ──────────────
+
+def test_forgot_password_conta_google(user_id, spy_email, sem_rate_limit):
+    email = _cria_conta(user_id, com_senha=False)
+    client = TestClient(dashboard.app)
+    csrf = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, csrf)
+    _limpa_rate_limits("ip:testclient", f"email:{email}")
+
+    try:
+        resp = client.post(
+            "/auth/forgot-password",
+            headers={dashboard.CSRF_HEADER_NAME: csrf},
+            json={"email": email},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == CORPO_ANONIMO  # igualdade: nada vaza "não tem senha"
+        assert "definir" in spy_email["subject"].lower()
+        assert "redefin" not in spy_email["subject"].lower()
+    finally:
+        _limpa_rate_limits("ip:testclient", f"email:{email}")
+
+
+def test_forgot_password_conta_com_senha(user_id, spy_email, sem_rate_limit):
+    """POSITIVO: quem TEM senha continua recebendo "redefinir" pelo fluxo anônimo.
+    Sem este caso o Grupo C fica verde mesmo se o endpoint mandar "definir" para
+    TODO mundo. O corpo continua sendo o mesmo, por igualdade."""
+    email = _cria_conta(user_id, com_senha=True)
+    client = TestClient(dashboard.app)
+    csrf = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, csrf)
+    _limpa_rate_limits("ip:testclient", f"email:{email}")
+
+    try:
+        resp = client.post(
+            "/auth/forgot-password",
+            headers={dashboard.CSRF_HEADER_NAME: csrf},
+            json={"email": email},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == CORPO_ANONIMO  # a invariante vale em TODOS os ramos
+        assert "redefin" in spy_email["subject"].lower()
+    finally:
+        _limpa_rate_limits("ip:testclient", f"email:{email}")
+
+
+def test_forgot_password_email_inexistente(spy_email, sem_rate_limit):
+    """POSITIVO/anti-enumeração: e-mail que não existe devolve o MESMO corpo, e
+    nenhum e-mail sai."""
+    email = f"nao-existe-{uuid.uuid4().hex}@test.local"
+    client = TestClient(dashboard.app)
+    csrf = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, csrf)
+    _limpa_rate_limits("ip:testclient", f"email:{email}")
+
+    try:
+        resp = client.post(
+            "/auth/forgot-password",
+            headers={dashboard.CSRF_HEADER_NAME: csrf},
+            json={"email": email},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == CORPO_ANONIMO
+        assert spy_email == {}  # nenhum envio capturado
+    finally:
+        _limpa_rate_limits("ip:testclient", f"email:{email}")
+
+
+# ── Grupo D — a página, servida pela rota ─────────────────────────────────────
+#
+# A asserção mira os ELEMENTOS que o usuário lê, não o documento inteiro:
+# `"redefin" not in resp.text` proibia a palavra em qualquer id, comentário ou
+# handler do arquivo e travava correção futura que precisasse dela no markup.
+# Extração por regex porque é o que o repo já faz com HTML (tests/test_error_pages.py:96,
+# tests/test_phosphor_subset.py:27) — nenhum parser novo.
+
+# nome -> (regex de captura, mínimo de ocorrências)
+ELEMENTOS_RESET = {
+    "title": (r"<title>(.*?)</title>", 1),
+    "h1": (r"<h1>(.*?)</h1>", 2),                        # formulário + sucesso
+    "subtitulo": (r'<p class="auth-sub">(.*?)</p>', 2),  # formulário + sucesso
+    "label": (r"<label[^>]*>(.*?)</label>", 2),
+    "botao": (r'id="submit-btn"[^>]*>(.*?)</button>', 1),
+    "botao_enviando": (r'submitBtn\.textContent = "(.*?)"', 1),
+}
+
+
+def test_pagina_reset_nao_promete_redefinicao():
+    resp = TestClient(dashboard.app).get("/reset-password")
+    assert resp.status_code == 200
+
+    for nome, (regex, minimo) in ELEMENTOS_RESET.items():
+        textos = re.findall(regex, resp.text, re.S)
+        # sem isto, um regex que deixou de casar passa verde sem medir nada
+        assert len(textos) >= minimo, f"{nome}: {len(textos)} ocorrência(s), esperado >= {minimo}"
+        for texto in textos:
+            assert "redefin" not in texto.lower(), f"{nome} promete redefinição: {texto!r}"
+
+
+def test_pagina_login_nao_promete_redefinicao():
+    """A primeira coisa que o usuário só-Google lê ao clicar "Esqueci minha senha"
+    é o toast de `login.html`, ANTES de qualquer resposta do servidor. Ele não pode
+    saber se a conta tem senha (seria enumeração), então tem de ser genérico.
+
+    Mira o corpo de `doForgot` — as mensagens desse fluxo — e não o arquivo inteiro."""
+    resp = TestClient(dashboard.app).get("/login")
+    assert resp.status_code == 200
+
+    corpo = re.search(r"async function doForgot\(.*?\n  \}", resp.text, re.S)
+    assert corpo, "doForgot não encontrado — o teste deixou de medir o toast"
+    assert "err('login-error'" in corpo.group(0)  # o toast está mesmo dentro do trecho
+    assert "redefin" not in corpo.group(0).lower(), corpo.group(0)


### PR DESCRIPTION
Segue o #232. Ele consertou os 401 nos 6 endpoints; a costura de copy dos dois passos
seguintes ficou de fora dele **de propósito**, e é este PR.

## O defeito

Conta criada só via Google (`auth_accounts.password_hash IS NULL`) clicava em "Definir
senha", recebia um e-mail dizendo "Recebemos uma solicitação para **redefinir** a senha" e
caía numa página cujo `<title>` e botão diziam "**Redefinir** senha" — para uma senha que
nunca existiu.

Verificado antes de planejar: `create_password_reset_token_impl` (`db_support.py:1017`) só
exige que o e-mail exista, **não** exige `password_hash`. O fluxo funciona ponta a ponta
hoje; a copy era a lacuna inteira.

## A regra que organiza o diff

**Onde o servidor sabe quem é o usuário, a copy varia. Onde não sabe, fica neutra.**

| Passo | Conta só-Google | Conta com senha |
|---|---|---|
| toast da rota (`routes/settings.py:376`) | "…definir sua senha" | "…redefinição de senha" *(igual a hoje)* |
| assunto + corpo + `text/plain` (`email_service.py:783`) | "Definir" | "Redefinir" *(igual a hoje)* |
| `reset-password.html` | "Escolha sua senha" | idem |
| `login.html:147` | "enviamos um link por e-mail" | idem |

`send_password_reset_email` ganhou `has_password: bool = True`. **Nenhuma função nova em
`db/`** — `auth_account_has_password` e `email_has_password` já existiam em
`db/google_auth.py` e já estavam exportadas.

## Anti-enumeração (o ponto que mais merece revisão)

`/auth/forgot-password` é chamado por usuário **anônimo** e a vagueza da resposta lá é
deliberada. O que foi feito e medido:

- a consulta nova fica **dentro do `if token:`** — ramo que só roda quando a conta existe e
  que já executa `resend.Emails.send(...)` bloqueante inline;
- as três respostas (e-mail inexistente / conta com senha / conta só-Google) são **idênticas
  em status, corpo e todos os headers exceto `date`**;
- o teste asserta o corpo por **igualdade**, não por `in`;
- o `return` não foi tocado.

Ressalva honesta: o ramo "e-mail existe" já era assimétrico antes deste PR (o `INSERT` em
`password_reset_tokens` só roda lá). Se `email_has_password` levantasse, e-mail existente
daria 503 e inexistente 200 — mas o mesmo vale na `main` fazendo `secrets.token_urlsafe`
falhar (500 × 200). O diff acrescenta uma query à janela já assimétrica; **não é regressão
dele**, e o comentário no código não deve prometer mais que isso.

## Por que a página ficou genérica

`reset-password.html` não sabe quem é o usuário antes de consumir o token. Rejeitados:

- **querystring** — vazaria no Referer (o `#token=` está no fragmento de propósito) e
  morreria no `history.replaceState` da linha 77, que descarta search *e* hash;
- **campo no token** — migração de schema + um endpoint anônimo novo, para consertar 7 strings.

A primeira tentativa usou "Defina sua senha", e o Tester provou que isso **só invertia a
mentira**: quem tem senha recebia e-mail dizendo "Redefinir" e abria página dizendo "Defina".
Daí "Escolha sua senha", que serve aos dois.

`login.html:147` entrou pela varredura da categoria (§2) — era a mesma mentira, na primeira
coisa que a pessoa lê depois de clicar em "Esqueci minha senha". Fica sem verbo, porque roda
antes de qualquer resposta do servidor e não pode saber se a conta tem senha.

## A tela de sucesso, e duas redações descartadas

Ficou `"Sua senha foi salva. Entre com ela para continuar."` — só o que o commit único de
`db_support.py:1079-1091` garante (se ele falhar, a tela de sucesso nem aparece).

Duas redações foram escritas e removidas por não serem verdade em todo caminho:

- **"as outras sessões foram encerradas"** — `revoke_other_sessions` (`core/sessions.py:178-180`)
  e `revoke_user_refresh_tokens` (`core/refresh_tokens.py:248-250`) **engolem a própria
  exceção e devolvem 0**. Numa falha de banco a rota devolve 200, a tela mostra sucesso e nada
  revogou. Tornar isso verdade custaria contrato novo em duas funções compartilhadas — fora
  deste PR.
- **"nenhuma senha antiga vale mais"** — afirma um passado que a conta só-Google nunca teve.
  Era a mesma classe de mentira, reintroduzida pela própria correção.

## Testes — os dois controles (§3)

`tests/test_copy_definir_senha.py`, 9 casos. Espia `email_service.send_email` (não
`send_password_reset_email`), então o texto é construído pelo código sob teste.

**Negativo — 5 mutações, cada uma deixando vermelho um caso que estava verde:**

| mutação | vermelhos |
|---|---|
| `has_password = True` no topo de `send_password_reset_email` | 3 |
| `settings.py` volta à string única de `message` | 1 |
| `reset-password.html` da `main` | 1 |
| `email_has_password(...)` → `False` fixo no monólito | 1 |
| `login.html` da `main` | 1 |

**Positivo** — conta COM senha continua recebendo "redefinir", nos dois emissores, e no
`subject`, no `html` **e no `text/plain`** (que é o que a notificação do celular mostra).
Sem esse caso, trocar o booleano por `False` fixo passava verde e **todo usuário comum**
receberia o texto de conta Google.

Duas armadilhas encontradas durante o ciclo e fechadas: `"definir" in "redefinir"` é `True`
(a asserção óbvia é tautológica — daí o `"redefin" not in` ao lado), e a asserção sobre a
página inteira foi trocada por asserção **por elemento** (`<title>`, `<h1>`, botão,
subtítulos), que não trava correções futuras.

## Medições

- **Suíte**: `origin/main` (`baefb02`) e este branch com **os mesmos 11 nomes vermelhos**
  (fuso/NLP — a rodada caiu 00:05 UTC, a janela conhecida). **Nenhum nome novo.** +9 passed
  = os casos deste PR.
- `npm run test:frontend`: **261 / 261**.
- Default byte a byte: `send_password_reset_email(to, url)` sem o 3º argumento renderiza
  `subject`+`html`+`text` idênticos à `main`.
- Isolamento: `auth_account_has_password(user_id)` filtra `where user_id=%s`, com o `user_id`
  já autorizado por `authorize_dashboard_access`. Usuário B chamando `/settings/{A}/password-reset`
  → **403**, zero e-mails.
- `frontend/service-worker.js` **não foi tocado** — e o gate não se aplicaria de qualquer
  forma: o SW faz `if (request.mode === "navigate") return;` e `html_file()` serve `no-store`,
  então essas páginas nunca entram no Cache Storage.

## Não verificado aqui (§7)

- **A entrega real do e-mail.** `send_email` é mockado em **100%** dos casos. Assunto
  recusado pelo Resend ou HTML quebrado no cliente: invisível nesta suíte.
- **A renderização.** Nenhuma medição de DOM das strings novas — quebra de linha, estouro do
  card, truncamento do toast em 320px. O app carrega o site ao vivo, então isso só aparece
  **depois do deploy**.
- **O fluxo Google real.** As contas `password_hash IS NULL` foram montadas via
  `insert_auth_account_pii`, como nos testes do #232; ninguém passou pelo `/auth/google/start`.

## Fora de escopo, deliberado

- **`login.html`, `doForgot`**: o toast afirma "enviamos um link" em **verde** mesmo com 429,
  500 ou rede caída — `res` é ignorado e o `catch(e){}` é vazio. Medido no Chromium nos três
  cenários, e alcançável de verdade (`EMAIL_RATE_LIMITS["forgot-password"] = (3, 3600)`).
  **Pré-existente** — a `main` tem o mesmo comportamento com outra redação — e é outro bug
  (falta tratar erro, não copy errada). Anotado como tarefa separada.
- `core/audit.py:41` (`"Senha redefinida"` no histórico), `{"message": "Senha redefinida com
  sucesso!"}` do `/auth/reset-password` (string morta — a página descarta `data.message` no
  sucesso), e a divergência de `password_hash = ''` entre `auth_account_has_password` e
  `email_has_password` (provada **inalcançável**: nenhum caminho de produção grava `''`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)