### PR TITLE
Clicar "Ativar agora" no convite de MFA queimava um convite de uso único

### DIFF
--- a/db/mfa.py
+++ b/db/mfa.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import logging
 import os
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -27,6 +28,7 @@ from cryptography.fernet import Fernet, InvalidToken
 
 from .connection import get_conn
 
+logger = logging.getLogger(__name__)
 
 _BACKUP_CODE_COUNT = 10
 _BACKUP_CODE_LENGTH = 10  # caracteres (alfanumerico legivel)
@@ -212,6 +214,26 @@ def verify_and_enable(user_id: int, code: str) -> list[str]:
                     (user_id, _hash_backup_code(code_plain)),
                 )
         conn.commit()
+
+    # O convite da /home some sozinho enquanto o MFA esta ligado, mas `disable_mfa`
+    # apaga a linha e o left join volta a `enabled = NULL` — sem marcar aqui, quem
+    # ativou e depois desligou volta a ser convidado em TODA carga da /home, para
+    # sempre. Marcar na ATIVACAO grava um fato; marcar no clique de "Ativar agora"
+    # gravava uma intencao e punia quem abandonava o setup no meio (por isso o
+    # botao nao marca mais — frontend/home.html).
+    #
+    # O erro e ENGOLIDO de proposito, e isto nao e defensivo demais: o commit
+    # acima ja ligou o MFA, e `backup_codes` so existe em texto puro dentro deste
+    # `return` — sao os 10 codigos mostrados UMA vez, a unica saida de quem perde
+    # o celular. Deixar esta cauda propagar troca "o convite reaparece" (o pior
+    # caso dela falhar) por "MFA ligado, codigos perdidos, 409 na retentativa" —
+    # escrita nova depois do ponto sem volta, a classe do `mark_bill_paid`
+    # (CLAUDE.md §1). O endpoint so trata ValueError, entao qualquer outra virava
+    # 500 em cima de uma ativacao que ja aconteceu.
+    try:
+        mark_mfa_onboarding_shown(user_id)
+    except Exception as exc:  # nunca derruba a resposta do enable
+        logger.warning("mfa onboarding mark falhou user=%s: %s", user_id, exc)
 
     return backup_codes
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1650,18 +1650,24 @@ window.pigModalKeys && pigModalKeys("mfa-onboarding-overlay", function () { mfaO
 
 async function _markMfaOnboardingSeen() {
   try {
-    await fetch(`${API}/auth/mfa/onboarding-seen`, {
+    const r = await fetch(`${API}/auth/mfa/onboarding-seen`, {
       method: "POST",
       credentials: "same-origin",
       headers: csrfHeaders({ "Content-Type": "application/json" }),
     });
+    if (!r.ok) console.warn("[mfa-onboarding] servidor recusou marcar como visto", r.status);
+    // `fetch` não lança em 4xx/5xx: sem esta linha o "Agora não" — hoje o único
+    // caminho que queima o convite — falha aberto e sem sinal nenhum.
   } catch (e) {
     console.warn("[mfa-onboarding] erro ao marcar como visto", e);
   }
 }
 
 async function mfaOnboardingActivate() {
-  await _markMfaOnboardingSeen();
+  // Não marca como visto de propósito: marcar no CLIQUE puniria quem abandona o
+  // setup no meio, que perderia o convite sem ter ativado nada. Quem conclui é
+  // marcado na ATIVAÇÃO, dentro de `verify_and_enable` (db/mfa.py) — e não por
+  // `not mfa_enabled`, que desfaz sozinho quando a pessoa desliga o MFA.
   window.location.href = "/settings?view=security&autoOpenMfa=1";
 }
 
@@ -1726,8 +1732,8 @@ Object.assign(window, {
     <h2>Proteja sua conta com 2 etapas</h2>
     <p>
       Adicione uma camada extra de segurança usando um app autenticador
-      (Google Authenticator, Authy, 1Password). Mesmo que sua senha vaze,
-      ninguém entra sem o código do seu celular.
+      (Google Authenticator, Authy, 1Password). Mesmo que alguém descubra
+      seus dados de acesso, ninguém entra sem o código do seu celular.
     </p>
     <ul class="mfa-ob-list">
       <li>Setup leva 1 minuto</li>

--- a/scripts/reset_mfa_onboarding_sem_senha.py
+++ b/scripts/reset_mfa_onboarding_sem_senha.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Devolve o convite de MFA às contas sem senha que já o gastaram.
+
+Conta criada só via Google tem `auth_accounts.password_hash` NULL, e o setup de
+MFA re-autentica por senha. O convite da /home é de UMA VEZ SÓ: qualquer coisa
+que grave `mfa_onboarding_shown_at` o apaga para sempre — e o "Ativar agora"
+gravava, então essas contas iam ao settings só para levar erro e voltavam sem
+convite. O "Ativar agora" não marca mais (frontend/home.html) e o settings agora
+tem "Definir senha" para elas (#232); este script repara o que já aconteceu,
+zerando `mfa_onboarding_shown_at` das contas SEM senha.
+
+O predicado NÃO distingue quem clicou "Ativar agora" de quem clicou "Agora não"
+(nem do Esc, que roteia pelo dismiss): os três gravavam o mesmo timestamp. Então
+o script PODE devolver o convite a quem dispensou de propósito. Separá-los
+exigiria coluna nova, que o dono vetou; o custo do falso positivo é ver o overlay
+mais uma vez, e agora ele leva a um lugar útil — o funil de senha do #232.
+
+Também não se aperta o predicado com `mfa_onboarding_shown_at < <data do deploy>`:
+sendo one-shot rodado logo APÓS o deploy, toda linha alvo já é pré-deploy e o
+filtro seria redundante. Quem rodar isto meses depois perde essa garantia — aí a
+data volta a fazer diferença e tem de entrar no `_ALVO`.
+
+Conta COM senha nunca é tocada — e não porque o `shown_at` dela signifique "viu e
+decidiu": quem tem senha e abandonou o setup no meio queimou o convite igual.
+É que elas são a base inteira; alargar o predicado para elas re-incomodaria todo
+mundo que dispensou legitimamente, risco muito maior que o reparo.
+
+O UPDATE não chama `invalidate_auth_user_cache`, contrariando o "chame após
+QUALQUER escrita em auth_accounts" de `db_support.py:541` — e não tem como: é
+outro processo. Já verificado, é inofensivo: o `select` do cache
+(`db_support.py:566-576`) não traz `mfa_onboarding_shown_at`, e o único leitor da
+coluna (`should_show_mfa_onboarding`, `db/mfa.py:396`) vai ao banco direto.
+
+É one-shot e idempotente: depois de aplicar, as linhas alvo ficam com
+`mfa_onboarding_shown_at` NULL e deixam de casar com o WHERE — rodar de novo
+reporta 0. Por isso mora aqui e não no `init_db()`, que é para estrutura de
+schema, não para correção histórica de dados rodando em todo boot.
+
+Uso:
+    # PRÉ-REQUISITO: rode só DEPOIS do deploy do frontend. Nada impede a escrita
+    # de acontecer de novo — uma aba da /home carregada ANTES do deploy ainda tem
+    # o "Ativar agora" que marcava, e re-queima o convite que este script acabou
+    # de devolver. A janela é só essa: o service worker não cacheia o HTML da
+    # /home — ele sai antes de qualquer cache no `if (request.mode ===
+    # "navigate") return;` (frontend/service-worker.js:103) —, então quem
+    # recarregar já pega a versão nova.
+    .venv/bin/python -m scripts.reset_mfa_onboarding_sem_senha            # dry-run (só conta)
+    .venv/bin/python -m scripts.reset_mfa_onboarding_sem_senha --apply    # aplica
+"""
+from __future__ import annotations
+
+import argparse
+
+import db
+
+# Uma fonte de verdade para o alvo: as duas queries usam LITERALMENTE o mesmo
+# predicado, então o número do dry-run é o número que o --apply altera. Só o
+# `where` mora aqui de propósito — com o `from auth_accounts` junto, o UPDATE
+# viraria `update auth_accounts ... from auth_accounts`, que o Postgres NEM
+# PARSA: `DuplicateAlias: table name "auth_accounts" specified more than once`.
+# Estouraria só no --apply, porque o dry-run não usa o `from` — passando batido
+# na revisão e quebrando na hora de reparar produção.
+_ALVO = "where password_hash is null and mfa_onboarding_shown_at is not null"
+
+
+def reparar(apply: bool = False) -> int:
+    """Sem `apply`, conta o alvo sem escrever nada. Com `apply`, zera o
+    `mfa_onboarding_shown_at` do alvo numa transação e devolve quantas linhas
+    mudaram."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(f"select count(*) as n from auth_accounts {_ALVO}")
+        total = int(cur.fetchone()["n"])
+        if not apply or not total:
+            return total
+        cur.execute(f"update auth_accounts set mfa_onboarding_shown_at = null {_ALVO}")
+        alteradas = cur.rowcount
+        conn.commit()
+    return alteradas
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true",
+                    help="aplica de verdade (sem isso, só conta — dry-run)")
+    args = ap.parse_args()
+
+    total = reparar(apply=args.apply)
+    if args.apply:
+        print(f"{total} conta(s) sem senha tiveram o convite de MFA devolvido.")
+    else:
+        print(f"{total} conta(s) sem senha com o convite de MFA queimado.")
+        if total:
+            print("Rode de novo com --apply para reparar.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/frontend/modal_keys.test.mjs
+++ b/tests/frontend/modal_keys.test.mjs
@@ -305,3 +305,82 @@ test("home: Esc não dispensa o onboarding de MFA quando há diálogo por cima",
       "o diálogo de baixo tinha que continuar de pé");
   } finally { await page.close(); }
 });
+
+// ── o convite de MFA é de uma vez só: quem o gasta e quem não gasta ─────────
+//
+// Os TRÊS abaixo cobrem o lado do navegador. "Ativar agora" NÃO pode marcar: quem
+// abandona o setup no meio perderia o convite sem ter ativado nada. Quem conclui
+// é marcado no servidor, na ATIVAÇÃO (`verify_and_enable`, db/mfa.py) — e não por
+// `not mfa_enabled`, que desfaz sozinho quando a pessoa desliga o MFA e devolvia
+// o convite para sempre. "Agora não" TEM que marcar — sem isso o overlay persegue
+// todo mundo em todo login, que é pior que o bug — e, sendo hoje o único caminho
+// do navegador que o marca, não pode falhar mudo (o terceiro teste).
+// Todos abrem o overlay pela classe porque na home as funções que o abrem não
+// são globais (contrato do PBPages), como nos testes acima.
+
+async function homeComOnboarding(vistos) {
+  const page = await newPage();
+  await page.route("**/auth/mfa/onboarding-seen", (route) => {
+    vistos.push(1);
+    route.fulfill(json({}));
+  });
+  await page.goto(`${ORIGIN}/home.html`);
+  await page.waitForFunction(() => typeof window.mfaOnboardingActivate === "function");
+  await page.evaluate(() =>
+    document.getElementById("mfa-onboarding-overlay").classList.add("open"));
+  return page;
+}
+
+test('home: "Ativar agora" leva ao setup SEM gastar o convite', async () => {
+  const vistos = [];
+  const page = await homeComOnboarding(vistos);
+  try {
+    await page.click("#mfa-onboarding-overlay .mfa-ob-btn-primary");
+    // Espera a navegação: prova que o botão continua funcionando, e não que ele
+    // só ficou mudo. Esperar a URL nova fecha a corrida em vez de torcer contra
+    // ela — o POST tem toda a navegação para acontecer, e `vistos` vive no Node,
+    // sobrevivendo a ela. Medido: pega o `await` de volta, o fire-and-forget sem
+    // await, o `setTimeout`, e marcar DEPOIS do `location.href`.
+    // Timeout curto de propósito: a navegação é local e leva ~300ms; com o
+    // default de 30s, um botão morto custaria 30s de CI para dar a mesma resposta.
+    await page.waitForURL(/autoOpenMfa=1/, { timeout: 5000 });
+    assert.equal(vistos.length, 0,
+      '"Ativar agora" marcou o onboarding como visto: quem abandonar o setup perde o convite');
+  } finally { await page.close(); }
+});
+
+test('home: "Agora não" gasta o convite, como tem que ser', async () => {
+  const vistos = [];
+  const page = await homeComOnboarding(vistos);
+  try {
+    await page.click("#mfa-onboarding-overlay .mfa-ob-btn-secondary");
+    await page.waitForFunction(() =>
+      !document.getElementById("mfa-onboarding-overlay").classList.contains("open"));
+    assert.equal(vistos.length, 1,
+      '"Agora não" fechou sem marcar: o overlay voltaria em todo login');
+  } finally { await page.close(); }
+});
+
+test('home: "Agora não" que o servidor recusa deixa sinal no console', async () => {
+  // O `catch` do `_markMfaOnboardingSeen` só pega erro de REDE, e `fetch` não
+  // lança em 5xx: sem o `if (!r.ok)` o único caminho que ainda queima o convite
+  // falha aberto e MUDO — o overlay fecha e ninguém fica sabendo.
+  const page = await newPage();
+  const avisos = [];
+  try {
+    page.on("console", (m) => { if (m.text().includes("[mfa-onboarding]")) avisos.push(m.text()); });
+    await page.route("**/auth/mfa/onboarding-seen", (route) =>
+      route.fulfill({ status: 500, contentType: "application/json", body: "{}" }));
+    await page.goto(`${ORIGIN}/home.html`);
+    await page.waitForFunction(() => typeof window.mfaOnboardingDismiss === "function");
+    await page.evaluate(() =>
+      document.getElementById("mfa-onboarding-overlay").classList.add("open"));
+
+    await page.click("#mfa-onboarding-overlay .mfa-ob-btn-secondary");
+    await page.waitForFunction(() =>
+      !document.getElementById("mfa-onboarding-overlay").classList.contains("open"));
+
+    assert.equal(avisos.length, 1, "o 500 passou sem sinal nenhum no console");
+    assert.match(avisos[0], /500/, "o sinal não diz qual status voltou");
+  } finally { await page.close(); }
+});

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -8,8 +8,11 @@ Cobre:
 - Login em duas etapas: senha → challenge → codigo TOTP
 - Disable do MFA (exige senha + codigo)
 - Idempotencia e protecao contra re-ativacao
+- Onboarding: quem gasta o convite de UMA VEZ SO da /home, e o script que o
+  devolve a quem o perdeu sem poder aceitar (bloco no fim do arquivo)
 """
 import os
+import uuid
 
 import pyotp
 from cryptography.fernet import Fernet
@@ -20,6 +23,7 @@ os.environ.setdefault("MFA_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
 import db
 import frontend.finance_bot_websocket_custom as dashboard
+from scripts import reset_mfa_onboarding_sem_senha
 
 
 def _csrf_headers(client: TestClient) -> dict:
@@ -259,3 +263,255 @@ def test_mfa_verify_login_rejects_wrong_code(user_id):
         headers=_csrf_headers(client),
     )
     assert verify_resp.status_code == 400
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Onboarding de MFA — o convite de UMA VEZ SÓ e quem pode queimá-lo
+#
+# O overlay da /home é convidado para TODO usuário sem MFA, inclusive conta
+# só-Google (`password_hash` NULL): desde o #232 o settings oferece "Definir
+# senha" a ela, então o convite leva a um lugar útil. Quem queima o convite,
+# gravando `mfa_onboarding_shown_at`:
+#
+#   "Agora não" (e o Esc, que roteia pelo dismiss)  → marca. Frontend; a medição
+#       está em `tests/frontend/modal_keys.test.mjs`, não aqui.
+#   ATIVAR o MFA de verdade (`verify_and_enable`)   → marca. É um FATO.
+#   clicar "Ativar agora" e abandonar o setup       → NÃO marca, e o convite
+#       volta. Era o bug: o clique gravava uma INTENÇÃO.
+#   errar o código e desistir                       → NÃO marca. É a forma mais
+#       comum de abandonar, e por isso a marcação fica no FIM de
+#       `verify_and_enable`: ela depende do sucesso, não da tentativa.
+#
+# `not mfa_enabled` NÃO substitui a marcação da ativação: `disable_mfa` apaga a
+# linha de `user_mfa`, o left join volta a `enabled = NULL` e sem o `shown_at`
+# gravado o convite reapareceria para sempre em quem desligou o MFA de propósito.
+#
+# CONTROLES NEGATIVOS DO GRUPO — resultados MEDIDOS em 2026-09-02 com
+#   PYTEST_DB_ISOLATION=1 .venv/bin/python -m pytest tests/test_mfa.py -q
+# (as letras são deste bloco; remeça antes de reusar — §2 do CLAUDE.md):
+#
+# A) o convite não pode voltar a ser negado a conta sem senha: pondo
+#    `and db.auth_account_has_password(user_id)` no return de
+#    `should_show_mfa_onboarding`  →  1 failed, 22 passed (o arquivo inteiro: 23 testes)
+#      VERMELHO: test_auth_validate_convida_conta_so_google_ao_mfa
+#
+# B) alvo do script: removendo `and mfa_onboarding_shown_at is not null` do
+#    `_ALVO`  →  1 failed, 22 passed
+#      VERMELHO: test_script_repara_convite_queimado_e_e_idempotente, no
+#                `== antes + 1` (mediu `assert 2 == (2 + 1)`). Antes do delta
+#                exato este controle dava 0 failed: metade do `_ALVO` podia
+#                sumir sem uma linha vermelha.
+#
+# C) marcação na ATIVAÇÃO: trocando o `mark_mfa_onboarding_shown(user_id)` do
+#    fim de `verify_and_enable` por `pass`  →  1 failed, 22 passed
+#      VERMELHO: test_desligar_o_mfa_nao_re_arma_o_convite, em
+#                `should_show_mfa_onboarding ... assert True is False` — o nag
+#                permanente reproduzido.
+#
+# F) cauda advisory: tirando o try/except de volta da chamada em
+#    `verify_and_enable`  →  1 failed, 22 passed
+#      VERMELHO: test_cauda_do_onboarding_nao_pode_derrubar_a_ativacao, com a
+#                `RuntimeError` subindo — que no endpoint viraria 500 com o MFA
+#                já ligado e os 10 códigos de backup perdidos.
+#
+# G) marcação depende do SUCESSO: movendo a chamada para o INÍCIO de
+#    `verify_and_enable` (refatoração plausível: "marca a tentativa"). O número
+#    depende de o try/except viajar junto — as duas variantes foram medidas:
+#
+#    G1) move o BLOCO inteiro (try/except junto)  →  1 failed, 22 passed
+#          VERMELHO: test_codigo_errado_no_setup_nao_gasta_o_convite
+#                    ("tentativa falha gastou o convite").
+#    G2) move só a CHAMADA, guarda apagada        →  2 failed, 21 passed
+#          VERMELHO: os dois. Além do acima, cai
+#                    test_cauda_do_onboarding_nao_pode_derrubar_a_ativacao: o
+#                    monkeypatch dele passa a disparar ANTES da guarda, e a
+#                    RuntimeError sobe. É a soma de G com F, não um vermelho novo.
+#
+#    Antes de test_codigo_errado_no_setup_nao_gasta_o_convite existir, G2 passava
+#    sem uma linha vermelha (21/21, medido na árvore da rodada 2, quando o grupo
+#    tinha 21 testes): ele media "marcou quando concluiu" e não media "não marcou
+#    quando falhou".
+#
+# CONTROLE POSITIVO, o mesmo em todos: fica VERDE o
+# test_onboarding_aparece_para_conta_com_senha. Prova que a regra não virou
+# "convida todo mundo para sempre" — com senha, o convite é de uma vez só.
+#
+# ponytail: `reparar(apply=True)` e um UPDATE SEM filtro de usuario (o script e
+# global de proposito), entao estes testes so rodam sob PYTEST_DB_ISOLATION=1
+# (default e CI), onde o banco e um `pytest_<uuid>` vazio. Com
+# PYTEST_DB_ISOLATION=0 eles zeram `mfa_onboarding_shown_at` de TODA conta sem
+# senha do banco apontado. Se um dia precisarem rodar sem isolamento, ai sim
+# passe um filtro de user_id ao `reparar()`.
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _seed() -> int:
+    return uuid.uuid4().int % 100_000_000
+
+
+def _conta_so_google(seed: int) -> tuple[int, str]:
+    """Conta criada pelo FLUXO REAL do Google — é ele quem grava password_hash NULL."""
+    email = f"google-mfa-{seed}@test.com"
+    token = db.create_pending_google_signup(f"sub-google-mfa-{seed}", email, "Fulano")
+    result = db.consume_pending_google_signup(token, "Fulano", f"119{seed:08d}")
+    return int(result["user_id"]), email
+
+
+def _queimar_convite(user_id: int) -> None:
+    """Grava `mfa_onboarding_shown_at` por SQL cru — o mesmo estado que o
+    "Agora não" produz, e exatamente o que o script existe para reparar. Direto
+    no banco para não depender do endpoint nem de qual botão gravou."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "update auth_accounts set mfa_onboarding_shown_at = now() where user_id = %s",
+            (user_id,),
+        )
+        conn.commit()
+
+
+def _shown_at(user_id: int):
+    """Lê a coluna crua — é ela que o convite queima, e o que não pode ser tocado."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "select mfa_onboarding_shown_at from auth_accounts where user_id = %s",
+            (user_id,),
+        )
+        row = cur.fetchone()
+    return row["mfa_onboarding_shown_at"] if row else None
+
+
+def test_onboarding_aparece_para_conta_com_senha(user_id):
+    """Controle positivo: quem TEM senha continua sendo convidado, e o convite
+    continua sendo de uma vez só."""
+    uid = int(db.register_auth_user(f"mfa-onb-{user_id}@test.com", "senha-forte-123")["user_id"])
+
+    assert db.auth_account_has_password(uid) is True
+    assert db.should_show_mfa_onboarding(uid) is True
+
+    db.mark_mfa_onboarding_shown(uid)
+
+    assert db.should_show_mfa_onboarding(uid) is False
+    assert db.auth_account_has_password(uid) is True
+
+
+def test_desligar_o_mfa_nao_re_arma_o_convite(user_id):
+    """A conversa que `not mfa_enabled` sozinho NÃO cobre: ativar e desligar
+    depois. `disable_mfa` apaga a linha de `user_mfa`, o left join volta a
+    `enabled = NULL` e — se a ativação não tivesse marcado nada — o overlay
+    voltaria em TODA carga da /home, para sempre, em cima de quem já decidiu."""
+    email = f"mfa-onb-off-{user_id}@test.com"
+    uid = int(db.register_auth_user(email, "senha-forte-123")["user_id"])
+    assert db.should_show_mfa_onboarding(uid) is True
+
+    secret = db.mfa_setup_secret(uid, email)["secret"]
+    db.mfa_verify_and_enable(uid, pyotp.TOTP(secret).now())
+    assert db.should_show_mfa_onboarding(uid) is False
+
+    db.disable_mfa(uid)
+
+    assert db.get_mfa_status(uid)["enabled"] is False   # pré-condição: desligou mesmo
+    # A asserção que discrimina, e ela vem ANTES da do mecanismo de propósito:
+    # tirando a marcação da ativação, quem estoura é esta — a linha que descreve
+    # o que o usuário sente — e não um detalhe de qual coluna guarda o quê.
+    assert db.should_show_mfa_onboarding(uid) is False, \
+        "quem ativou e desligou o MFA voltou a ser convidado, em toda carga da /home"
+    assert _shown_at(uid) is not None      # o mecanismo: quem segura é o fato gravado
+
+
+def test_codigo_errado_no_setup_nao_gasta_o_convite(user_id):
+    """A outra metade do "grava um FATO, não uma INTENÇÃO": a forma mais comum de
+    abandonar o setup não é fechar a aba no QR, é errar o código e desistir. A
+    marcação tem de depender do SUCESSO de `verify_and_enable`, não da tentativa
+    — senão mover a chamada para o início dela (refatoração plausível: "marca a
+    tentativa") queimaria o convite com código errado, sem uma linha vermelha."""
+    email = f"mfa-onb-err-{user_id}@test.com"
+    uid = int(db.register_auth_user(email, "senha-forte-123")["user_id"])
+    db.mfa_setup_secret(uid, email)
+
+    import pytest   # local, como nos vizinhos deste arquivo
+    with pytest.raises(ValueError, match="MFA_CODE_INVALID"):
+        db.mfa_verify_and_enable(uid, "000000")
+
+    assert _shown_at(uid) is None, "tentativa falha gastou o convite"
+    assert db.should_show_mfa_onboarding(uid) is True
+
+
+def test_cauda_do_onboarding_nao_pode_derrubar_a_ativacao(user_id, monkeypatch):
+    """O commit que liga o MFA já aconteceu quando a marcação roda, e os 10
+    códigos de backup só existem em texto puro no `return` — se a cauda propagar,
+    `/auth/mfa/enable` (que só trata ValueError) devolve 500 com o MFA LIGADO e os
+    códigos perdidos, e a retentativa dá MFA_ALREADY_ENABLED. Escrita nova depois
+    do ponto sem volta: a classe do `mark_bill_paid` (CLAUDE.md §1)."""
+    email = f"mfa-onb-cauda-{user_id}@test.com"
+    uid = int(db.register_auth_user(email, "senha-forte-123")["user_id"])
+    secret = db.mfa_setup_secret(uid, email)["secret"]
+
+    import db.mfa as mfa_mod
+    def explode(_uid):
+        raise RuntimeError("banco fora no meio da cauda")
+    monkeypatch.setattr(mfa_mod, "mark_mfa_onboarding_shown", explode)
+
+    codigos = db.mfa_verify_and_enable(uid, pyotp.TOTP(secret).now())
+
+    assert len(codigos) == 10, "os códigos de backup se perderam com a cauda quebrada"
+    assert db.get_mfa_status(uid)["enabled"] is True
+    assert _shown_at(uid) is None      # a marcação falhou mesmo: o nag volta, e tudo bem
+
+
+def test_auth_validate_convida_conta_so_google_ao_mfa():
+    """Anti-regressão contra repor o gate de senha na leitura: conta só-Google É
+    convidada. Vai pelo endpoint que a /home realmente lê (home.html:1516 usa o
+    `validateData` do /auth/validate, não o /auth/me)."""
+    uid, _ = _conta_so_google(_seed())
+    assert db.auth_account_has_password(uid) is False
+    client = TestClient(dashboard.app)
+    client.cookies.set("dashboard_token", dashboard.make_dashboard_token(uid, hours=1))
+
+    resp = client.get("/auth/validate")
+
+    assert resp.status_code == 200
+    assert resp.json()["show_mfa_onboarding"] is True
+
+
+def test_script_repara_convite_queimado_e_e_idempotente():
+    uid, _ = _conta_so_google(_seed())
+    intacto, _ = _conta_so_google(_seed())   # sem senha, mas convite NUNCA queimado
+    antes = reset_mfa_onboarding_sem_senha.reparar()
+
+    _queimar_convite(uid)
+    assert _shown_at(uid) is not None
+    assert _shown_at(intacto) is None
+
+    # Delta EXATO de +1, e é ele que discrimina o `mfa_onboarding_shown_at is
+    # not null` do `_ALVO`: sem essa metade do predicado a conta `intacto` já
+    # entraria na contagem ANTES da queima e o delta seria 0. Com `>= 1` no
+    # lugar, apagar metade do predicado passa verde.
+    assert reset_mfa_onboarding_sem_senha.reparar() == antes + 1
+    assert _shown_at(uid) is not None        # dry-run não escreve
+
+    assert reset_mfa_onboarding_sem_senha.reparar(apply=True) >= 1
+    assert _shown_at(uid) is None
+
+    # idempotência: a segunda passada não muda mais esta linha
+    reset_mfa_onboarding_sem_senha.reparar(apply=True)
+    assert _shown_at(uid) is None
+
+
+def test_script_nao_toca_quem_tem_senha_nem_convite_intacto(user_id):
+    # (a) conta COM senha que já queimou o convite: não dá para saber se dispensou
+    #     ou abandonou o setup, e por isso ela fica fora do alvo do script
+    com_senha = int(
+        db.register_auth_user(f"mfa-script-{user_id}@test.com", "senha-forte-123")["user_id"]
+    )
+    db.mark_mfa_onboarding_shown(com_senha)
+    antes = _shown_at(com_senha)
+    assert antes is not None
+
+    # (b) conta só-Google que nunca viu o convite: já está NULL, nada a fazer
+    so_google, _ = _conta_so_google(_seed())
+    assert _shown_at(so_google) is None
+
+    reset_mfa_onboarding_sem_senha.reparar(apply=True)
+
+    assert _shown_at(com_senha) == antes
+    assert _shown_at(so_google) is None
+    assert db.should_show_mfa_onboarding(com_senha) is False


### PR DESCRIPTION
O overlay de duas etapas da `/home` aparece **uma vez só**. `mfaOnboardingActivate()` marcava como visto **antes** de navegar para o settings — então quem abandonava o setup no meio perdia o convite para sempre, sem ter ativado nada.

O relato veio de conta criada só via Google (`password_hash` NULL), mas o defeito nunca foi só dela: quem tem senha e desiste no QR, ou erra o código e não tenta de novo, paga igual.

## O que muda

A marcação sai do clique e vai para a **ativação efetiva** (`verify_and_enable`). Grava um fato, não uma intenção:

| o usuário | `mfa_onboarding_shown_at` | volta a ser convidado? |
|---|---|---|
| conclui o MFA | marcado | não — **nem se desligar depois** |
| abandona no QR | NULL | sim |
| erra o código e desiste | NULL | sim |
| "Agora não" / Esc | marcado | não *(inalterado)* |

A linha "nem se desligar depois" é o que o `not mfa_enabled` **não** garantia: `disable_mfa()` apaga a linha de `user_mfa`, o left join volta a `enabled = NULL`, e sem marcar na ativação o convite reaparecia em toda carga da `/home`, para sempre.

**A cauda é advisory e engole o erro de propósito.** Ela roda depois do `conn.commit()` que liga o MFA, e `backup_codes` só existe em texto puro naquele `return` — são os 10 códigos mostrados uma vez, a única saída de quem perde o celular. Propagar trocaria "o convite reaparece" por "MFA ligado, códigos perdidos, 409 na retentativa": escrita nova depois do ponto sem volta, a classe do `mark_bill_paid` (CLAUDE.md §1).

**Copy:** *"Mesmo que sua senha vaze"* ficou falsa para conta sem senha, que agora também vê o convite → *"Mesmo que alguém descubra seus dados de acesso"*.

**Sinal:** `_markMfaOnboardingSeen` agora loga quando o servidor recusa. "Agora não" virou a única saída do convite, e `fetch` não lança em 5xx — sem isso, um 500 era silêncio total.

## O script de reparo

`scripts/reset_mfa_onboarding_sem_senha.py` devolve o convite a quem já o perdeu **sem poder aceitar**: conta só-Google, cujo destino era um beco sem saída antes do #232. Dry-run por default, `--apply` muta, one-shot, idempotente.

**Ordem de operações — o deploy vem primeiro.** Uma aba da `/home` carregada antes do deploy ainda tem o "Ativar agora" que marcava, e re-queima o que o script devolveu.

**O `--apply` é global, sem `where user_id`** — a única query do PR sem filtro por usuário. É de propósito (o alvo é uma coluna nullable, não config de usuário), mas o dry-run antes é obrigatório.

Ele **pode** devolver o convite a quem clicou "Agora não" de propósito: os dois botões gravavam o mesmo timestamp e separá-los exigiria coluna nova. O custo é ver o overlay mais uma vez — e agora ele leva ao funil de senha do #232, não a um erro.

## Verificado aqui

- **Suíte completa: `5387 passed, 1 xfailed, 0 failed`** (111s, comando canônico da skill `baseline-testes`, sem `TZ=UTC`).
- `npm run test:frontend`: **264 pass, 0 fail**. `tests/test_mfa.py`: **23 passed**.
- **Controles negativos, por nome** (documentados no bloco de `tests/test_mfa.py`, cada um remedido pelo Tester e pelo Manager):

| injeção | vermelho |
|---|---|
| repor o gate no return de `should_show_mfa_onboarding` | `test_auth_validate_convida_conta_so_google_ao_mfa` |
| tirar `and mfa_onboarding_shown_at is not null` do `_ALVO` | `test_script_repara_convite_queimado_e_e_idempotente` |
| marcação → `pass` | `test_desligar_o_mfa_nao_re_arma_o_convite` |
| tirar o `try/except` da cauda | `test_cauda_do_onboarding_nao_pode_derrubar_a_ativacao` |
| marcação no **início** de `verify_and_enable` | `test_codigo_errado_no_setup_nao_gasta_o_convite` |
| tirar o `if (!r.ok)` | `home: "Agora não" que o servidor recusa deixa sinal no console` |
| repor o `await` no activate | `home: "Ativar agora" leva ao setup SEM gastar o convite` |

- **Controle positivo** verde em todos: `test_onboarding_aparece_para_conta_com_senha` — a mudança não virou "nunca marca", que seria pior que o bug.
- O teste do "Ativar agora" foi atacado com 4 mutantes (com `await`, sem `await`, `setTimeout`, marcar depois do `location.href`): todos vermelhos por asserção, nenhum por timeout.
- A célula que sustenta o desenho (conta sem senha clica "Ativar agora" e cai no funil de senha, não num beco) já tem lastro na main: `tests/frontend/settings_conta_sem_senha.test.mjs:152`.

## **Não** verificado

- **Nada no aparelho nem pós-deploy.** O app carrega o site ao vivo: a copy nova, o "Ativar agora" que não marca e o `console.warn` só existem depois do deploy. O que foi provado é Chromium headless + Postgres local.
- **O script nunca rodou contra produção.** Quantas contas ele alcança lá é **desconhecido** — o "0 conta(s)" medido é do banco de teste vazio.
- **O `--apply` nunca rodou pelo CLI**, só `reparar(apply=True)` direto nos testes. O `main()`/argparse foi exercitado só em dry-run.
- **A linha de log da cauda não tem teste.** `except Exception: pass` no lugar dela dá 23 passed — o grupo assere o resultado (MFA ligado, códigos devolvidos), não o log.

## Pendências nomeadas (fora deste PR)

1. **O nag é por carga da `/home`, não por login.** `/home` é link de navegação no settings, no dashboard e no comandos-app: quem clica "Ativar agora", cai no diálogo de senha e volta por "Minha conta" vê o overlay na hora. Mitigação de duas linhas (`sessionStorage` calando só a sessão corrente, convite vivo no servidor) — não implementada, é feature nova para um custo aceito.
2. **Copy irmã ainda imprecisa** para conta sem senha, no mesmo card: "Setup leva 1 minuto" e "Pode ativar depois em Configurações se preferir". Mesma classe da frase corrigida; não mexi em copy de produto sem decisão do dono.
3. **Forward-only:** quem ativou MFA **antes** deste deploy tem `shown_at` NULL e ainda pega o nag se desligar. Idêntico ao comportamento de hoje (o PR só reduz essa população), e o script não os alcança. Tamanho não medido.
4. **Quem TEM senha e abandonou** também queimou o convite e **não é reparado** — alargar o predicado re-incomodaria toda a base que dispensou legitimamente.

## Nota para o CI

O verde local foi medido **sem** `TZ=UTC PGTZ=UTC`. Forçar essas variáveis perto da virada UTC derruba `test_fuso_do_app.py` e `test_dia_das_listagens_no_fuso.py` — 10 falsos vermelhos, nenhum relacionado a este diff. Se o CI abrir vermelho na janela 00–03 UTC, comparar os **nomes** antes de culpar o PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
