### PR TITLE
Tira a coluna Grátis da tabela comparativa da /precos

### DIFF
--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -98,10 +98,9 @@
   .cmp-scroll:focus-visible { outline: 2px solid var(--pink); outline-offset: 4px; border-radius: 8px; }
 
   /* table-layout:fixed: no automático as colunas ficam do tamanho do texto
-     mais largo de cada uma (medido: 195/196/155/148/130px), e coluna estreita
-     se lê como plano menos importante — justo o contrário do que a faixa do
-     Plus está dizendo. Fixo, as 5 dividem em partes iguais o que sobra da
-     coluna de recursos. */
+     mais largo de cada uma, e coluna estreita se lê como plano menos
+     importante — justo o contrário do que a faixa do Plus está dizendo. Fixo,
+     as 4 dividem em partes iguais o que sobra da coluna de recursos. */
   .cmp-table { width: 100%; table-layout: fixed; border-collapse: separate; border-spacing: 0; font-size: .88rem; font-variant-numeric: tabular-nums; }
   .cmp-table th, .cmp-table td { padding: 13px 12px; text-align: center; vertical-align: middle; border-bottom: 1px solid var(--line); }
   .cmp-table td { color: var(--ink-2); }
@@ -175,7 +174,8 @@
   @media (max-width: 900px) {
     .cmp-hint { display: flex; }
     .cmp-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-    .cmp-table { min-width: 664px; font-size: .82rem; }
+    /* 154px da coluna de recursos + 4 x 102px dos planos. */
+    .cmp-table { min-width: 562px; font-size: .82rem; }
     .cmp-table th, .cmp-table td { padding: 11px 8px; }
     .cmp-table .cmp-feat { width: 154px; min-width: 154px; padding-left: 0; padding-right: 10px; }
     .cmp-table thead th { position: static; padding: 12px 8px 12px; }
@@ -224,11 +224,10 @@
            e hardcoded da página (lançada 2026-08-06, sem flag: nada de flash
            de conteúdo antigo). Sem classes CSS novas de propósito: reusa
            .plan/.price/.plan-badge + estilos inline.
-           O card do Grátis SAIU: assinar virou obrigatório pra entrar pela web,
-           então ele não é mais uma escolha oferecida aqui. O tier `free`
-           continua existindo no backend como ESTADO (fallback após falha de
-           cobrança) e como COLUNA da tabela comparativa abaixo — o que morreu é
-           a escolha, não o plano. -->
+           O Grátis SAIU inteiro: o card daqui e a coluna da tabela comparativa
+           abaixo. Assinar virou obrigatório pra entrar pela web, então ele não é
+           mais uma escolha nem um degrau de comparação. O tier `free` continua
+           existindo no backend como ESTADO (fallback após falha de cobrança). -->
       <!-- width breakout: a escada de 4 cards precisa de mais que os 1200px do
            .wrap pra não ficar espremida; centraliza na página via translate. -->
       <div id="plans-v2-wrap" style="width:min(1560px,calc(100vw - 48px));margin-left:50%;transform:translateX(-50%)">
@@ -340,15 +339,11 @@
             <table class="cmp-table">
               <caption class="sr-only">Recursos incluídos em cada plano do PigBank</caption>
               <colgroup>
-                <col /><col /><col /><col class="cmp-col-hl" /><col /><col />
+                <col /><col /><col class="cmp-col-hl" /><col /><col />
               </colgroup>
               <thead>
                 <tr>
                   <th scope="col" class="cmp-feat"><span class="sr-only">Recurso</span></th>
-                  <th scope="col">
-                    <span class="cmp-plan-name">Grátis</span>
-                    <span class="cmp-plan-price">R$&nbsp;0</span>
-                  </th>
                   <th scope="col">
                     <span class="cmp-plan-name">Essencial</span>
                     <span class="cmp-plan-price"><span data-price-monthly>R$&nbsp;9,90/mês</span><span data-price-annual style="display:none">R$&nbsp;99/ano</span></span>
@@ -370,10 +365,9 @@
               </thead>
 
               <tbody>
-                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Registro no WhatsApp</span></th></tr>
+                <tr class="cmp-group"><th colspan="5" scope="colgroup"><span>Registro no WhatsApp</span></th></tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Registro por texto</th>
-                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
@@ -381,7 +375,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Lançamentos por mês</th>
-                  <td><span class="c-val">30</span></td>
                   <td><span class="c-val">Ilimitados</span></td>
                   <td><span class="c-val">Ilimitados</span></td>
                   <td><span class="c-val">Ilimitados</span></td>
@@ -389,7 +382,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Registro por áudio</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
@@ -397,7 +389,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Foto de cupom e comprovante</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
@@ -405,17 +396,15 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Importar extrato (OFX, CSV, PDF)</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
 
-                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Contas e organização</span></th></tr>
+                <tr class="cmp-group"><th colspan="5" scope="colgroup"><span>Contas e organização</span></th></tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Bancos conectados (Open&nbsp;Finance)</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhum</span></span></td>
                   <td><span class="c-val">1</span></td>
                   <td><span class="c-val">2</span></td>
                   <td><span class="c-val">5</span></td>
@@ -423,7 +412,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Investimentos no painel</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
@@ -431,7 +419,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Caixinhas e metas</th>
-                  <td><span class="c-val">1</span></td>
                   <td><span class="c-val">Ilimitadas</span></td>
                   <td><span class="c-val">Ilimitadas</span></td>
                   <td><span class="c-val">Ilimitadas</span></td>
@@ -439,7 +426,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Cartões</th>
-                  <td><span class="c-val">1</span></td>
                   <td><span class="c-val">Ilimitados</span></td>
                   <td><span class="c-val">Ilimitados</span></td>
                   <td><span class="c-val">Ilimitados</span></td>
@@ -447,7 +433,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Boletos com lembrete de vencimento</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
@@ -455,17 +440,15 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Gastos recorrentes</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
 
-                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Piggy IA</span></th></tr>
+                <tr class="cmp-group"><th colspan="5" scope="colgroup"><span>Piggy IA</span></th></tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Mensagens com a Piggy</th>
-                  <td><span class="c-val">20<small>por mês</small></span></td>
                   <td><span class="c-val">200<small>por mês</small></span></td>
                   <!-- Plus/Pro/Premium: `ai_monthly_messages: None` cai no teto GLOBAL
                        AI_CHAT_MONTHLY_LIMIT, não em "ilimitado" (ver o card do Plus). -->
@@ -479,13 +462,11 @@
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
-                  <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
 
-                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Agentes do Piggy</span></th></tr>
+                <tr class="cmp-group"><th colspan="5" scope="colgroup"><span>Agentes do Piggy</span></th></tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Agentes liberados</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhum</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhum</span></span></td>
                   <td><span class="c-val">Os 7<small>você escolhe</small></span></td>
                   <td><span class="c-val">Os 7<small>você escolhe</small></span></td>
@@ -493,7 +474,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Energia para mantê-los ligados</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhuma</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Nenhuma</span></span></td>
                   <td><span class="c-val"><i class="ph ph-lightning" aria-hidden="true"></i> 4<small>até 3 agentes</small></span></td>
                   <td><span class="c-val"><i class="ph ph-lightning" aria-hidden="true"></i> 14<small>a equipe inteira</small></span></td>
@@ -504,14 +484,12 @@
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
 
-                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Histórico e relatórios</span></th></tr>
+                <tr class="cmp-group"><th colspan="5" scope="colgroup"><span>Histórico e relatórios</span></th></tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Histórico que você enxerga</th>
-                  <td><span class="c-val">Mês corrente</span></td>
                   <td><span class="c-val">90 dias</span></td>
                   <td><span class="c-val">12 meses</span></td>
                   <td><span class="c-val">24 meses</span></td>
@@ -519,7 +497,6 @@
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Exportar seus dados</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
@@ -529,7 +506,6 @@
                   <th scope="row" class="cmp-feat">Previsão de saldo 30/60/90 dias</th>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
@@ -537,15 +513,13 @@
                   <th scope="row" class="cmp-feat">Relatórios semanais</th>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
 
-                <tr class="cmp-group"><th colspan="6" scope="colgroup"><span>Ainda por vir, no Premium</span></th></tr>
+                <tr class="cmp-group"><th colspan="5" scope="colgroup"><span>Ainda por vir, no Premium</span></th></tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Modo família</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
@@ -556,12 +530,10 @@
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-yes"><i class="ph ph-check" aria-hidden="true"></i><span class="sr-only">Incluído</span></span></td>
                 </tr>
                 <tr>
                   <th scope="row" class="cmp-feat">Suporte exclusivo</th>
-                  <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
                   <td><span class="c-no"><i class="ph ph-minus" aria-hidden="true"></i><span class="sr-only">Não incluído</span></span></td>
@@ -572,11 +544,6 @@
               <tfoot>
                 <tr>
                   <td class="cmp-feat"></td>
-                  <!-- Coluna Grátis sem CTA: a coluna FICA (é informação — o que
-                       você perde descendo o degrau), mas o Grátis não é mais
-                       escolhível. Célula vazia, não colspan: as 6 colunas do
-                       colgroup e do tbody continuam valendo. -->
-                  <td></td>
                   <td><button class="btn btn-outline" type="button" data-plan-btn="essencial" onclick="startCheckout(currentCycle, this, 'essencial')">Assinar Essencial</button></td>
                   <td class="is-hl"><button class="btn btn-primary" type="button" data-plan-btn="plus" onclick="startCheckout(currentCycle, this, 'plus')">Assinar Plus</button></td>
                   <td><button class="btn btn-outline" type="button" data-plan-btn="pro" onclick="startCheckout(currentCycle, this, 'pro')">Assinar Pro</button></td>

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -173,6 +173,10 @@
 
   @media (max-width: 900px) {
     .cmp-hint { display: flex; }
+    /* O media query não sabe se a tabela rola: com 4 colunas ela cabe a partir
+       de ~610px, e a dica pedia pra arrastar o que não arrasta. Quem sabe é o
+       updateCmpFade, que já mede o overflow pros véus das bordas. */
+    .cmp-hint.cmp-hint-off { display: none; }
     .cmp-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
     /* 154px da coluna de recursos + 4 x 102px dos planos. */
     .cmp-table { min-width: 562px; font-size: .82rem; }
@@ -640,6 +644,8 @@ function updateCmpFade() {
   const max = sc.scrollWidth - sc.clientWidth;
   wrap.classList.toggle("fade-left", sc.scrollLeft > 2);
   wrap.classList.toggle("fade-right", max > 2 && sc.scrollLeft < max - 2);
+  // Mesmo `max > 2` dos véus: a dica só aparece se houver o que arrastar.
+  document.querySelector(".cmp-hint")?.classList.toggle("cmp-hint-off", max <= 2);
 }
 (function initCmpFade() {
   const sc = document.getElementById("cmp-scroll");

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -4,12 +4,20 @@
  * Assinar virou obrigatório pra entrar pela web, então o card do Grátis e os
  * dois CTAs `[data-free-cta]` saíram da página, junto com o `selectFree` que
  * batia em POST /billing/select-free. A COLUNA Grátis da tabela comparativa
- * FICA (é informação: o que você perde descendo o degrau) — só o CTA dela some.
+ * também saiu — no #239 ela tinha ficado como informação, e o dono reverteu:
+ * o Grátis não é mais nem uma escolha nem um degrau de comparação.
  *
  * O grupo tem os dois controles do CLAUDE.md §3:
  *   · asserção do conserto — nenhum CTA de Grátis, nenhum card "Grátis", e
  *     nenhuma requisição pro /billing/select-free em nenhum dos dois estados
  *     (deslogado e needs_plan_selection);
+ *   · asserção do conserto na tabela — nenhum <th> "Grátis" e a contagem de
+ *     colunas IGUAL (5) no colgroup, no thead, em CADA <tr> do tbody (contando
+ *     colspan) e no tfoot;
+ *   · asserção de ALINHAMENTO — o `left` de cada <th> do thead contra o de
+ *     cada <td> do tfoot, listas idênticas. É a que pega o bug de verdade:
+ *     esquecer um `colspan` ou uma célula desloca a tabela sem mudar contagem
+ *     nenhuma que um teste de células veria;
  *   · copy do gate — as 6 células de {deslogado, logado sem gate, logado com
  *     gate} × {com ?escolha=1, sem marcador}: quem decide é o
  *     needs_plan_selection do /auth/me, não a URL (o marcador se perde num
@@ -45,9 +53,10 @@ after(async () => { await browser?.close(); server?.kill(); });
  * requisição por rota — a contagem é por INTERCEPTAÇÃO, não por efeito visível.
  */
 async function abrirPrecos({ me = null, query = "", app = false,
+                             viewport = { width: 1280, height: 900 },
                              plansConfig = { essencial_available: true, plus_available: true, pro_available: true },
                            } = {}) {
-  const page = await browser.newPage({ viewport: { width: 1280, height: 900 },
+  const page = await browser.newPage({ viewport,
                                        ...(app ? { userAgent: APP_UA } : {}) });
   const chamadas = { selectFree: 0, checkout: 0 };
   const corposCheckout = [];
@@ -127,16 +136,95 @@ for (const [rotulo, ctx] of [
   });
 }
 
-test("a coluna Grátis da tabela comparativa fica: 6 colunas, tfoot sem CTA", async () => {
+// ── a coluna Grátis saiu da tabela comparativa ──────────────────────────────
+// A tabela é o par obrigatório do CLAUDE.md §2: colgroup, thead, os 23 <tr> de
+// dado, os 6 colspan das linhas de grupo e o tfoot só ficam alinhados se TODOS
+// mudarem juntos. Uma célula sobrando desloca a tabela inteira.
+const COLUNAS = 5;   // 1 de recursos + Essencial, Plus, Pro, Premium
+
+/** Contagem de colunas de cada parte da tabela, contando `colspan`. */
+function lerColunas(page) {
+  return page.evaluate(() => {
+    const somaLinha = (tr) => [...tr.children].reduce((a, c) => a + (c.colSpan || 1), 0);
+    return {
+      colgroup: document.querySelectorAll(".cmp-table colgroup col").length,
+      thead: [...document.querySelectorAll(".cmp-table thead tr")].map(somaLinha),
+      tbody: [...document.querySelectorAll(".cmp-table tbody tr")].map(somaLinha),
+      tfoot: [...document.querySelectorAll(".cmp-table tfoot tr")].map(somaLinha),
+      nomes: [...document.querySelectorAll(".cmp-table thead tr th")].map((t) => t.textContent.trim()),
+      celulas: [...document.querySelectorAll(".cmp-table tfoot tr td")].map((t) => t.textContent.trim()),
+    };
+  });
+}
+
+test("a tabela comparativa não tem mais coluna Grátis, e as 5 colunas fecham", async () => {
   const { page } = await abrirPrecos();
-  // O cabeçalho continua com a coluna do Grátis (é informação, não oferta).
-  const cabecalho = await page.$$eval(".cmp-table thead tr th", (e) => e.map((t) => t.textContent.trim()));
-  assert.ok(cabecalho.some((t) => t.includes("Grátis")), `thead sem Grátis: ${JSON.stringify(cabecalho)}`);
-  // 6 colunas no tfoot (1 rótulo + 5 planos), e a do Grátis vazia.
-  const tfoot = await page.$$eval(".cmp-table tfoot tr td", (e) => e.map((t) => t.textContent.trim()));
-  assert.equal(tfoot.length, 6, `tfoot com ${tfoot.length} células: ${JSON.stringify(tfoot)}`);
-  assert.equal(tfoot[1], "", `a célula do Grátis não está vazia: ${JSON.stringify(tfoot)}`);
-  assert.deepEqual(tfoot.slice(2), ["Assinar Essencial", "Assinar Plus", "Assinar Pro", "Em breve"]);
+  const t = await lerColunas(page);
+
+  // O conserto: nenhum cabeçalho de plano fala em Grátis.
+  assert.ok(!t.nomes.some((n) => n.includes("Grátis")),
+    `thead ainda tem Grátis: ${JSON.stringify(t.nomes)}`);
+  assert.deepEqual(t.nomes.slice(1).map((n) => n.split(/R\$|Em breve/)[0].replace("Mais popular", "").trim()),
+    ["Essencial", "Plus", "Pro", "Premium"], `cabeçalhos: ${JSON.stringify(t.nomes)}`);
+
+  // Consistência: a MESMA contagem em todas as partes, e uma menos que as 6 de
+  // antes do conserto (colgroup 6, thead 6, cada tbody 6, tfoot 6 — medido em
+  // 7a87ae7). Cada linha entra na asserção, não só uma amostra.
+  assert.equal(t.colgroup, COLUNAS, `colgroup com ${t.colgroup} <col>`);
+  assert.deepEqual(t.thead, [COLUNAS], `thead: ${JSON.stringify(t.thead)}`);
+  assert.equal(t.tbody.length, 29, `tbody com ${t.tbody.length} linhas (23 de dado + 6 de grupo)`);
+  assert.deepEqual([...new Set(t.tbody)], [COLUNAS],
+    `linhas do tbody fora das ${COLUNAS} colunas: ${JSON.stringify(t.tbody)}`);
+  assert.deepEqual(t.tfoot, [COLUNAS], `tfoot: ${JSON.stringify(t.tfoot)}`);
+
+  // Rodapé: rótulo vazio + os 4 CTAs, sem célula órfã do Grátis no meio.
+  assert.deepEqual(t.celulas, ["", "Assinar Essencial", "Assinar Plus", "Assinar Pro", "Em breve"]);
+  await page.close();
+});
+
+// A asserção que um teste de contagem de células NUNCA pegaria: se thead e
+// tfoot discordarem de uma célula, os `left` deslizam e o CTA do Plus fica
+// embaixo da coluna do Pro. Nos dois viewports porque a tabela troca de regime
+// aos 900px (scroller horizontal + min-width no celular, fixed no desktop).
+for (const viewport of [{ width: 390, height: 844 }, { width: 1560, height: 900 }]) {
+  test(`thead e tfoot alinhados coluna a coluna em ${viewport.width}x${viewport.height}`, async () => {
+    const { page } = await abrirPrecos({ viewport });
+    const { thead, tfoot } = await page.evaluate(() => {
+      const lefts = (sel) => [...document.querySelectorAll(sel)]
+        .map((e) => +e.getBoundingClientRect().left.toFixed(1));
+      return { thead: lefts(".cmp-table thead tr th"), tfoot: lefts(".cmp-table tfoot tr td") };
+    });
+    assert.equal(thead.length, COLUNAS, `thead com ${thead.length} células`);
+    assert.deepEqual(tfoot, thead,
+      `rodapé desalinhado do cabeçalho: thead=${JSON.stringify(thead)} tfoot=${JSON.stringify(tfoot)}`);
+    await page.close();
+  });
+}
+
+// Controle POSITIVO da remoção: os dados dos planos PAGOS continuam na tabela,
+// nas colunas certas. Sem ele, uma tabela que perdeu a coluna errada (ou duas)
+// passaria nas asserções de contagem acima.
+test("controle positivo: os dados dos planos pagos seguem nas colunas certas", async () => {
+  const { page } = await abrirPrecos();
+  // O ` ` dos `&nbsp;` do HTML ("Open&nbsp;Finance") não é o espaço que se
+  // digita aqui: sem normalizar, o `find` não acha a linha e o teste passaria a
+  // estourar em vez de comparar.
+  const linha = (nome) => page.evaluate((n) => {
+    const txt = (e) => e.textContent.replace(/\u00a0/g, " ").trim();
+    const th = [...document.querySelectorAll(".cmp-table tbody th.cmp-feat")].find((t) => txt(t) === n);
+    if (!th) throw new Error(`linha "${n}" não existe na tabela`);
+    return [...th.parentElement.querySelectorAll("td")].map(txt);
+  }, nome);
+
+  // Valores de core/services/plan_limits.py, na ordem Essencial/Plus/Pro/Premium.
+  assert.deepEqual(await linha("Lançamentos por mês"),
+    ["Ilimitados", "Ilimitados", "Ilimitados", "Ilimitados"]);
+  assert.deepEqual(await linha("Histórico que você enxerga"),
+    ["90 dias", "12 meses", "24 meses", "Completo"]);
+  assert.deepEqual(await linha("Mensagens com a Piggy"),
+    ["200por mês", "1.000por mês", "1.000por mês", "1.000por mês"]);
+  assert.deepEqual(await linha("Bancos conectados (Open Finance)"),
+    ["1", "2", "5", "Ilimitados"]);
   await page.close();
 });
 

--- a/tests/frontend/precos_sem_plano_gratis.test.mjs
+++ b/tests/frontend/precos_sem_plano_gratis.test.mjs
@@ -362,3 +362,38 @@ test("plus_available:false marca EXATAMENTE os 2 botões do Plus como indisponí
   ]);
   await page.close();
 });
+
+// ── a dica de arrastar só aparece onde a tabela realmente rola ───────────────
+// O media query de 900px não sabe medir overflow. Com 4 colunas a tabela cabe
+// a partir de ~610px, então entre ~610 e 900 a página pedia pra arrastar o que
+// não arrasta — faixa que ESTE PR alargou (antes o corte era ~712px). Quem sabe
+// é o updateCmpFade, que já mede o mesmo `max > 2` dos véus das bordas.
+//
+// O par é obrigatório: sem o caso de 390px, a asserção passaria numa página que
+// escondeu a dica pra sempre, que é pior que mostrá-la demais.
+for (const [rotulo, largura, deveAparecer] of [
+  ["390px: a tabela rola, a dica aparece", 390, true],
+  ["800px: a tabela cabe, a dica some", 800, false],
+]) {
+  test(`dica de arrastar — ${rotulo}`, async () => {
+    const { page } = await abrirPrecos({ viewport: { width: largura, height: 844 } });
+
+    const { oculto, visivel } = await page.evaluate(() => {
+      const sc = document.getElementById("cmp-scroll");
+      const hint = document.querySelector(".cmp-hint");
+      return {
+        oculto: sc.scrollWidth - sc.clientWidth,
+        // getComputedStyle, não a classe: é o que o usuário enxerga.
+        visivel: getComputedStyle(hint).display !== "none",
+      };
+    });
+
+    // Âncora do próprio caso: se o overflow não for o esperado, a asserção de
+    // baixo mediria outra coisa e passaria por acidente.
+    assert.equal(oculto > 2, deveAparecer,
+      `${largura}px devia ${deveAparecer ? "" : "não "}ter overflow e tem ${oculto}px`);
+    assert.equal(visivel, deveAparecer,
+      `${largura}px: overflow=${oculto}px mas a dica está ${visivel ? "visível" : "escondida"}`);
+    await page.close();
+  });
+}


### PR DESCRIPTION
## O que muda

O #239 tirou o card do Grátis da `/precos` e **manteve** a coluna da tabela comparativa como informação, por decisão do dono. Ele reverteu: o Grátis não é mais nem escolha nem degrau de comparação. Este PR remove a coluna.

O plano `free` continua existindo no backend como **estado** (fallback após falha de cobrança ou cancelamento). O que sai é a última presença dele na tela de planos.

## Por que é mais que apagar uma coluna

A tabela é o par obrigatório do `CLAUDE.md` §2: ela só fica alinhada se todas as peças mudarem juntas. O inventário, medido e não lembrado:

| peça | antes | depois |
|---|---|---|
| `<colgroup>` | 6 `<col>`, `.cmp-col-hl` no 4º | 5 `<col>`, `.cmp-col-hl` no **3º** |
| `<thead>` | 6 `<th>` | 5 |
| `<tbody>` linhas de dado | 23 × a 1ª `<td>` do Grátis | 23 células removidas |
| `<tbody>` linhas de grupo | 6 × `colspan="6"` | `colspan="5"` |
| `<tfoot>` | 6 células (a do Grátis vazia, do #239) | 5 |
| `min-width` do scroller | `664px` = 154 + 5×102 | `562px` = 154 + 4×102 |
| CSS com `nth-child` contando coluna | nenhum (verificado) | — |

A migração do `.cmp-col-hl` para a terceira coluna não é cosmética: sem ela o realce cairia no **Pro** em vez do Plus.

Contagem por linha medida no DOM, contando `colspan`: `colgroup` 5, `thead` 5, **todas** as 29 linhas do `tbody` (23 de dado + 6 de grupo) em 5, `tfoot` 5.

## O teste que importa não é o de contagem

Contar células não pega a classe de bug que esta tabela produz. A asserção que pega compara o `left` de cada `<th>` do cabeçalho com o de cada `<td>` do rodapé e exige listas **idênticas**.

A prova de que ela não é redundante foi uma mutação deliberada: dar `colspan="2"` ao rótulo do rodapé e remover uma célula. A soma continua **5 em todo lugar**, consistente com `colgroup`, `thead` e `tbody`, passa por qualquer teste de contagem — e coloca o CTA do Essencial embaixo da coluna do Plus.

```
not ok 4 - thead e tfoot alinhados coluna a coluna em 390x844
  rodapé desalinhado do cabeçalho:
    thead=[24,178,280,382,484]  tfoot=[24,280,382,484]
```

**Controle negativo** (coluna restaurada, HTML de volta ao estado da `main`): as 4 asserções ficam vermelhas, `13 pass / 4 fail`. Com o conserto: `17 pass / 0 fail`. Rodado duas vezes, uma pelo Coder e uma por mim.

**Controle positivo:** "Assinar Plus" continua disparando exatamente 1 `POST /billing/create-checkout`, os 6 CTAs pagos seguem habilitados, e os dados dos planos pagos seguem nas colunas certas. Sem isso o grupo passaria numa tabela que apagou tudo.

## A dica de arrastar (`f308c76`)

Este PR abriu declarando a `.cmp-hint` como bug preexistente que ele alarga, e deixando sem conserto. **O Codex apontou, e o enquadramento estava errado:** o corte saiu de ~712px para ~610px de viewport **por causa desta mudança**, então a faixa em que a página instrui uma interação impossível cresceu, para usuários que antes não a viam. Herdar a fraqueza não é herdar o tamanho dela — era regressão deste PR.

Corrigido no lugar que ele indicou: uma linha no `updateCmpFade`, reusando o mesmo `max > 2` que a função já calcula para os véus das bordas.

```js
document.querySelector(".cmp-hint")?.classList.toggle("cmp-hint-off", max <= 2);
```

Precisou de classe em vez de `hidden`: o `.cmp-hint { display: flex }` dentro do `@media (max-width: 900px)` vence o `[hidden] { display: none }` do agente por especificidade.

O teste é o par, não só o caso apontado — em 390px a tabela rola e a dica aparece, em 800px ela cabe e a dica some. Sem o primeiro, a asserção passaria numa página que escondeu a dica para sempre, que é pior que mostrá-la demais. Cada caso ancora no overflow **medido** antes de olhar a visibilidade, senão mediria outra coisa e passaria por acidente; e a visibilidade é lida por `getComputedStyle`, não pela classe.

Controle negativo, desligando só a linha nova: `not ok 19 — 800px: a tabela cabe, a dica some`, com o caso de 390px verde. `18 pass / 1 fail` → `19 pass / 0 fail`.

## Medições (§7: números, não adjetivos)

| | 390×844 antes | 390×844 depois | 1560×900 antes | 1560×900 depois |
|---|---|---|---|---|
| `scrollWidth` de `#cmp-scroll` | 664 | **562** | 1060 | 1060 |
| oculto (scroll horizontal) | 322 | **220** | 0 | 0 |
| largura das colunas de plano | 102×5 | 102×4 | 158,4×5 | **198×4** |

Pergunta de controle: esses números **não** dariam o mesmo se a mudança não fizesse nada — a 390px o `scrollWidth` seguiria 664, e no desktop as colunas seguiriam 158,4px.

Suítes: frontend **283/283**. `tests/test_static_pages_routes.py` 17/17. Suíte Python comparada **por nome** contra `7a87ae7` em worktree: **249 falhas idênticas nos dois lados**, `comm` vazio nos dois sentidos. As 249 são preexistentes (remedidas nesta árvore, não reusadas de medição anterior). `handlers_inline.baseline.json` não mudou.

## Comentários corrigidos

Dois comentários que a mudança tornou falsos: o da escada dizia que o `free` sobrevivia "como COLUNA da tabela comparativa abaixo", e o do `table-layout: fixed` falava em 5 colunas dividindo em partes iguais. As larguras que o segundo documentava (`195/196/155/148/130px`) foram **removidas** em vez de atualizadas: número medido dentro de comentário envelhece em silêncio (§2).

## O que não foi verificado

Frontend só aparece **depois do deploy** — o app carrega o site ao vivo, e nada disto foi visto num iPhone real. `env(safe-area-inset-top)` vale 0 no Chromium headless, então o `top` do cabeçalho sticky foi medido com inset zero (a regra não foi tocada). E as colunas 25% mais largas no desktop tiveram a largura medida, não o visual julgado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF