### PR TITLE
Meta CAPI: a compra leva o clique que a gerou (_fbp/_fbc)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,13 @@ META_PIXEL_ID=
 # Configurações → Conversions API → "Gerar token de acesso".
 # Requer META_PIXEL_ID setado. Vazio → só o rastreio client-side roda.
 META_PIXEL_ACCESS_TOKEN=
+#
+# Código da aba "Testar eventos" (Events Manager → Testar eventos). Setado, os
+# eventos do SERVIDOR aparecem lá em vez de contarem no relatório — é o único
+# jeito de validar a CAPI sem esperar uma venda real, porque aquela aba não
+# enxerga o server-side sozinha. DEIXE VAZIO EM PRODUÇÃO: com ele setado, a
+# venda de verdade vira evento de teste e não conta como conversão.
+META_TEST_EVENT_CODE=
 
 # ── Google Analytics 4 ──────────────────────────────────────────────────────
 # Measurement ID da propriedade. Já vem chumbado no código (é público: sai no

--- a/core/services/meta_capi.py
+++ b/core/services/meta_capi.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 
 import requests
 
@@ -41,11 +42,37 @@ _REQUEST_TIMEOUT_SECONDS = 10.0
 
 _PIXEL_ID_ENV = "META_PIXEL_ID"
 _ACCESS_TOKEN_ENV = "META_PIXEL_ACCESS_TOKEN"
+# Código de teste do Events Manager ("Testar eventos"). Setado → os eventos deste
+# servidor aparecem lá em vez de irem pro relatório. NUNCA deixar setado em
+# produção: evento de teste não conta como conversão.
+_TEST_EVENT_CODE_ENV = "META_TEST_EVENT_CODE"
+
+# Cookies do pixel, no formato `fb.<subdominios>.<timestamp>.<id>`:
+#   _fbp — identifica o NAVEGADOR (o pixel cria em toda visita);
+#   _fbc — identifica o CLIQUE no anúncio (o pixel cria a partir do `fbclid` da
+#          URL de entrada). É ele que amarra a compra à campanha.
+# Sem os dois, o único identificador que sobe é o e-mail com hash — e a
+# qualidade da correspondência do Meta cai junto. Vão CRUS de propósito: ao
+# contrário do e-mail e do telefone, o Meta não aceita esses dois com hash.
+_FB_COOKIE_RE = re.compile(r"^fb\.[0-9]\.\d{10,20}\.[A-Za-z0-9_-]{1,400}$")
 
 
 def _sha256(value: str) -> str:
     """Hash exigido pelo Meta pros dados de contato (email, telefone, etc.)."""
     return hashlib.sha256(value.strip().lower().encode("utf-8")).hexdigest()
+
+
+def sanitize_fb_cookie(raw: object) -> str | None:
+    """Cookie `_fbp`/`_fbc` do navegador → o próprio valor, ou None.
+
+    Fronteira de confiança: o valor vem do cliente e vai parar no metadata do
+    Stripe. Fora do formato do Meta é ruído — descartar é melhor que gravar, e
+    melhor que mandar pro Graph (que rejeitaria o evento inteiro).
+    """
+    if not isinstance(raw, str):
+        return None
+    valor = raw.strip()
+    return valor if _FB_COOKIE_RE.match(valor) else None
 
 
 def capi_configured() -> bool:
@@ -87,6 +114,8 @@ def send_event(
     value: float | None = None,
     currency: str = "BRL",
     email: str | None = None,
+    fbp: str | None = None,
+    fbc: str | None = None,
     event_source_url: str | None = None,
     action_source: str = "website",
 ) -> bool:
@@ -103,11 +132,18 @@ def send_event(
         return False
 
     # user_data precisa de ao menos um identificador pro Meta casar o evento.
-    user_data: dict[str, list[str]] = {}
+    # `em` vai com hash (exigência do Meta pra dado pessoal); `fbp`/`fbc` vão
+    # crus — são identificadores do próprio Meta, e com hash seriam ignorados.
+    user_data: dict = {}
     if email:
         user_data["em"] = [_sha256(email)]
+    if fbp:
+        user_data["fbp"] = fbp
+    if fbc:
+        user_data["fbc"] = fbc
     if not user_data:
-        logger.warning("[meta_capi] %s sem identificador (email) — pulando envio.", event_name)
+        logger.warning(
+            "[meta_capi] %s sem identificador (email/fbp/fbc) — pulando envio.", event_name)
         return False
 
     event: dict = {
@@ -125,12 +161,20 @@ def send_event(
     if event_source_url:
         event["event_source_url"] = event_source_url
 
+    corpo: dict = {"data": [event]}
+    # Com o código setado, o evento vai pra aba "Testar eventos" do Events
+    # Manager em vez do relatório — é o único jeito de validar o server-side
+    # sem esperar uma venda real (a aba de teste não enxerga o CAPI sozinha).
+    codigo_teste = (os.getenv(_TEST_EVENT_CODE_ENV) or "").strip()
+    if codigo_teste:
+        corpo["test_event_code"] = codigo_teste
+
     url = f"https://graph.facebook.com/{_GRAPH_VERSION}/{pixel_id}/events"
     try:
         resp = requests.post(
             url,
             params={"access_token": token},
-            json={"data": [event]},
+            json=corpo,
             timeout=_REQUEST_TIMEOUT_SECONDS,
         )
         if 200 <= resp.status_code < 300:

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2642,7 +2642,12 @@ async def auth_verify_email(request: Request, response: Response, body: VerifyEm
     # background task (roda DEPOIS da resposta) pra um Meta lento/fora nunca
     # atrasar o cadastro. event_id signup_<uid> casa com o pixel do /cadastro.
     try:
-        from core.services.meta_capi import capi_configured, registration_event_id, send_event
+        from core.services.meta_capi import (
+            capi_configured,
+            registration_event_id,
+            sanitize_fb_cookie,
+            send_event,
+        )
         if capi_configured():
             background_tasks.add_task(
                 send_event,
@@ -2650,6 +2655,10 @@ async def auth_verify_email(request: Request, response: Response, body: VerifyEm
                 event_id=registration_event_id(user_id),
                 event_time=int(datetime.now(timezone.utc).timestamp()),
                 email=body.email.strip().lower(),
+                # Mesma classe do Purchase: sem os cookies do pixel, o cadastro
+                # chega ao Meta sem o clique que o originou.
+                fbp=sanitize_fb_cookie(request.cookies.get("_fbp")),
+                fbc=sanitize_fb_cookie(request.cookies.get("_fbc")),
                 event_source_url=f"{DASHBOARD_URL}/cadastro",
             )
     except Exception as exc:
@@ -3836,7 +3845,12 @@ async def auth_google_complete_signup(
     # Background task (roda após a resposta); event_id signup_<uid> casa com o
     # pixel do /completar-cadastro pro Meta deduplicar.
     try:
-        from core.services.meta_capi import capi_configured, registration_event_id, send_event
+        from core.services.meta_capi import (
+            capi_configured,
+            registration_event_id,
+            sanitize_fb_cookie,
+            send_event,
+        )
         if capi_configured():
             background_tasks.add_task(
                 send_event,
@@ -3844,6 +3858,8 @@ async def auth_google_complete_signup(
                 event_id=registration_event_id(user_id),
                 event_time=int(datetime.now(timezone.utc).timestamp()),
                 email=email,
+                fbp=sanitize_fb_cookie(request.cookies.get("_fbp")),
+                fbc=sanitize_fb_cookie(request.cookies.get("_fbc")),
                 event_source_url=f"{DASHBOARD_URL}/completar-cadastro",
             )
     except Exception as exc:
@@ -3926,14 +3942,18 @@ def _checkout_session_matches(session, user_id: int, plan: str, interval: str, p
 
 
 async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interval: str,
-                                     price_id: str, ga_client_id: str | None = None):
+                                     price_id: str, rastreio: dict[str, str] | None = None):
     """Cria ou reutiliza um checkout. Deve rodar sob ``_billing_user_lock``.
 
-    `ga_client_id` (já validado) entra no metadata da sessão e da assinatura pro
-    webhook conseguir mandar a compra pro GA4 na pessoa certa. Sessão REUTILIZADA
-    mantém o metadata de quando nasceu — o `_checkout_session_matches` não olha
-    este campo de propósito: recriar um checkout só porque o cookie do GA mudou
-    trocaria a URL que o usuário já tem aberta.
+    `rastreio` são os identificadores de anúncio já validados (`ga_client_id`,
+    `fbp`, `fbc`), lidos dos cookies no endpoint. Eles entram no metadata da
+    sessão e da assinatura porque é de lá que o webhook os lê pra mandar a compra
+    pro GA4 e pro Meta atribuída à pessoa — e à campanha — certa.
+
+    Sessão REUTILIZADA mantém o metadata de quando nasceu: o
+    `_checkout_session_matches` não olha estes campos de propósito, porque
+    recriar um checkout só porque um cookie mudou trocaria a URL que o usuário
+    já tem aberta.
     """
     from db import get_auth_user, set_stripe_customer
 
@@ -4084,8 +4104,7 @@ async def _billing_checkout_for_user(stripe_mod, user_id: int, plan: str, interv
             "plan": plan,
             "price_id": price_id,
         }
-        if ga_client_id:
-            metadata["ga_client_id"] = ga_client_id
+        metadata.update(rastreio or {})
         subscription_data = {"metadata": metadata.copy()}
         if trial_days > 0:
             subscription_data["trial_period_days"] = trial_days
@@ -4180,21 +4199,30 @@ async def billing_create_checkout(
     if not STRIPE_SECRET_KEY or not price_id:
         raise HTTPException(status_code=503, detail="Pagamentos ainda não configurados.")
 
-    # client_id do GA4 pro `purchase` do webhook cair na mesma pessoa que
-    # navegou. Sai do cookie `_ga`, que o navegador já manda neste POST — não do
-    # corpo: pedir pro JS ler e enviar era mais código na /precos e mais um campo
-    # de entrada pra validar, pelo mesmo dado. Ausente (visitante novo cujo
-    # gtag.js ainda não criou o cookie, ou bloqueado) → o webhook usa o
-    # `fallback_client_id` e a venda entra sem origem, nunca se perde.
+    # Identificadores de anúncio, todos lidos dos COOKIES que o navegador já
+    # manda neste POST — nenhum JS precisa lê-los e reenviá-los:
+    #   _ga  → client_id do GA4 (a compra cai na mesma pessoa que navegou);
+    #   _fbp → o navegador, pro Meta;
+    #   _fbc → o CLIQUE no anúncio, criado pelo pixel a partir do `fbclid` da URL
+    #          de entrada. É ele que amarra a compra à campanha.
+    # Cada um ausente (cookie bloqueado, pixel/gtag ainda carregando, visita
+    # orgânica sem fbclid) simplesmente não vai: o evento continua sendo enviado
+    # com o que houver, e o GA4 ainda tem o `fallback_client_id`.
     from core.services.ga4_mp import client_id_from_ga_cookie
-    ga_client_id = client_id_from_ga_cookie(request.cookies.get("_ga"))
+    from core.services.meta_capi import sanitize_fb_cookie
+    rastreio = {
+        "ga_client_id": client_id_from_ga_cookie(request.cookies.get("_ga")),
+        "fbp": sanitize_fb_cookie(request.cookies.get("_fbp")),
+        "fbc": sanitize_fb_cookie(request.cookies.get("_fbc")),
+    }
+    rastreio = {k: v for k, v in rastreio.items() if v}
 
     import stripe
     stripe.api_key = STRIPE_SECRET_KEY
     try:
         async with _billing_user_lock(user_id):
             result = await _billing_checkout_for_user(
-                stripe, user_id, plan, interval, price_id, ga_client_id)
+                stripe, user_id, plan, interval, price_id, rastreio)
         # Funil de checkout: registra a ABERTURA na tabela dedicada, com o
         # session_id do Stripe (par do record_checkout_completed no webhook —
         # correlaciona a mesma tentativa). Só depois da sessão nascer de fato.
@@ -4605,6 +4633,21 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                 return valor
         return None
 
+    def _fb_ids(*objetos) -> tuple[str | None, str | None]:
+        """(`fbp`, `fbc`) do metadata do Stripe — os cookies do pixel gravados na
+        criação do checkout. São o que amarra a compra ao clique no anúncio; sem
+        eles o único identificador do evento é o e-mail com hash.
+
+        Assinatura criada antes desta versão não tem os campos: o evento vai com
+        o que houver, nunca deixa de ir.
+        """
+        for obj in objetos:
+            meta = _g(obj, "metadata", {})
+            fbp, fbc = _g(meta, "fbp"), _g(meta, "fbc")
+            if fbp or fbc:
+                return fbp, fbc
+        return None, None
+
     def _invoice_subscription_id(invoice) -> str | None:
         sub_id = _g(invoice, "subscription")
         if sub_id:
@@ -4713,6 +4756,7 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                         _ev_name, _ev_id = "StartTrial", trial_event_id(_sid)
                     else:
                         _ev_name, _ev_id = "Purchase", purchase_event_id(_sid)
+                    _fbp, _fbc = _fb_ids(sub, session)
                     background_tasks.add_task(
                         send_event,
                         event_name=_ev_name,
@@ -4721,6 +4765,8 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                         value=_value,
                         currency=_currency,
                         email=_capi_email,
+                        fbp=_fbp,
+                        fbc=_fbc,
                         event_source_url=f"{DASHBOARD_URL}/home",
                     )
             except Exception as exc:
@@ -4848,6 +4894,7 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                     if capi_configured() and _inv_id and _billing_reason != "subscription_create":
                         _capi_email = await _user_email(user_id)
                         _evt_time = int(_g(event, "created") or _g(invoice, "created") or 0)
+                        _fbp, _fbc = _fb_ids(sub)
                         background_tasks.add_task(
                             send_event,
                             event_name="Purchase",
@@ -4856,6 +4903,8 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                             value=amount_brl,
                             currency=(_g(invoice, "currency") or "brl").upper(),
                             email=_capi_email,
+                            fbp=_fbp,
+                            fbc=_fbc,
                             event_source_url=f"{DASHBOARD_URL}/home",
                         )
                 except Exception as exc:

--- a/tests/test_meta_capi_cookies.py
+++ b/tests/test_meta_capi_cookies.py
@@ -1,0 +1,194 @@
+"""Meta CAPI: o clique no anúncio tem de chegar junto com a compra.
+
+O evento server-side já ia com o e-mail (com hash), e só. Faltavam os dois
+cookies que o próprio pixel cria e que o Meta usa pra casar a conversão:
+
+  _fbp — o navegador;
+  _fbc — o CLIQUE no anúncio (o pixel deriva do `fbclid` da URL de entrada).
+
+Sem `_fbc`, a compra chega ao Meta sem a campanha que a gerou — que é o motivo
+de existir a CAPI. Os dois viajam pelo mesmo caminho do `ga_client_id`: cookie no
+POST do checkout → metadata do Stripe → webhook.
+
+Como no arquivo do GA4, os testes leem o CORPO que iria pro Graph, não se uma
+função foi chamada.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core.services import meta_capi
+from tests.test_billing_webhook_lifecycle import (
+    _cleanup_trial,
+    _fake_sub,
+    _post,
+    _setup,
+)
+
+_FBP = "fb.1.1596403881668.1116446470"
+_FBC = "fb.1.1554763741205.IwAR2Ta-abcDEF_ghi123-XYZ"
+
+
+class _Captura:
+    def __init__(self):
+        self.chamadas: list[dict] = []
+
+    def post(self, url, params=None, json=None, timeout=None):
+        self.chamadas.append({"url": url, "params": params or {}, "json": json or {}})
+        return SimpleNamespace(status_code=200, text="{}")
+
+    def unico(self) -> dict:
+        assert len(self.chamadas) == 1, f"esperava 1 envio, veio {len(self.chamadas)}"
+        return self.chamadas[0]["json"]
+
+
+def _ligar_capi(monkeypatch, *, test_event_code: str | None = None) -> _Captura:
+    monkeypatch.setenv("META_PIXEL_ID", "111111111111111")
+    monkeypatch.setenv("META_PIXEL_ACCESS_TOKEN", "token-de-teste")
+    if test_event_code:
+        monkeypatch.setenv("META_TEST_EVENT_CODE", test_event_code)
+    else:
+        monkeypatch.delenv("META_TEST_EVENT_CODE", raising=False)
+    captura = _Captura()
+    monkeypatch.setattr(meta_capi, "requests", captura)
+    return captura
+
+
+def _sub_pago(metadata=None) -> dict:
+    sub = _fake_sub("active", "price_capi")
+    sub["items"]["data"][0]["price"].update({"unit_amount": 1990, "currency": "brl"})
+    sub["metadata"] = metadata or {}
+    return sub
+
+
+def _evento_checkout(uid: int, metadata=None) -> dict:
+    return {
+        "type": "checkout.session.completed",
+        "data": {"object": {
+            "id": "cs_capi_1",
+            "amount_total": 1990,
+            "currency": "brl",
+            "metadata": {"finbot_user_id": str(uid), **(metadata or {})},
+            "subscription": "sub_capi",
+        }},
+    }
+
+
+# ── o caminho completo: cookie → metadata → webhook → Graph ──────────────────
+
+def test_compra_leva_os_cookies_do_pixel_pro_meta(user_id, monkeypatch):
+    uid, client, fake = _setup(monkeypatch, f"capi-ok-{user_id}")
+    captura = _ligar_capi(monkeypatch)
+    try:
+        meta = {"fbp": _FBP, "fbc": _FBC}
+        r = _post(client, fake, _evento_checkout(uid, meta),
+                  subs={"sub_capi": _sub_pago(meta)})
+        assert r.status_code == 200, r.text
+
+        corpo = captura.unico()
+        user_data = corpo["data"][0]["user_data"]
+        # Crus, e não com hash: o Meta ignora esses dois se vierem hasheados —
+        # o evento seria aceito (2xx) e a atribuição continuaria perdida.
+        assert user_data["fbp"] == _FBP
+        assert user_data["fbc"] == _FBC
+        # O e-mail continua indo com hash (64 hex do sha256), como antes.
+        assert len(user_data["em"][0]) == 64
+        assert "@" not in user_data["em"][0]
+    finally:
+        _cleanup_trial(uid)
+
+
+def test_sem_cookies_o_evento_continua_indo(user_id, monkeypatch):
+    """Compra orgânica, cookie bloqueado, assinatura criada antes desta versão:
+    o evento não pode deixar de ser enviado por falta dos cookies — só perde
+    qualidade de correspondência."""
+    uid, client, fake = _setup(monkeypatch, f"capi-sem-{user_id}")
+    captura = _ligar_capi(monkeypatch)
+    try:
+        _post(client, fake, _evento_checkout(uid), subs={"sub_capi": _sub_pago()})
+
+        user_data = captura.unico()["data"][0]["user_data"]
+        assert "fbp" not in user_data and "fbc" not in user_data
+        assert user_data["em"]                      # o e-mail sozinho ainda vale
+    finally:
+        _cleanup_trial(uid)
+
+
+def test_test_event_code_desvia_o_evento_pra_aba_de_teste(user_id, monkeypatch):
+    """A aba "Testar eventos" do Events Manager não enxerga a CAPI sozinha. Com
+    META_TEST_EVENT_CODE setado dá pra validar o server-side sem esperar uma
+    venda real — e sem ele o campo NÃO pode ir, senão a venda de verdade viraria
+    evento de teste e não contaria como conversão."""
+    uid, client, fake = _setup(monkeypatch, f"capi-tst-{user_id}")
+    captura = _ligar_capi(monkeypatch, test_event_code="TEST12345")
+    try:
+        _post(client, fake, _evento_checkout(uid), subs={"sub_capi": _sub_pago()})
+        assert captura.unico()["test_event_code"] == "TEST12345"
+    finally:
+        _cleanup_trial(uid)
+
+    uid2, client2, fake2 = _setup(monkeypatch, f"capi-prod-{user_id}")
+    captura2 = _ligar_capi(monkeypatch)          # sem a env
+    try:
+        _post(client2, fake2, _evento_checkout(uid2), subs={"sub_capi": _sub_pago()})
+        assert "test_event_code" not in captura2.unico()
+    finally:
+        _cleanup_trial(uid2)
+
+
+# ── a ponta de entrada: cookie do navegador → metadata do Stripe ─────────────
+
+def test_cookies_do_pixel_viram_metadata_do_checkout(user_id, monkeypatch):
+    from tests.test_billing_checkout import (
+        _CSRF_HEADERS,
+        _auth_user_setup,
+        _patch_stripe,
+    )
+    import frontend.finance_bot_websocket_custom as dashboard
+
+    _, _, client = _auth_user_setup(f"capi-cookie-{user_id}")
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_m")
+    fake = _patch_stripe(monkeypatch)
+    client.cookies.set("_fbp", _FBP)
+    client.cookies.set("_fbc", _FBC)
+
+    r = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    assert r.status_code == 200, r.text
+
+    kwargs = fake.last_session_kwargs
+    assert kwargs["metadata"]["fbp"] == _FBP
+    assert kwargs["metadata"]["fbc"] == _FBC
+    # A RENOVAÇÃO só enxerga o metadata da assinatura — sem a cópia, toda
+    # cobrança pós-trial chegaria ao Meta sem a campanha.
+    assert kwargs["subscription_data"]["metadata"]["fbc"] == _FBC
+
+
+def test_cookie_forjado_nao_vira_metadata(user_id, monkeypatch):
+    """Fronteira de confiança: o valor vem do cliente e ia parar no metadata do
+    Stripe e no corpo do Graph. Fora do formato do Meta, é descartado."""
+    from tests.test_billing_checkout import (
+        _CSRF_HEADERS,
+        _auth_user_setup,
+        _patch_stripe,
+    )
+    import frontend.finance_bot_websocket_custom as dashboard
+
+    _, _, client = _auth_user_setup(f"capi-forja-{user_id}")
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_m")
+    fake = _patch_stripe(monkeypatch)
+    client.cookies.set("_fbp", "sou-um-cookie-inventado")
+
+    r = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    assert r.status_code == 200, r.text
+    assert "fbp" not in fake.last_session_kwargs["metadata"]
+
+
+def test_formato_do_cookie_e_validado():
+    assert meta_capi.sanitize_fb_cookie(_FBP) == _FBP
+    assert meta_capi.sanitize_fb_cookie(f"  {_FBC}  ") == _FBC
+
+    for lixo in ["", "fb.1", "fb.1.abc.xyz", "xx.1.1596403881668.111",
+                 "fb.1.1596403881668." + "x" * 500, None, 42, {"a": 1}]:
+        assert meta_capi.sanitize_fb_cookie(lixo) is None, lixo


### PR DESCRIPTION
A CAPI já mandava `Purchase`, `StartTrial` e `CompleteRegistration` do servidor — mas o `user_data` levava só o e-mail com hash. Faltavam os dois cookies que o próprio pixel cria e que são o que o Meta usa para casar a conversão com o anúncio:

- **`_fbp`** — identifica o navegador;
- **`_fbc`** — identifica o **clique** (o pixel deriva do `fbclid` da URL de entrada).

Sem o `_fbc`, a venda chega ao Meta e **não chega à campanha** — que é a razão de existir a CAPI.

## Como os cookies chegam lá

Mesmo caminho do `ga_client_id` do #244, e pelo mesmo motivo: os cookies **já viajam sozinhos** no POST do `/billing/create-checkout`. São lidos no servidor (nenhum JS novo), validados na fronteira (`sanitize_fb_cookie` — eles acabam no metadata do Stripe e no corpo do Graph), e o webhook os lê do metadata na compra e em **cada renovação**.

A cópia no `subscription_data` não é redundância: a renovação só enxerga o metadata da assinatura. Sem ela, toda cobrança pós-trial chegaria ao Meta sem a campanha — tem teste para isso.

Os dois vão **crus**, de propósito: ao contrário do e-mail, o Meta ignora esses campos se vierem com hash. O evento seria aceito (2xx) com a atribuição perdida do mesmo jeito — falha silenciosa, do tipo que só aparece semanas depois no relatório.

Levei junto os **dois `CompleteRegistration`** (cadastro por e-mail e por Google): é a mesma classe, e ali os cookies estão a uma linha de distância, no próprio request.

## `META_TEST_EVENT_CODE` (env nova, opcional)

Setada, os eventos do servidor vão para a aba **Testar eventos** do Events Manager em vez do relatório. É o único jeito de validar o server-side sem esperar uma venda real — aquela aba não enxerga a CAPI sozinha.

**Vazia em produção.** Com ela setada, venda de verdade vira evento de teste e não conta como conversão. Está dito assim no `.env.example`.

## O que NÃO entrou, de propósito

Sintetizar o `_fbc` a partir do `fbclid` da URL no front-end. O pixel já faz isso sozinho na página de entrada; refazer em JS cobriria só o caso de pixel bloqueado — que é justamente quando o evento já perdeu o navegador de qualquer forma.

## Testes

Primeiro arquivo de teste da CAPI neste repositório (`grep meta_capi tests/` não achava nada). Eles leem o **corpo que iria pro Graph**, não se uma função foi chamada:

- cookies chegam crus no `user_data`, e o e-mail continua com hash (64 hex, sem `@`);
- **sem cookies o evento continua sendo enviado** — só perde correspondência, nunca deixa de ir;
- `test_event_code` aparece com a env e **não** aparece sem ela;
- cookie forjado não vira metadata;
- a cópia para o metadata da assinatura existe.

**Controle negativo medido:** desligando os três consertos (cookies no `user_data`, `test_event_code`, leitura dos cookies no endpoint), exatamente os 3 testes deles ficam vermelhos e os outros 3 seguem verdes.

**Suíte completa, comparada por nome:** `28 failed, 5553 passed` — os mesmos 13 testes vermelhos da `main` (fuso horário, subset de fonte, allowlist do #214, barra invertida do Windows). Zero regressão; os +6 que passam são os novos.

**Não verificado:** o Meta recebendo de fato. Depende de deploy e de uma venda real — ou do `META_TEST_EVENT_CODE`, que é o que essa env existe para permitir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
