### PR TITLE
O webhook passa a dizer o que fez com o rastreio

### DIFF
--- a/core/services/ga4_mp.py
+++ b/core/services/ga4_mp.py
@@ -145,6 +145,12 @@ def send_event(
             timeout=_REQUEST_TIMEOUT_SECONDS,
         )
         if 200 <= resp.status_code < 300:
+            # Loga o sucesso pelo mesmo motivo do meta_capi: sem isto, "enviei e
+            # o Google descartou" e "nem tentei" são o mesmo silêncio no log.
+            # (O GA4 responde 204 pra quase tudo — 2xx aqui significa "chegou",
+            # não "está certo". Pra ver o que ele achou do evento, DebugView.)
+            logger.info("[ga4_mp] %s enviado (client_id=%s, status=%s)",
+                        name, client_id, resp.status_code)
             return True
         logger.warning("[ga4_mp] %s rejeitado (%s): %s", name, resp.status_code, resp.text[:300])
         return False

--- a/core/services/meta_capi.py
+++ b/core/services/meta_capi.py
@@ -178,6 +178,12 @@ def send_event(
             timeout=_REQUEST_TIMEOUT_SECONDS,
         )
         if 200 <= resp.status_code < 300:
+            # Sucesso também loga, e não é ruído: sem esta linha, "não apareceu
+            # no Meta" e "nem tentou" ficam indistinguíveis no log — foi
+            # exatamente onde uma investigação empacou. O corpo traz
+            # `events_received`, que é a confirmação do lado do Meta.
+            logger.info("[meta_capi] %s enviado (event_id=%s): %s",
+                        event_name, event_id, resp.text[:200])
             return True
         logger.warning(
             "[meta_capi] %s rejeitado (%s): %s",

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4736,6 +4736,20 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                 )
             except Exception as exc:
                 print(f"[billing] admin notify falhou user={user_id}: {exc}")
+            # Uma linha dizendo o que este webhook DECIDIU sobre rastreio, antes
+            # de decidir. Sem ela, "não apareceu no Meta" não distinguia
+            # configuração ausente de envio recusado: os dois davam log nenhum, e
+            # foi onde uma investigação real empacou. Nunca pode quebrar o
+            # webhook, daí o try próprio.
+            try:
+                from core.services.ga4_mp import mp_configured as _mp_ok
+                from core.services.meta_capi import capi_configured as _capi_ok
+                print(f"[billing] rastreio checkout user={user_id} "
+                      f"status={sub_status} sid={_g(session, 'id')} "
+                      f"capi={_capi_ok()} ga4={_mp_ok()}")
+            except Exception as exc:
+                print(f"[billing] rastreio checkout: log falhou: {exc}")
+
             # Meta Conversions API — conversão server-side, deduplicada com o
             # pixel via event_id derivado da sessão. Trial → StartTrial; compra
             # imediata (sem trial) → Purchase. A cobrança REAL pós-trial e as
@@ -4880,6 +4894,20 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                         )
                 except Exception as exc:
                     print(f"[affiliates] comissao falhou user={user_id}: {exc}")
+
+                # O par do log do ramo de checkout: `billing_reason` é o que
+                # decide se esta fatura vira Purchase ou é pulada por já ter sido
+                # contada no checkout — sem ele no log, "pulou" e "falhou" são a
+                # mesma linha em branco.
+                try:
+                    from core.services.ga4_mp import mp_configured as _mp_ok
+                    from core.services.meta_capi import capi_configured as _capi_ok
+                    print(f"[billing] rastreio invoice user={user_id} "
+                          f"invoice={_g(invoice, 'id')} "
+                          f"reason={_g(invoice, 'billing_reason')} "
+                          f"capi={_capi_ok()} ga4={_mp_ok()}")
+                except Exception as exc:
+                    print(f"[billing] rastreio invoice: log falhou: {exc}")
 
                 # Meta Conversions API — Purchase da cobrança REAL (fim do trial
                 # e renovações), com o valor efetivamente pago. A primeira fatura

--- a/tests/test_meta_capi_cookies.py
+++ b/tests/test_meta_capi_cookies.py
@@ -185,6 +185,39 @@ def test_cookie_forjado_nao_vira_metadata(user_id, monkeypatch):
     assert "fbp" not in fake.last_session_kwargs["metadata"]
 
 
+def test_webhook_diz_o_que_decidiu_sobre_rastreio(user_id, monkeypatch, capsys):
+    """Observabilidade, e não é firula: numa investigação real o log ficou mudo e
+    "não chegou no Meta" era indistinguível de "nem tentou" — as duas davam
+    silêncio. A linha tem de sair SEMPRE, com as flags de configuração, mesmo
+    quando o envio é pulado."""
+    uid, client, fake = _setup(monkeypatch, f"capi-log-{user_id}")
+    _ligar_capi(monkeypatch)
+    try:
+        _post(client, fake, _evento_checkout(uid), subs={"sub_capi": _sub_pago()})
+        saida = capsys.readouterr().out
+        assert "rastreio checkout" in saida
+        assert f"user={uid}" in saida
+        assert "capi=True" in saida          # a flag, não só o rótulo
+    finally:
+        _cleanup_trial(uid)
+
+
+def test_log_de_rastreio_sai_ate_com_a_capi_desligada(user_id, monkeypatch, capsys):
+    """O caso que importa: desconfigurado, nada é enviado — e é justamente aí que
+    o log precisa existir, senão o silêncio volta a não significar nada."""
+    uid, client, fake = _setup(monkeypatch, f"capi-log-off-{user_id}")
+    monkeypatch.delenv("META_PIXEL_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("GA4_API_SECRET", raising=False)
+    try:
+        _post(client, fake, _evento_checkout(uid), subs={"sub_capi": _sub_pago()})
+        saida = capsys.readouterr().out
+        assert "rastreio checkout" in saida
+        assert "capi=False" in saida
+        assert "ga4=False" in saida
+    finally:
+        _cleanup_trial(uid)
+
+
 def test_formato_do_cookie_e_validado():
     assert meta_capi.sanitize_fb_cookie(_FBP) == _FBP
     assert meta_capi.sanitize_fb_cookie(f"  {_FBC}  ") == _FBC


### PR DESCRIPTION
Numa investigação real hoje — "a compra não apareceu no Meta" — o log do webhook não respondeu **nada**. Ele só escrevia em caso de exceção, então três situações muito diferentes produziam a mesma tela vazia:

- enviou e o Meta descartou;
- enviou para o balde de teste (`test_event_code` setado) e por isso não aparece no relatório;
- nem tentou, por falta de token.

A investigação virou adivinhação. Este PR conserta isso, sem mexer em comportamento.

## O que muda

**1. `meta_capi.send_event` loga o sucesso** (nível info) com o `event_id` e o corpo da resposta do Graph — que traz o `events_received`, a confirmação do lado do Meta. Antes só o 4xx/5xx aparecia.

**2. `ga4_mp.send_event` idem.** Com uma ressalva no comentário: o GA4 responde 204 para quase tudo, então 2xx ali significa "chegou", não "está certo" — para o resto, DebugView.

**3. O webhook imprime uma linha por ramo dizendo o que decidiu, antes de decidir:**

```
[billing] rastreio checkout user=123 status=active sid=cs_… capi=True ga4=True
[billing] rastreio invoice  user=123 invoice=in_… reason=subscription_cycle capi=True ga4=False
```

É a linha que separa "não configurado" de "recusado". O ramo de fatura mostra também o `billing_reason`, que é o que decide se aquela fatura vira `Purchase` ou é pulada por já ter sido contada no checkout — sem ele, "pulei de propósito" e "falhei" eram a mesma ausência de log.

Os prints têm `try` próprio: log de diagnóstico nunca pode derrubar um webhook de pagamento.

## Testes

- o log sai com a CAPI ligada (`capi=True`, com o `user=` certo);
- e sai **também com ela desligada** (`capi=False`, `ga4=False`) — justamente o caso em que nada é enviado, e onde o silêncio custava caro.

Não mutei este par: os asserts são sobre a string que só aquela linha produz, então a discriminação é por construção. Digo isso explicitamente porque o resto do histórico deste tracking tem controle negativo medido, e este não tem.

**Suíte completa, comparada por nome:** `28 failed, 5555 passed` — os mesmos 13 vermelhos da `main` (fuso horário, subset de fonte, allowlist do #214, barra invertida do Windows). Zero regressão; os +2 são os testes novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
