### PR TITLE
A frase abaixo da VSL vira botão: "COMECE JÁ" quando o vídeo acaba

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,9 +68,37 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     box-shadow: 0 24px 60px rgba(255,45,142,.16);
   }
   .vsl-video { display: block; width: 100%; height: auto; aspect-ratio: 16 / 9; background: #000; }
-  .vsl-status { margin: 16px auto 0; text-align: center; color: var(--text-muted); font-size: .9rem; }
+  .vsl-cta-wrap { margin: 26px auto 0; text-align: center; }
+  /* Reusa .btn/.btn-primary/.btn-lg do site.css — aqui só o que faz ele gritar. */
+  .vsl-cta {
+    font-size: 1.18rem; letter-spacing: .04em; padding: 19px 52px;
+    border: 2px solid rgba(255,255,255,.92);
+    border-radius: var(--radius-pill);
+    box-shadow: 0 16px 44px rgba(255,45,142,.45);
+  }
+  /* Travado NÃO é o .btn.is-locked cinza-desbotado: um botão apagado lê-se como
+     quebrado. Aqui ele vira superfície de espera, com a razão escrita nele. */
+  .vsl-cta.is-locked {
+    background: var(--bg-elev); color: var(--text-muted);
+    border: 2px dashed var(--border-strong);
+    box-shadow: none; opacity: 1; filter: none;
+    font-size: .96rem; letter-spacing: 0; padding: 16px 34px;
+  }
+  .vsl-cta.is-locked:hover { transform: none; box-shadow: none; }
+  /* O pulso só existe no estado liberado — é o que puxa o olho pro clique. */
+  @keyframes vslPulso {
+    0%, 100% { box-shadow: 0 16px 44px rgba(255,45,142,.42), 0 0 0 0 rgba(255,45,142,.45); }
+    50%      { box-shadow: 0 16px 44px rgba(255,45,142,.58), 0 0 0 16px rgba(255,45,142,0); }
+  }
+  .vsl-cta:not(.is-locked) { animation: vslPulso 2.4s ease-in-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .vsl-cta:not(.is-locked) { animation: none; } }
+  .vsl-status { margin: 14px auto 0; text-align: center; color: var(--text-muted); font-size: .88rem; min-height: 1.2em; }
   .vsl-status.is-ok { color: var(--pig-neon); }
   .vsl-status.is-alerta { color: var(--pig-pink); font-weight: 600; }
+  @media (max-width: 560px) {
+    .vsl-cta { font-size: 1.05rem; padding: 17px 34px; }
+    .vsl-cta.is-locked { padding: 15px 22px; font-size: .9rem; }
+  }
   /* Travado fica VISÍVEL e legível de propósito: CTA que some deixa a pessoa
      procurando o botão em vez de assistir ao vídeo. */
   .btn.is-locked { opacity: .55; cursor: not-allowed; filter: grayscale(.35); }
@@ -197,7 +225,16 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
                preload="metadata" poster="/brand/vsl-poster.jpg?v=1"
                src="/brand/vsl.mp4?v=1"></video>
       </div>
-      <p class="vsl-status" id="vsl-status" role="status">Assista ao vídeo para liberar o cadastro.</p>
+      <!-- É um <a href="/cadastro"> de verdade, e não um <button>: assim ele entra
+           sozinho no `alvos` do vsl-gate e no handler de clique, sem caso especial.
+           Nasce TRAVADO no HTML — se o JS não rodar, o que aparece é o convite a
+           assistir, nunca um botão morto. O rótulo vira "COMECE JÁ" ao liberar. -->
+      <div class="vsl-cta-wrap" data-reveal>
+        <a class="btn btn-primary btn-lg vsl-cta is-locked" id="vsl-cta"
+           href="/cadastro" aria-disabled="true"
+           ><span id="vsl-cta-txt">Assista ao vídeo para liberar</span></a>
+        <p class="vsl-status" id="vsl-status" role="status"></p>
+      </div>
     </section>
 
     <!-- ─── Faixa de valor ────────────────────────────────────────── -->
@@ -783,6 +820,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
   (function () {
     var video  = document.getElementById("vsl-video");
     var status = document.getElementById("vsl-status");
+    var rotulo = document.getElementById("vsl-cta-txt");
     if (!video) return;
 
     var CHAVE = "pb_vsl_visto";
@@ -807,8 +845,15 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         a.classList.remove("is-locked");
         a.removeAttribute("aria-disabled");
       });
+      // Quem está logado NÃO recebe "COMECE JÁ": o nav-auth.js já escreveu
+      // "Ir para o dashboard" e o href aponta pro /app. Na prática ele também já
+      // destruiu este <span> (`a.textContent = ...` troca os filhos — medido:
+      // `parentNode` fica null), então a escrita cairia no vazio de qualquer
+      // jeito. A condição fica porque a regra tem de estar dita em algum lugar
+      // que não seja um efeito colateral de outro arquivo.
+      if (motivo !== "logado" && rotulo) rotulo.textContent = "COMECE JÁ";
       if (status) {
-        status.textContent = "Cadastro liberado. É só clicar em começar.";
+        status.textContent = "Cadastro liberado.";
         status.className = "vsl-status is-ok";
       }
       // Só "assistiu" vira memória. "erro" não: um tropeço de rede não pode

--- a/tests/frontend/vsl_gate.test.mjs
+++ b/tests/frontend/vsl_gate.test.mjs
@@ -18,7 +18,14 @@
  * /brand/vsl.mp4 não dar 404 e abrir o portão pelo `error` antes da troca.
  *
  * O grupo tem os dois controles do CLAUDE.md §3:
- *   · conserto — os 5 CTAs nascem travados, e o clique NÃO navega;
+ *   · conserto — os 6 CTAs nascem travados, e o clique NÃO navega;
+ *   · o rótulo do botão da VSL — "Assista ao vídeo para liberar" antes,
+ *     "COMECE JÁ" depois;
+ *   · SEM JavaScript o botão continua travado. É o caso que prova o `is-locked`
+ *     escrito no HTML: com JS ligado o `travar()` põe a classe de qualquer jeito,
+ *     então apagá-la do markup não muda nada que os outros casos vejam — e o
+ *     visitante sem JS ficaria com um "COMECE JÁ" rosa e pulsante que promete o
+ *     que a página não pode cumprir;
  *   · anti-pulo — arrastar pro fim volta pro ponto assistido e o portão
  *     continua fechado (é o caso que morre se o `seeking` sair);
  *   · falha ABERTA — vídeo em 404 libera. Portão que trava por defeito zera
@@ -103,7 +110,8 @@ const assistirAteOFim = page => page.evaluate(() => new Promise(ok => {
 test("os CTAs de /cadastro nascem travados, e o clique não navega", async () => {
   const { page, ctx } = await abrirLanding();
   const estados = await travados(page);
-  assert.equal(estados.length, 5, "a landing tem 5 CTAs de /cadastro");
+  assert.equal(estados.length, 6, "a landing tem 6 CTAs de /cadastro (5 + o botão da VSL)");
+  assert.match(await page.textContent("#vsl-cta"), /Assista ao vídeo/);
   assert.ok(estados.every(Boolean), "todo CTA de /cadastro nasce travado");
 
   // `force` porque o Playwright recusa clicar em [aria-disabled=true] por conta
@@ -144,6 +152,7 @@ test("assistindo até o fim, o cadastro abre — e o clique navega", async () =>
   await assistirAteOFim(page);
   assert.ok((await travados(page)).every(e => e === false), "assistiu e continuou travado");
   assert.match(await page.textContent("#vsl-status"), /liberado/);
+  assert.equal((await page.textContent("#vsl-cta")).trim(), "COMECE JÁ");
 
   await Promise.all([
     page.waitForURL(/\/cadastro$/, { timeout: 5000 }),
@@ -178,5 +187,24 @@ test("quem já tem conta não fica com os CTAs travados", async () => {
                "o nav-auth deveria ter reescrito todos os CTAs");
   // E não vira memória: quem sair da conta volta a ser visitante e reassiste.
   assert.equal(await page.evaluate(() => localStorage.getItem("pb_vsl_visto")), null);
+  // Trava o comportamento do NAV-AUTH, não o meu: ele faz `a.textContent = ...`,
+  // que destrói o <span> do rótulo (medido: `parentNode` vira null), então nenhuma
+  // mutação do vsl-gate muda esta linha. Ela fica porque, se o nav-auth um dia
+  // parar de reescrever o texto, o cliente existente passa a ver "COMECE JÁ"
+  // apontando pro /app — e este caso é o que avisa.
+  assert.equal(await page.textContent("#vsl-cta"), "Ir para o dashboard");
+  await ctx.close();
+});
+
+test("sem JavaScript o botão continua travado", async () => {
+  const ctx = await browser.newContext({ javaScriptEnabled: false });
+  const page = await ctx.newPage();
+  await page.goto(`${ORIGIN}/index.html`, { waitUntil: "domcontentloaded" });
+  const b = await page.$eval("#vsl-cta", el => ({
+    classe: el.className, aria: el.getAttribute("aria-disabled"), texto: el.textContent.trim(),
+  }));
+  assert.ok(b.classe.includes("is-locked"), `o botão veio destravado do servidor: ${b.classe}`);
+  assert.equal(b.aria, "true");
+  assert.match(b.texto, /Assista ao vídeo/);
   await ctx.close();
 });


### PR DESCRIPTION
## O que muda

A linha cinza `Assista ao vídeo para liberar o cadastro.` abaixo do vídeo não pedia clique nenhum. Agora são dois estados desenhados:

| | |
|---|---|
| **travado** | pílula de borda **tracejada**, superfície de espera, com a razão escrita nele — "Assista ao vídeo para liberar" |
| **liberado** | **"COMECE JÁ"** em rosa, borda branca, pílula, com pulso de `box-shadow` |

O travado **não** usa o `.btn.is-locked` cinza-desbotado do `site.css`: botão apagado lê-se como quebrado, e este precisa dizer *"ainda não"*, não *"estragado"*.

O pulso respeita `prefers-reduced-motion`.

## Decisões

- **É um `<a href="/cadastro">`, não um `<button>`.** Assim ele entra sozinho no `alvos` e no handler de clique do `vsl-gate`, sem caso especial.
- **Nasce com `is-locked` no HTML.** Se o JS não rodar, o visitante vê o convite a assistir — nunca um "COMECE JÁ" rosa e pulsante prometendo o que a página não pode cumprir.
- **Reusa `.btn` / `.btn-primary` / `.btn-lg`** do `site.css`. O CSS novo é só o que faz ele gritar.
- **Quem está logado não recebe "COMECE JÁ"**: o `nav-auth.js` já escreveu "Ir para o dashboard" e o href aponta pro `/app`.

## Testes

**290/290 verde.** A contagem de CTAs vai de 5 para 6, e entra um caso novo com `javaScriptEnabled: false` — o único que discrimina o `is-locked` do markup, porque com JS ligado o `travar()` põe a classe de qualquer jeito.

### Duas asserções minhas que NÃO mediam nada

Achadas pela mutação, antes do push:

1. **O rótulo de quem já tem conta** é impossível de quebrar pelo `vsl-gate`: o `nav-auth` faz `a.textContent = ...`, que **destrói o `<span>` do rótulo** (medido — `parentNode` vira `null`). A asserção fica, mas agora o comentário diz o que ela realmente trava: o comportamento do *nav-auth*, não o meu. Se ele um dia parar de reescrever o texto, o cliente existente passa a ver "COMECE JÁ" apontando pro `/app`, e esse caso avisa.
2. **O `is-locked` do markup** — substituída pelo caso sem JavaScript, que discrimina de verdade.

### Controles

| desligado | caso que fica vermelho |
|---|---|
| `is-locked` do markup | sem JavaScript |
| escrita do rótulo "COMECE JÁ" | controle positivo (assistiu até o fim) |

## Medido

- Botão liberado: 183×62 px em 1280, 170×59 px em 390.
- `scrollWidth == innerWidth` nos dois — sem overflow horizontal.

## Não verificado

Safari e Firefox reais (só Chromium aqui), e a página no ar — frontend só aparece depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)