### PR TITLE
Botão no admin para liberar novo trial de um telefone

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1156,11 +1156,20 @@ async def fetch_admin_user_detail(user_id: int, admin_user: str = "admin") -> di
                     a.engagement_opt_out, a.tip_email_opt_out, a.insight_email_opt_out,
                     a.deletion_status, a.deletion_requested_at, a.signup_source,
                     a.ai_messages_this_month,
+                    -- Trava de trial: plan_trials é keyed por TELEFONE e
+                    -- sobrevive à conta, então ela pode existir com
+                    -- a.trial_started_at NULL (trava herdada de outra conta com
+                    -- o mesmo número). Sem estas duas colunas a tela dizia
+                    -- "Trial iniciado —" numa conta inelegível. phone_hash NÃO
+                    -- é selecionado: é HMAC de PII e o front não precisa.
+                    pt.started_at AS trial_lock_started_at,
+                    pt.user_id    AS trial_lock_user_id,
                     EXISTS (
                         SELECT 1 FROM user_identities ui
                         WHERE ui.user_id = a.user_id AND ui.provider = 'whatsapp'
                     ) AS has_whatsapp_identity
                 FROM auth_accounts a
+                LEFT JOIN plan_trials pt ON pt.phone_hash = a.phone_hash
                 WHERE a.user_id = %s
                 """,
                 (int(user_id),),
@@ -1638,6 +1647,71 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
             "plan": row["plan"],
             "plan_expires_at": row["plan_expires_at"],
             "last_payment_status": row["last_payment_status"],
+        }))
+
+    @app.post("/admin/api/users/{user_id}/trial-reset")
+    async def admin_api_user_trial_reset(
+        user_id: int, username: str = Depends(_get_current_admin)
+    ):
+        """Sem body: apaga a trava de trial do TELEFONE desta conta.
+
+        Serve a retestar o funil de assinatura com o próprio número. Como o
+        /plan, mexe só no banco — não fala com a Stripe. Por isso recusa com
+        409 quando há assinatura viva lá: apagar a trava não cancelaria nada, e
+        o checkout novo esbarraria na assinatura existente de qualquer forma.
+        """
+        # Uma coluna, sem passar pelo fetch_admin_user_detail: aquele decifra
+        # e-mail/telefone/nome e grava pii_access_log — acesso a PII que esta
+        # ação não precisa.
+        async with await db_connect() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT last_payment_status FROM auth_accounts WHERE user_id = %s",
+                    (int(user_id),),
+                )
+                acc = await cur.fetchone()
+        if acc is None:
+            raise HTTPException(status_code=404, detail="Conta não encontrada.")
+        pay = (acc.get("last_payment_status") or "").strip().lower()
+        if pay in {"trialing", "active", "past_due"}:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"A conta tem assinatura viva na Stripe (status {pay}). "
+                    "Quem manda no trial é a Stripe: liberar a trava aqui não "
+                    "cancela nada e o checkout novo esbarraria na assinatura "
+                    "existente. Cancele no Stripe primeiro e tente de novo."
+                ),
+            )
+        from db.plans import reset_trial_for_user
+        row = await asyncio.to_thread(reset_trial_for_user, user_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="Conta não encontrada.")
+        if row["phone"] is False:
+            raise HTTPException(
+                status_code=422,
+                detail=("Conta sem telefone vinculado: a trava é por telefone, "
+                        "não há o que liberar."),
+            )
+        # warning de propósito: é remoção de trava anti-abuso, tem que saltar na
+        # lista de eventos. Nada de telefone nem de phone_hash no details.
+        await log_system_event(
+            "warning",
+            "admin_trial_reset",
+            f"Trava de trial da conta {user_id} removida (admin {username}).",
+            source="admin",
+            user_id=int(user_id),
+            details={
+                "admin": username,
+                "deleted": row["deleted"],
+                "previous_started_at": _json_safe(row["previous_started_at"]),
+            },
+        )
+        return JSONResponse(content=_json_safe({
+            "ok": True,
+            "user_id": int(user_id),
+            "deleted": row["deleted"],
+            "previous_started_at": row["previous_started_at"],
         }))
 
     @app.delete("/admin/api/events/{event_id}")

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -1713,7 +1713,12 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
             details={
                 "admin": username,
                 "deleted": row["deleted"],
+                # As duas datas, porque divergem no caso que mais importa: na
+                # trava herdada (conta anterior apagada, plan_trials.user_id
+                # nulo) a âncora da conta é nula e a data do trial queimado só
+                # existe na linha destruída — sem registrá-la aqui ela some.
                 "previous_started_at": _json_safe(row["previous_started_at"]),
+                "previous_lock_started_at": _json_safe(row["previous_lock_started_at"]),
             },
         )
         return JSONResponse(content=_json_safe({

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -754,6 +754,15 @@ async def _fetch_admin_overview_inner(days: int = 30, admin_user: str = "admin")
 _USER_STATUSES = ("paying", "trial", "past_due", "canceled", "granted", "free")
 
 
+# Status crus de last_payment_status (o webhook grava o do Stripe sem traduzir,
+# db_support.set_payment_status) que ainda descrevem uma assinatura VIVA lá:
+# 'unpaid' é dunning e 'incomplete' é 3DS pendente — não são terminais. Os
+# terminais são 'canceled' e 'incomplete_expired'. Uma lista só porque a mesma
+# regra decide o rótulo do painel e o gate de /trial-reset (§0.7).
+_PAST_DUE_PAYMENT_STATUSES = ("past_due", "unpaid", "incomplete")
+_LIVE_PAYMENT_STATUSES = frozenset({"trialing", "active", *_PAST_DUE_PAYMENT_STATUSES})
+
+
 def _derive_account_status(row: dict, now: datetime) -> str:
     """Classifica a conta numa categoria única de assinatura.
 
@@ -782,7 +791,7 @@ def _derive_account_status(row: dict, now: datetime) -> str:
         return "trial"
     if pay == "active":
         return "paying"
-    if pay in ("past_due", "unpaid", "incomplete"):
+    if pay in _PAST_DUE_PAYMENT_STATUSES:
         return "past_due"
     if pay in ("canceled", "incomplete_expired"):
         return "canceled"
@@ -1673,7 +1682,7 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
         if acc is None:
             raise HTTPException(status_code=404, detail="Conta não encontrada.")
         pay = (acc.get("last_payment_status") or "").strip().lower()
-        if pay in {"trialing", "active", "past_due"}:
+        if pay in _LIVE_PAYMENT_STATUSES:
             raise HTTPException(
                 status_code=409,
                 detail=(

--- a/db/plans.py
+++ b/db/plans.py
@@ -121,6 +121,67 @@ def is_trial_eligible_for_user(user_id: int) -> bool:
         raise TrialEligibilityError("Falha ao consultar a elegibilidade do trial.") from exc
 
 
+def reset_trial_for_user(user_id: int) -> dict | None:
+    """Apaga a trava de trial do TELEFONE desta conta e reancora a conta.
+
+    Ação de admin (drill-down do painel): devolve a esta conta o direito ao
+    trial de 15 dias. Tudo numa transação só — ler e apagar juntos evita a
+    corrida com a troca de telefone (frontend/routes/settings.py reescreve
+    phone_hash).
+
+    Apaga por UM phone_hash, o da própria conta, lido exatamente como
+    is_trial_eligible_for_user lê. NUNCA por phone_lookup_candidates: as
+    variantes de nono dígito produzem hash que pode ser de OUTRA conta, e
+    apagar a trava dela seria vazar a ação entre usuários. phone_hash é único
+    em auth_accounts e PK em plan_trials, então um hash é de no máximo uma conta.
+
+    Limpar `trial_started_at` é parte do conserto, não enfeite:
+    claim_trial_for_user só grava a âncora quando ela é nula ou mais nova que o
+    started_at novo, então uma âncora velha faria o trial seguinte nascer
+    vencido (get_trial_status calcula o fim pela data antiga e devolve
+    days_left=0 enquanto a Stripe dá os 15 dias). `trial_downsell_sent_at` vai
+    no mesmo UPDATE pro funil de downsell poder ser testado de novo.
+
+    Não fala com a Stripe: assinatura viva continua onde está (quem recusa esse
+    caso é o chamador). Retorna None se a conta não existe; `phone: False`
+    quando não há telefone vinculado — aí não há trava a remover e nada é escrito.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select phone_hash, trial_started_at from auth_accounts where user_id = %s",
+                (int(user_id),),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            phone_hash = row.get("phone_hash")
+            deleted = 0
+            if phone_hash:
+                cur.execute(
+                    "delete from plan_trials where phone_hash = %s", (phone_hash,)
+                )
+                deleted = cur.rowcount
+                cur.execute(
+                    """
+                    update auth_accounts
+                    set trial_started_at = null, trial_downsell_sent_at = null
+                    where user_id = %s
+                    """,
+                    (int(user_id),),
+                )
+        conn.commit()
+    # get_auth_user cacheia trial_started_at (db_support.py) — mesmo par que
+    # claim_trial_for_user usa depois de escrever.
+    from db_support import invalidate_auth_user_cache
+    invalidate_auth_user_cache(user_id)
+    return {
+        "phone": bool(phone_hash),
+        "deleted": deleted,
+        "previous_started_at": row.get("trial_started_at"),
+    }
+
+
 def get_trial_started_at(user_id: int) -> datetime | None:
     with get_conn() as conn:
         with conn.cursor() as cur:

--- a/db/plans.py
+++ b/db/plans.py
@@ -125,9 +125,13 @@ def reset_trial_for_user(user_id: int) -> dict | None:
     """Apaga a trava de trial do TELEFONE desta conta e reancora a conta.
 
     Ação de admin (drill-down do painel): devolve a esta conta o direito ao
-    trial de 15 dias. Tudo numa transação só — ler e apagar juntos evita a
-    corrida com a troca de telefone (frontend/routes/settings.py reescreve
-    phone_hash).
+    trial de 15 dias. Tudo numa transação só, e o SELECT é `for update`: sem o
+    lock de linha a transação seria READ COMMITTED pura, e uma troca de telefone
+    concorrente (frontend/routes/settings.py reescreve phone_hash) commitando
+    entre o SELECT e o DELETE faria isto apagar a trava do número ANTIGO e
+    reportar sucesso com o número atual ainda travado. O `for update` faz a
+    troca esperar ou o reset ler o hash já novo — nas duas ordens a trava
+    apagada é a do telefone que a conta tem no fim.
 
     Apaga por UM phone_hash, o da própria conta, lido exatamente como
     is_trial_eligible_for_user lê. NUNCA por phone_lookup_candidates: as
@@ -145,11 +149,19 @@ def reset_trial_for_user(user_id: int) -> dict | None:
     Não fala com a Stripe: assinatura viva continua onde está (quem recusa esse
     caso é o chamador). Retorna None se a conta não existe; `phone: False`
     quando não há telefone vinculado — aí não há trava a remover e nada é escrito.
+
+    Devolve as DUAS datas, porque elas não são a mesma e a auditoria precisa da
+    que se perde: `previous_lock_started_at` é o started_at da linha de
+    plan_trials destruída (quando o trial foi queimado NAQUELE telefone) e
+    `previous_started_at` é a âncora da conta. Numa trava herdada — conta
+    anterior apagada, plan_trials.user_id nulo por ON DELETE SET NULL, número
+    recadastrado — a âncora é nula e só a primeira registra o que existia.
     """
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "select phone_hash, trial_started_at from auth_accounts where user_id = %s",
+                "select phone_hash, trial_started_at from auth_accounts "
+                "where user_id = %s for update",
                 (int(user_id),),
             )
             row = cur.fetchone()
@@ -157,11 +169,16 @@ def reset_trial_for_user(user_id: int) -> dict | None:
                 return None
             phone_hash = row.get("phone_hash")
             deleted = 0
+            lock_started_at = None
             if phone_hash:
                 cur.execute(
-                    "delete from plan_trials where phone_hash = %s", (phone_hash,)
+                    "delete from plan_trials where phone_hash = %s returning started_at",
+                    (phone_hash,),
                 )
-                deleted = cur.rowcount
+                # phone_hash é PK em plan_trials: no máximo uma linha.
+                apagada = cur.fetchone()
+                deleted = 1 if apagada else 0
+                lock_started_at = apagada.get("started_at") if apagada else None
                 cur.execute(
                     """
                     update auth_accounts
@@ -179,6 +196,7 @@ def reset_trial_for_user(user_id: int) -> dict | None:
         "phone": bool(phone_hash),
         "deleted": deleted,
         "previous_started_at": row.get("trial_started_at"),
+        "previous_lock_started_at": lock_started_at,
     }
 
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -201,6 +201,12 @@ O drill-down de uma conta troca o plano à mão (`POST /admin/api/users/{id}/pla
 `plan`/`plan_expires_at` no banco e **não fala com a Stripe** — assinatura viva
 continua lá e o próximo webhook dela sobrescreve.
 
+A segunda escrita do drill-down libera novo trial
+(`POST /admin/api/users/{id}/trial-reset` → `db.plans.reset_trial_for_user`):
+apaga a linha de `plan_trials` do **telefone** da conta e zera
+`trial_started_at`/`trial_downsell_sent_at`. **Também não fala com a Stripe** —
+por isso recusa com 409 quando `last_payment_status` é `trialing|active|past_due`.
+
 ### Tarefas de fundo
 
 Sobem no startup do app quando `RUN_BACKGROUND_TASKS != "0"`: rendimento de

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -2157,15 +2157,32 @@ function renderUserDetail(data) {
   // sobrevive à conta: pode existir com trial_started_at NULL aqui, herdada de
   // outra conta que usou o mesmo número. É essa linha que explica a conta
   // inelegível cujo "Trial (conta)" está vazio.
-  const lockedByOther = p.trial_lock_started_at
-    && p.trial_lock_user_id != null && Number(p.trial_lock_user_id) !== Number(p.user_id);
+  //
+  // E são TRÊS casos, não dois: plan_trials.user_id é ON DELETE SET NULL
+  // (db/schema.py), então a trava herdada de uma conta já APAGADA chega com
+  // user_id NULO. Esse é o caso mais comum, e era o que renderizava uma data
+  // pelada sem explicação nenhuma — a confusão que esta linha existe para
+  // resolver.
+  const lockOwner = !p.trial_lock_started_at ? ''
+    : p.trial_lock_user_id == null
+      ? ' · trava herdada: a conta que queimou o trial neste número foi apagada'
+      : Number(p.trial_lock_user_id) !== Number(p.user_id)
+        ? ` · trava de OUTRA conta com o mesmo número (user ${Number(p.trial_lock_user_id)})`
+        : '';
   const trialLock = p.trial_lock_started_at
-    ? `${fDate(p.trial_lock_started_at)}${lockedByOther
-        ? ` · trava de OUTRA conta com o mesmo número (user ${Number(p.trial_lock_user_id)})` : ''}`
+    ? `${fDate(p.trial_lock_started_at)}${lockOwner}`
     : 'sem trava — telefone ainda elegível';
+  // Só bloqueia quando não há NADA a limpar. Âncora sem trava é estado real
+  // (a troca de telefone reescreve phone_hash e deixa trial_started_at para
+  // trás) e é justamente o que faz o próximo trial nascer vencido — recusar o
+  // botão aí seria recusar o único remédio.
   const resetBlocked = !p.phone_e164
     ? 'Conta sem telefone vinculado: a trava é por telefone, não há o que liberar.'
-    : (!p.trial_lock_started_at ? 'Sem trava registrada para este telefone — nada a liberar.' : '');
+    : (!p.trial_lock_started_at && !p.trial_started_at
+        ? 'Sem trava no telefone e sem âncora de trial na conta — nada a liberar.' : '');
+  const resetHint = resetBlocked || (p.trial_lock_started_at
+    ? 'Apaga a trava do TELEFONE desta conta (o direito ao trial é 1 por número, na vida) e zera a âncora do trial e o downsell. Não fala com a Stripe: assinatura viva lá continua de pé e é recusada aqui.'
+    : 'Sem trava no telefone, mas a conta guarda uma âncora de trial antiga — ela faria o próximo trial nascer vencido. Zera a âncora e o downsell; não há trava a apagar.');
 
   $id('user-detail').innerHTML = `
     <div class="detail-head" style="display:flex;align-items:center;gap:10px;margin:4px 0 14px">
@@ -2217,8 +2234,7 @@ function renderUserDetail(data) {
               data-email="${esc(p.email || '')}" data-phone="${esc(p.phone_e164 || '')}"
               data-lock="${p.trial_lock_started_at ? esc(fDate(p.trial_lock_started_at)) : ''}"
               onclick="resetTrial(${Number(p.user_id)})">Liberar novo trial</button>
-      <span class="plan-hint ${resetBlocked ? 'warn' : ''}">${resetBlocked
-        || 'Apaga a trava do TELEFONE desta conta (o direito ao trial é 1 por número, na vida) e zera a âncora do trial e o downsell. Não fala com a Stripe: assinatura viva lá continua de pé e é recusada aqui.'}</span>
+      <span class="plan-hint ${resetBlocked ? 'warn' : ''}">${resetHint}</span>
     </div>
 
     <div class="detail-section-title">Uso (contagens — sem conteúdo financeiro)</div>
@@ -2290,9 +2306,11 @@ async function applyPlanChange(userId) {
 async function resetTrial(userId) {
   const btn = $id('trial-reset');
   const phone = btn.dataset.phone || 'sem telefone';
-  const lock = btn.dataset.lock || '—';
+  const lock = btn.dataset.lock;
   if (!confirm(`Liberar novo trial para ${btn.dataset.email || `user ${userId}`} (${phone})?\n\n`
-    + `A trava atual do telefone (${lock}) será APAGADA, junto com a data de trial da conta `
+    + (lock
+        ? `A trava atual do telefone (${lock}) será APAGADA, junto com a data de trial da conta `
+        : 'Este telefone não tem trava registrada. Será apagada a data de trial da conta ')
     + 'e o registro de downsell.\n\nA Stripe NÃO é alterada por aqui.')) return;
 
   btn.disabled = true;

--- a/frontend/admin-dashboard.html
+++ b/frontend/admin-dashboard.html
@@ -2153,6 +2153,20 @@ function renderUserDetail(data) {
   const planNow = stored === 'plus' ? 'pro'
     : (PLAN_WRITE_VALUES.includes(stored) ? stored : 'free');
 
+  // A trava de trial é por TELEFONE (plan_trials, keyed por phone_hash) e
+  // sobrevive à conta: pode existir com trial_started_at NULL aqui, herdada de
+  // outra conta que usou o mesmo número. É essa linha que explica a conta
+  // inelegível cujo "Trial (conta)" está vazio.
+  const lockedByOther = p.trial_lock_started_at
+    && p.trial_lock_user_id != null && Number(p.trial_lock_user_id) !== Number(p.user_id);
+  const trialLock = p.trial_lock_started_at
+    ? `${fDate(p.trial_lock_started_at)}${lockedByOther
+        ? ` · trava de OUTRA conta com o mesmo número (user ${Number(p.trial_lock_user_id)})` : ''}`
+    : 'sem trava — telefone ainda elegível';
+  const resetBlocked = !p.phone_e164
+    ? 'Conta sem telefone vinculado: a trava é por telefone, não há o que liberar.'
+    : (!p.trial_lock_started_at ? 'Sem trava registrada para este telefone — nada a liberar.' : '');
+
   $id('user-detail').innerHTML = `
     <div class="detail-head" style="display:flex;align-items:center;gap:10px;margin:4px 0 14px">
       <button onclick="showUsersList()"><i class="ph ph-arrow-left" aria-hidden="true"></i> Voltar</button>
@@ -2170,7 +2184,8 @@ function renderUserDetail(data) {
       ${item('Plano', `${esc(planLabel(p.plan))}${p.plan_expires_at ? ` · expira ${fDate(p.plan_expires_at)}` : ''}`)}
       ${item('Origem do cadastro', esc(sourceLabel(p.signup_source)))}
       ${item('Status pagamento', esc(p.last_payment_status || '—'))}
-      ${item('Trial iniciado', p.trial_started_at ? fDate(p.trial_started_at) : '—')}
+      ${item('Trial (conta)', p.trial_started_at ? fDate(p.trial_started_at) : '—')}
+      ${item('Trial (trava do telefone)', trialLock)}
       ${item('Plano escolhido em', p.plan_selected_at ? fDate(p.plan_selected_at) : '—')}
       ${item('Cadastro', fDate(p.created_at))}
       ${item('Última atividade', p.last_activity_at ? `${fRelTime(p.last_activity_at)}` : '—')}
@@ -2194,6 +2209,16 @@ function renderUserDetail(data) {
       <span class="plan-hint ${p.stripe_customer_id ? 'warn' : ''}">${p.stripe_customer_id
         ? 'Conta com cliente na Stripe: isto muda só o banco — a assinatura continua lá e o próximo webhook dela sobrescreve o plano. Cancele/troque no Stripe também.'
         : 'Vale na hora para os limites do plano. Bancos de Open Finance e agentes acima do teto novo caem na varredura de downgrade (a cada 6h).'}</span>
+    </div>
+
+    <div class="detail-section-title">Liberar novo trial</div>
+    <div class="plan-editor">
+      <button class="btn-primary" id="trial-reset" ${resetBlocked ? 'disabled' : ''}
+              data-email="${esc(p.email || '')}" data-phone="${esc(p.phone_e164 || '')}"
+              data-lock="${p.trial_lock_started_at ? esc(fDate(p.trial_lock_started_at)) : ''}"
+              onclick="resetTrial(${Number(p.user_id)})">Liberar novo trial</button>
+      <span class="plan-hint ${resetBlocked ? 'warn' : ''}">${resetBlocked
+        || 'Apaga a trava do TELEFONE desta conta (o direito ao trial é 1 por número, na vida) e zera a âncora do trial e o downsell. Não fala com a Stripe: assinatura viva lá continua de pé e é recusada aqui.'}</span>
     </div>
 
     <div class="detail-section-title">Uso (contagens — sem conteúdo financeiro)</div>
@@ -2254,6 +2279,35 @@ async function applyPlanChange(userId) {
   } catch (e) {
     console.error('plan-change:', e);
     alert('Falha de rede ao alterar o plano.');
+    btn.disabled = false;
+  }
+}
+
+/* Apaga a trava de trial do TELEFONE desta conta (1 trial por número, na vida)
+   para o número poder testar o funil de assinatura de novo. Só o banco: a
+   Stripe não é consultada nem alterada, e o backend recusa (409) conta com
+   assinatura viva lá. Não redesenha a lista: ela não mostra trial. */
+async function resetTrial(userId) {
+  const btn = $id('trial-reset');
+  const phone = btn.dataset.phone || 'sem telefone';
+  const lock = btn.dataset.lock || '—';
+  if (!confirm(`Liberar novo trial para ${btn.dataset.email || `user ${userId}`} (${phone})?\n\n`
+    + `A trava atual do telefone (${lock}) será APAGADA, junto com a data de trial da conta `
+    + 'e o registro de downsell.\n\nA Stripe NÃO é alterada por aqui.')) return;
+
+  btn.disabled = true;
+  try {
+    const res = await fetch(`/admin/api/users/${userId}/trial-reset`, {
+      method: 'POST',
+      headers: authH(),
+    });
+    if (res.status === 401) { window.location.href = '/admin/login'; return; }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) { alert(data.detail || 'Erro ao liberar o trial.'); btn.disabled = false; return; }
+    await openUserDetail(userId);
+  } catch (e) {
+    console.error('trial-reset:', e);
+    alert('Falha de rede ao liberar o trial.');
     btn.disabled = false;
   }
 }

--- a/tests/frontend/admin_trial_lock_row.test.mjs
+++ b/tests/frontend/admin_trial_lock_row.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * Drill-down do painel de admin: a linha da trava de trial e o botão "Liberar
+ * novo trial".
+ *
+ * Os dois defeitos que isto pega, ambos no caso REAL do dono (`plan_trials` é
+ * keyed por telefone, PK = phone_hash, e a FK pro usuário é ON DELETE SET NULL
+ * — db/schema.py):
+ *
+ *   1. TRAVA HERDADA: conta antiga apagada, número recadastrado. A linha da
+ *      trava sobrevive com `user_id` NULO. A versão anterior exigia
+ *      `trial_lock_user_id != null` para explicar a trava, então esse caso —
+ *      o mais comum — renderizava uma data pelada, sem uma palavra de porquê.
+ *      É exatamente a confusão que a linha foi criada para resolver.
+ *
+ *   2. ÂNCORA SEM TRAVA: a troca de telefone (frontend/routes/settings.py)
+ *      reescreve `phone_hash` e deixa `trial_started_at` para trás. A conta
+ *      fica sem trava e com âncora velha — o estado que faz o próximo trial
+ *      nascer VENCIDO. A versão anterior desabilitava o botão sempre que não
+ *      havia trava, recusando o único remédio.
+ *
+ * Os dois controles do CLAUDE.md §3, para o GRUPO:
+ *   · negativo — desligar qualquer um dos dois consertos deixa pelo menos um
+ *     caso vermelho: sem o ramo `trial_lock_user_id == null` a herdada perde o
+ *     texto; sem o `&& !p.trial_started_at` a âncora-sem-trava volta a ficar
+ *     desabilitada. As duas rodadas estão no relato do PR.
+ *   · positivo — `sem_nada` e `sem_telefone` continuam DESABILITADOS. Sem eles
+ *     o grupo passaria numa versão que habilita o botão sempre, que é pior que
+ *     o bug: apaga âncora e downsell de conta que não tinha nada a liberar.
+ *
+ * A medição é de DOM renderizado pelo caminho real (`openUserDetail` → fetch
+ * → `renderUserDetail`), não de texto do arquivo: ler o .html com regex mede o
+ * arquivo, não o comportamento.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+const UID = 4242;
+
+/** Perfil mínimo que o `renderUserDetail` consome, com os campos do caso. */
+function perfil(extra) {
+  return {
+    user_id: UID, email: "dono@test.local", display_name: "Dono",
+    phone_e164: "+5511999990000", plan: "free", plan_expires_at: null,
+    signup_source: "web", last_payment_status: null, account_status: "free",
+    trial_started_at: null, trial_lock_started_at: null, trial_lock_user_id: null,
+    plan_selected_at: null, created_at: "2026-01-01T00:00:00+00:00",
+    last_activity_at: null, phone_status: "confirmed", has_whatsapp_identity: true,
+    ai_messages_this_month: 0, stripe_customer_id: null, deletion_status: null,
+    engagement_opt_out: false, tip_email_opt_out: false,
+    insight_email_opt_out: false, whatsapp_updates_opt_out: false,
+    ...extra,
+  };
+}
+
+/**
+ * Abre a página, força o drill-down do UID com o perfil dado e devolve o que a
+ * tela mostra: o texto da linha da trava, se o botão está desabilitado, e a
+ * dica ao lado dele.
+ */
+async function renderizar(extra) {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  // Catch-all ANTES do específico: o Playwright casa as rotas da mais recente
+  // para a mais antiga. Tudo 200 de propósito — um único 401 dispara
+  // `window.location.href = '/admin/login'` e a página some debaixo do teste.
+  await page.route("**/admin/api/**", (route) => route.fulfill({
+    contentType: "application/json", body: "{}",
+  }));
+  await page.route(`**/admin/api/users/${UID}`, (route) => route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({
+      profile: perfil(extra),
+      usage: { tx_total: 0, tx_30d: 0, last_tx_at: null, pockets_count: 0,
+               investments_count: 0, cards_count: 0 },
+      recent_events: [], recent_logins: [],
+    }),
+  }));
+
+  await page.goto(`${ORIGIN}/admin-dashboard.html`, { waitUntil: "domcontentloaded" });
+  await page.evaluate((uid) => window.openUserDetail(uid), UID);
+  // `attached`, não `visible`: o drill-down vive dentro do modal de usuários,
+  // que só abre por clique. O que se mede aqui é o markup que o
+  // `renderUserDetail` produz, e ele já está no DOM.
+  await page.waitForSelector("#trial-reset", { state: "attached" });
+
+  const visto = await page.evaluate(() => {
+    const linha = [...document.querySelectorAll("#user-detail .detail-item")]
+      .find((el) => el.querySelector(".k")?.textContent.includes("trava do telefone"));
+    const btn = document.getElementById("trial-reset");
+    return {
+      trava: linha?.querySelector(".v")?.textContent.trim() ?? null,
+      desabilitado: btn.disabled,
+      dica: btn.closest(".plan-editor").querySelector(".plan-hint").textContent.trim(),
+    };
+  });
+  await page.close();
+  return visto;
+}
+
+const ONTEM = "2026-08-01T12:00:00+00:00";
+
+// ── (4) os TRÊS casos da trava, não dois ───────────────────────────────────
+
+test("trava herdada (user_id nulo) é EXPLICADA, não uma data pelada", async () => {
+  const v = await renderizar({ trial_lock_started_at: ONTEM, trial_lock_user_id: null });
+  assert.match(v.trava, /trava herdada/i, `linha da trava: ${v.trava}`);
+  assert.match(v.trava, /apagada/i, `linha da trava: ${v.trava}`);
+  // E a data continua lá — a explicação não pode ter comido o dado.
+  assert.match(v.trava, /\d/, `linha da trava: ${v.trava}`);
+  // O remédio tem de estar disponível: é o caso canônico do recurso.
+  assert.equal(v.desabilitado, false);
+});
+
+test("trava de OUTRA conta identificável cita o user dela", async () => {
+  const v = await renderizar({ trial_lock_started_at: ONTEM, trial_lock_user_id: 777 });
+  assert.match(v.trava, /OUTRA conta/, `linha da trava: ${v.trava}`);
+  assert.match(v.trava, /777/, `linha da trava: ${v.trava}`);
+  assert.doesNotMatch(v.trava, /herdada/i, `linha da trava: ${v.trava}`);
+  assert.equal(v.desabilitado, false);
+});
+
+test("trava da PRÓPRIA conta é só a data, sem ressalva nenhuma", async () => {
+  const v = await renderizar({ trial_lock_started_at: ONTEM, trial_lock_user_id: UID,
+                               trial_started_at: ONTEM });
+  assert.doesNotMatch(v.trava, /herdada|OUTRA conta/i, `linha da trava: ${v.trava}`);
+  assert.equal(v.desabilitado, false);
+});
+
+// ── (1) âncora sem trava: o botão existe para consertar ISTO ───────────────
+
+test("âncora sem trava (pós-troca de telefone) NÃO bloqueia o botão", async () => {
+  const v = await renderizar({ trial_started_at: ONTEM, trial_lock_started_at: null });
+  assert.equal(v.desabilitado, false,
+    "o estado que faz o trial nascer vencido é o que o botão conserta");
+  assert.match(v.trava, /sem trava/i, `linha da trava: ${v.trava}`);
+  // A dica tem de dizer QUAL dos dois casos está tratando: aqui não há trava a
+  // apagar, e prometer que apaga uma seria mentir na confirmação.
+  assert.match(v.dica, /âncora/i, `dica: ${v.dica}`);
+  assert.doesNotMatch(v.dica, /Apaga a trava do TELEFONE/, `dica: ${v.dica}`);
+});
+
+test("com trava, a dica é a da trava — não a da âncora", async () => {
+  const v = await renderizar({ trial_lock_started_at: ONTEM, trial_lock_user_id: UID });
+  assert.match(v.dica, /Apaga a trava do TELEFONE/, `dica: ${v.dica}`);
+});
+
+// ── controles POSITIVOS: o botão continua recusando o que não tem remédio ──
+
+test("sem trava e sem âncora: botão DESABILITADO", async () => {
+  const v = await renderizar({});
+  assert.equal(v.desabilitado, true);
+  assert.match(v.dica, /nada a liberar/i, `dica: ${v.dica}`);
+});
+
+test("conta sem telefone: botão DESABILITADO mesmo com âncora", async () => {
+  const v = await renderizar({ phone_e164: null, trial_started_at: ONTEM });
+  assert.equal(v.desabilitado, true);
+  assert.match(v.dica, /sem telefone vinculado/i, `dica: ${v.dica}`);
+});

--- a/tests/frontend/handlers_inline.baseline.json
+++ b/tests/frontend/handlers_inline.baseline.json
@@ -13,6 +13,7 @@
       "openUserDetail",
       "openUsersModal",
       "payoutAction",
+      "resetTrial",
       "setUsersStatus",
       "showPayoutPix",
       "showUsersList",

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -682,3 +682,320 @@ def test_planos_gravaveis_do_html_espelham_o_backend():
     assert match, "PLAN_WRITE_VALUES sumiu de frontend/admin-dashboard.html"
     do_html = tuple(re.findall(r"'([a-z_]+)'", match.group(1)))
     assert do_html == admin_dashboard.ADMIN_PLAN_VALUES
+
+
+# ── Liberar novo trial (POST /admin/api/users/{id}/trial-reset) ────────────
+#
+# A trava de trial é por TELEFONE (plan_trials, PK = phone_hash) e sobrevive à
+# conta. _mk_account não grava phone_hash — os testes abaixo setam à mão e
+# limpam plan_trials no finally (a FK é ON DELETE SET NULL, não CASCADE, então
+# apagar a conta deixa a linha da trava para trás).
+
+def _set_phone(uid: int, phone: str) -> str:
+    """Vincula um telefone à conta e devolve o phone_hash gravado."""
+    from core.crypto import hash_pii
+    h = hash_pii(phone, kind="phone")
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set phone_e164 = %s, phone_hash = %s where user_id = %s",
+                (phone, h, uid),
+            )
+        conn.commit()
+    return h
+
+
+def _lock_trial(phone_hash: str, uid: int, started_at=None) -> None:
+    """Queima o trial daquele telefone (o que claim_trial_for_user grava)."""
+    started_at = started_at or (NOW - timedelta(days=40))
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                insert into plan_trials (phone_hash, user_id, started_at, model_version)
+                values (%s, %s, %s, 2)
+                on conflict (phone_hash) do update set started_at = excluded.started_at
+                """,
+                (phone_hash, uid, started_at),
+            )
+            cur.execute(
+                "update auth_accounts set trial_started_at = %s where user_id = %s",
+                (started_at, uid),
+            )
+        conn.commit()
+
+
+def _trial_lock_exists(phone_hash: str) -> bool:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select 1 from plan_trials where phone_hash = %s", (phone_hash,))
+            return cur.fetchone() is not None
+
+
+def _drop_locks(*hashes: str) -> None:
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("delete from plan_trials where phone_hash = any(%s)", (list(hashes),))
+        conn.commit()
+
+
+def _reset_trial(client: TestClient, uid: int):
+    return client.post(
+        f"/admin/api/users/{uid}/trial-reset",
+        headers={dashboard.CSRF_HEADER_NAME: "test-admin-csrf"},
+    )
+
+
+def test_trial_reset_exige_sessao_admin(panel_accounts):
+    """Sem sessão: 401 E a trava continua de pé (não basta o status)."""
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, uid)
+    try:
+        anon = TestClient(dashboard.app, base_url="https://testserver")
+        anon.cookies.set(dashboard.CSRF_COOKIE_NAME, "test-admin-csrf")
+        assert _reset_trial(anon, uid).status_code == 401
+        assert _trial_lock_exists(h) is True
+    finally:
+        _drop_locks(h)
+
+
+def test_trial_reset_devolve_a_elegibilidade_de_verdade(panel_accounts):
+    """O caso principal, medido pelas funções REAIS de db.plans (sem mock):
+    inelegível antes → 200 → linha some, âncora zerada e elegível depois."""
+    from db.plans import get_trial_started_at, is_trial_eligible_for_user
+
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, uid)
+    try:
+        assert is_trial_eligible_for_user(uid) is False
+        assert get_trial_started_at(uid) is not None
+
+        resp = _reset_trial(_admin_client(), uid)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["deleted"] == 1
+
+        assert _trial_lock_exists(h) is False
+        assert get_trial_started_at(uid) is None
+        assert is_trial_eligible_for_user(uid) is True
+    finally:
+        _drop_locks(h)
+
+
+def test_trial_reset_limpa_o_downsell_junto(panel_accounts):
+    """Decisão do dono: o funil de downsell tem que poder rodar de novo."""
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, uid)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set trial_downsell_sent_at = now() where user_id = %s",
+                (uid,),
+            )
+        conn.commit()
+    try:
+        assert _reset_trial(_admin_client(), uid).status_code == 200
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "select trial_downsell_sent_at from auth_accounts where user_id = %s",
+                    (uid,),
+                )
+                assert cur.fetchone()["trial_downsell_sent_at"] is None
+    finally:
+        _drop_locks(h)
+
+
+def test_trial_reset_nao_libera_o_telefone_de_outra_conta(panel_accounts):
+    """Isolamento (controle positivo): resetar A não pode tocar a trava de B.
+    Sem isto o grupo passaria numa implementação que apaga a plan_trials inteira
+    — ou que casasse variantes de nono dígito (phone_lookup_candidates)."""
+    from db.plans import is_trial_eligible_for_user
+
+    _tag, uids = panel_accounts
+    a, b = uids["free"], uids["granted"]
+    ha = _set_phone(a, f"+5511{a % 100000000:08d}")
+    hb = _set_phone(b, f"+5521{b % 100000000:08d}")
+    _lock_trial(ha, a)
+    _lock_trial(hb, b)
+    try:
+        assert _reset_trial(_admin_client(), a).status_code == 200
+        assert _trial_lock_exists(ha) is False
+        assert _trial_lock_exists(hb) is True
+        assert is_trial_eligible_for_user(a) is True
+        assert is_trial_eligible_for_user(b) is False
+    finally:
+        _drop_locks(ha, hb)
+
+
+def test_trial_reset_404_para_conta_inexistente():
+    assert _reset_trial(_admin_client(), 999999999999).status_code == 404
+
+
+def test_trial_reset_422_sem_telefone_vinculado(panel_accounts):
+    """A trava é por telefone: sem número não há o que liberar."""
+    _tag, uids = panel_accounts
+    resp = _reset_trial(_admin_client(), uids["free"])
+    assert resp.status_code == 422
+    assert "telefone" in resp.json()["detail"].lower()
+
+
+def test_trial_reset_409_com_assinatura_viva_e_nao_apaga_nada(panel_accounts):
+    """Decisão do dono: quem manda no trial é a Stripe. Controle positivo do
+    grupo — prova que a trava continua valendo para quem não é alvo."""
+    from db.plans import is_trial_eligible_for_user
+
+    _tag, uids = panel_accounts
+    uid = uids["trial"]  # last_payment_status = 'trialing'
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, uid)
+    try:
+        resp = _reset_trial(_admin_client(), uid)
+        assert resp.status_code == 409, resp.text
+        assert "stripe" in resp.json()["detail"].lower()
+        assert _trial_lock_exists(h) is True
+        assert is_trial_eligible_for_user(uid) is False
+    finally:
+        _drop_locks(h)
+
+
+@pytest.mark.parametrize("pay", ["active", "past_due"])
+def test_trial_reset_409_para_os_outros_status_vivos(panel_accounts, pay):
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, uid)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set last_payment_status = %s where user_id = %s",
+                (pay, uid),
+            )
+        conn.commit()
+    try:
+        assert _reset_trial(_admin_client(), uid).status_code == 409
+        assert _trial_lock_exists(h) is True
+    finally:
+        _drop_locks(h)
+
+
+def test_trial_reset_audita_sem_vazar_telefone_nem_hash(panel_accounts, monkeypatch):
+    """O evento é registrado como warning (remoção de trava anti-abuso) e o
+    details NÃO carrega telefone nem phone_hash — é HMAC de PII."""
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    phone = f"+5511{uid % 100000000:08d}"
+    h = _set_phone(uid, phone)
+    _lock_trial(h, uid)
+
+    eventos = []
+
+    async def _capture(level, event_type, message, **kwargs):
+        eventos.append((level, event_type, message, kwargs))
+
+    monkeypatch.setattr(admin_dashboard, "log_system_event", _capture)
+    try:
+        assert _reset_trial(_admin_client(), uid).status_code == 200
+        # _admin_client() loga antes e gera admin_login_success no mesmo capture.
+        meus = [e for e in eventos if e[1] == "admin_trial_reset"]
+        assert len(meus) == 1
+        level, _tipo, message, kwargs = meus[0]
+        assert level == "warning"
+        assert kwargs["source"] == "admin"
+        assert kwargs["user_id"] == uid
+        assert kwargs["details"]["deleted"] == 1
+        blob = repr(kwargs["details"]) + message
+        assert phone not in blob
+        assert phone.lstrip("+") not in blob
+        assert h not in blob
+        assert "phone" not in repr(kwargs["details"]).lower()
+    finally:
+        _drop_locks(h)
+
+
+def test_drilldown_mostra_a_trava_do_telefone_de_outra_conta(panel_accounts):
+    """(b) do plano: a tela dizia 'Trial iniciado —' numa conta inelegível
+    porque só mostrava a âncora da CONTA. trial_lock_* é o que explica o caso.
+    E phone_hash não pode vazar pro JSON — é HMAC de PII."""
+    _tag, uids = panel_accounts
+    dona, outra = uids["free"], uids["granted"]
+    h = _set_phone(dona, f"+5511{dona % 100000000:08d}")
+    # Trava gravada em nome de OUTRA conta, com a conta atual sem âncora.
+    _lock_trial(h, outra)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set trial_started_at = null where user_id = %s",
+                (dona,),
+            )
+        conn.commit()
+    try:
+        resp = _admin_client().get(f"/admin/api/users/{dona}")
+        assert resp.status_code == 200, resp.text
+        p = resp.json()["profile"]
+        assert p["trial_started_at"] is None
+        assert p["trial_lock_started_at"] is not None
+        assert int(p["trial_lock_user_id"]) == outra
+        assert "phone_hash" not in p
+    finally:
+        _drop_locks(h)
+
+
+def test_reset_faz_o_checkout_voltar_a_mandar_trial(panel_accounts, monkeypatch):
+    """A prova que importa: depois do reset, o /billing/create-checkout volta a
+    pedir trial_period_days à Stripe. Roda a elegibilidade REAL — monkeypatchar
+    is_trial_eligible_for_user anularia a medição."""
+    from tests.test_billing_checkout import _patch_stripe
+    from db.plans import claim_trial_for_user
+
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    email = f"panel-{_tag}-free@test.local"
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+
+    monkeypatch.setenv("PLANS_V2_ENABLED", "1")
+    monkeypatch.setenv("PLANS_TRIAL_DAYS", "15")
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+    fake = _patch_stripe(monkeypatch)
+
+    user_client = TestClient(dashboard.app)
+    user_client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(uid, email))
+    user_client.cookies.set(dashboard.CSRF_COOKIE_NAME, "test-admin-csrf")
+    headers = {dashboard.CSRF_HEADER_NAME: "test-admin-csrf"}
+
+    try:
+        # 1. o telefone queima o trial pelo caminho real
+        assert claim_trial_for_user(uid) is not None
+        try:
+            dashboard.limiter._storage.reset()
+        except Exception:
+            pass
+        r1 = user_client.post("/billing/create-checkout", headers=headers)
+        assert r1.status_code == 200, r1.text
+        assert "trial_period_days" not in fake.last_session_kwargs["subscription_data"]
+
+        # 2. o admin libera
+        assert _reset_trial(_admin_client(), uid).status_code == 200
+
+        # O checkout aberto do passo 1 seria REAPROVEITADO (mesmo plano/intervalo)
+        # e devolveria a URL antiga sem consultar a elegibilidade de novo. Expira
+        # como a Stripe faz depois de 24h, para forçar uma sessão nova.
+        for session in fake.open_sessions:
+            session["status"] = "expired"
+
+        # 3. o checkout novo volta a conceder os 15 dias
+        try:
+            dashboard.limiter._storage.reset()
+        except Exception:
+            pass
+        r2 = user_client.post("/billing/create-checkout", headers=headers)
+        assert r2.status_code == 200, r2.text
+        assert fake.last_session_kwargs["subscription_data"]["trial_period_days"] == 15
+    finally:
+        _drop_locks(h)

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -5,6 +5,7 @@ Cobrem: exigência de auth, classificação de assinatura por conta
 e-mail, paginação e o drill-down individual. O resumo Stripe roda com a
 chave vazia (billing.available == False) — a API externa nunca é chamada.
 """
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -174,6 +175,49 @@ class TestDeriveAccountStatus:
         assert self._st(plan="pro", last_payment_status="inactive",
                         stripe_customer_id="cus_x",
                         plan_expires_at=NOW - timedelta(days=1)) == "canceled"
+
+
+# O CASE em SQL não importa constante Python: a regra vive nos dois lados e a
+# única defesa é um teste que os compare (CLAUDE.md §0.7, mesmo precedente de
+# tests/test_phosphor_subset.py). O regex casa os dois formatos usados no CASE,
+# `= 'x'` e `IN ('x', 'y')`, e devolve a categoria do THEN.
+_WHEN_STATUS_RX = re.compile(
+    r"a\.last_payment_status.*?(?:=\s*'([a-z_]+)'|IN\s*\(([^)]*)\))\s*THEN\s*'([a-z_]+)'",
+    re.S,
+)
+
+
+def _status_do_case_sql() -> dict:
+    """Mapa {status cru -> categoria} lido do _ACCOUNT_STATUS_SQL."""
+    sql = admin_dashboard._ACCOUNT_STATUS_SQL
+    ramos = list(_WHEN_STATUS_RX.finditer(sql))
+    # Guarda contra parse cego: cada ramo cita a coluna exatamente uma vez, então
+    # ramo novo numa forma que o regex não casa faz ESTA linha ficar vermelha em
+    # vez de o ramo sumir da comparação em silêncio.
+    assert len(ramos) == sql.count("last_payment_status"), ramos
+    mapa = {}
+    for m in ramos:
+        unico, lista, categoria = m.groups()
+        for st in ([unico] if unico else re.findall(r"'([a-z_]+)'", lista)):
+            assert mapa.setdefault(st, categoria) == categoria, st
+    return mapa
+
+
+def test_status_vivos_do_sql_batem_com_a_constante_python():
+    """Divergir aqui é o bug real que aconteceu: o CASE tratava 'unpaid' e
+    'incomplete' como Past due (assinatura viva) e o gate do /trial-reset não —
+    passavam e a trava era apagada."""
+    mapa = _status_do_case_sql()
+    vivos_sql = {st for st, cat in mapa.items() if cat in ("trial", "paying", "past_due")}
+    assert vivos_sql == set(admin_dashboard._LIVE_PAYMENT_STATUSES)
+    assert {st for st, cat in mapa.items() if cat == "past_due"} == set(
+        admin_dashboard._PAST_DUE_PAYMENT_STATUSES
+    )
+    # Terceiro lugar da mesma regra: a função Python que o SQL espelha.
+    for st, cat in mapa.items():
+        assert admin_dashboard._derive_account_status(
+            {"plan": "pro", "last_payment_status": st}, NOW
+        ) == cat, st
 
 
 # ── Resumo Stripe (MRR / ticket médio) ─────────────────────────────────────
@@ -864,8 +908,23 @@ def test_trial_reset_409_com_assinatura_viva_e_nao_apaga_nada(panel_accounts):
         _drop_locks(h)
 
 
-@pytest.mark.parametrize("pay", ["active", "past_due"])
-def test_trial_reset_409_para_os_outros_status_vivos(panel_accounts, pay):
+@pytest.mark.parametrize("pay,esperado", [
+    # Vivos na Stripe: o gate recusa e a trava fica de pé. 'unpaid' (dunning) e
+    # 'incomplete' (3DS pendente) entram aqui porque o painel já os mostra como
+    # "Past due" — assinatura viva (_LIVE_PAYMENT_STATUSES).
+    ("active", 409),
+    ("past_due", 409),
+    ("unpaid", 409),
+    ("incomplete", 409),
+    # Terminais/ausentes: o botão TEM de funcionar. Controle positivo do grupo —
+    # sem estes, um gate que recusa tudo passaria no teste, e é pior que o bug.
+    ("canceled", 200),
+    ("incomplete_expired", 200),
+    ("inactive", 200),
+    ("", 200),  # NULL não entra: a coluna é NOT NULL (default 'inactive')
+    ("status_novo_que_a_stripe_inventar", 200),
+])
+def test_trial_reset_gate_por_status_de_pagamento(panel_accounts, pay, esperado):
     _tag, uids = panel_accounts
     uid = uids["free"]
     h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
@@ -878,8 +937,9 @@ def test_trial_reset_409_para_os_outros_status_vivos(panel_accounts, pay):
             )
         conn.commit()
     try:
-        assert _reset_trial(_admin_client(), uid).status_code == 409
-        assert _trial_lock_exists(h) is True
+        resp = _reset_trial(_admin_client(), uid)
+        assert resp.status_code == esperado, resp.text
+        assert _trial_lock_exists(h) is (esperado == 409)
     finally:
         _drop_locks(h)
 
@@ -908,12 +968,16 @@ def test_trial_reset_audita_sem_vazar_telefone_nem_hash(panel_accounts, monkeypa
         assert level == "warning"
         assert kwargs["source"] == "admin"
         assert kwargs["user_id"] == uid
-        assert kwargs["details"]["deleted"] == 1
-        blob = repr(kwargs["details"]) + message
-        assert phone not in blob
-        assert phone.lstrip("+") not in blob
-        assert h not in blob
-        assert "phone" not in repr(kwargs["details"]).lower()
+        # Lista BRANCA: procurar o telefone por substring é cego a formato
+        # (um espaço no meio do número passa batido). Chave nova qualquer, com
+        # qualquer conteúdo, derruba este teste e obriga a justificar.
+        detalhes = kwargs["details"]
+        assert set(detalhes) == {"admin", "deleted", "previous_started_at"}
+        assert isinstance(detalhes["admin"], str)
+        assert detalhes["deleted"] == 1
+        assert isinstance(detalhes["previous_started_at"], str)
+        # phone_hash é hex de HMAC, não tem variação de formato: substring serve.
+        assert h not in repr(detalhes) + message
     finally:
         _drop_locks(h)
 

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -749,8 +749,16 @@ def _set_phone(uid: int, phone: str) -> str:
     return h
 
 
-def _lock_trial(phone_hash: str, uid: int, started_at=None) -> None:
-    """Queima o trial daquele telefone (o que claim_trial_for_user grava)."""
+def _lock_trial(phone_hash: str, uid: int | None, started_at=None,
+                *, ancora: bool = True) -> None:
+    """Queima o trial daquele telefone (o que claim_trial_for_user grava).
+
+    `uid=None` + `ancora=False` monta a TRAVA HERDADA: a conta que queimou o
+    trial foi apagada, a FK é ON DELETE SET NULL (db/schema.py) e a linha
+    sobreviveu sem dono; o número foi recadastrado numa conta nova, que não tem
+    âncora nenhuma. É o caso real do dono e o único em que a data da trava e a
+    âncora da conta divergem — nele a âncora nem existe.
+    """
     started_at = started_at or (NOW - timedelta(days=40))
     with get_conn() as conn:
         with conn.cursor() as cur:
@@ -758,14 +766,16 @@ def _lock_trial(phone_hash: str, uid: int, started_at=None) -> None:
                 """
                 insert into plan_trials (phone_hash, user_id, started_at, model_version)
                 values (%s, %s, %s, 2)
-                on conflict (phone_hash) do update set started_at = excluded.started_at
+                on conflict (phone_hash) do update
+                    set started_at = excluded.started_at, user_id = excluded.user_id
                 """,
                 (phone_hash, uid, started_at),
             )
-            cur.execute(
-                "update auth_accounts set trial_started_at = %s where user_id = %s",
-                (started_at, uid),
-            )
+            if ancora:
+                cur.execute(
+                    "update auth_accounts set trial_started_at = %s where user_id = %s",
+                    (started_at, uid),
+                )
         conn.commit()
 
 
@@ -972,10 +982,12 @@ def test_trial_reset_audita_sem_vazar_telefone_nem_hash(panel_accounts, monkeypa
         # (um espaço no meio do número passa batido). Chave nova qualquer, com
         # qualquer conteúdo, derruba este teste e obriga a justificar.
         detalhes = kwargs["details"]
-        assert set(detalhes) == {"admin", "deleted", "previous_started_at"}
+        assert set(detalhes) == {"admin", "deleted", "previous_started_at",
+                                 "previous_lock_started_at"}
         assert isinstance(detalhes["admin"], str)
         assert detalhes["deleted"] == 1
         assert isinstance(detalhes["previous_started_at"], str)
+        assert isinstance(detalhes["previous_lock_started_at"], str)
         # phone_hash é hex de HMAC, não tem variação de formato: substring serve.
         assert h not in repr(detalhes) + message
     finally:
@@ -1063,3 +1075,226 @@ def test_reset_faz_o_checkout_voltar_a_mandar_trial(panel_accounts, monkeypatch)
         assert fake.last_session_kwargs["subscription_data"]["trial_period_days"] == 15
     finally:
         _drop_locks(h)
+
+
+# ── Trava herdada: o caso do dono, e o único em que as duas datas divergem ──
+
+def test_trial_reset_registra_a_data_da_trava_herdada_que_a_ancora_nao_tem(
+    panel_accounts, monkeypatch
+):
+    """A conta que queimou o trial foi apagada (plan_trials.user_id é
+    ON DELETE SET NULL) e o número foi recadastrado: a linha da trava sobrevive
+    sem dono e a conta ATUAL não tem âncora.
+
+    Aqui `previous_started_at` (a âncora) é null e a ÚNICA data que existe é a
+    da linha destruída. Logar só a âncora — o que a versão anterior fazia —
+    apagava para sempre a data do trial queimado, que é justamente o que se
+    quer saber depois. O `_lock_trial` padrão escondia isso porque sempre
+    gravava as duas iguais.
+    """
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    queimado = NOW - timedelta(days=120)
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, None, queimado, ancora=False)   # herdada: sem dono, sem âncora
+
+    eventos = []
+
+    async def _capture(level, event_type, message, **kwargs):
+        eventos.append((level, event_type, message, kwargs))
+
+    monkeypatch.setattr(admin_dashboard, "log_system_event", _capture)
+    try:
+        # Pré-condição: as duas datas DIVERGEM de verdade (senão o teste não
+        # mediria nada — é o defeito que ele existe para pegar).
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "select trial_started_at from auth_accounts where user_id = %s",
+                    (uid,),
+                )
+                assert cur.fetchone()["trial_started_at"] is None
+
+        assert _reset_trial(_admin_client(), uid).status_code == 200
+        detalhes = [e for e in eventos if e[1] == "admin_trial_reset"][0][3]["details"]
+        assert detalhes["deleted"] == 1
+        assert detalhes["previous_started_at"] is None
+        assert detalhes["previous_lock_started_at"] is not None
+        assert detalhes["previous_lock_started_at"].startswith(
+            queimado.date().isoformat()
+        ), detalhes
+        assert not _trial_lock_exists(h)
+    finally:
+        _drop_locks(h)
+
+
+def test_reset_libera_a_ancora_velha_mesmo_sem_trava_no_telefone(panel_accounts):
+    """Troca de telefone (frontend/routes/settings.py reescreve phone_hash e
+    deixa trial_started_at para trás): a conta fica SEM trava e COM âncora
+    velha — o estado que faz o próximo trial nascer vencido, porque
+    claim_trial_for_user não sobrescreve âncora mais antiga.
+
+    O reset tem de aceitar e limpar a âncora. É o caminho que o botão do painel
+    recusava.
+    """
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    _set_phone(uid, f"+5511{uid % 100000000:08d}")   # hash NOVO, sem linha em plan_trials
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set trial_started_at = %s where user_id = %s",
+                (NOW - timedelta(days=200), uid),
+            )
+        conn.commit()
+
+    resp = _reset_trial(_admin_client(), uid)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["deleted"] == 0          # não havia trava — e não é erro
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select trial_started_at, trial_downsell_sent_at "
+                "from auth_accounts where user_id = %s",
+                (uid,),
+            )
+            depois = cur.fetchone()
+    assert depois["trial_started_at"] is None
+    assert depois["trial_downsell_sent_at"] is None
+
+
+def test_gate_do_reset_recusa_pago_vencido_ainda_que_o_painel_diga_cancelado(
+    panel_accounts,
+):
+    """DIVERGÊNCIA DELIBERADA, fixada aqui para ninguém "consertar" num buraco.
+
+    plan='pro' + plan_expires_at no passado + last_payment_status='active':
+      · o painel rotula 'canceled' (_ACCOUNT_STATUS_SQL põe a expiração ANTES
+        do status, e _derive_account_status idem);
+      · o gate do /trial-reset responde 409 mesmo assim.
+
+    As duas coisas estão certas porque respondem a perguntas diferentes. O
+    rótulo é ENTITLEMENT: plan_expires_at vem de _subscription_period_end
+    (frontend/finance_bot_websocket_custom.py) ou do grant do admin, e um
+    período vencido não pode continuar liberando recurso pago. O gate é
+    LIVENESS na Stripe, e a única evidência dela é last_payment_status, que
+    espelha o status da subscription. Período vencido COM status 'active' é o
+    caso do webhook de renovação perdido — ali a assinatura está mais provável
+    de viva, não de morta, e apagar a trava anti-abuso não cancelaria nada.
+    """
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    h = _set_phone(uid, f"+5511{uid % 100000000:08d}")
+    _lock_trial(h, uid)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set plan = 'pro', last_payment_status = 'active',"
+                " plan_expires_at = %s where user_id = %s",
+                (NOW - timedelta(days=3), uid),
+            )
+        conn.commit()
+    try:
+        client = _admin_client()
+        # O rótulo do painel: 'canceled'.
+        assert client.get(f"/admin/api/users/{uid}").json()["profile"][
+            "account_status"] == "canceled"
+        # O gate: 409, e a trava CONTINUA de pé (não basta o status).
+        resp = _reset_trial(client, uid)
+        assert resp.status_code == 409, resp.text
+        assert _trial_lock_exists(h)
+    finally:
+        _drop_locks(h)
+
+
+def _esperar_backend_travado(timeout: float = 15.0) -> bool:
+    """Espera algum backend DESTE database ficar parado esperando um lock.
+
+    É o que torna o teste abaixo determinístico em vez de dependente de sleep:
+    sem isto, uma thread lenta a começar faria o commit da troca acontecer
+    ANTES do SELECT do reset, e o caso passaria verde sem medir nada.
+    """
+    import time
+    fim = time.monotonic() + timeout
+    while time.monotonic() < fim:
+        with get_conn() as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    "select count(*) as n from pg_stat_activity "
+                    "where datname = current_database() and wait_event_type = 'Lock'"
+                )
+                if cur.fetchone()["n"] > 0:
+                    return True
+        time.sleep(0.05)
+    return False
+
+
+def test_reset_apaga_a_trava_do_telefone_NOVO_numa_troca_concorrente(panel_accounts):
+    """O `for update` do SELECT em reset_trial_for_user, medido pelo efeito.
+
+    Cena: a conta tem o telefone A (trava A) e uma troca para o telefone B
+    (trava B) está aberta e ainda não commitada — é o que
+    frontend/routes/settings.py faz. O reset entra no meio.
+
+      · com `for update`: o SELECT espera a troca commitar, relê e enxerga B.
+        Apaga a trava de B — o telefone que a conta REALMENTE tem no fim.
+      · sem ele (READ COMMITTED puro): o SELECT lê o snapshot velho, enxerga A,
+        apaga a trava de A e só depois esbarra no lock no UPDATE. Termina
+        reportando sucesso com o número atual (B) ainda travado.
+
+    A discriminação é a IDENTIDADE da trava apagada, não o tempo: medir só
+    "o reset bloqueia" não separa as duas versões, porque sem `for update` ele
+    bloqueia mesmo assim — um passo adiante, no UPDATE, e depois de já ter
+    apagado a trava errada. (Foi assim que a primeira versão deste teste passou
+    verde com o conserto desligado.)
+    """
+    import threading
+    from db.plans import reset_trial_for_user
+
+    _tag, uids = panel_accounts
+    uid = uids["free"]
+    telefone_a = f"+5511{uid % 100000000:08d}"
+    telefone_b = f"+5521{uid % 100000000:08d}"
+    from core.crypto import hash_pii
+    ha, hb = hash_pii(telefone_a, kind="phone"), hash_pii(telefone_b, kind="phone")
+    assert ha != hb
+    _set_phone(uid, telefone_a)
+    _lock_trial(ha, uid)              # trava do número antigo
+    _lock_trial(hb, None, ancora=False)   # o número novo também já queimou o dele
+
+    pronto = threading.Event()
+    resultado = {}
+
+    def _correr():
+        try:
+            resultado["row"] = reset_trial_for_user(uid)
+        except Exception as exc:      # pragma: no cover - só para não pendurar
+            resultado["erro"] = exc
+        finally:
+            pronto.set()
+
+    t = threading.Thread(target=_correr, daemon=True)
+    try:
+        with get_conn() as troca:
+            with troca.cursor() as cur:
+                cur.execute(
+                    "update auth_accounts set phone_e164 = %s, phone_hash = %s "
+                    "where user_id = %s",
+                    (telefone_b, hb, uid),
+                )
+            t.start()
+            assert _esperar_backend_travado(), "o reset nunca chegou a esperar o lock"
+            troca.commit()
+        assert pronto.wait(20), "o reset não destravou depois do commit da troca"
+        t.join(5)
+        assert "erro" not in resultado, resultado.get("erro")
+        # O que separa as duas versões: QUAL trava foi apagada.
+        assert not _trial_lock_exists(hb), (
+            "a trava do telefone ATUAL sobreviveu — o reset leu o hash velho"
+        )
+        assert _trial_lock_exists(ha), (
+            "apagou a trava do telefone ANTIGO, que já não é desta conta"
+        )
+        assert resultado["row"]["deleted"] == 1
+    finally:
+        _drop_locks(ha, hb)


### PR DESCRIPTION
## Por que

A trava do trial é por **telefone** e vale para a vida toda: `plan_trials` é keyed por `phone_hash` e o registro sobrevive à deleção da conta, de propósito, como anti-abuso. Está correto como regra, mas deixava um único caminho para retestar o funil de assinatura com o mesmo número: SQL manual em produção. As únicas deleções de `plan_trials` no repositório estavam em testes.

Este PR dá ao dono um botão no drill-down do admin que faz isso de forma repetível, mostrando antes o que vai apagar.

## Dois achados do inventário que definiram a implementação

**Apagar só a linha de `plan_trials` não bastava.** `claim_trial_for_user` só grava `trial_started_at` quando a data nova é mais antiga que a existente. Com a âncora velha na conta, o trial seguinte **nasceria vencido**: a Stripe daria 15 dias e o `get_trial_status` calcularia zero pela data antiga. A ação limpa as duas, mais o `trial_downsell_sent_at`.

**O painel mostrava a coluna errada.** Ele exibia `trial_started_at`, a âncora da **conta**, que é NULL quando a trava veio de outra conta com o mesmo número. A tela dizia "Trial iniciado —" enquanto `is_trial_eligible_for_user` recusava — foi exatamente a tela que não explicou o problema quando ele foi investigar.

## Isolamento

O delete usa **um** `phone_hash`, o da conta alvo, lido do banco na mesma transação, com `for update`. Nunca `phone_lookup_candidates`: as variantes de nono dígito geram hashes que podem pertencer a outra pessoa. O schema garante um hash por conta (`idx_auth_accounts_phone_hash_unique`, parcial) e `plan_trials.phone_hash` é PK.

A função recebe `user_id` e nada mais — telefone e hash nunca vêm do cliente.

## `unpaid` e `incomplete` (`025977a`)

O gate 409 recusava com `{trialing, active, past_due}` enquanto o `CASE` que monta o rótulo do painel, no mesmo arquivo, tratava `past_due, unpaid, incomplete` como **assinatura viva**. O webhook grava o status cru da Stripe, então `unpaid` (dunning) e `incomplete` (3DS pendente) chegam de verdade: uma conta nesses estados aparecia como "Past due" na tela e ainda assim teria a trava liberada.

Uma constante decide os dois agora. Como o SQL não importa Python, a duplicação é inevitável e o §0.7 pede o teste que compara: ele extrai os ramos do `CASE` e confere contra a constante **e** contra `_derive_account_status`. O que o torna defensável não é o regex — é a guarda que exige um ramo casado por menção da coluna, para que um ramo que o regex não entenda derrube o teste em vez de sumir calado.

## Rodada de revisão (`2a43790`)

O Codex bateu o limite de uso da conta e não revisou este PR. Rodei a skill `code-review` no lugar, em esforço alto. Ela achou cinco coisas; quatro viraram conserto.

**A trava herdada não era explicada — e é o caso que motivou o recurso.** `plan_trials.user_id` é `on delete set null` (`db/schema.py:1747`), então quando a conta antiga foi deletada o campo vem nulo e a linha nova do painel caía no ramo vazio: data pelada. Eram três casos, não dois, e o terceiro é o mais comum.

**O botão recusava consertar o estado que existe para consertar.** Ele bloqueava quando não havia trava, mas a ação também limpa a âncora, e uma troca de telefone (`frontend/routes/settings.py` reescreve `phone_hash` sem tocar na âncora) deixa a conta sem trava e com âncora velha — o estado que faz o trial nascer vencido. O backend já tratava; só a tela negava.

**A auditoria registrava a data errada.** Logava a âncora da conta como se fosse a data da trava destruída. Na trava herdada a âncora é nula, então o log dizia `deleted: 1` com `previous_started_at: null` e a data do trial queimado sumia. O teste escondia porque o helper gravava as duas juntas. O `delete` agora tem `returning started_at` e o log registra as duas.

**O `select` ganhou `for update`.** A docstring prometia que ler e apagar na mesma transação fechava a corrida com troca de telefone, e sob READ COMMITTED não fechava: o reset apagaria a trava do número antigo, deixaria a do atual e reportaria sucesso. Onze caracteres entregam a garantia que o texto já dava; a alternativa "honesta" seria documentar um falso sucesso em caminho anti-abuso.

**O quinto não procedeu como correção, e está fixado em teste.** O gate lê `last_payment_status` e o rótulo do painel dá precedência a `plan_expires_at`, então `pro` + expirado + `active` mostra "Cancelado" e o gate responde 409. Mas as duas perguntas são diferentes: período vencido com status `active` é o webhook de renovação perdido, onde a assinatura provavelmente está **viva**. O painel decide entitlement e não libera recurso pago com dado velho; o gate decide liveness na Stripe. Trocar um pelo outro derruba cinco casos e passaria a liberar a trava com assinatura viva. A divergência ficou fixada num teste com o motivo escrito, para ninguém "consertar" isso num buraco depois.

## Controles

**Negativo fino** — mantendo o `delete from plan_trials` e removendo **só** a limpeza da âncora, a asserção `get_trial_started_at is None` fica vermelha **sozinha**, e o caso do checkout segue verde. Prova que a asserção da âncora não é redundante.

**Negativo do gate** — com a lista antiga, exatamente `unpaid` e `incomplete` ficam vermelhos e os outros sete casos seguem verdes.

**Negativo da corrida** — sem o `for update`, o teste da troca concorrente fica vermelho sozinho. **A primeira versão desse teste foi descartada por ser tautológica**: media "o reset bloqueia", e sem o conserto ele bloqueia igual, um passo adiante, depois de já ter apagado a trava errada. A versão que ficou monta a troca de verdade, sincroniza por `pg_stat_activity.wait_event_type = 'Lock'` em vez de `sleep`, e mede **qual** trava foi apagada.

**Negativos do frontend** — desligando o ramo da trava herdada, ou a condição que habilita o botão pela âncora, exatamente o caso correspondente fica vermelho.

**Positivos** — reset numa conta não libera o telefone da outra (o Tester trocou o `WHERE phone_hash` por um delete sem filtro e o caso ficou vermelho); "sem trava e sem âncora" e "conta sem telefone" continuam desabilitando o botão.

**Transação** — o Tester forçou exceção entre o delete e o update: rollback completo. Não existe o estado "trava some, âncora fica".

Também verificados sem achado: CSRF cobre a rota, ids forjados dão 404 ou 422, o índice único de `phone_hash` rejeita duplicata, e `invalidate_auth_user_cache` só roda após commit bem-sucedido.

## Medição

Suíte Python comparada **por nome** contra a base, em worktree: **249 falhas idênticas nos dois lados**, `comm` vazio nos dois sentidos. As 249 são preexistentes, todas na cadeia `handle_incoming → ofx_service → ofxparse`, ausente no ambiente, e nenhuma toca admin, planos ou trial. Frontend **290/290**.

## O que não foi verificado

**Nada da tela foi visto por olho humano.** O que foi medido do frontend é DOM renderizado em Chromium headless pelo caminho real (`openUserDetail` → fetch → `renderUserDetail`), com backend mockado. Layout, contraste e como o texto novo da trava quebra em tela estreita: não medidos. Só **depois do deploy**.

**A corrida foi provada contra Postgres real**, mas montando o `UPDATE` equivalente à mão; o caminho de produção (a tela de configurações chegando concorrente ao reset) não foi exercitado ponta a ponta.

**A Stripe real nunca foi chamada** em nenhum momento deste PR. O 409 é medido pelo estado do banco.

## Apontado e não consertado

**Uma terceira lista do mesmo conceito**, em `set_account_plan`, trata `unpaid` como **terminal** — o oposto das outras duas. Mexer nela muda o comportamento de um endpoint que escreve `last_payment_status` de conta em dunning, então é decisão do dono.

**O checkout reaproveita sessão aberta** do mesmo plano e ciclo sem reconsultar elegibilidade. Preexistente, mas encosta direto no que o botão promete: se houver um checkout abandonado, o trial só reaparece depois de concluí-lo ou de a sessão expirar em 24h.

**`tests/conftest.py`** tem a lista `_OFXPARSE_DEPENDENTES` desatualizada em relação a dois arquivos de teste, que abortam a coleta neste ambiente. Preexistente, atrapalha qualquer medição aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF