### PR TITLE
Nome do usuário deixa de virar marcação do WhatsApp (#146, fatia 1 de 2)

### DIFF
--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -40,7 +40,7 @@ from core.handle_incoming import handle_incoming
 from core.intent_router import abandona_pergunta_de_valor
 from core.handlers import report as h_report
 from core.observability import log_system_event_sync
-from core.response_formatter import escape_wa_markup
+from core.response_formatter import wrap_wa_markup
 from core.types import IncomingMessage
 from db import (
     attempt_whatsapp_phone_link,
@@ -349,7 +349,7 @@ def _apply_recategorize(user_id: int, launch_id: int, raw_categoria: str) -> str
         return "Lançamento não encontrado (talvez já tenha sido apagado)."
     ensure_user_category(user_id, canon)
     display = display_id_for(user_id, launch_id)
-    return f"✅ Categoria do lançamento #{display} atualizada para *{escape_wa_markup(canon)}*."
+    return f"✅ Categoria do lançamento #{display} atualizada para {wrap_wa_markup(canon)}."
 
 
 def _download_attachments_sync(att_refs: list[InboundAttachmentRef]) -> list[Attachment]:
@@ -802,7 +802,7 @@ def process_message(message: InboundMessage) -> None:
                         return
                     _send_reply(
                         reply_to,
-                        f"Quanto veio a conta de *{escape_wa_markup(nome_conta)}* este mês?{hint}\n"
+                        f"Quanto veio a conta de {wrap_wa_markup(nome_conta)} este mês?{hint}\n"
                         f"É só mandar o valor. Ex: *132,50*",
                     )
                     return
@@ -819,7 +819,7 @@ def process_message(message: InboundMessage) -> None:
                     val = paid.get("paid_amount") or paid.get("amount") or 0
                     _send_reply(
                         reply_to,
-                        f"✅ Conta paga: *{escape_wa_markup(paid.get('name'))}* — {fmt_brl(val)} lançado e "
+                        f"✅ Conta paga: {wrap_wa_markup(paid.get('name'))} — {fmt_brl(val)} lançado e "
                         f"categorizado. Tá tudo em dia! 🐷",
                     )
                 return
@@ -957,7 +957,7 @@ def process_message(message: InboundMessage) -> None:
                         consume_pending_action(uid, pending_recat)
                     except Exception:
                         pass
-                    _send_reply(reply_to, f"Ok, deixei a conta de *{escape_wa_markup(name)}* pendente. Quando pagar é só avisar. 🐷")
+                    _send_reply(reply_to, f"Ok, deixei a conta de {wrap_wa_markup(name)} pendente. Quando pagar é só avisar. 🐷")
                     return
                 from utils_text import (fmt_brl, limpa_pontuacao_final,
                                         parse_money, valor_perigoso)
@@ -979,9 +979,9 @@ def process_message(message: InboundMessage) -> None:
                     # recusa → re-pergunta, mantém o pending de pé (descartá-lo
                     # jogaria o usuário no fallback genérico).
                     if perigo == "nao_positivo":
-                        _send_reply(reply_to, f"O valor da conta de *{escape_wa_markup(name)}* precisa ser maior que zero. Quanto veio? Ex: *132,50* (ou *cancelar*)")
+                        _send_reply(reply_to, f"O valor da conta de {wrap_wa_markup(name)} precisa ser maior que zero. Quanto veio? Ex: *132,50* (ou *cancelar*)")
                     else:
-                        _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de *{escape_wa_markup(name)}*. Ex: *132,50* (ou *cancelar*)")
+                        _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de {wrap_wa_markup(name)}. Ex: *132,50* (ou *cancelar*)")
                     return
                 amount = round(amount, 2)
                 # REIVINDICA antes de pagar, e condicionado ao que foi lido:
@@ -1017,7 +1017,7 @@ def process_message(message: InboundMessage) -> None:
                         val = paid.get("paid_amount") or paid.get("amount") or amount
                         _send_reply(
                             reply_to,
-                            f"✅ Conta paga: *{escape_wa_markup(paid.get('name'))}* — {fmt_brl(val)} lançado e "
+                            f"✅ Conta paga: {wrap_wa_markup(paid.get('name'))} — {fmt_brl(val)} lançado e "
                             f"categorizado. Tá tudo em dia! 🐷",
                         )
                     return

--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -40,6 +40,7 @@ from core.handle_incoming import handle_incoming
 from core.intent_router import abandona_pergunta_de_valor
 from core.handlers import report as h_report
 from core.observability import log_system_event_sync
+from core.response_formatter import escape_wa_markup
 from core.types import IncomingMessage
 from db import (
     attempt_whatsapp_phone_link,
@@ -348,7 +349,7 @@ def _apply_recategorize(user_id: int, launch_id: int, raw_categoria: str) -> str
         return "Lançamento não encontrado (talvez já tenha sido apagado)."
     ensure_user_category(user_id, canon)
     display = display_id_for(user_id, launch_id)
-    return f"✅ Categoria do lançamento #{display} atualizada para *{canon}*."
+    return f"✅ Categoria do lançamento #{display} atualizada para *{escape_wa_markup(canon)}*."
 
 
 def _download_attachments_sync(att_refs: list[InboundAttachmentRef]) -> list[Attachment]:
@@ -801,7 +802,7 @@ def process_message(message: InboundMessage) -> None:
                         return
                     _send_reply(
                         reply_to,
-                        f"Quanto veio a conta de *{nome_conta}* este mês?{hint}\n"
+                        f"Quanto veio a conta de *{escape_wa_markup(nome_conta)}* este mês?{hint}\n"
                         f"É só mandar o valor. Ex: *132,50*",
                     )
                     return
@@ -818,7 +819,7 @@ def process_message(message: InboundMessage) -> None:
                     val = paid.get("paid_amount") or paid.get("amount") or 0
                     _send_reply(
                         reply_to,
-                        f"✅ Conta paga: *{paid.get('name')}* — {fmt_brl(val)} lançado e "
+                        f"✅ Conta paga: *{escape_wa_markup(paid.get('name'))}* — {fmt_brl(val)} lançado e "
                         f"categorizado. Tá tudo em dia! 🐷",
                     )
                 return
@@ -956,7 +957,7 @@ def process_message(message: InboundMessage) -> None:
                         consume_pending_action(uid, pending_recat)
                     except Exception:
                         pass
-                    _send_reply(reply_to, f"Ok, deixei a conta de *{name}* pendente. Quando pagar é só avisar. 🐷")
+                    _send_reply(reply_to, f"Ok, deixei a conta de *{escape_wa_markup(name)}* pendente. Quando pagar é só avisar. 🐷")
                     return
                 from utils_text import (fmt_brl, limpa_pontuacao_final,
                                         parse_money, valor_perigoso)
@@ -978,9 +979,9 @@ def process_message(message: InboundMessage) -> None:
                     # recusa → re-pergunta, mantém o pending de pé (descartá-lo
                     # jogaria o usuário no fallback genérico).
                     if perigo == "nao_positivo":
-                        _send_reply(reply_to, f"O valor da conta de *{name}* precisa ser maior que zero. Quanto veio? Ex: *132,50* (ou *cancelar*)")
+                        _send_reply(reply_to, f"O valor da conta de *{escape_wa_markup(name)}* precisa ser maior que zero. Quanto veio? Ex: *132,50* (ou *cancelar*)")
                     else:
-                        _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de *{name}*. Ex: *132,50* (ou *cancelar*)")
+                        _send_reply(reply_to, f"Não peguei o valor. Manda só o número da conta de *{escape_wa_markup(name)}*. Ex: *132,50* (ou *cancelar*)")
                     return
                 amount = round(amount, 2)
                 # REIVINDICA antes de pagar, e condicionado ao que foi lido:
@@ -1016,7 +1017,7 @@ def process_message(message: InboundMessage) -> None:
                         val = paid.get("paid_amount") or paid.get("amount") or amount
                         _send_reply(
                             reply_to,
-                            f"✅ Conta paga: *{paid.get('name')}* — {fmt_brl(val)} lançado e "
+                            f"✅ Conta paga: *{escape_wa_markup(paid.get('name'))}* — {fmt_brl(val)} lançado e "
                             f"categorizado. Tá tudo em dia! 🐷",
                         )
                     return

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -173,7 +173,7 @@ def try_pay_from_text(user_id: int, text: str) -> str | None:
         return None
     val = paid.get("paid_amount") or paid.get("amount") or 0
     return (
-        f"✅ Conta paga: *{paid.get('name')}* — {fmt_brl(val)} lançado e "
+        f"✅ Conta paga: {wrap_wa_markup(paid.get('name'))} — {fmt_brl(val)} lançado e "
         f"categorizado. Tá tudo em dia! 🐷"
     )
 
@@ -294,7 +294,7 @@ def resolve_bill_amount(user_id: int, text: str, pending: dict) -> str | None:
         return "Essa conta não está mais pendente."
     val = paid.get("paid_amount") or paid.get("amount") or 0
     return (
-        f"✅ Conta paga: *{paid.get('name')}* — {fmt_brl(val)} lançado e "
+        f"✅ Conta paga: {wrap_wa_markup(paid.get('name'))} — {fmt_brl(val)} lançado e "
         f"categorizado. Tá tudo em dia! 🐷"
     )
 

--- a/core/handlers/bills.py
+++ b/core/handlers/bills.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import re
 
+from core.response_formatter import wrap_wa_markup
 from utils_text import (_ENCHIMENTO, _TRACOS, fmt_brl, limpa_pontuacao_final,
                         normalize_text, parse_money, valor_perigoso)
 
@@ -59,10 +60,11 @@ def pergunta_de_valor_sem_contexto(user_id: int, nome: str) -> str:
     except Exception:
         pergunta = None
     espera = f'esperando: "{pergunta}"' if pergunta else "esperando resposta."
+    rotulo = wrap_wa_markup(nome)
     return (
-        f"A conta de *{nome}* tem valor variável, mas antes tem outra pergunta "
+        f"A conta de {rotulo} tem valor variável, mas antes tem outra pergunta "
         f"minha {espera}\n"
-        f"Me responde ela primeiro; a *{nome}* fica pendente aqui e a gente "
+        f"Me responde ela primeiro; a {rotulo} fica pendente aqui e a gente "
         f"resolve o valor em seguida."
     )
 

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -7,6 +7,7 @@ import logging
 
 import db
 from core.observability import _log_falha
+from core.response_formatter import escape_wa_markup
 from utils_text import fmt_brl
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
         msg_out = handle_quick_entry(user_id, text)
         if msg_out:
             return f"✅ Lançamento registrado!\n{msg_out.text}"
-        return f"⚠️ Não consegui registrar automaticamente. Tente: `{text}`"
+        return f"⚠️ Não consegui registrar automaticamente. Tente: `{escape_wa_markup(text)}`"
 
     # ── Oferta "virar gasto fixo" (despesa que se repetiu) ───────────────────
     if action_type == "confirm_recurring_offer":

--- a/core/handlers/pending.py
+++ b/core/handlers/pending.py
@@ -7,7 +7,7 @@ import logging
 
 import db
 from core.observability import _log_falha
-from core.response_formatter import escape_wa_markup
+from core.response_formatter import wrap_wa_markup
 from utils_text import fmt_brl
 
 logger = logging.getLogger(__name__)
@@ -87,7 +87,7 @@ def resolve_delete(user_id: int, confirmed: bool) -> str | None:
         msg_out = handle_quick_entry(user_id, text)
         if msg_out:
             return f"✅ Lançamento registrado!\n{msg_out.text}"
-        return f"⚠️ Não consegui registrar automaticamente. Tente: `{escape_wa_markup(text)}`"
+        return f"⚠️ Não consegui registrar automaticamente. Tente: {wrap_wa_markup(text, '`')}"
 
     # ── Oferta "virar gasto fixo" (despesa que se repetiu) ───────────────────
     if action_type == "confirm_recurring_offer":

--- a/core/response_formatter.py
+++ b/core/response_formatter.py
@@ -30,7 +30,12 @@ def format_for_platform(text: str, platform: str) -> str:
 
 
 # `*`, `_`, `~` e crase são os quatro delimitadores de marcação do WhatsApp.
-_MARCACAO_WA = re.compile(r"[*_~`]")
+# O `_` entra com fronteira, os outros três não — MEDIDO pelo dono no cliente
+# real do WhatsApp em 2026-09-04: `meta_casa_nova` sai LITERAL (underscore no
+# meio de palavra não pareia), enquanto `~x~` sai RISCADO (o til pareia mesmo
+# colado à palavra). Sem a fronteira, todo nome com `_` no miolo perdia o
+# negrito do bot sem que houvesse nada a consertar.
+_MARCACAO_WA = re.compile(r"[*~`]|(?<!\w)_|_(?!\w)")
 
 
 def wrap_wa_markup(text: object, delim: str = "*") -> str:

--- a/core/response_formatter.py
+++ b/core/response_formatter.py
@@ -29,26 +29,27 @@ def format_for_platform(text: str, platform: str) -> str:
     return text
 
 
-# WORD JOINER (U+2060): invisível, sem quebra, e da categoria Cf — a mesma que
-# `_normalize_category_name` (db/categories.py:276) já converte em espaço. Medido:
-# copiar a resposta do bot e mandá-la de volta como nome grava `a* b`, não o
-# invisível — o banco nunca guarda o caractere.
-_WORD_JOINER = "\u2060"
-
 # `*`, `_`, `~` e crase são os quatro delimitadores de marcação do WhatsApp.
 _MARCACAO_WA = re.compile(r"[*_~`]")
 
 
-def escape_wa_markup(text: object) -> str:
-    """Neutraliza marcação do WhatsApp em texto que veio do usuário.
+def wrap_wa_markup(text: object, delim: str = "*") -> str:
+    """Embrulha texto do usuário em marcação do WhatsApp — só quando dá.
 
     O WhatsApp NÃO tem caractere de escape: `\\*` não existe e entidade HTML
-    aparece literal na tela. A saída é quebrar o PAREAMENTO — um WORD JOINER
-    logo depois de cada delimitador — sem alterar o texto visível.
+    aparece literal na tela. Neutralizar o delimitador do usuário também não
+    resolve — medido no cliente real do WhatsApp, `*a*<WJ>b*` (WJ = U+2060)
+    renderiza `ab*`: o WORD JOINER cega a ABERTURA, e o FECHAMENTO olha o
+    caractere ANTERIOR, não o seguinte. A saída é não embrulhar: se o texto
+    do usuário já tem marcação, o negrito do bot sai de cena e o nome aparece
+    inteiro.
 
-    Só para o argumento interpolado, nunca para a mensagem montada: os
-    handlers misturam marcação própria e texto do usuário na mesma f-string
-    (ex.: core/handlers/pockets.py:124), e depois de interpolar não há como
-    distinguir as duas.
+    Custo aceito: perde-se o negrito nesses nomes. Nesse mesmo caso a
+    formatação já estava quebrada antes, então não se perde nada que funcione.
+
+    `delim` porque um dos sítios embrulha em crase (core/handlers/pending.py).
+    `str(text)` de propósito: `paid.get("name")` pode ser `None`, e imprimir
+    `None` é melhor que estourar `TypeError` no caminho do dinheiro.
     """
-    return _MARCACAO_WA.sub(lambda m: m.group() + _WORD_JOINER, str(text))
+    text = str(text)
+    return text if _MARCACAO_WA.search(text) else f"{delim}{text}{delim}"

--- a/core/response_formatter.py
+++ b/core/response_formatter.py
@@ -27,3 +27,28 @@ def format_for_platform(text: str, platform: str) -> str:
         text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
 
     return text
+
+
+# WORD JOINER (U+2060): invisível, sem quebra, e da categoria Cf — a mesma que
+# `_normalize_category_name` (db/categories.py:276) já converte em espaço. Medido:
+# copiar a resposta do bot e mandá-la de volta como nome grava `a* b`, não o
+# invisível — o banco nunca guarda o caractere.
+_WORD_JOINER = "\u2060"
+
+# `*`, `_`, `~` e crase são os quatro delimitadores de marcação do WhatsApp.
+_MARCACAO_WA = re.compile(r"[*_~`]")
+
+
+def escape_wa_markup(text: object) -> str:
+    """Neutraliza marcação do WhatsApp em texto que veio do usuário.
+
+    O WhatsApp NÃO tem caractere de escape: `\\*` não existe e entidade HTML
+    aparece literal na tela. A saída é quebrar o PAREAMENTO — um WORD JOINER
+    logo depois de cada delimitador — sem alterar o texto visível.
+
+    Só para o argumento interpolado, nunca para a mensagem montada: os
+    handlers misturam marcação própria e texto do usuário na mesma f-string
+    (ex.: core/handlers/pockets.py:124), e depois de interpolar não há como
+    distinguir as duas.
+    """
+    return _MARCACAO_WA.sub(lambda m: m.group() + _WORD_JOINER, str(text))

--- a/tests/test_whatsapp_markup_escape.py
+++ b/tests/test_whatsapp_markup_escape.py
@@ -18,18 +18,25 @@ caso a formatação já estava quebrada antes, então não se perde nada que
 funcione.
 
 CONTROLE NEGATIVO — quatro mutações, todas medidas em 2026-09-04 contra os
-`18 passed` deste arquivo com o conserto de pé. Nenhuma foi injetada num caso
-que já estava vermelho:
+`18 passed, 2 xfailed` deste arquivo com o conserto de pé. Nenhuma foi injetada
+num caso que já estava vermelho:
 
   1. `wrap_wa_markup` embrulha sempre (`return f"{delim}{text}{delim}"`)
      → `9 failed, 9 passed`: caem os 9 testes de não-embrulho;
   2. `wrap_wa_markup` nunca embrulha (`return text`)
      → `9 failed, 9 passed`: caem os 9 controles positivos (partição limpa);
-  3. `_MARCACAO_WA` volta ao `[*_~\`]` (o `_` sem fronteira)
+  3. `_MARCACAO_WA` volta ao filtro sem a fronteira do `_`
      → `1 failed, 17 passed`: só `test_categoria_legitima_mantem_o_negrito
      [meta_casa_nova]`, que é exatamente o que a precisão do `_` conserta;
   4. `core/handlers/bills.py:176/:297` voltam ao `*{paid.get('name')}*` literal
      → `2 failed, 16 passed`: os dois casos `luz *casa*` da porta digitada.
+
+Os 2 `xfailed` são da #276 e ficam de fora dessas quatro de propósito: eles
+afirmam o comportamento DESEJADO, não o atual. Que o `strict` está armado foi
+medido no mesmo dia — virando a asserção de um deles para o estado de hoje, o
+pytest devolve `[XPASS(strict)]` e `1 failed`. Ou seja: no dia em que a #276 for
+consertada, este arquivo fica VERMELHO pedindo a remoção do marcador, e não
+existe caminho em que o defeito seja lido como comportamento correto.
 
 CONTROLE POSITIVO — o conserto RESTRINGE (passa a omitir o negrito), então
 precisa provar que não engole o negrito de quem escreveu certo: `McDonald's`,
@@ -43,11 +50,14 @@ se o embrulho de marcação está presente ou ausente. Isso NÃO é a tela: em p
 menos um sítio (pending.py:90) ainda passa um `format_for_platform`
 (core/handle_incoming.py:150) que remove pares de crase no WhatsApp.
 
-SEGUNDA CLASSE CEGA: o helper decide POR ARGUMENTO, o WhatsApp pareia POR
-MENSAGEM. Onde o template tem marcação PRÓPRIA além do embrulho, o `*` ímpar do
-usuário casa com o do bot e o negrito vaza mesmo sem embrulho — medido pelo
-`process_message` real em wa_runtime.py:805 (3 asteriscos) e :982/:984 (5).
-Fechar isso é mudança de desenho e fica fora deste PR.
+ISSUE #276 — o helper decide POR ARGUMENTO, o WhatsApp pareia POR MENSAGEM.
+Onde o template tem marcação PRÓPRIA além do embrulho, o `*` ímpar do usuário
+casa com o do bot e o negrito vaza mesmo sem embrulho — medido pelo
+`process_message` real em wa_runtime.py:805 (3 asteriscos) e :982/:984 (5). E há
+um SEGUNDO mecanismo na mesma classe: bills.py:63 não tem marcação própria, mas
+interpola o nome DUAS vezes, então o `*` do usuário pareia consigo mesmo (2
+asteriscos). Fechar isso é mudança de desenho e fica fora deste PR — os dois
+casos estão aqui como `xfail(strict=True)` afirmando o estado DESEJADO.
 
 ESCOPO: os 7 sítios de `adapters/whatsapp/wa_runtime.py`, o
 `pergunta_de_valor_sem_contexto` (core/handlers/bills.py:63, chamado de
@@ -163,24 +173,13 @@ def test_conta_paga_legitima_mantem_o_negrito(monkeypatch):
 # ─── wa_runtime:805 — pergunta de valor de conta variável ───────────────────
 
 
-def test_pergunta_de_valor_com_asterisco_no_nome(monkeypatch):
-    """O que este sítio fecha, e o que NÃO fecha.
-
-    `conta_de_luz` estava aqui e era a única entrada da lista que ESCONDIA o
-    vazamento: sem asterisco nenhum, o total da mensagem ficava par de graça.
-    Com `a*b` o `process_message` real devolve (medido em 2026-09-04):
-
-        'Quanto veio a conta de a*b este mês?\nÉ só mandar o valor. Ex: *132,50*'
-
-    TRÊS asteriscos — o embrulho sai (é o que se afirma abaixo), mas o `*` do
-    usuário ainda pareia com o `*132,50*` do template e o negrito vaza na tela.
-    Fechar isso exige decidir por MENSAGEM, não por argumento; fica fora do PR.
-    """
+def _pergunta_de_valor(monkeypatch, nome: str) -> str:
+    """Roda o `process_message` real até a pergunta de valor (wa_runtime.py:805)."""
     replies: list[tuple[str, str]] = []
     _mock_wa_boot(monkeypatch, replies, uid=4242)
     monkeypatch.setattr(
         "db.bills.get_bill",
-        lambda uid, bid: {"id": bid, "name": "a*b", "status": "pending",
+        lambda uid, bid: {"id": bid, "name": nome, "status": "pending",
                           "variable_amount": True, "amount": None},
     )
     monkeypatch.setattr("adapters.whatsapp.wa_runtime.claim_pending_action",
@@ -189,10 +188,40 @@ def test_pergunta_de_valor_com_asterisco_no_nome(monkeypatch):
     wa_runtime.process_message(_botao(wa_runtime.WA_BILL_PAID_PREFIX + "41"))
 
     assert len(replies) == 1
-    body = replies[0][1]
+    return replies[0][1]
+
+
+def test_pergunta_de_valor_com_asterisco_no_nome(monkeypatch):
+    """O que ESTE PR fecha neste sítio: o embrulho sai.
+
+    `conta_de_luz` estava aqui e era a única entrada da lista que ESCONDIA o
+    vazamento da #276: sem asterisco nenhum, o total da mensagem ficava par de
+    graça. Com `a*b` o sítio é de fato exercitado.
+    """
+    body = _pergunta_de_valor(monkeypatch, "a*b")
+
     assert "Quanto veio a conta de a*b este mês?" in body
     assert "*a*b*" not in body
-    assert body.count("*") == 3   # o vazamento por mensagem, documentado
+
+
+@pytest.mark.xfail(strict=True, reason="issue #276: o WhatsApp pareia por MENSAGEM, "
+                                       "e wrap_wa_markup decide por argumento")
+def test_pergunta_de_valor_nao_deixa_asterisco_impar(monkeypatch):
+    """O que a #276 fecha: delimitador PAREADO na mensagem inteira.
+
+    Medido em 2026-09-04, o `process_message` real devolve:
+
+        'Quanto veio a conta de a*b este mês?\nÉ só mandar o valor. Ex: *132,50*'
+
+    TRÊS asteriscos: o embrulho saiu, mas o `*` do usuário pareia com o
+    `*132,50*` do TEMPLATE e o negrito vaza na tela mesmo assim. A asserção
+    abaixo é o estado DESEJADO, não o atual — `strict` de propósito: quando a
+    #276 for consertada isto vira XPASS e a mensagem pede a remoção do marcador,
+    em vez de parecer regressão.
+    """
+    body = _pergunta_de_valor(monkeypatch, "a*b")
+
+    assert body.count("*") % 2 == 0
 
 
 # ─── bills.py:63 — o irmão de wa_runtime.py:800, mesma variável ────────────
@@ -208,6 +237,21 @@ def test_pergunta_sem_contexto_com_underscore_no_nome(monkeypatch):
     assert msg.count("luz _extra_") == 2
     assert "*luz _extra_*" not in msg
     assert msg.count("*") == 0   # o template não tem marcação própria
+
+
+@pytest.mark.xfail(strict=True, reason="issue #276: o WhatsApp pareia por MENSAGEM, "
+                                       "e wrap_wa_markup decide por argumento")
+def test_pergunta_sem_contexto_nao_deixa_asterisco_impar(monkeypatch):
+    """A #276 por OUTRO mecanismo: aqui o template não tem marcação própria,
+    mas interpola o nome DUAS vezes — o `*` do usuário pareia consigo mesmo
+    através da mensagem. Medido em 2026-09-04: 2 asteriscos, e o que fica em
+    negrito é `b tem valor variável... Me responde ela primeiro; a a`.
+    """
+    monkeypatch.setattr(db, "get_pending_action", lambda uid: {})
+
+    msg = h_bills.pergunta_de_valor_sem_contexto(9, "a*b")
+
+    assert msg.count("*") == 0
 
 
 def test_pergunta_sem_contexto_legitima_mantem_o_negrito(monkeypatch):

--- a/tests/test_whatsapp_markup_escape.py
+++ b/tests/test_whatsapp_markup_escape.py
@@ -9,34 +9,54 @@ justamente quando o delimitador do usuário é igual ao do template — o `a*b`
 dentro de `*{...}*`, que é o caso do título da issue.
 
 O mecanismo é `wrap_wa_markup` (core/response_formatter.py): quando o texto do
-usuário contém `*`, `_`, `~` ou crase, a mensagem sai SEM o embrulho de
-marcação. Custo aceito: perde-se o negrito nesses nomes — e nesse mesmo caso a
-formatação já estava quebrada antes, então não se perde nada que funcione.
+usuário contém `*`, `~`, crase — ou um `_` que PODE parear (com não-palavra ou
+borda de um dos lados) —, a mensagem sai SEM o embrulho de marcação. O `_` no
+MEIO de palavra não entra: MEDIDO pelo dono no cliente real em 2026-09-04,
+`meta_casa_nova` sai literal, sem itálico, enquanto `~x~` sai riscado mesmo
+colado. Custo aceito: perde-se o negrito nos nomes que casam — e nesse mesmo
+caso a formatação já estava quebrada antes, então não se perde nada que
+funcione.
 
-CONTROLE NEGATIVO — faça `wrap_wa_markup` embrulhar sempre
-(`return f"{delim}{text}{delim}"`) e rode este arquivo: os 7 testes de
-não-embrulho ficam VERMELHOS (medido em 2026-09-04: `7 failed, 6 passed`; com o
-conserto de pé, `13 passed`). Os 7 estavam VERDES com o conserto — nenhum foi
-injetado num caso já vermelho. Os 6 que continuam verdes são os controles
-positivos, e é exatamente o que se espera deles.
+CONTROLE NEGATIVO — quatro mutações, todas medidas em 2026-09-04 contra os
+`18 passed` deste arquivo com o conserto de pé. Nenhuma foi injetada num caso
+que já estava vermelho:
+
+  1. `wrap_wa_markup` embrulha sempre (`return f"{delim}{text}{delim}"`)
+     → `9 failed, 9 passed`: caem os 9 testes de não-embrulho;
+  2. `wrap_wa_markup` nunca embrulha (`return text`)
+     → `9 failed, 9 passed`: caem os 9 controles positivos (partição limpa);
+  3. `_MARCACAO_WA` volta ao `[*_~\`]` (o `_` sem fronteira)
+     → `1 failed, 17 passed`: só `test_categoria_legitima_mantem_o_negrito
+     [meta_casa_nova]`, que é exatamente o que a precisão do `_` conserta;
+  4. `core/handlers/bills.py:176/:297` voltam ao `*{paid.get('name')}*` literal
+     → `2 failed, 16 passed`: os dois casos `luz *casa*` da porta digitada.
 
 CONTROLE POSITIVO — o conserto RESTRINGE (passa a omitir o negrito), então
 precisa provar que não engole o negrito de quem escreveu certo: `McDonald's`,
-`café & pão` e `Cartão Nubank` (a mesma lista de tests/test_export_pdf_escape.py,
-#145) saem COM o par de asteriscos, e a pendência legada sai com as crases. O
-controle do controle, medido no mesmo dia: com `return text` (helper que nunca
-embrulha) são os 6 positivos que ficam vermelhos — `6 failed, 7 passed`.
+`café & pão`, `Cartão Nubank` (a mesma lista de tests/test_export_pdf_escape.py,
+#145) e `meta_casa_nova` saem COM o par de asteriscos, e a pendência legada sai
+com as crases. É a mutação 2 acima que prova que esse grupo mede alguma coisa.
 
 CLASSE CEGA: a RENDERIZAÇÃO do cliente WhatsApp (Android/iOS) não é exercitável
 aqui. O que se mede é a estrutura da STRING que sai da função real do handler —
-se o embrulho de marcação está presente ou ausente.
+se o embrulho de marcação está presente ou ausente. Isso NÃO é a tela: em pelo
+menos um sítio (pending.py:90) ainda passa um `format_for_platform`
+(core/handle_incoming.py:150) que remove pares de crase no WhatsApp.
+
+SEGUNDA CLASSE CEGA: o helper decide POR ARGUMENTO, o WhatsApp pareia POR
+MENSAGEM. Onde o template tem marcação PRÓPRIA além do embrulho, o `*` ímpar do
+usuário casa com o do bot e o negrito vaza mesmo sem embrulho — medido pelo
+`process_message` real em wa_runtime.py:805 (3 asteriscos) e :982/:984 (5).
+Fechar isso é mudança de desenho e fica fora deste PR.
 
 ESCOPO: os 7 sítios de `adapters/whatsapp/wa_runtime.py`, o
-`pergunta_de_valor_sem_contexto` (core/handlers/bills.py, chamado de
-wa_runtime.py:800) e o `core/handlers/pending.py:90`. Ficam FORA:
-`core/handlers/bills.py:174` e `:295`, que têm a string idêntica à de
-wa_runtime.py:822/1020 — a outra porta da MESMA pergunta —, e os 125 sítios
-restantes em ~20 arquivos. Tudo isso é a fatia 2.
+`pergunta_de_valor_sem_contexto` (core/handlers/bills.py:63, chamado de
+wa_runtime.py:800), o `core/handlers/pending.py:90` e — porque é a MESMA
+pergunta pela outra porta, com a string byte-idêntica — `core/handlers/
+bills.py:176` e `:297`, que atendem quem DIGITA "paguei luz" em vez de tocar o
+botão. Ficam FORA: `core/handlers/bills.py:169-170`, onde o nome cai DENTRO da
+marcação do bot (`*paguei {nome} 132,50*`, forma que o helper não alcança por
+construção), e os sítios restantes em ~20 arquivos.
 """
 from __future__ import annotations
 
@@ -67,7 +87,7 @@ def _novo_launch(user_id: int) -> int:
 
 @pytest.mark.parametrize("nome", [
     "a*b",            # delimitador IGUAL ao do template: o caso que o WJ não fechava
-    "meta_casa_nova",  # dois underscores pareiam e o WhatsApp italiza "casa"
+    "luz _extra_",     # underscore COM fronteira: pareia e italiza "extra"
     "conta_",          # termina em delimitador: com WJ o negrito do bot vazava
 ])
 def test_categoria_com_marcacao_sai_sem_negrito(pro_user_id, nome):
@@ -79,7 +99,14 @@ def test_categoria_com_marcacao_sai_sem_negrito(pro_user_id, nome):
     assert f"*{nome}*" not in msg                     # e sem o embrulho
 
 
-@pytest.mark.parametrize("nome,canon", NOMES_LEGITIMOS)
+@pytest.mark.parametrize("nome,canon", NOMES_LEGITIMOS + [
+    # MEDIDO pelo dono no cliente real em 2026-09-04: `meta_casa_nova` sai
+    # LITERAL, sem itálico — underscore no MEIO de palavra não pareia. Não há
+    # nada a neutralizar aqui, então o negrito do bot fica. Este caso já esteve
+    # do lado errado da tabela, com o comentário afirmando que o WhatsApp
+    # italizava "casa".
+    ("meta_casa_nova", "meta_casa_nova"),
+])
 def test_categoria_legitima_mantem_o_negrito(pro_user_id, nome, canon):
     """CONTROLE POSITIVO: sem isto, um helper que nunca embrulha passaria."""
     launch_id = _novo_launch(pro_user_id)
@@ -136,12 +163,24 @@ def test_conta_paga_legitima_mantem_o_negrito(monkeypatch):
 # ─── wa_runtime:805 — pergunta de valor de conta variável ───────────────────
 
 
-def test_pergunta_de_valor_com_underscore_no_nome(monkeypatch):
+def test_pergunta_de_valor_com_asterisco_no_nome(monkeypatch):
+    """O que este sítio fecha, e o que NÃO fecha.
+
+    `conta_de_luz` estava aqui e era a única entrada da lista que ESCONDIA o
+    vazamento: sem asterisco nenhum, o total da mensagem ficava par de graça.
+    Com `a*b` o `process_message` real devolve (medido em 2026-09-04):
+
+        'Quanto veio a conta de a*b este mês?\nÉ só mandar o valor. Ex: *132,50*'
+
+    TRÊS asteriscos — o embrulho sai (é o que se afirma abaixo), mas o `*` do
+    usuário ainda pareia com o `*132,50*` do template e o negrito vaza na tela.
+    Fechar isso exige decidir por MENSAGEM, não por argumento; fica fora do PR.
+    """
     replies: list[tuple[str, str]] = []
     _mock_wa_boot(monkeypatch, replies, uid=4242)
     monkeypatch.setattr(
         "db.bills.get_bill",
-        lambda uid, bid: {"id": bid, "name": "conta_de_luz", "status": "pending",
+        lambda uid, bid: {"id": bid, "name": "a*b", "status": "pending",
                           "variable_amount": True, "amount": None},
     )
     monkeypatch.setattr("adapters.whatsapp.wa_runtime.claim_pending_action",
@@ -151,8 +190,9 @@ def test_pergunta_de_valor_com_underscore_no_nome(monkeypatch):
 
     assert len(replies) == 1
     body = replies[0][1]
-    assert "Quanto veio a conta de conta_de_luz este mês?" in body
-    assert "*conta_de_luz*" not in body
+    assert "Quanto veio a conta de a*b este mês?" in body
+    assert "*a*b*" not in body
+    assert body.count("*") == 3   # o vazamento por mensagem, documentado
 
 
 # ─── bills.py:63 — o irmão de wa_runtime.py:800, mesma variável ────────────
@@ -163,10 +203,11 @@ def test_pergunta_sem_contexto_com_underscore_no_nome(monkeypatch):
     interpola o nome DUAS vezes."""
     monkeypatch.setattr(db, "get_pending_action", lambda uid: {})
 
-    msg = h_bills.pergunta_de_valor_sem_contexto(9, "conta_de_luz")
+    msg = h_bills.pergunta_de_valor_sem_contexto(9, "luz _extra_")
 
-    assert msg.count("conta_de_luz") == 2
-    assert "*conta_de_luz*" not in msg
+    assert msg.count("luz _extra_") == 2
+    assert "*luz _extra_*" not in msg
+    assert msg.count("*") == 0   # o template não tem marcação própria
 
 
 def test_pergunta_sem_contexto_legitima_mantem_o_negrito(monkeypatch):
@@ -176,6 +217,50 @@ def test_pergunta_sem_contexto_legitima_mantem_o_negrito(monkeypatch):
     msg = h_bills.pergunta_de_valor_sem_contexto(9, "Cartão Nubank")
 
     assert msg.count("*Cartão Nubank*") == 2
+
+
+# ─── bills.py:176/:297 — a porta GÊMEA de wa_runtime.py:822/1020 ───────────
+#
+# String byte-idêntica, mesma ação do mesmo usuário: quem toca o BOTÃO cai no
+# wa_runtime, quem DIGITA "paguei luz" cai aqui. Sem estas duas linhas, metade
+# dos usuários recebia a versão quebrada.
+
+
+def _conta(nome: str, **extra) -> dict:
+    return {"id": 41, "name": nome, "status": "pending",
+            "variable_amount": False, "amount": 132.5, **extra}
+
+
+@pytest.mark.parametrize("nome,esperado", [
+    ("luz *casa*", "Conta paga: luz *casa* —"),      # marcação do usuário: sem embrulho
+    ("Cartão Nubank", "Conta paga: *Cartão Nubank* —"),  # CONTROLE POSITIVO
+])
+def test_conta_paga_digitando_bills_176(monkeypatch, nome, esperado):
+    """`paguei ...` no texto — bills.py:176, o irmão de wa_runtime.py:822."""
+    monkeypatch.setattr("db.bills.list_bills", lambda uid, include_paid=False: [_conta(nome)])
+    monkeypatch.setattr("db.bills.mark_bill_paid",
+                        lambda uid, bid, amount=None: {"name": nome, "paid_amount": 132.5})
+
+    msg = h_bills.try_pay_from_text(9, "paguei")
+
+    assert esperado in msg
+
+
+@pytest.mark.parametrize("nome,esperado", [
+    ("luz *casa*", "Conta paga: luz *casa* —"),
+    ("Cartão Nubank", "Conta paga: *Cartão Nubank* —"),  # CONTROLE POSITIVO
+])
+def test_conta_paga_respondendo_o_valor_bills_297(monkeypatch, nome, esperado):
+    """Resposta só com o valor — bills.py:297, o irmão de wa_runtime.py:1020."""
+    monkeypatch.setattr(db, "consume_pending_action", lambda uid, p: True)
+    monkeypatch.setattr("db.bills.mark_bill_paid",
+                        lambda uid, bid, amount: {"name": nome, "paid_amount": amount})
+    pend = {"action_type": "bill_amount_expected",
+            "payload": {"bill_id": 41, "bill_name": nome}}
+
+    msg = h_bills.resolve_bill_amount(9, "132,50", pend)
+
+    assert esperado in msg
 
 
 # ─── core/handlers/pending.py:90 — a mensagem CRUA do usuário, em crase ────
@@ -201,7 +286,13 @@ def test_pendencia_legada_com_crase_na_mensagem_crua(monkeypatch):
 
 
 def test_pendencia_legada_legitima_mantem_a_crase(monkeypatch):
-    """CONTROLE POSITIVO: texto sem marcação continua saindo em crase."""
+    """CONTROLE POSITIVO: a string CRUA do handler continua saindo em crase.
+
+    Não é a tela: depois daqui ainda roda o `format_for_platform`
+    (core/handle_incoming.py:150), que remove os pares de crase no WhatsApp.
+    O que se prova é que o embrulho do helper não sumiu — o teste acima é que
+    mede a tela, passando pelo `format_for_platform`.
+    """
     bruto = _pendencia_legada(monkeypatch, "gastei 50 no mercado")
 
     assert bruto.endswith("Tente: `gastei 50 no mercado`")

--- a/tests/test_whatsapp_markup_escape.py
+++ b/tests/test_whatsapp_markup_escape.py
@@ -1,30 +1,42 @@
 """Nome do usuário é CONTEÚDO, não marcação do WhatsApp (#146, fatia 1 de 2).
 
 O WhatsApp NÃO tem caractere de escape: `\\*` não existe, entidade HTML aparece
-literal na tela. O mecanismo é `escape_wa_markup` (core/response_formatter.py):
-um WORD JOINER (U+2060, invisível) logo depois de cada `*`, `_`, `~` e crase que
-veio do usuário, quebrando o PAREAMENTO sem alterar o texto visível.
+literal na tela. E neutralizar o delimitador do usuário com um WORD JOINER
+(U+2060) também não resolve — MEDIDO pelo dono no cliente real do WhatsApp,
+`*a*<WJ>b*` renderiza `ab*`, idêntico ao que a `main` já mostra: o WJ cega a
+ABERTURA, mas o FECHAMENTO olha o caractere ANTERIOR. Ou seja, era inerte
+justamente quando o delimitador do usuário é igual ao do template — o `a*b`
+dentro de `*{...}*`, que é o caso do título da issue.
 
-CONTROLE NEGATIVO — faça `escape_wa_markup` devolver a entrada intacta
-(`return str(text)`) e rode este arquivo:
-os 5 testes de neutralização ficam VERMELHOS (medido: `5 failed, 3 passed`;
-com o conserto de pé, `8 passed`). Os 5 estavam VERDES com o conserto — nenhum
-foi injetado num caso já vermelho. Os 3 que continuam verdes são os controles
+O mecanismo é `wrap_wa_markup` (core/response_formatter.py): quando o texto do
+usuário contém `*`, `_`, `~` ou crase, a mensagem sai SEM o embrulho de
+marcação. Custo aceito: perde-se o negrito nesses nomes — e nesse mesmo caso a
+formatação já estava quebrada antes, então não se perde nada que funcione.
+
+CONTROLE NEGATIVO — faça `wrap_wa_markup` embrulhar sempre
+(`return f"{delim}{text}{delim}"`) e rode este arquivo: os 7 testes de
+não-embrulho ficam VERMELHOS (medido em 2026-09-04: `7 failed, 6 passed`; com o
+conserto de pé, `13 passed`). Os 7 estavam VERDES com o conserto — nenhum foi
+injetado num caso já vermelho. Os 6 que continuam verdes são os controles
 positivos, e é exatamente o que se espera deles.
 
-CONTROLE POSITIVO — `test_pontuacao_legitima_sobrevive_com_negrito_intacto`: o
-conserto RESTRINGE (passa a inserir caractere), então precisa provar que não
-mutila quem escreveu certo. `McDonald's`, `café & pão` e `Cartão Nubank` saem com
-o caractere original E com o par de asteriscos do negrito de pé.
+CONTROLE POSITIVO — o conserto RESTRINGE (passa a omitir o negrito), então
+precisa provar que não engole o negrito de quem escreveu certo: `McDonald's`,
+`café & pão` e `Cartão Nubank` (a mesma lista de tests/test_export_pdf_escape.py,
+#145) saem COM o par de asteriscos, e a pendência legada sai com as crases. O
+controle do controle, medido no mesmo dia: com `return text` (helper que nunca
+embrulha) são os 6 positivos que ficam vermelhos — `6 failed, 7 passed`.
 
 CLASSE CEGA: a RENDERIZAÇÃO do cliente WhatsApp (Android/iOS) não é exercitável
-aqui. Nada neste arquivo prova que o U+2060 realmente impede o negrito no
-aparelho — isso é verificação pós-deploy. O que se mede aqui é a estrutura da
-STRING que sai: quais delimitadores continuam pareáveis.
+aqui. O que se mede é a estrutura da STRING que sai da função real do handler —
+se o embrulho de marcação está presente ou ausente.
 
-ESCOPO: os 7 sítios de `adapters/whatsapp/wa_runtime.py` e o de
-`core/handlers/pending.py:89`. Os ~90 restantes (`credit.py`, `pockets.py`,
-`investments.py`…) são a fatia 2 e NÃO estão cobertos aqui.
+ESCOPO: os 7 sítios de `adapters/whatsapp/wa_runtime.py`, o
+`pergunta_de_valor_sem_contexto` (core/handlers/bills.py, chamado de
+wa_runtime.py:800) e o `core/handlers/pending.py:90`. Ficam FORA:
+`core/handlers/bills.py:174` e `:295`, que têm a string idêntica à de
+wa_runtime.py:822/1020 — a outra porta da MESMA pergunta —, e os 125 sítios
+restantes em ~20 arquivos. Tudo isso é a fatia 2.
 """
 from __future__ import annotations
 
@@ -32,22 +44,14 @@ import pytest
 
 import db
 from adapters.whatsapp import wa_runtime
+from core.handlers import bills as h_bills
 from core.handlers import pending as h_pending
 from core.response_formatter import format_for_platform
 
-WJ = "⁠"
-
-
-def _delimitadores_ativos(texto: str) -> str:
-    """Os marcadores que o WhatsApp ainda pode parear.
-
-    Um marcador seguido de WORD JOINER está neutralizado; o que sobra é o que
-    o cliente ainda enxerga como abertura/fechamento.
-    """
-    return "".join(
-        c for i, c in enumerate(texto)
-        if c in "*_~`" and texto[i + 1:i + 2] != WJ
-    )
+# A lista de nomes legítimos do #145 (tests/test_export_pdf_escape.py:105).
+NOMES_LEGITIMOS = [("McDonald's", "mcdonald's"),
+                   ("café & pão", "café & pão"),
+                   ("Cartão Nubank", "cartão nubank")]
 
 
 def _novo_launch(user_id: int) -> int:
@@ -58,49 +62,34 @@ def _novo_launch(user_id: int) -> int:
     return launch_id
 
 
-# ─── wa_runtime:351 — categoria (a linha citada na issue) ────────────────────
+# ─── wa_runtime:352 — categoria (a linha citada na issue) ────────────────────
 
 
-def test_categoria_com_asterisco_nao_abre_negrito(pro_user_id):
-    """`a*b` é nome legítimo desde o #143. Os asteriscos ativos têm que ser
-    só o par do template — 3 asteriscos ativos é negrito vazando."""
-    launch_id = _novo_launch(pro_user_id)
-
-    msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, "a*b")
-
-    assert "a*" + WJ + "b" in msg          # o texto visível é o mesmo
-    assert _delimitadores_ativos(msg) == "**"
-
-
-def test_categoria_com_underscore_nao_italiza(pro_user_id):
-    """`meta_casa_nova`: dois underscores pareiam e o WhatsApp italiza "casa".
-    É o caractere realmente alcançável — asterisco em nome é raro, underscore não."""
-    launch_id = _novo_launch(pro_user_id)
-
-    msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, "meta_casa_nova")
-
-    assert "meta_" + WJ + "casa_" + WJ + "nova" in msg
-    assert _delimitadores_ativos(msg) == "**"
-
-
-@pytest.mark.parametrize("nome,canon", [
-    ("McDonald's", "mcdonald's"),
-    ("café & pão", "café & pão"),
-    ("Cartão Nubank", "cartão nubank"),
+@pytest.mark.parametrize("nome", [
+    "a*b",            # delimitador IGUAL ao do template: o caso que o WJ não fechava
+    "meta_casa_nova",  # dois underscores pareiam e o WhatsApp italiza "casa"
+    "conta_",          # termina em delimitador: com WJ o negrito do bot vazava
 ])
-def test_pontuacao_legitima_sobrevive_com_negrito_intacto(pro_user_id, nome, canon):
-    """CONTROLE POSITIVO: o conserto restringe, então tem que provar que o
-    caminho legítimo continua — caractere original E negrito de pé."""
+def test_categoria_com_marcacao_sai_sem_negrito(pro_user_id, nome):
     launch_id = _novo_launch(pro_user_id)
 
     msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, nome)
 
-    assert f"*{canon}*" in msg      # sem WJ nenhum no meio, e o par intacto
-    assert WJ not in msg
-    assert _delimitadores_ativos(msg) == "**"
+    assert msg.endswith(f"atualizada para {nome}.")   # o nome inteiro, na tela
+    assert f"*{nome}*" not in msg                     # e sem o embrulho
 
 
-# ─── wa_runtime:821/1019 — nome da conta no caminho do dinheiro ─────────────
+@pytest.mark.parametrize("nome,canon", NOMES_LEGITIMOS)
+def test_categoria_legitima_mantem_o_negrito(pro_user_id, nome, canon):
+    """CONTROLE POSITIVO: sem isto, um helper que nunca embrulha passaria."""
+    launch_id = _novo_launch(pro_user_id)
+
+    msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, nome)
+
+    assert msg.endswith(f"atualizada para *{canon}*.")
+
+
+# ─── wa_runtime:822/1020 — nome da conta no caminho do dinheiro ─────────────
 
 
 def test_conta_paga_com_asterisco_no_nome(monkeypatch):
@@ -121,12 +110,33 @@ def test_conta_paga_com_asterisco_no_nome(monkeypatch):
 
     assert len(replies) == 1
     body = replies[0][1]
-    assert "luz *" + WJ + "casa*" + WJ in body
-    assert _delimitadores_ativos(body) == "**"
+    assert "Conta paga: luz *casa* —" in body
+    assert "*luz *casa**" not in body
+
+
+def test_conta_paga_legitima_mantem_o_negrito(monkeypatch):
+    """CONTROLE POSITIVO no caminho do dinheiro."""
+    replies: list[tuple[str, str]] = []
+    _mock_wa_boot(monkeypatch, replies, uid=4242)
+    monkeypatch.setattr(
+        "db.bills.get_bill",
+        lambda uid, bid: {"id": bid, "name": "Cartão Nubank", "status": "pending",
+                          "variable_amount": False, "amount": 132.5},
+    )
+    monkeypatch.setattr(
+        "db.bills.mark_bill_paid",
+        lambda uid, bid: {"name": "Cartão Nubank", "paid_amount": 132.5},
+    )
+
+    wa_runtime.process_message(_botao(wa_runtime.WA_BILL_PAID_PREFIX + "41"))
+
+    assert "Conta paga: *Cartão Nubank* —" in replies[0][1]
+
+
+# ─── wa_runtime:805 — pergunta de valor de conta variável ───────────────────
 
 
 def test_pergunta_de_valor_com_underscore_no_nome(monkeypatch):
-    """wa_runtime:804 — conta de valor variável chamada `conta_de_luz`."""
     replies: list[tuple[str, str]] = []
     _mock_wa_boot(monkeypatch, replies, uid=4242)
     monkeypatch.setattr(
@@ -141,33 +151,60 @@ def test_pergunta_de_valor_com_underscore_no_nome(monkeypatch):
 
     assert len(replies) == 1
     body = replies[0][1]
-    assert "conta_" + WJ + "de_" + WJ + "luz" in body
-    # o template tem 4 asteriscos ativos: *{nome}* e *132,50*
-    assert _delimitadores_ativos(body) == "****"
+    assert "Quanto veio a conta de conta_de_luz este mês?" in body
+    assert "*conta_de_luz*" not in body
 
 
-# ─── core/handlers/pending.py:89 — a mensagem CRUA do usuário ───────────────
+# ─── bills.py:63 — o irmão de wa_runtime.py:800, mesma variável ────────────
 
 
-def test_pendencia_legada_com_crase_na_mensagem_crua(monkeypatch):
-    """O pior caso: `text` é a mensagem que o usuário digitou, inteira, e o
-    template usa crase.
+def test_pergunta_sem_contexto_com_underscore_no_nome(monkeypatch):
+    """O `claim` perdeu a linha: o texto vem de core/handlers/bills.py e
+    interpola o nome DUAS vezes."""
+    monkeypatch.setattr(db, "get_pending_action", lambda uid: {})
 
-    Medido na `main`: com o texto ``paguei a `luz` ``, o
-    `format_for_platform` (que remove crase no WhatsApp) pareia errado e sobram
-    DUAS crases soltas na tela — `Tente: paguei a luz``.
-    """
-    pend = {"action_type": "confirm_media_launch",
-            "payload": {"text": "paguei a `luz`"}}
+    msg = h_bills.pergunta_de_valor_sem_contexto(9, "conta_de_luz")
+
+    assert msg.count("conta_de_luz") == 2
+    assert "*conta_de_luz*" not in msg
+
+
+def test_pergunta_sem_contexto_legitima_mantem_o_negrito(monkeypatch):
+    """CONTROLE POSITIVO."""
+    monkeypatch.setattr(db, "get_pending_action", lambda uid: {})
+
+    msg = h_bills.pergunta_de_valor_sem_contexto(9, "Cartão Nubank")
+
+    assert msg.count("*Cartão Nubank*") == 2
+
+
+# ─── core/handlers/pending.py:90 — a mensagem CRUA do usuário, em crase ────
+
+
+def _pendencia_legada(monkeypatch, texto: str) -> str:
+    pend = {"action_type": "confirm_media_launch", "payload": {"text": texto}}
     monkeypatch.setattr(db, "get_pending_action", lambda uid: pend)
     monkeypatch.setattr(db, "consume_pending_action", lambda uid, p: True)
     monkeypatch.setattr("core.services.quick_entry.handle_quick_entry",
                         lambda uid, text: None)
+    return h_pending.resolve_delete(9, confirmed=True)
 
-    bruto = h_pending.resolve_delete(9, confirmed=True)
-    saida = format_for_platform(bruto, "whatsapp")
 
-    assert _delimitadores_ativos(saida) == ""
+def test_pendencia_legada_com_crase_na_mensagem_crua(monkeypatch):
+    """Medido na `main`: com ``paguei a `luz` ``, o `format_for_platform`
+    (que remove crase no WhatsApp) pareia errado e sobram DUAS crases soltas
+    na tela — `Tente: paguei a luz``."""
+    bruto = _pendencia_legada(monkeypatch, "paguei a `luz`")
+
+    assert bruto.endswith("Tente: paguei a `luz`")
+    assert format_for_platform(bruto, "whatsapp").count("`") == 0
+
+
+def test_pendencia_legada_legitima_mantem_a_crase(monkeypatch):
+    """CONTROLE POSITIVO: texto sem marcação continua saindo em crase."""
+    bruto = _pendencia_legada(monkeypatch, "gastei 50 no mercado")
+
+    assert bruto.endswith("Tente: `gastei 50 no mercado`")
 
 
 # ─── plumbing do process_message (só monkeypatch de borda) ──────────────────

--- a/tests/test_whatsapp_markup_escape.py
+++ b/tests/test_whatsapp_markup_escape.py
@@ -1,0 +1,196 @@
+"""Nome do usuário é CONTEÚDO, não marcação do WhatsApp (#146, fatia 1 de 2).
+
+O WhatsApp NÃO tem caractere de escape: `\\*` não existe, entidade HTML aparece
+literal na tela. O mecanismo é `escape_wa_markup` (core/response_formatter.py):
+um WORD JOINER (U+2060, invisível) logo depois de cada `*`, `_`, `~` e crase que
+veio do usuário, quebrando o PAREAMENTO sem alterar o texto visível.
+
+CONTROLE NEGATIVO — faça `escape_wa_markup` devolver a entrada intacta
+(`return str(text)`) e rode este arquivo:
+os 5 testes de neutralização ficam VERMELHOS (medido: `5 failed, 3 passed`;
+com o conserto de pé, `8 passed`). Os 5 estavam VERDES com o conserto — nenhum
+foi injetado num caso já vermelho. Os 3 que continuam verdes são os controles
+positivos, e é exatamente o que se espera deles.
+
+CONTROLE POSITIVO — `test_pontuacao_legitima_sobrevive_com_negrito_intacto`: o
+conserto RESTRINGE (passa a inserir caractere), então precisa provar que não
+mutila quem escreveu certo. `McDonald's`, `café & pão` e `Cartão Nubank` saem com
+o caractere original E com o par de asteriscos do negrito de pé.
+
+CLASSE CEGA: a RENDERIZAÇÃO do cliente WhatsApp (Android/iOS) não é exercitável
+aqui. Nada neste arquivo prova que o U+2060 realmente impede o negrito no
+aparelho — isso é verificação pós-deploy. O que se mede aqui é a estrutura da
+STRING que sai: quais delimitadores continuam pareáveis.
+
+ESCOPO: os 7 sítios de `adapters/whatsapp/wa_runtime.py` e o de
+`core/handlers/pending.py:89`. Os ~90 restantes (`credit.py`, `pockets.py`,
+`investments.py`…) são a fatia 2 e NÃO estão cobertos aqui.
+"""
+from __future__ import annotations
+
+import pytest
+
+import db
+from adapters.whatsapp import wa_runtime
+from core.handlers import pending as h_pending
+from core.response_formatter import format_for_platform
+
+WJ = "⁠"
+
+
+def _delimitadores_ativos(texto: str) -> str:
+    """Os marcadores que o WhatsApp ainda pode parear.
+
+    Um marcador seguido de WORD JOINER está neutralizado; o que sobra é o que
+    o cliente ainda enxerga como abertura/fechamento.
+    """
+    return "".join(
+        c for i, c in enumerate(texto)
+        if c in "*_~`" and texto[i + 1:i + 2] != WJ
+    )
+
+
+def _novo_launch(user_id: int) -> int:
+    launch_id, _seq, _bal = db.add_launch_and_update_balance(
+        user_id=user_id, tipo="despesa", valor=39.90,
+        alvo="mercado", nota="mercado", categoria="outros",
+    )
+    return launch_id
+
+
+# ─── wa_runtime:351 — categoria (a linha citada na issue) ────────────────────
+
+
+def test_categoria_com_asterisco_nao_abre_negrito(pro_user_id):
+    """`a*b` é nome legítimo desde o #143. Os asteriscos ativos têm que ser
+    só o par do template — 3 asteriscos ativos é negrito vazando."""
+    launch_id = _novo_launch(pro_user_id)
+
+    msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, "a*b")
+
+    assert "a*" + WJ + "b" in msg          # o texto visível é o mesmo
+    assert _delimitadores_ativos(msg) == "**"
+
+
+def test_categoria_com_underscore_nao_italiza(pro_user_id):
+    """`meta_casa_nova`: dois underscores pareiam e o WhatsApp italiza "casa".
+    É o caractere realmente alcançável — asterisco em nome é raro, underscore não."""
+    launch_id = _novo_launch(pro_user_id)
+
+    msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, "meta_casa_nova")
+
+    assert "meta_" + WJ + "casa_" + WJ + "nova" in msg
+    assert _delimitadores_ativos(msg) == "**"
+
+
+@pytest.mark.parametrize("nome,canon", [
+    ("McDonald's", "mcdonald's"),
+    ("café & pão", "café & pão"),
+    ("Cartão Nubank", "cartão nubank"),
+])
+def test_pontuacao_legitima_sobrevive_com_negrito_intacto(pro_user_id, nome, canon):
+    """CONTROLE POSITIVO: o conserto restringe, então tem que provar que o
+    caminho legítimo continua — caractere original E negrito de pé."""
+    launch_id = _novo_launch(pro_user_id)
+
+    msg = wa_runtime._apply_recategorize(pro_user_id, launch_id, nome)
+
+    assert f"*{canon}*" in msg      # sem WJ nenhum no meio, e o par intacto
+    assert WJ not in msg
+    assert _delimitadores_ativos(msg) == "**"
+
+
+# ─── wa_runtime:821/1019 — nome da conta no caminho do dinheiro ─────────────
+
+
+def test_conta_paga_com_asterisco_no_nome(monkeypatch):
+    """Botão "✅ Já paguei" numa conta de valor fixo chamada `luz *casa*`."""
+    replies: list[tuple[str, str]] = []
+    _mock_wa_boot(monkeypatch, replies, uid=4242)
+    monkeypatch.setattr(
+        "db.bills.get_bill",
+        lambda uid, bid: {"id": bid, "name": "luz *casa*", "status": "pending",
+                          "variable_amount": False, "amount": 132.5},
+    )
+    monkeypatch.setattr(
+        "db.bills.mark_bill_paid",
+        lambda uid, bid: {"name": "luz *casa*", "paid_amount": 132.5},
+    )
+
+    wa_runtime.process_message(_botao(wa_runtime.WA_BILL_PAID_PREFIX + "41"))
+
+    assert len(replies) == 1
+    body = replies[0][1]
+    assert "luz *" + WJ + "casa*" + WJ in body
+    assert _delimitadores_ativos(body) == "**"
+
+
+def test_pergunta_de_valor_com_underscore_no_nome(monkeypatch):
+    """wa_runtime:804 — conta de valor variável chamada `conta_de_luz`."""
+    replies: list[tuple[str, str]] = []
+    _mock_wa_boot(monkeypatch, replies, uid=4242)
+    monkeypatch.setattr(
+        "db.bills.get_bill",
+        lambda uid, bid: {"id": bid, "name": "conta_de_luz", "status": "pending",
+                          "variable_amount": True, "amount": None},
+    )
+    monkeypatch.setattr("adapters.whatsapp.wa_runtime.claim_pending_action",
+                        lambda *a, **k: True)
+
+    wa_runtime.process_message(_botao(wa_runtime.WA_BILL_PAID_PREFIX + "41"))
+
+    assert len(replies) == 1
+    body = replies[0][1]
+    assert "conta_" + WJ + "de_" + WJ + "luz" in body
+    # o template tem 4 asteriscos ativos: *{nome}* e *132,50*
+    assert _delimitadores_ativos(body) == "****"
+
+
+# ─── core/handlers/pending.py:89 — a mensagem CRUA do usuário ───────────────
+
+
+def test_pendencia_legada_com_crase_na_mensagem_crua(monkeypatch):
+    """O pior caso: `text` é a mensagem que o usuário digitou, inteira, e o
+    template usa crase.
+
+    Medido na `main`: com o texto ``paguei a `luz` ``, o
+    `format_for_platform` (que remove crase no WhatsApp) pareia errado e sobram
+    DUAS crases soltas na tela — `Tente: paguei a luz``.
+    """
+    pend = {"action_type": "confirm_media_launch",
+            "payload": {"text": "paguei a `luz`"}}
+    monkeypatch.setattr(db, "get_pending_action", lambda uid: pend)
+    monkeypatch.setattr(db, "consume_pending_action", lambda uid, p: True)
+    monkeypatch.setattr("core.services.quick_entry.handle_quick_entry",
+                        lambda uid, text: None)
+
+    bruto = h_pending.resolve_delete(9, confirmed=True)
+    saida = format_for_platform(bruto, "whatsapp")
+
+    assert _delimitadores_ativos(saida) == ""
+
+
+# ─── plumbing do process_message (só monkeypatch de borda) ──────────────────
+
+
+def _botao(interactive_id: str):
+    from adapters.whatsapp.wa_parse import InboundMessage
+
+    return InboundMessage(
+        wa_id="5511988887777", text="", timestamp="123", attachments=[],
+        raw={"id": "wamid." + interactive_id, "type": "interactive",
+             "interactive": {"type": "button_reply",
+                             "button_reply": {"id": interactive_id, "title": "✅ Já paguei"}}},
+    )
+
+
+def _mock_wa_boot(monkeypatch, replies: list, *, uid: int) -> None:
+    monkeypatch.setattr(wa_runtime, "get_or_create_canonical_user",
+                        lambda provider, external_id: uid)
+    monkeypatch.setattr(wa_runtime, "attempt_whatsapp_phone_link",
+                        lambda wa_id, current_user_id=None: {"status": "linked", "user_id": uid})
+    monkeypatch.setattr(wa_runtime, "log_system_event_sync", lambda *a, **k: None)
+    monkeypatch.setattr(wa_runtime, "send_typing_indicator", lambda *a, **k: None)
+    monkeypatch.setattr(wa_runtime, "_seen_recent", lambda message_id: False)
+    monkeypatch.setattr(wa_runtime, "_send_reply",
+                        lambda to, body: replies.append((to, body)))


### PR DESCRIPTION
Fecha a issue #146 na fatia 1: nome de categoria/conta e mensagem crua do usuário deixam de virar marcação do WhatsApp na resposta do bot.

## O mecanismo foi TROCADO nesta rodada

A versão anterior deste PR usava um WORD JOINER (U+2060) depois de cada delimitador vindo do usuário. **Ela sai.** Medição do dono, no cliente real do WhatsApp:

```
*a*⁠b*   ->   ab*     (só o "a" em negrito)
```

Idêntico ao que a `main` já renderiza. O WJ neutraliza o delimitador como **abertura**, não como **fechamento** — que olha o caractere **anterior**. Logo o conserto era **inerte exatamente quando o delimitador do usuário é igual ao do template**, que é o `a*b` dentro de `*{...}*` — o caso do título da issue.

E havia risco não medido na outra ponta: nome terminando em delimitador punha o WJ **antes** do `*` de fechamento, podendo fazer o negrito do bot vazar.

## O mecanismo novo

`wrap_wa_markup` em `core/response_formatter.py`, ao lado do `format_for_platform` (§0.7):

- quando o texto do usuário contém `*`, `~`, crase — ou um `_` que **pode parear** —, a mensagem sai **sem o embrulho de marcação**;
- caso contrário, embrulha normalmente.

Deleção em vez de adição (§0.2), e não depende de como a Meta pareia. O helper devolve a string **já embrulhada ou não** porque quem emite o `*` é o template. O `delim` existe porque um dos sítios embrulha em crase (`core/handlers/pending.py:90`). O `str(text)` foi mantido: `paid.get('name')` pode ser `None`, e imprimir `None` é melhor que estourar `TypeError` no caminho do dinheiro.

**Custo aceito: perde-se o negrito quando o nome tem marcação que pareia.** Nesse mesmo caso a formatação já estava quebrada hoje (é o bug da issue), então não se perde nada que funcione.

### O `_` entra com fronteira, os outros três não

Duas medições do dono no cliente real, em 2026-09-04:

```
meta_casa_nova   ->  saiu LITERAL, sem itálico     (underscore no meio de palavra NÃO pareia)
~x~              ->  x RISCADO                      (til pareia mesmo colado à palavra)
```

O filtro anterior era `[*_~\`]`: tratava **qualquer** `_` como perigoso e cobrava o negrito de `meta_casa_nova` e `conta_de_luz` à toa — não havia nada a consertar neles. O `_` **não sai** do filtro (com fronteira ele pareia: `_meta_`, `luz _extra_`, `nome_`), a regra é que fica precisa:

```python
_MARCACAO_WA = re.compile(r"[*~`]|(?<!\w)_|_(?!\w)")
```

| entrada | casa o filtro? | efeito |
|---|---|---|
| `meta_casa_nova`, `conta_de_luz`, `a_b_c` | não | **mantém o negrito** |
| `_meta_`, `luz _extra_`, `nome_`, `_nome`, `_` | sim | sem embrulho |
| `a*b`, `~x~`, `` a`b ``, `luz *casa*` | sim | sem embrulho (inalterado) |

A assimetria entre o `_` e os outros três está registrada em comentário no código, com as duas medições e a data (§2).

## Sítios (11)

| arquivo | linhas |
|---|---|
| `adapters/whatsapp/wa_runtime.py` | 352, 805, 822, 960, 982, 984, 1020 |
| `core/handlers/pending.py` | 90 (mensagem CRUA do usuário, em crase) |
| `core/handlers/bills.py` | 63 — `pergunta_de_valor_sem_contexto` |
| `core/handlers/bills.py` | **176 e 297 — novos nesta rodada** |

`bills.py:63` entrou por exigência da revisão: `wa_runtime.py:800` o chama com a **mesma variável** (`nome_conta`), 5 linhas acima da linha corrigida.

`bills.py:176` e `:297` entraram agora: a string era **byte-idêntica** à de `wa_runtime.py:822/1020`. Mesma frase, mesmo usuário, mesma ação — quem toca o **botão** recebia a versão consertada, quem **digita** `paguei luz` recebia a quebrada. Duas linhas (§2: "achei um caso" ≠ "resolvi a categoria").

## O que este PR NÃO fecha

**1. O vazamento por mensagem — issue #276, em 4 dos 11 sítios.** `wrap_wa_markup` decide **por argumento**; o WhatsApp pareia **por mensagem**. Dois mecanismos diferentes, mesma classe:

*(a) o template tem marcação própria além do embrulho* — o `*` ímpar do usuário casa com o do bot. Medido pelo `process_message` real, `wa_runtime.py:805` com nome `a*b`:

```
'Quanto veio a conta de a*b este mês?\nÉ só mandar o valor. Ex: *132,50*'   <- 3 asteriscos
```

O negrito engole tudo entre eles. Idem `wa_runtime.py:982` e `:984` (5 asteriscos).

*(b) o template interpola o nome DUAS vezes* — `core/handlers/bills.py:63` não tem marcação própria, mas o `*` do usuário pareia **consigo mesmo** através da mensagem (2 asteriscos). Este sítio estava listado como fechado; a medição desta rodada mostrou que não está.

**Como isso está nos testes.** Dois testes por sítio, e não um só:

- um **verde**, afirmando o que ESTE PR fecha (o embrulho sai). É ele que as mutações de controle negativo derrubam;
- um **`xfail(strict=True)`** citando a **#276** nominalmente, afirmando o comportamento **desejado** (`body.count("*") % 2 == 0` — delimitadores pareados), no padrão de `tests/test_full_handler_smoke.py:343`.

Uma versão anterior deste commit tinha `assert body.count("*") == 3`, que **trava o defeito como comportamento correto**: no dia do conserto ficaria vermelho parecendo regressão — o mesmo anti-padrão apontado no PR #271. Com o `xfail` estrito, o dia do conserto produz `XPASS(strict)`, cuja mensagem pede a remoção do marcador. **Medido**: virando a asserção do :805 para o estado de hoje, o pytest devolve `[XPASS(strict)] issue #276: ...` e `1 failed` — o marcador está armado.

**O teste do sítio :805 também trocou de entrada**: usava `conta_de_luz`, a única da lista que escondia o vazamento por não ter asterisco nenhum; agora usa `a*b`.

Sítios genuinamente fechados: `wa_runtime.py:352`, `:822`, `:960`, `:1020`, `core/handlers/bills.py:176`, `:297`, `core/handlers/pending.py:90`. São **7 de 11**; os outros 4 são a #276.

**2. Delimitador interno já pareado.** `~x~` no nome não é alcançado: o embrulho some, mas o par do usuário continua riscando na tela. Não há conserto sem escape, e o WhatsApp não tem escape.

**3. `core/handlers/bills.py:169-170`** — `f"Manda assim: *paguei {str(nome).lower()} 132,50*"`: o nome fica **dentro** da marcação do bot, forma que o helper não alcança por construção.

**4. `*None*` no caminho do dinheiro (pré-existente).** `wa_runtime.py:822` com `mark_bill_paid` sem `name` sai `Conta paga: *None*`; com `name=""` sai `Conta paga: ** —`. A guarda `or "conta"` existe em `:780` e não em `:822`. Anterior a este PR, não tocado aqui.

**5. Os sítios restantes em ~20 arquivos** (`credit.py`, `pockets.py`, `investments.py`…) — fatia 2.

## Testes

`tests/test_whatsapp_markup_escape.py`. A asserção é sobre o que aparece na tela — **com** marcação que pareia o embrulho **não existe**; **sem** ela, ele **existe**. Tudo montado pela função real do handler (`_apply_recategorize`, `process_message`, `pergunta_de_valor_sem_contexto`, `try_pay_from_text`, `resolve_bill_amount`, `resolve_delete`), nunca lendo texto de arquivo.

Com o conserto de pé: **`18 passed, 2 xfailed`** (era `13 passed` na rodada anterior; os +5 verdes são o controle positivo novo de `meta_casa_nova` e os 4 casos da porta digitada; os 2 xfailed são a #276).

**Controles negativos — quatro mutações, todas medidas em 2026-09-04, nenhuma injetada em caso já vermelho:**

| mutação | resultado |
|---|---|
| `wrap_wa_markup` embrulha sempre | `9 failed, 9 passed` — caem os 9 de não-embrulho |
| `wrap_wa_markup` nunca embrulha | `9 failed, 9 passed` — caem os 9 controles positivos (partição limpa) |
| `_MARCACAO_WA` volta ao `[*_~\`]` (o `_` sem fronteira) | `1 failed, 17 passed` — só `test_categoria_legitima_mantem_o_negrito[meta_casa_nova]` |
| `bills.py:176/:297` voltam ao `*{paid.get('name')}*` literal | `2 failed, 16 passed` — os dois casos `luz *casa*` da porta digitada |

Os 2 `xfailed` ficam de fora dessas quatro **de propósito**: eles afirmam o comportamento desejado, não o atual, e nenhuma mutação do conserto de hoje os move. O controle deles é o `strict`, medido acima.

**Controles positivos**: `McDonald's`, `café & pão`, `Cartão Nubank` (a mesma lista de `tests/test_export_pdf_escape.py`, #145) e agora `meta_casa_nova` saem **com** o negrito; a pendência legada sai com as crases.

**Correções de afirmação falsa nos testes desta rodada:**

- `test_whatsapp_markup_escape.py:70` dizia `"meta_casa_nova",  # dois underscores pareiam e o WhatsApp italiza "casa"`. **Falso, medido.** O caso mudou de lado: virou controle **positivo**;
- o sítio `:805` trocou `conta_de_luz` por `a*b` (ver acima), e o vazamento que isso expõe virou `xfail(strict=True)` da #276 em vez de `assert` travando o bug;
- `core/handlers/bills.py:63` estava descrito como fechado e **não está** — a dupla interpolação faz o `*` do usuário parear consigo mesmo. Ganhou o mesmo `xfail(strict=True)` da #276;
- o docstring de `test_pendencia_legada_legitima_mantem_a_crase` falava em "a estrutura da STRING que sai" como se fosse a tela. Naquele sítio ainda roda um `format_for_platform` depois (`core/handle_incoming.py:150`), que remove pares de crase no WhatsApp. O teste em si é controle positivo válido; o docstring é que estava impreciso.

**Suíte inteira, com a `origin/main` integrada (`git rev-list --count HEAD..origin/main` = 0): `5833 passed, 4 xfailed, 0 failed`.** Baseline da rodada anterior: `5828 passed, 2 xfailed, 0 failed`. Os `+5 passed` são os casos novos, os `+2 xfailed` são os da #276. Comparação por nome: nenhuma falha nova.

## Não verificado aqui

A **renderização** no cliente WhatsApp (Android/iOS) não é exercitável neste ambiente. As medições que decidiram o mecanismo e a fronteira do `_` foram feitas **pelo dono no aparelho**. O que esta suíte prova é a **estrutura da string** que sai da função real do handler; a ausência/presença do negrito na tela só se confirma no aparelho, pós-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
