### PR TITLE
Marcas de fast food nas LOCAL_RULES: 14 das 16 saem de "outros"

### DIFF
--- a/tests/test_local_rules_marcas_alimentacao.py
+++ b/tests/test_local_rules_marcas_alimentacao.py
@@ -15,14 +15,20 @@ import pytest
 from db.categories import create_user_category
 from core.services.category_service import infer_category
 from ofx_import import resolve_category
-from utils_text import normalize_text
+from utils_text import guess_category, normalize_text
 
 
 # Todo termo acrescentado às LOCAL_RULES aparece aqui — inclusive na forma que
 # o usuário digita (com apóstrofo, com acento, em CAIXA ALTA).
 MARCAS = [
-    "mcdonalds", "mcdonald's", "McDonalds", "mc donalds", "mequi",
-    "bk", "subway", "habibs", "habib's", "bobs",
+    # As 4 grafias de McDonald's: "mc donald's" é a mais provável no WhatsApp e
+    # era a que faltava — a lista antiga só tinha "mc donalds"/"mcdonald's" e a
+    # keyword "mc donalds" não casa normalize_text("mc donald's") == "mc donald s".
+    "mcdonalds", "mcdonald's", "McDonalds",
+    "mc donalds", "mc donald's", "mc donald",
+    "mequi",
+    # Bob's se escreve COM apóstrofo; as duas grafias precisam casar.
+    "bk", "subway", "habibs", "habib's", "bobs", "bob's",
     "kfc", "KFC", "giraffas", "ragazzo", "china in box", "dominos",
     "divino fogao", "divino fogão",
     "starbucks", "the coffee", "kopenhagen", "cacau show",
@@ -50,6 +56,11 @@ def test_marca_ja_coberta_pelo_termo_generico(user_id, marca):
 # uma frase vizinha que NÃO pode virar alimentação.
 @pytest.mark.parametrize("frase,esperado", [
     ("comprei um bkzinho", "outros"),
+    # "bobs"/"bob s" entram explícitos justamente pra NÃO virar a keyword "bob"
+    # (3 letras, palavra inteira), que roubaria o cachorro chamado Bob.
+    ("racao do bob", "pets"),
+    ("levei o bob no veterinario", "pets"),
+    ("consulta do bob", "saúde"),
     ("paguei o bkp do servidor", "outros"),
     ("paguei o kfcloud", "outros"),
     # o próprio eletrodoméstico continua moradia — o blocker de "fogao" só
@@ -77,10 +88,42 @@ def test_categoria_custom_vence_marca_nova(user_id):
 
 # --- caminho do importador (OFX/extrato) ---------------------------------
 def test_marca_no_importador_de_extrato():
-    """`resolve_category` do OFX lê as mesmas LOCAL_RULES — a marca vale lá
-    também. Ceiling conhecido: esse laço casa por substring mesmo em keyword
-    curta (não usa EXACT_WORD_KEYWORDS nem o corte de <=3 letras), então "bk"
-    dentro de outra palavra casa ali. Comportamento pré-existente da função
-    para "pet"/"casa"/"cao"; documentado, não corrigido nesta issue."""
+    """`resolve_category` do OFX lê as mesmas LOCAL_RULES — a marca vale lá também."""
     assert resolve_category(normalize_text("COMPRA CARTAO MCDONALDS 1234"), []) == "alimentacao"
-    assert resolve_category(normalize_text("PAG BKZINHO"), []) == "alimentacao"  # ceiling
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="issue #272: resolve_category/_categorize casam keyword <=3 letras por "
+           "substring; quando o corte de palavra inteira entrar, este teste fica "
+           "XPASS(strict) e é só remover o marcador",
+)
+def test_importador_nao_deveria_casar_keyword_curta_dentro_de_palavra():
+    """Teto conhecido, NÃO conserto desta issue — e não é um assert positivo, senão
+    a #272 chegaria como falsa regressão.
+
+    Os importadores (`ofx_import.resolve_category` e `ofx_credit_import._categorize`)
+    casam por substring mesmo em keyword de <=3 letras, sem `EXACT_WORD_KEYWORDS`
+    nem o corte que `local_rule_category` faz. A classe é pré-existente e maior que
+    esta issue: são 39 keywords <=3 letras já na `main` (bar, sol, gas, luz, pet,
+    cao, ada, nft…). Medido num corpus de 32 memos realistas de fatura:
+    27 falsos positivos na `main`, 32 aqui — "bk"/"kfc" acrescentam 5 a uma classe
+    que já valia 27, e tirá-las corrigiria a instância, não a classe (CLAUDE.md §2).
+    """
+    assert resolve_category(normalize_text("PAG BKZINHO"), []) == "outros"
+
+
+def test_divino_fogao_continua_categorizado_no_motor_de_recorrente():
+    """KEYWORD_BLOCKERS["fogao"] tem DOIS consumidores: `local_rule_category` e
+    `guess_category` (utils_text), este último vivo em `core/handlers/recurring.py:171`
+    pra classificar gasto fixo quando a IA não classificou.
+
+    As 22 marcas entraram só em LOCAL_RULES, então o blocker sozinho tirava
+    "divino fogão" de moradia (errado) e deixava em "outros" (nada) no recorrente.
+    A marca na lista de alimentação de CATEGORY_KEYWORDS fecha o par — e alimentação
+    é avaliada antes de moradia, então a marca vence o eletrodoméstico.
+    """
+    assert guess_category("divino fogão") == "alimentação"
+    assert guess_category("divino fogao") == "alimentação"
+    # controle positivo: o eletrodoméstico continua moradia nos DOIS motores
+    assert guess_category("comprei um fogão novo") == "moradia"

--- a/tests/test_local_rules_marcas_alimentacao.py
+++ b/tests/test_local_rules_marcas_alimentacao.py
@@ -1,0 +1,86 @@
+"""
+Issue #138: marcas de fast food/restaurante nas LOCAL_RULES.
+
+Antes deste bloco, 14 das 16 marcas medidas na issue caíam em "outros" para
+quem não tem IA (plano Grátis) — e `learn_from_inference` ignora
+reason="default", então caíam em "outros" para sempre.
+
+Controle negativo: apague o bloco de marcas de `utils_text.LOCAL_RULES` e
+`test_marca_vai_para_alimentacao` fica vermelho em todos os termos novos.
+"""
+from __future__ import annotations
+
+import pytest
+
+from db.categories import create_user_category
+from core.services.category_service import infer_category
+from ofx_import import resolve_category
+from utils_text import normalize_text
+
+
+# Todo termo acrescentado às LOCAL_RULES aparece aqui — inclusive na forma que
+# o usuário digita (com apóstrofo, com acento, em CAIXA ALTA).
+MARCAS = [
+    "mcdonalds", "mcdonald's", "McDonalds", "mc donalds", "mequi",
+    "bk", "subway", "habibs", "habib's", "bobs",
+    "kfc", "KFC", "giraffas", "ragazzo", "china in box", "dominos",
+    "divino fogao", "divino fogão",
+    "starbucks", "the coffee", "kopenhagen", "cacau show",
+    "outback", "madero", "coco bambu", "spoleto", "applebees", "applebee's",
+]
+
+
+@pytest.mark.parametrize("marca", MARCAS)
+def test_marca_vai_para_alimentacao(user_id, marca):
+    res = infer_category(user_id, f"gastei 39,90 no {marca}", allow_ai=False)
+    assert (res.category, res.reason) == ("alimentação", "local_rule"), marca
+
+
+@pytest.mark.parametrize("marca", ["burger king", "pizza hut"])
+def test_marca_ja_coberta_pelo_termo_generico(user_id, marca):
+    """As 2 das 16 que já funcionavam — por "burger"/"pizza", não por marca.
+    Ficaram FORA do bloco novo de propósito (§0.2: sem termo redundante)."""
+    res = infer_category(user_id, f"gastei 39,90 no {marca}", allow_ai=False)
+    assert res.category == "alimentação"
+
+
+# --- anti-falso-positivo -------------------------------------------------
+# "bk" (2 letras) e "kfc" (3) casam só como palavra inteira em
+# local_rule_category; os demais casam por substring, então cada um precisa de
+# uma frase vizinha que NÃO pode virar alimentação.
+@pytest.mark.parametrize("frase,esperado", [
+    ("comprei um bkzinho", "outros"),
+    ("paguei o bkp do servidor", "outros"),
+    ("paguei o kfcloud", "outros"),
+    # o próprio eletrodoméstico continua moradia — o blocker de "fogao" só
+    # dispara com "divino" na frente
+    ("comprei um fogao novo", "moradia"),
+    ("conserto do fogao", "moradia"),
+    # termos genéricos que sobrevivem ao bloco novo
+    ("gastei 50 no mercado", "mercado"),
+    ("curso de japones", "educação"),
+    ("paguei o aluguel", "moradia"),
+])
+def test_nao_vira_alimentacao(user_id, frase, esperado):
+    assert infer_category(user_id, frase, allow_ai=False).category == esperado
+
+
+# --- categoria custom do usuário continua ganhando -----------------------
+def test_categoria_custom_vence_marca_nova(user_id):
+    """B2 (custom_category_match) roda ANTES do passo C (LOCAL_RULES) em
+    infer_category — quem criou uma categoria chamada como a marca não perde
+    o lançamento para a regra local nova."""
+    create_user_category(user_id, "outback")
+    res = infer_category(user_id, "gastei 39,90 no outback", allow_ai=False)
+    assert (res.category, res.reason) == ("outback", "user_category")
+
+
+# --- caminho do importador (OFX/extrato) ---------------------------------
+def test_marca_no_importador_de_extrato():
+    """`resolve_category` do OFX lê as mesmas LOCAL_RULES — a marca vale lá
+    também. Ceiling conhecido: esse laço casa por substring mesmo em keyword
+    curta (não usa EXACT_WORD_KEYWORDS nem o corte de <=3 letras), então "bk"
+    dentro de outra palavra casa ali. Comportamento pré-existente da função
+    para "pet"/"casa"/"cao"; documentado, não corrigido nesta issue."""
+    assert resolve_category(normalize_text("COMPRA CARTAO MCDONALDS 1234"), []) == "alimentacao"
+    assert resolve_category(normalize_text("PAG BKZINHO"), []) == "alimentacao"  # ceiling

--- a/utils_text.py
+++ b/utils_text.py
@@ -275,7 +275,17 @@ LOCAL_RULES = [
       "salgado", "salgados", "pastel", "esfiha", "coxinha",
       # "prime rib" é comida; "prime" sozinho é assinatura (regra mais abaixo).
       # Este bloco vem antes de assinaturas, então o prato ganha a disputa.
-      "prime rib", "prime ribs"], "alimentação"),
+      "prime rib", "prime ribs",
+      # Marcas (issue #138): sem elas, 14 das 16 marcas mais lançadas caíam em
+      # "outros" pra quem não tem IA. "burger king" e "pizza hut" não entram:
+      # já casam por "burger"/"pizza" acima.
+      # Formas com apóstrofo entram pelo radical: normalize_text("habib's") vira
+      # "habib s", que contém "habib". Idem "mcdonald's"/"applebee's".
+      "mcdonald", "mc donalds", "mequi", "bk", "subway", "habib", "bobs",
+      "kfc", "giraffas", "ragazzo", "china in box", "dominos", "divino fogao",
+      "starbucks", "the coffee", "kopenhagen", "cacau show",
+      "outback", "madero", "coco bambu", "spoleto", "applebee",
+      ], "alimentação"),
     # ─── Lazer ────────────────────────────────────────────────────────────────
     # Fica depois de alimentação pra bar/boteco/chopp seguirem sendo comida.
     # "clube" e "jogo" entram só como palavra inteira: "clube de assinatura" e
@@ -468,6 +478,10 @@ KEYWORD_BLOCKERS = {
     # "juros" é rendimento (receita); mas juros de dívida são DESPESA — esses
     # saem da regra de rendimentos e vão pra IA decidir a categoria certa.
     "juros": re.compile(r"\bjuros\s+d[eoa]\s+(cartao|cartão|cheque|rotativo|atraso|financiamento|emprestimo|empréstimo|mora|parcelamento)\b"),
+    # "fogao" é moradia (eletrodoméstico), mas "divino fogão" é rede de
+    # restaurante — sem este blocker a regra de moradia vence antes de
+    # alimentação chegar na marca (issue #138).
+    "fogao": re.compile(r"\bdivino\s+fogao\b"),
     # "aluguel de carro/bike" é transporte/lazer, não moradia.
     "aluguel": re.compile(r"\baluguel\s+de\s+(carro|carros|veiculo|veiculos|bicicleta|bike|moto)\b"),
     # "passagem" é lazer (viagem); "passagem de ônibus/metrô/trem" é transporte

--- a/utils_text.py
+++ b/utils_text.py
@@ -279,9 +279,25 @@ LOCAL_RULES = [
       # Marcas (issue #138): sem elas, 14 das 16 marcas mais lançadas caíam em
       # "outros" pra quem não tem IA. "burger king" e "pizza hut" não entram:
       # já casam por "burger"/"pizza" acima.
-      # Formas com apóstrofo entram pelo radical: normalize_text("habib's") vira
-      # "habib s", que contém "habib". Idem "mcdonald's"/"applebee's".
-      "mcdonald", "mc donalds", "mequi", "bk", "subway", "habib", "bobs",
+      # Apóstrofo vira ESPAÇO em normalize_text ("habib's" → "habib s"), então a
+      # grafia com apóstrofo entra pelo RADICAL, sem o "s": "habib", "mcdonald",
+      # "applebee" e "mc donald" — este último cobre de uma vez "mc donald's",
+      # "mc donald" e "mc donalds" (a versão anterior, "mc donalds", não casava
+      # "mc donald s" e deixava a grafia mais provável cair em "outros").
+      # "bobs" é a exceção: o radical "bob" tem 3 letras, casaria como palavra
+      # inteira e roubaria "ração do bob"/"consulta do bob" de pets/saúde
+      # (medido: 6 falsos positivos em 8 frases; cachorro chamado Bob é comum).
+      # Por isso as duas grafias entram explícitas, e nenhuma delas é "bob".
+      # "bk" e "kfc" ficam apesar de <=3 letras: aqui em local_rule_category elas
+      # só casam como PALAVRA INTEIRA. Nos importadores (ofx_import.resolve_category
+      # e ofx_credit_import._categorize) o laço casa por substring e elas geram
+      # falso positivo ("PAG BKB CONSULTORIA" → alimentação) — mas isso é a issue
+      # #272, e a classe inteira já existe na main: são 39 keywords <=3 letras
+      # (bar, sol, gas, luz, pet, cao, ada…), que num corpus de 32 memos realistas
+      # dão 27 falsos positivos na main contra 32 aqui. Tirar bk/kfc corrigiria 5
+      # instâncias e deixaria a classe intacta; a correção certa é o corte de
+      # palavra inteira nos dois importadores (#272).
+      "mcdonald", "mc donald", "mequi", "bk", "subway", "habib", "bobs", "bob s",
       "kfc", "giraffas", "ragazzo", "china in box", "dominos", "divino fogao",
       "starbucks", "the coffee", "kopenhagen", "cacau show",
       "outback", "madero", "coco bambu", "spoleto", "applebee",
@@ -1292,7 +1308,15 @@ CATEGORY_KEYWORDS = {
     "alimentação": ["ifood", "uber eats", "rappi", "restaurante", "lanche", "pizza", "hamburguer", "cafe", "café", "cafeteria", "padaria",
                     "comida", "alimento", "almoço", "almoco", "janta", "jantar", "marmita", "refeição", "refeicao", "delivery", "açaí", "acai", "sushi", "churrasco",
                     "food truck", "self service", "buffet", "boteco", "botequim", "cerveja", "japonês", "japones", "feira livre", "prime rib",
-                    "bar", "pub", "happy hour", "drinks", "chopp", "chope"],
+                    "bar", "pub", "happy hour", "drinks", "chopp", "chope",
+                    # KEYWORD_BLOCKERS["fogao"] (issue #138) é lido pelos DOIS
+                    # motores: local_rule_category e guess_category. As marcas
+                    # entraram só em LOCAL_RULES, então sem esta linha "divino
+                    # fogão" saía de moradia (errado) para outros (nada) no
+                    # motor de gasto recorrente. Alimentação é avaliada ANTES de
+                    # moradia aqui, então a marca vence o eletrodoméstico. A keyword é
+                    # normalizada no laço, então a forma sem acento casa junto.
+                    "divino fogão"],
     "transporte": ["uber", "lyft", "99", "metro", "trem", "ônibus", "gasolina", "combustível", "posto", "estacionamento", "parking",
                    "indriver", "cabify", "mototáxi", "blablacar", "etanol", "diesel", "abastecimento",
                    "posto de gasolina", "passagem de ônibus", "bilhete único", "vale-transporte",


### PR DESCRIPTION
Fecha #138.

## Medição

Mesma bateria da issue — `infer_category(user_id, "gastei 39,90 no <marca>", allow_ai=False)` num usuário limpo (sem regra e sem categoria própria):

| | em `outros` |
|---|---|
| **antes** (`origin/main`, 67b106c) | **14 de 16** |
| **depois** | **0 de 16** |

As 2 que já acertavam antes (`burger king`, `pizza hut`) acertavam por `burger`/`pizza`, e continuam por ali — **não** entraram no bloco novo, seria termo redundante.

## O que mudou

`utils_text.py` — 2 pontos, 15 linhas:

1. Marcas acrescentadas ao **bloco genérico de comida que já existe** (não uma regra nova): `mcdonald`, `mc donalds`, `mequi`, `bk`, `subway`, `habib`, `bobs`, `kfc`, `giraffas`, `ragazzo`, `china in box`, `dominos`, `divino fogao`, `starbucks`, `the coffee`, `kopenhagen`, `cacau show`, `outback`, `madero`, `coco bambu`, `spoleto`, `applebee`. A posição já é a que a issue pede (depois do bloco de educação).
   Apóstrofo entra pelo radical: `normalize_text("habib's")` vira `"habib s"`, que contém `"habib"` — vale para `mcdonald's` e `applebee's` também. Acento e caixa alta o `normalize_text` já resolvia (testado com `divino fogão` e `KFC`).
2. Blocker novo em `KEYWORD_BLOCKERS["fogao"]` para `divino fogao` — era o achado secundário da issue: a regra de **moradia** vem antes e casava `fogao`, então a marca virava eletrodoméstico. Sem o blocker, acrescentar `divino fogao` seria no-op. O blocker só dispara com `divino` na frente: `comprei um fogao novo` continua moradia (testado).

## Testes — `tests/test_local_rules_marcas_alimentacao.py`, 40 casos

- **Positivo:** todo termo acrescentado tem caso, inclusive nas formas que o usuário digita (`mcdonald's`, `McDonalds`, `habib's`, `KFC`, `divino fogão`).
- **Controle negativo (medido):** apaguei o bloco novo (`git checkout -- utils_text.py`) e rodei — **29 falharam, 11 passaram**. Os 29 vermelhos são exatamente os termos novos + o caso do importador; os 11 verdes são os controles que não dependem do fix (anti-falso-positivo, `burger king`/`pizza hut`, categoria custom). Fix reposto: **40 passaram**.
- **Anti-falso-positivo:** `bkzinho`, `bkp do servidor`, `kfcloud` continuam `outros` — `bk` (2 letras) e `kfc` (3) casam só como palavra inteira em `local_rule_category`. `fogao novo` e `conserto do fogao` continuam `moradia`; `mercado`, `curso de japones` e `aluguel` intactos.
- **Categoria custom vence (medido, não deduzido):** usuário com categoria própria chamada `outback` continua recebendo `("outback", "user_category")`. O passo B2 (`custom_category_match`) roda antes do passo C (LOCAL_RULES) em `core/services/category_service.py`.

## Suíte

Mesma árvore, antes e depois, comparadas por **nome**:

- baseline (`origin/main` + worktree limpo): `5739 passed, 1 xfailed` — zero `FAILED`
- 1º commit: `5779 passed, 1 xfailed` — zero `FAILED`
- 2º commit (revisão, 08ee44c): `5786 passed, 2 xfailed` — zero `FAILED`
- `diff` das linhas `FAILED` das rodadas: vazio em todas

## Rodada de revisão — 5 achados (commit 08ee44c)

**1. `mc donalds` não casava a grafia mais provável.** `normalize_text("mc donald's")` = `mc donald s`, e a keyword com o `s` colado não é substring disso. Trocada por **`mc donald`** (sem o `s`): cobre `mc donald's`, `mc donald` e `mc donalds` de uma vez, e é menor. As 4 grafias entraram no teste — a lista antiga foi escrita a partir do dado, não do que o usuário digita.

**2. `bobs` — mudei a decisão anterior deste PR, com medição.** O corpo antigo dizia que `bob's` ficou de fora porque `"bob s"` casaria em `"bob silva"`. Medi as três opções:

| opção | falsos positivos medidos |
|---|---|
| `bob` (3 letras, palavra inteira) | **6 em 8** — rouba `ração do bob` (pets), `consulta do bob` (saúde), `levei o bob no veterinario` (pets). Cachorro chamado Bob é comum, e o `learn_from_inference` gravaria isso como regra permanente |
| `bobs` + **`bob s`** (escolhida) | **1 em 13** — só `bob silva advogados` (nome próprio + sobrenome com S) |
| só corrigir o comentário | 0, mas `bob's` (a grafia da marca) continua caindo em `outros` |

Escolhi `bobs` + `bob s`: é estritamente mais estreito que o `habib` que este PR já aceita, e se o achado 1 considera o apóstrofo provável o bastante pra bloquear o McDonald's, ele é provável pro Bob's. **Fácil de reverter se o dono preferir a opção 3** — é uma keyword. O comentário do bloco agora explica por que `bob` é a exceção, em vez de afirmar cobertura que a medição desmente.

**3. Teto do importador virou `xfail(strict)`, não assert positivo.** O `assert resolve_category("PAG BKZINHO") == "alimentacao"` ficaria vermelho como *falsa regressão* no dia da #272. Agora o teste afirma o comportamento **correto** (`== "outros"`) sob `xfail(strict=True, reason="issue #272...")` — mesmo padrão de `tests/test_full_handler_smoke.py:343`. Medido: aplicando o corte de palavra inteira no `ofx_import`, ele vira `[XPASS(strict)]` e pede a remoção do marcador.

**4. `bk`/`kfc` ficam — a premissa do achado não se sustenta.** Elas não são "as duas primeiras keywords de ≤3 letras do repositório": a `main` já tem **39**. Coluna dupla sobre 32 memos realistas de fatura:

| | falsos positivos |
|---|---|
| `main` | **27 de 32** — `SOLUCOES EM TI` → `investimento_aporte`, `SOLAR ENERGIA LTDA` → `criptomoedas`, `GASTOS DIVERSOS` → `moradia`, `COELHO ADVOGADOS` → `investimento_aporte` |
| este ramo | **32 de 32** (+5 de `bk`/`kfc`) |

Tirar as duas corrigiria **5 instâncias de uma classe de 39** e deixaria a classe intacta — é o "achei um caso ≠ resolvi a categoria" do CLAUDE.md §2. No caminho do chat (`local_rule_category`, o da issue #138) `bk`/`kfc` já casam só como palavra inteira e não erram.

> ⚠️ **A #272 tem DOIS sites, não um.** Além de `ofx_import.resolve_category:73`, o mesmo laço está em **`ofx_credit_import._categorize:141`** — justamente o caminho da fatura de cartão, onde vivem os memos realistas. Medido: `PAG BKB CONSULTORIA` → `alimentacao` também por lá.

**5. `KEYWORD_BLOCKERS["fogao"]` tinha dois consumidores e só um recebeu o dado.** `guess_category` também lê o blocker via `keyword_blocked`, e está vivo em `core/handlers/recurring.py:171`. Medido nas 22 marcas, `main` × ramo: **`divino fogão` era a única divergência** — as outras 21 já eram `outros` na `main` e continuam. Uma keyword em `CATEGORY_KEYWORDS["alimentação"]` fecha o par, em vez de duplicar as 22 marcas num segundo lugar (§0.7). Resultado é **melhor que a `main`**: `moradia` (errado) → `alimentação` (certo). Controle positivo no teste: `comprei um fogão novo` continua `moradia`.

### Controles negativos desta rodada (um por conserto, cada um num caso que estava verde)

| mutação | resultado |
|---|---|
| `mc donald` → `mc donalds` | 2 vermelhos: `[mc donald's]`, `[mc donald]` |
| remover `bob s` | 1 vermelho: `[bob's]` |
| remover a marca de `CATEGORY_KEYWORDS` | 1 vermelho: `test_divino_fogao_continua_categorizado_no_motor_de_recorrente` |
| aplicar a #272 no `ofx_import` | `[XPASS(strict)]` — o teto pede atualização |

Todas restauradas e conferidas com `diff -q`.

## O que NÃO foi verificado / tetos conhecidos

- **Nada foi testado no WhatsApp real nem no aparelho.** A suíte mocka LLM e envio; o provado aqui é `infer_category` com `allow_ai=False`, `resolve_category` do importador e `guess_category`.
- **`resolve_category` (OFX/extrato) e `ofx_credit_import._categorize` casam por substring mesmo em keyword ≤3 letras.** Classe pré-existente de 39 keywords, 27 falsos positivos já na `main` (tabela do achado 4). Documentado com `xfail(strict)` citando a **#272**, não corrigido aqui.
- **`bob s` casa em `bob silva`** — 1 falso positivo medido em 13, aceito conscientemente (tabela do achado 2).
- `habib` casa por substring: um lançamento com o nome próprio "Habib" viraria alimentação. Mesmo teto de qualquer marca que também é nome.
- Falsos positivos das marcas ambíguas (`dominos` o jogo, `outback` o carro, `spoleto` a cidade, `subway` o metrô) e o fato de o `learn_from_inference` gravar match de `local_rule` como regra permanente: fora do escopo deste PR, vira issue própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
