### PR TITLE
Só o 401 de autenticação renova o token, e o servidor é quem marca

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -124,6 +124,7 @@ from frontend.routes.shared import (
     DASHBOARD_CURRENT_CACHE_TTL_SECONDS as _DASHBOARD_CURRENT_CACHE_TTL_SECONDS,
     DASHBOARD_URL,
     JWT_SECRET,
+    WWW_AUTHENTICATE_401,
     authorize_dashboard_access as _authorize_dashboard_access,
     dashboard_current_cache as _dashboard_current_cache,
     dashboard_current_cache_epoch as _dashboard_current_cache_epoch,
@@ -2330,10 +2331,12 @@ async def _get_current_user(
 ) -> int:
     token = _get_auth_token_from_request(request, creds)
     if not token:
-        raise HTTPException(status_code=401, detail="Token não fornecido.")
+        raise HTTPException(status_code=401, detail="Token não fornecido.",
+                            headers=WWW_AUTHENTICATE_401)
     payload = _decode_jwt(token)
     if not payload or payload.get("type") != "auth":
-        raise HTTPException(status_code=401, detail="Token inválido ou expirado.")
+        raise HTTPException(status_code=401, detail="Token inválido ou expirado.",
+                            headers=WWW_AUTHENTICATE_401)
     request.state.auth_payload = payload
     user_id = int(payload["sub"])
 
@@ -2343,7 +2346,8 @@ async def _get_current_user(
     if jti:
         session = await asyncio.to_thread(get_active_session, jti)
         if not session or int(session.get("user_id") or 0) != user_id:
-            raise HTTPException(status_code=401, detail="Sessão encerrada. Faça login novamente.")
+            raise HTTPException(status_code=401, detail="Sessão encerrada. Faça login novamente.",
+                                headers=WWW_AUTHENTICATE_401)
         request.state.session_jti = jti
         # Atualiza last_seen com debounce; falha silenciosa.
         asyncio.create_task(asyncio.to_thread(touch_session, jti))
@@ -2354,7 +2358,8 @@ async def _get_current_user(
         # de sessão feita no reset.
         from db import get_password_changed_at
         if await asyncio.to_thread(get_password_changed_at, user_id):
-            raise HTTPException(status_code=401, detail="Sessão expirada. Faça login novamente.")
+            raise HTTPException(status_code=401, detail="Sessão expirada. Faça login novamente.",
+                                headers=WWW_AUTHENTICATE_401)
 
     _raise_if_account_scheduled_for_deletion(user_id)
     return user_id
@@ -2447,7 +2452,8 @@ async def auth_validate(request: Request, response: Response):
     """
     user_id = _resolve_dashboard_user_id(request)
     if not user_id:
-        raise HTTPException(status_code=401, detail="Token inválido")
+        raise HTTPException(status_code=401, detail="Token inválido",
+                            headers=WWW_AUTHENTICATE_401)
     _raise_if_account_scheduled_for_deletion(int(user_id))
     _no_store(response)
 

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -54,6 +54,22 @@ JWT_SECRET = (os.getenv("JWT_SECRET") or "").strip()
 AUTH_COOKIE_NAME = "auth_token"
 DASHBOARD_COOKIE_NAME = "dashboard_token"
 
+# Marca a FAMÍLIA do 401 para o interceptor de `frontend/static/auth-refresh.js`:
+# só o 401 que leva este header é falha de access/dashboard token, o único caso em
+# que renovar resolve. 401 de aplicação (senha incorreta, magic link expirado, chave
+# de API) fica sem ele — o token está ótimo, e o retry automático reenviava a senha
+# errada, gastando DOIS slots do `@limiter.limit` da rota por digitação (as de
+# 3/hour trancavam o usuário por uma hora no segundo erro) e duplicando o
+# `data_export_password_failed` no log de segurança.
+#
+# Um literal só (§0.7) — os 8 sítios de autenticação importam daqui. Quem adicionar
+# um 401 novo é obrigado a classificá-lo pelo gate
+# `test_401_de_autenticacao_declara_familia` (tests/test_static_pages_routes.py).
+#
+# `Bearer` de propósito: navegador não abre diálogo nativo de credencial para este
+# esquema (só para `Basic`/`Digest`), então marcar a família não muda a UI.
+WWW_AUTHENTICATE_401 = {"WWW-Authenticate": 'Bearer realm="pigbank", error="invalid_token"'}
+
 # Meta (Facebook) Pixel — injetado no <head> das páginas públicas quando setado.
 # Vazio em dev/staging → nenhum pixel é injetado (site limpo, sem rastreio).
 META_PIXEL_ID = (os.getenv("META_PIXEL_ID") or "").strip()
@@ -712,7 +728,8 @@ def resolve_dashboard_user_id(request: Request) -> int:
     )
     payload = decode_dashboard_token_full(token or "")
     if not payload:
-        raise HTTPException(status_code=401, detail="Token de dashboard inválido ou expirado.")
+        raise HTTPException(status_code=401, detail="Token de dashboard inválido ou expirado.",
+                            headers=WWW_AUTHENTICATE_401)
     user_id = payload["user_id"]
     jti = payload.get("jti")
     # Tokens com jti: validar contra auth_sessions (revogacao instantanea).
@@ -720,14 +737,16 @@ def resolve_dashboard_user_id(request: Request) -> int:
     if jti:
         session = get_active_session(jti)
         if not session or int(session.get("user_id") or 0) != user_id:
-            raise HTTPException(status_code=401, detail="Sessão encerrada. Faça login novamente.")
+            raise HTTPException(status_code=401, detail="Sessão encerrada. Faça login novamente.",
+                                headers=WWW_AUTHENTICATE_401)
         request.state.session_jti = jti
     else:
         # Token de dashboard legado sem jti: se a conta trocou de senha (reset),
         # invalida — senão um token roubado sobrevive ao reset até expirar (12h).
         from db import get_password_changed_at
         if get_password_changed_at(user_id):
-            raise HTTPException(status_code=401, detail="Sessão encerrada. Faça login novamente.")
+            raise HTTPException(status_code=401, detail="Sessão encerrada. Faça login novamente.",
+                                headers=WWW_AUTHENTICATE_401)
     return int(user_id)
 
 

--- a/frontend/static/auth-refresh.js
+++ b/frontend/static/auth-refresh.js
@@ -357,6 +357,22 @@
     // 401 no próprio refresh: não tenta de novo — caller redireciona pro login
     if (_isRefreshEndpoint(input)) return resp;
 
+    // Só o 401 de AUTENTICAÇÃO é renovável, e quem marca é o servidor: o
+    // `WWW_AUTHENTICATE_401` de `frontend/routes/shared.py` viaja nos 8 `raise`
+    // de falha de access/dashboard token. Sem esta linha o status sozinho decidia,
+    // e um 401 de aplicação ("Senha incorreta.") virava refresh + RETRY — a senha
+    // errada ia duas vezes e queimava dois slots do rate limit da rota (as de
+    // 3/hour davam 429 no segundo erro de digitação).
+    //
+    // Falha FECHADA de propósito: 401 sem marca não renova e o usuário cai no
+    // login. Quem prende as duas listas é o gate
+    // `test_401_de_autenticacao_declara_familia` (tests/test_static_pages_routes.py),
+    // que deixa vermelho todo 401 novo sem família declarada.
+    //
+    // ABAIXO do `_requestComLimpeza` acima, nunca acima dele: a limpeza central de
+    // fim de sessão roda lá e não pode ser pulada por um `return` antecipado.
+    if (!resp.headers.get("WWW-Authenticate")) return resp;
+
     // Tenta renovar e refazer a request original
     const ok = await _doRefresh();
     if (!ok) return resp;

--- a/tests/frontend/auth_refresh_gatilho.test.mjs
+++ b/tests/frontend/auth_refresh_gatilho.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * O GATILHO da renovação do `auth-refresh.js` (issue #176).
+ *
+ * Até aqui o único critério era o status: QUALQUER 401 disparava
+ * `/auth/refresh` + retry da request original. Medido num Chromium com
+ * `POST /auth/mfa/setup` respondendo 401 "Senha incorreta.":
+ *
+ *     POST /auth/mfa/setup
+ *     POST /auth/refresh
+ *     POST /auth/mfa/setup      <- a senha errada ia DE NOVO
+ *
+ * Duas vezes, ou seja DOIS slots do `@limiter.limit` da rota por digitação
+ * errada. `/auth/mfa/regenerate-backup-codes` e `/auth/account/export` são
+ * 3/hour: o segundo erro já tomava 429 e trancava o usuário por uma hora.
+ *
+ * Desde o #176 quem classifica é o SERVIDOR, pelo `WWW-Authenticate`
+ * (`WWW_AUTHENTICATE_401` em `frontend/routes/shared.py`, nos 8 `raise` de falha
+ * de access/dashboard token). O interceptor renova só quando o header vem.
+ *
+ * CONTROLES do grupo (§3):
+ *   - NEGATIVO — "senha errada não renova": desligando a linha nova do
+ *     interceptor este caso vira 2 chamadas à rota e 1 refresh. Verificado por
+ *     mutação nesta sessão.
+ *   - POSITIVO — "401 de autenticação AINDA renova": sem ele o grupo passaria
+ *     num interceptor que nunca renova, que é PIOR que o bug — a mudança faz o
+ *     gatilho falhar FECHADO e o usuário cairia no login a cada 15 min.
+ *
+ * O lado SERVIDOR desta costura (que o header sai vivo de um 401 real) é o
+ * `test_401_de_autenticacao_manda_www_authenticate_e_o_de_aplicacao_nao` em
+ * `tests/test_auth_cookie.py` — aqui as respostas são mockadas, então este
+ * arquivo sozinho só prova o lado do JS. Quem prende as duas listas é o gate
+ * `test_401_de_autenticacao_declara_familia` (tests/test_static_pages_routes.py).
+ *
+ * Rodar:  npm run test:frontend
+ *         (um arquivo só: node --test tests/frontend/auth_refresh_gatilho.test.mjs)
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+// A marca de família. Valor igual ao do `WWW_AUTHENTICATE_401` do Python — mas o
+// que o interceptor testa é a PRESENÇA do header, nunca este texto.
+const MARCA = 'Bearer realm="pigbank", error="invalid_token"';
+
+/** 401 de AUTENTICAÇÃO (access token morto): leva a marca, o interceptor renova. */
+const r401Auth = {
+  status: 401, contentType: "application/json",
+  headers: { "WWW-Authenticate": MARCA },
+  body: JSON.stringify({ detail: "Token inválido ou expirado." }),
+};
+/** 401 de APLICAÇÃO (senha errada): sem marca, o token está ótimo. */
+const r401App = {
+  status: 401, contentType: "application/json",
+  body: JSON.stringify({ detail: "Senha incorreta." }),
+};
+const r200 = (corpo) => ({
+  status: 200, contentType: "application/json", body: JSON.stringify(corpo),
+});
+
+/**
+ * Página mínima que carrega o `auth-refresh.js` REAL (o do disco, servido pelo
+ * http.server em /static/) e mais nada — sem dashboard, sem boot, sem corrida.
+ *
+ * `mapa` responde por pathname; o valor pode ser uma resposta de `route.fulfill`
+ * ou uma função `(route, chamadas) => ...` para o caso que muda a cada tentativa.
+ * Devolve também a lista de chamadas interceptadas, em ordem.
+ */
+async function abrir(mapa) {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  const chamadas = [];
+
+  await page.route(`${ORIGIN}/__gatilho.html`, (route) => route.fulfill({
+    status: 200, contentType: "text/html",
+    body: '<!doctype html><meta charset="utf-8"><title>gatilho</title>'
+        + '<script src="/static/auth-refresh.js"></script>',
+  }));
+
+  for (const caminho of Object.keys(mapa)) {
+    await page.route(`${ORIGIN}${caminho}`, (route) => {
+      chamadas.push(`${route.request().method()} ${caminho}`);
+      const r = mapa[caminho];
+      return typeof r === "function" ? r(route, chamadas) : route.fulfill(r);
+    });
+  }
+
+  await page.goto(`${ORIGIN}/__gatilho.html`);
+  // Sem isto o `window.fetch` do teste podia ser o ORIGINAL: o <script> é
+  // clássico e síncrono, mas o `goto` resolve no `load` — provar que o wrapper
+  // existe custa uma linha e evita um verde que não mediu nada.
+  assert.equal(await page.evaluate(() => typeof window.pbCsrfHeaders), "function",
+               "o auth-refresh.js não carregou — o teste não mede o caminho certo");
+
+  return { page, ctx, chamadas };
+}
+
+/** `fetch` na página, devolvendo status + corpo (ou a rejeição). */
+const chamar = (page, url, init) => page.evaluate(
+  ([u, i]) => window.fetch(u, i)
+    .then((r) => r.text().then((t) => ({ status: r.status, corpo: t })))
+    .catch((e) => ({ rejeitou: String(e && e.message || e) })),
+  [url, init || {}]);
+
+test("401 de APLICAÇÃO (senha errada) não renova e não reenvia a senha", async () => {
+  const { page, ctx, chamadas } = await abrir({
+    "/auth/mfa/setup": r401App,
+    "/auth/refresh": r200({ ok: true }),
+  });
+
+  const resp = await chamar(page, "/auth/mfa/setup", { method: "POST" });
+
+  // O número que a issue mediu: era 2, tem de ser 1.
+  assert.deepEqual(chamadas, ["POST /auth/mfa/setup"],
+                   `a senha errada foi reenviada — chamadas: ${JSON.stringify(chamadas)}`);
+  assert.equal(resp.status, 401, "o 401 da senha errada tem que chegar ao chamador");
+  assert.ok(resp.corpo.includes("Senha incorreta"), "o corpo original não chegou ao chamador");
+
+  await ctx.close();
+});
+
+test("401 de AUTENTICAÇÃO ainda renova, refaz a request e devolve o RETRY", async () => {
+  // Controle POSITIVO do grupo. Sem ele, um interceptor que parou de renovar
+  // passaria nos outros casos — e é a regressão pior que o bug.
+  let tentativas = 0;
+  const { page, ctx, chamadas } = await abrir({
+    "/data/42": (route) => route.fulfill(
+      ++tentativas === 1 ? r401Auth : r200({ valor: "depois-do-retry" })),
+    "/auth/refresh": r200({ ok: true }),
+  });
+
+  const resp = await chamar(page, "/data/42");
+
+  assert.deepEqual(chamadas, ["GET /data/42", "POST /auth/refresh", "GET /data/42"],
+                   `esperado 1 refresh + 1 retry — chamadas: ${JSON.stringify(chamadas)}`);
+  assert.equal(resp.status, 200);
+  assert.ok(resp.corpo.includes("depois-do-retry"),
+            "o chamador recebeu a resposta do 401, não a do retry");
+
+  await ctx.close();
+});
+
+test("o RETRY continua passando pela limpeza — DELETE /auth/account renovado", async () => {
+  // O retry sai por `_requestComLimpeza`, não por `_origFetch`: o access token
+  // vence no meio da exclusão, o interceptor renova, o retry dá 200 — e é o
+  // RETRY que encerra a sessão. A linha nova entrou ABAIXO do
+  // `_requestComLimpeza`, nunca acima, exatamente para não pular isto.
+  let tentativas = 0;
+  const { page, ctx, chamadas } = await abrir({
+    "/auth/account": (route) => route.fulfill(
+      ++tentativas === 1 ? r401Auth : r200({ scheduled: true })),
+    "/auth/refresh": r200({ ok: true }),
+  });
+
+  // Estado de aparelho REAL para a limpeza ter o que apagar: o service worker
+  // do repo (que cria o cache `pigbank-vN` no install dele).
+  await page.evaluate(() => navigator.serviceWorker.register("/service-worker.js"));
+  await page.waitForFunction(async () => (await caches.keys()).length > 0, null,
+                             { timeout: 15000 });
+
+  const resp = await chamar(page, "/auth/account", { method: "DELETE" });
+
+  assert.deepEqual(chamadas,
+                   ["DELETE /auth/account", "POST /auth/refresh", "DELETE /auth/account"],
+                   `chamadas: ${JSON.stringify(chamadas)}`);
+  assert.equal(resp.status, 200, "o retry não chegou ao chamador");
+  assert.deepEqual(await page.evaluate(() => caches.keys()), [],
+                   "o retry encerrou a sessão e o Cache Storage sobreviveu no aparelho");
+  assert.deepEqual(
+    await page.evaluate(() => navigator.serviceWorker.getRegistrations().then((r) => r.length)),
+    0, "o service worker continuou registrado depois da exclusão da conta");
+
+  await ctx.close();
+});
+
+test("logout que REJEITA (offline) ainda limpa, e a rejeição sobe ao chamador", async () => {
+  // A limpeza central roda no `catch` do `_requestComLimpeza`. A linha nova lê
+  // `resp.headers` e só é alcançada quando HÁ resposta — um `return` posto acima
+  // do `_requestComLimpeza` teria matado este caminho inteiro.
+  const { page, ctx, chamadas } = await abrir({
+    "/auth/logout": (route) => route.abort(),
+  });
+
+  await page.evaluate(() => navigator.serviceWorker.register("/service-worker.js"));
+  await page.waitForFunction(async () => (await caches.keys()).length > 0, null,
+                             { timeout: 15000 });
+
+  const resp = await chamar(page, "/auth/logout", { method: "POST" });
+
+  assert.deepEqual(chamadas, ["POST /auth/logout"]);
+  assert.ok(resp.rejeitou, `o fetch resolveu em vez de rejeitar: ${JSON.stringify(resp)}`);
+  assert.deepEqual(await page.evaluate(() => caches.keys()), [],
+                   "logout offline deixou o Cache Storage no aparelho");
+
+  await ctx.close();
+});

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -468,9 +468,19 @@ test("nav-auth preserva a mesma lista que o auth-refresh", () => {
 // a limpeza rodava so' no primeiro: as respostas internas saiam por baixo dela
 // (Codex, #170). Nenhum dos casos acima os alcanca.
 
-/** fetch falso que responde por caminho, e conta as chamadas. */
-function fetchPorRota(mapa) {
+/** fetch falso que responde por caminho, e conta as chamadas.
+ *
+ * `autenticacao` lista os caminhos cujo 401 sai com `WWW-Authenticate` — a marca
+ * de FAMÍLIA que o interceptor passou a exigir para renovar (#176). 401 sem ela é
+ * de aplicação (senha errada, chave inválida) e não dispara refresh nenhum.
+ *
+ * O `headers` não é enfeite de fidelidade: um duplo sem ele rebentava com
+ * `TypeError: Cannot read properties of undefined` na linha nova do interceptor,
+ * porque `Response.headers` sempre existe no navegador e aqui não existia.
+ */
+function fetchPorRota(mapa, autenticacao = []) {
   const chamadas = [];
+  const marcados = new Set(autenticacao);
   return {
     chamadas,
     fn: async (input, init) => {
@@ -479,14 +489,16 @@ function fetchPorRota(mapa) {
       chamadas.push({ caminho, method: (init && init.method) || "GET" });
       const r = mapa[caminho];
       const status = typeof r === "function" ? r(chamadas) : r;
-      return { ok: status >= 200 && status < 300, status };
+      const marca = status === 401 && marcados.has(caminho)
+        ? { "WWW-Authenticate": 'Bearer realm="pigbank", error="invalid_token"' } : {};
+      return { ok: status >= 200 && status < 300, status, headers: new Headers(marca) };
     },
   };
 }
 
 test("refresh interno que falha (401) limpa — deslogue involuntario", async () => {
   const apagados = [];
-  const falso = fetchPorRota({ "/data/42": 401, "/auth/refresh": 401 });
+  const falso = fetchPorRota({ "/data/42": 401, "/auth/refresh": 401 }, ["/data/42"]);
   const { ctx } = paginaComCache("static/auth-refresh.js", (c) => {
     c.fetch = falso.fn;
     c.caches.delete = async (k) => { apagados.push(k); return true; };
@@ -507,21 +519,26 @@ test("refresh interno que falha (401) limpa — deslogue involuntario", async ()
 // cobre o 401; os tres abaixo cobrem o 400 e o teto de renovacoes (#173).
 
 test("refresh interno que devolve 400 NAO limpa — a sessao esta' de pe", async () => {
-  // Senha errada no MFA leva 401 de APLICACAO. O interceptor renova por
-  // reflexo (#176), o backend responde 400 porque o access token ainda vale, e
-  // tratar isso como fim de sessao apagava o aparelho de quem so' errou a senha.
+  // O predicado do #173: 400 no /auth/refresh e' "refresh ausente com o access
+  // token de pe", nao fim de sessao — trata-lo como fim apagava o aparelho.
+  //
+  // O GATILHO mudou com o #176 e o caso trocou de rota por isso: antes quem
+  // chegava aqui era a senha errada do MFA, que hoje nao renova mais (401 de
+  // aplicacao, sem WWW-Authenticate — ver `auth_refresh_gatilho.test.mjs`).
+  // Quem ainda alcanca este ramo e' o 401 de AUTENTICACAO, que renova e pode
+  // receber 400. O invariante medido e' o mesmo; so' a porta de entrada mudou.
   const apagados = [];
-  const falso = fetchPorRota({ "/auth/mfa/setup": 401, "/auth/refresh": 400 });
+  const falso = fetchPorRota({ "/data/42": 401, "/auth/refresh": 400 }, ["/data/42"]);
   const { ctx } = paginaComCache("static/auth-refresh.js", (c) => {
     c.fetch = falso.fn;
     c.caches.delete = async (k) => { apagados.push(k); return true; };
   });
 
-  const resp = await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+  const resp = await ctx.window.fetch("/data/42");
 
   assert.ok(falso.chamadas.some((c) => c.caminho === "/auth/refresh"),
             "o interceptor nem tentou renovar — o teste nao mede o caminho certo");
-  assert.equal(resp.status, 401, "o 401 da senha errada tem que chegar ao chamador");
+  assert.equal(resp.status, 401, "o 401 tem que chegar ao chamador");
   assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao viva");
 });
 
@@ -553,29 +570,31 @@ test("senha errada com refresh ausente: o estado fica E a chamada seguinte funci
 });
 
 test("uma renovacao por 401 interceptado, e nenhum retry quando ela falha", async () => {
-  // O teto. O interceptor renova em QUALQUER 401 (#176), entao o que segura o
-  // custo e' nao haver recursao: uma renovacao, e a request original refeita
-  // so' quando a renovacao da' certo.
-  const falso = fetchPorRota({ "/auth/mfa/setup": 401, "/auth/refresh": 400 });
+  // O teto do 401 que AINDA renova (o de autenticacao — desde o #176 o de
+  // aplicacao nao entra mais aqui): nao ha recursao, e' uma renovacao so', e a
+  // request original so' e' refeita quando a renovacao da' certo.
+  const falso = fetchPorRota({ "/data/42": 401, "/auth/refresh": 400 }, ["/data/42"]);
   const { ctx } = paginaComCache("static/auth-refresh.js", (c) => { c.fetch = falso.fn; });
 
-  await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+  await ctx.window.fetch("/data/42");
 
   const refresh = falso.chamadas.filter((c) => c.caminho === "/auth/refresh");
-  const setup = falso.chamadas.filter((c) => c.caminho === "/auth/mfa/setup");
+  const original = falso.chamadas.filter((c) => c.caminho === "/data/42");
   assert.equal(refresh.length, 1, `esperado 1 refresh, vieram ${refresh.length}`);
-  assert.equal(setup.length, 1, "a request original foi refeita com o refresh falhando");
+  assert.equal(original.length, 1, "a request original foi refeita com o refresh falhando");
 });
 
 test("retry pos-refresh que encerra a sessao limpa", async () => {
-  // DELETE /auth/account leva 401, o refresh renova, o retry da' certo — e o
-  // retry e' que encerra a sessao. Ele saia por baixo da limpeza.
+  // DELETE /auth/account com o ACCESS TOKEN vencido (401 de autenticacao, o que
+  // leva WWW-Authenticate — a senha errada da mesma rota e' 401 de aplicacao e
+  // desde o #176 nao renova). O refresh renova, o retry da' certo — e o retry e'
+  // que encerra a sessao. Ele saia por baixo da limpeza.
   const apagados = [];
   let tentativas = 0;
   const falso = fetchPorRota({
     "/auth/account": () => (++tentativas === 1 ? 401 : 200),
     "/auth/refresh": 200,
-  });
+  }, ["/auth/account"]);
   const { ctx } = paginaComCache("static/auth-refresh.js", (c) => {
     c.fetch = falso.fn;
     c.caches.delete = async (k) => { apagados.push(k); return true; };
@@ -596,7 +615,7 @@ test("request comum que renova e da' certo NAO limpa", async () => {
   const falso = fetchPorRota({
     "/data/42": () => (++tentativas === 1 ? 401 : 200),
     "/auth/refresh": 200,
-  });
+  }, ["/data/42"]);
   const { ctx } = paginaComCache("static/auth-refresh.js", (c) => {
     c.fetch = falso.fn;
     c.caches.delete = async (k) => { apagados.push(k); return true; };

--- a/tests/frontend/sw_cache_privado.test.mjs
+++ b/tests/frontend/sw_cache_privado.test.mjs
@@ -542,20 +542,29 @@ test("refresh interno que devolve 400 NAO limpa — a sessao esta' de pe", async
   assert.deepEqual(apagados, [], "apagou o Cache Storage com a sessao viva");
 });
 
-test("senha errada com refresh ausente: o estado fica E a chamada seguinte funciona", async () => {
+test("401 de autenticacao com refresh ausente: o estado fica E a chamada seguinte funciona", async () => {
   // O cenario inteiro, ponta a ponta: nao basta nao apagar, a sessao tem que
   // seguir utilizavel depois. Sem a segunda metade o caso passaria num
   // interceptor que engoliu a sessao de outro jeito.
+  //
+  // A marca de familia no `/auth/mfa/setup` NAO e' enfeite: sem ela o #176
+  // devolve o 401 antes de renovar, o `"/auth/refresh": 400` do mapa vira letra
+  // morta e o caso deixa de medir a metade que importa (o 400 nao apagando o
+  // aparelho). Medido: com a mutacao da #173 o caso ficava VERDE sem a marca.
+  // Aqui o 401 e' access token vencido ao abrir o setup do MFA, nao senha
+  // errada — essa e' 401 de aplicacao e vive no `auth_refresh_gatilho.test.mjs`.
   const apagados = [];
   const falso = fetchPorRota({
     "/auth/mfa/setup": 401, "/auth/refresh": 400, "/data/42": 200,
-  });
+  }, ["/auth/mfa/setup"]);
   const { ctx, local, sessao } = comStorageCheio("static/auth-refresh.js", (c) => {
     c.fetch = falso.fn;
     c.caches.delete = async (k) => { apagados.push(k); return true; };
   });
 
   const erro = await ctx.window.fetch("/auth/mfa/setup", { method: "POST" });
+  assert.ok(falso.chamadas.some((c) => c.caminho === "/auth/refresh"),
+            "o interceptor nem tentou renovar — o teste nao mede o caminho certo");
   assert.equal(erro.status, 401);
 
   for (const k of Object.keys(DERIVADO_DE_CONTA)) {

--- a/tests/test_auth_cookie.py
+++ b/tests/test_auth_cookie.py
@@ -774,3 +774,51 @@ def test_refresh_que_encerra_sessao_ainda_permite_logar_em_seguida():
     assert entrar.status_code != 403, (
         "403 aqui é o CSRF barrando o login, não credencial errada"
     )
+
+
+def test_401_de_autenticacao_manda_www_authenticate_e_o_de_aplicacao_nao(monkeypatch):
+    """A costura servidor→navegador da #176, num 401 REAL (não sintético).
+
+    O teste de navegador (`tests/frontend/auth_refresh_gatilho.test.mjs`) escreve
+    ele mesmo o header nas rotas mockadas, então ele prova só o lado do JS. Aqui
+    se prova o outro lado: que o `headers=WWW_AUTHENTICATE_401` do `raise`
+    sobrevive à pilha inteira (ExceptionMiddleware → `http_exception_page_handler`
+    → `http_exception_handler` → `vary_accept`) e chega na resposta.
+
+    Os dois casos juntos, porque o header só vale se DISCRIMINAR: se ele saísse em
+    todo 401 o interceptor voltaria a renovar em senha errada, que é o bug.
+    """
+    client = TestClient(dashboard.app)
+
+    # Família A — `_get_current_user` sem token: renovar é exatamente o conserto.
+    sem_token = client.post("/auth/dashboard-token", headers=_csrf_headers(client))
+    assert sem_token.status_code == 401
+    assert sem_token.json()["detail"] == "Token não fornecido."
+    assert sem_token.headers["www-authenticate"] == dashboard.WWW_AUTHENTICATE_401[
+        "WWW-Authenticate"
+    ]
+
+    # Família A — token inválido (o caso do access vencido no aparelho parado).
+    invalido = client.post(
+        "/auth/dashboard-token",
+        headers={"Authorization": "Bearer nao-e-um-jwt", **_csrf_headers(client)},
+    )
+    assert invalido.status_code == 401
+    assert invalido.json()["detail"] == "Token inválido ou expirado."
+    assert "www-authenticate" in invalido.headers
+
+    # Família B — chave de API errada no lead engine (rota de outro router, o que
+    # de quebra prova que `frontend/routes/*.py` sai pelo mesmo handler). Tem de
+    # vir SEM o header: renovar access token não conserta chave errada.
+    monkeypatch.setenv("PROSPECT_API_KEY", "chave-certa")
+    chave_errada = client.post(
+        "/api/prospect/status",
+        headers={"X-Prospect-Key": "chave-errada"},
+        json={"codes": ["abc"]},
+    )
+    assert chave_errada.status_code == 401
+    assert chave_errada.json()["detail"] == "Chave inválida."
+    assert "www-authenticate" not in chave_errada.headers, (
+        "401 de aplicação marcado como renovável — o interceptor volta a gastar "
+        "refresh + retry, que é o bug da #176"
+    )

--- a/tests/test_error_pages.py
+++ b/tests/test_error_pages.py
@@ -667,9 +667,14 @@ def test_401_de_rota_protegida_nos_dois_ramos(accept_html):
 def test_401_www_authenticate_sobrevive_ao_ramo_html():
     """A allowlist já tem teste unitário (`test_headers_da_allowlist_passam`), mas
     ninguém provava que o header sai vivo do outro lado da pilha — do `exc.headers`
-    do `raise` até a resposta. Rota sintética porque HOJE nenhum 401 do produto
-    manda WWW-Authenticate (`git grep -i www-authenticate` só acha o comentário do
-    handler, a allowlist e o teste): quem adicionar um vai depender deste caminho."""
+    do `raise` até a resposta.
+
+    Rota sintética porque este caso é o ramo HTML: desde a #176 os 8 `raise` de
+    falha de access/dashboard token mandam o `WWW_AUTHENTICATE_401` de verdade
+    (`git grep -n WWW_AUTHENTICATE_401`), mas eles são consumidos por fetch, que
+    cai no ramo JSON — coberto por
+    `tests/test_auth_cookie.py::test_401_de_autenticacao_manda_www_authenticate_e_o_de_aplicacao_nao`.
+    Aqui se prova o outro ramo, o do `error_page_response`."""
     path = f"/__401-{uuid.uuid4().hex}"
 
     @dashboard.app.get(path)

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -338,3 +338,122 @@ def test_rotas_que_encerram_sessao_estao_no_auth_refresh():
         "o cache privado sobrevive nesse fluxo. "
         f"só no Python: {sorted(do_python - do_js)}; só no JS: {sorted(do_js - do_python)}"
     )
+
+
+# Classificação EXPLÍCITA de cada `raise HTTPException(status_code=401, ...)` de
+# `frontend/finance_bot_websocket_custom.py` + `frontend/routes/*.py`, por
+# `(arquivo, detail)`. `True` = falha de access/dashboard token, leva o
+# `WWW_AUTHENTICATE_401` e o interceptor renova; `False` = 401 de aplicação, não
+# leva e não renova.
+#
+# `core/admin_dashboard.py` fica FORA por caminho: é outra árvore de auth (sessão
+# de admin, cookie próprio) e nenhuma página dela carrega o `auth-refresh.js`.
+_401_RENOVAVEL = {
+    # ── família A: o access/dashboard token falhou → renovar resolve ──────────
+    ("frontend/finance_bot_websocket_custom.py", "Token não fornecido."): True,
+    ("frontend/finance_bot_websocket_custom.py", "Token inválido ou expirado."): True,
+    ("frontend/finance_bot_websocket_custom.py", "Sessão encerrada. Faça login novamente."): True,
+    ("frontend/finance_bot_websocket_custom.py", "Sessão expirada. Faça login novamente."): True,
+    ("frontend/finance_bot_websocket_custom.py", "Token inválido"): True,
+    ("frontend/routes/shared.py", "Token de dashboard inválido ou expirado."): True,
+    ("frontend/routes/shared.py", "Sessão encerrada. Faça login novamente."): True,
+    # ── família B: 401 de aplicação, o token está ótimo ───────────────────────
+    # Senha incorreta em MFA setup/disable, regenerar backup codes e export.
+    ("frontend/finance_bot_websocket_custom.py", "Senha incorreta."): False,
+    # Login: nem chega ao interceptor — login.html não carrega o auth-refresh.js.
+    ("frontend/finance_bot_websocket_custom.py", "E-mail ou senha incorretos."): False,
+    # Magic link consumido/expirado. É a pegadinha da lista: parece autenticação
+    # e NÃO é renovável — access token novo não ressuscita um link expirado.
+    ("frontend/finance_bot_websocket_custom.py", "Link de dashboard inválido ou expirado."): False,
+    # `detail=str(exc)` de um PermissionError: senha errada no DELETE /auth/account
+    # (monólito) e no reset de dados (settings.py). Dinâmico, daí o marcador.
+    ("frontend/finance_bot_websocket_custom.py", "<str(exc)>"): False,
+    ("frontend/routes/settings.py", "<str(exc)>"): False,
+    # Chave de API do lead engine e webhook server-to-server: sem sessão nenhuma.
+    ("frontend/routes/prospects.py", "Chave inválida."): False,
+    ("frontend/routes/open_finance.py", "Não autorizado."): False,
+}
+
+
+def _varre_401(caminho, fonte):
+    """Devolve (chave, tem_header) de cada `raise HTTPException(status_code=401)`.
+
+    `chave` é `(arquivo, detail)`; `detail` dinâmico vira o marcador `<str(exc)>`.
+    """
+    import ast
+
+    achados = []
+    for no in ast.walk(ast.parse(fonte)):
+        if not (isinstance(no, ast.Raise) and isinstance(no.exc, ast.Call)):
+            continue
+        chamada = no.exc
+        nome = getattr(chamada.func, "id", None) or getattr(chamada.func, "attr", None)
+        if nome != "HTTPException":
+            continue
+        kw = {k.arg: k.value for k in chamada.keywords}
+        status = kw.get("status_code")
+        if not (isinstance(status, ast.Constant) and status.value == 401):
+            continue
+        detail = kw.get("detail")
+        chave = (
+            detail.value if isinstance(detail, ast.Constant) and isinstance(detail.value, str)
+            else "<str(exc)>"
+        )
+        header = kw.get("headers")
+        achados.append(((caminho, chave), getattr(header, "id", None) == "WWW_AUTHENTICATE_401"))
+    return achados
+
+
+def test_401_de_autenticacao_declara_familia():
+    """§0.7: o `auth-refresh.js` não importa Python, então um teste prende as listas.
+
+    Desde a #176 o interceptor só renova o 401 que traz `WWW-Authenticate` — ele
+    falha FECHADO, e é por isso que este gate é obrigatório e não opcional: um 401
+    de autenticação que alguém esqueça de marcar deixa de ser renovado e joga o
+    usuário para o login, regressão PIOR que o bug original (uma request extra).
+
+    Duas direções, as duas vermelhas:
+      - 401 novo sem entrada em `_401_RENOVAVEL` → o autor é obrigado a decidir a
+        família, em vez de herdar um default errado em silêncio;
+      - família declarada que não bate com o `headers=` do código.
+
+    Fora do alcance por caminho: `core/admin_dashboard.py`, que é outra árvore de
+    auth (sessão de admin) e cujas páginas não carregam o `auth-refresh.js`.
+    """
+    import pathlib
+
+    raiz = pathlib.Path(__file__).resolve().parents[1]
+    alvos = [pathlib.Path("frontend/finance_bot_websocket_custom.py")]
+    alvos += sorted(
+        p.relative_to(raiz) for p in (raiz / "frontend" / "routes").glob("*.py")
+    )
+
+    achados = []
+    for rel in alvos:
+        achados += _varre_401(rel.as_posix(), (raiz / rel).read_text(encoding="utf-8"))
+
+    assert achados, "a varredura não achou 401 nenhum — o walk quebrou"
+
+    sem_classificacao = sorted({c for c, _ in achados if c not in _401_RENOVAVEL})
+    assert not sem_classificacao, (
+        "401 novo sem família declarada. O interceptor do auth-refresh.js falha "
+        "FECHADO: sem `WWW_AUTHENTICATE_401` ele não renova e o usuário cai no "
+        f"login. Classifique em `_401_RENOVAVEL`: {sem_classificacao}"
+    )
+
+    divergentes = sorted(
+        f"{c} código={tem} classificação={_401_RENOVAVEL[c]}"
+        for c, tem in achados
+        if _401_RENOVAVEL[c] != tem
+    )
+    assert not divergentes, (
+        "o `headers=` do código não bate com a família declarada — renovável sem "
+        f"header nunca renova; de aplicação com header renova à toa: {divergentes}"
+    )
+
+    # Controle positivo: a família A não pode ter esvaziado. Se um refactor tirar
+    # o `headers=` de todos os sítios, as duas asserções acima continuariam verdes
+    # caso a classificação fosse trocada junto — este número não.
+    assert sum(1 for _, tem in achados if tem) == 8, sorted(
+        c for c, tem in achados if tem
+    )

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -416,17 +416,23 @@ def _forma_do_header(no):
     comportamento e errado na §0.7 (duplica o valor da constante), e a mensagem
     que o autor recebe tem que ser essa, não "sem header nunca renova".
 
-    A constante conta nas três escritas que o repositório usa: o nome nu, o
-    apelido com `_` (o bloco de import do monólito apelida quase tudo assim —
+    A constante casa pelo nome final, então três escritas contam igual: o nome nu,
+    o apelido com `_` (o bloco de import do monólito apelida quase tudo assim —
     `stamp_asset_versions as _stamp_asset_versions`) e o acesso por atributo
-    (`shared.WWW_AUTHENTICATE_401`). Sem isso o gate ficava VERMELHO em código
-    correto, mandando o autor procurar um header que está na linha.
+    (`shared.WWW_AUTHENTICATE_401`). É guarda PROSPECTIVA, não conserto de um
+    vermelho observado: hoje os 8 sítios usam o nome nu (`git grep -n
+    WWW_AUTHENTICATE_401`), e as outras duas formas não existem no repositório.
     """
     import ast
 
-    # ponytail: casa pelo nome final, não resolve o import. Um apelido sem
-    # relação (`as WWW`) passaria por ausente; resolver aliases exige ler o
-    # bloco de import — faça se alguém escrever um.
+    # ponytail: casa pelo nome final, não resolve o import. Três tetos, medidos:
+    # (1) fail-closed — um apelido sem relação (`as WWW`) passa por ausente;
+    # (2) fail-open — `qualquer_coisa.WWW_AUTHENTICATE_401` devolve "constante":
+    #     serve QUALQUER atributo com esse nome final, em qualquer objeto;
+    # (3) assimetria — `_varre_401` lê status e detail posicionalmente, o header
+    #     só por kwarg: `HTTPException(401, "m", WWW_AUTHENTICATE_401)` dá forma
+    #     None. Fail-closed, e ninguém escreve assim aqui.
+    # Resolver alias e objeto exige ler o bloco de import — faça se aparecer um.
     nome = getattr(no, "id", None) or getattr(no, "attr", None) or ""
     if nome.lstrip("_") == "WWW_AUTHENTICATE_401":
         return "constante"
@@ -494,8 +500,10 @@ def _varre_401(caminho, fonte):
         if not _e_401(status):
             continue
         detail = kw.get("detail")
-        # `HTTPException(401, "mensagem")` — detail é o 2º posicional, e lê-lo
-        # evita que uma mensagem constante nova caia no curinga `<str(exc)>`.
+        # `HTTPException(401, "mensagem")` — detail é o 2º posicional. Medido: sem
+        # esta leitura o gate CONTINUA vermelho no sítio novo (quem fecha o buraco
+        # é o sufixo `#2` abaixo). O que ela entrega é a chave legível — a
+        # mensagem — em vez de mais um `<str(exc)>` na tabela.
         if detail is None and nome == "HTTPException" and len(chamada.args) > 1:
             detail = chamada.args[1]
         if detail is None and isinstance(kw.get("content"), ast.Dict):
@@ -521,6 +529,41 @@ def _varre_401(caminho, fonte):
                 marca = f"{marca}#{n}"
         achados.append(((caminho, funcao, marca), _forma_do_header(kw.get("headers"))))
     return achados
+
+
+def test_varredura_401_reconhece_as_formas():
+    """Controle do GATE, não do código de produção.
+
+    Sem ele as três partes da varredura podem ser apagadas com a suíte verde
+    (medido em `0dc1f5c`: 18 passed com cada uma removida) — e uma varredura que
+    falha ABERTO deixa o 401 novo passar sem família, que é a regressão que este
+    arquivo inteiro existe para impedir.
+    """
+    fonte = '''
+def f():
+    raise HTTPException(401, "posicional")
+    raise HTTPException(status_code=401, detail=str(exc))
+    raise HTTPException(status_code=401, detail=str(erro))
+
+def g():
+    raise HTTPException(401, "a", headers=_WWW_AUTHENTICATE_401)
+    raise HTTPException(401, "b", headers=shared.WWW_AUTHENTICATE_401)
+    raise HTTPException(401, "c", headers={"WWW-Authenticate": "Bearer"})
+    raise HTTPException(401, "d")
+'''
+
+    assert dict(_varre_401("x.py", fonte)) == {
+        # detail no 2º posicional vira a mensagem, não o curinga
+        ("x.py", "f", "posicional"): None,
+        # dois curingas iguais na MESMA função: o segundo cai fora da tabela
+        ("x.py", "f", "<str(exc)>"): None,
+        ("x.py", "f", "<str(exc)>#2"): None,
+        # as três escritas da constante e o dict literal
+        ("x.py", "g", "a"): "constante",
+        ("x.py", "g", "b"): "constante",
+        ("x.py", "g", "c"): "literal",
+        ("x.py", "g", "d"): None,
+    }, dict(_varre_401("x.py", fonte))
 
 
 def test_401_de_autenticacao_declara_familia():
@@ -560,6 +603,13 @@ def test_401_de_autenticacao_declara_familia():
         achados += _varre_401(rel.as_posix(), (raiz / rel).read_text(encoding="utf-8"))
 
     assert achados, "a varredura não achou 401 nenhum — o walk quebrou"
+
+    mortas = sorted(set(_401_RENOVAVEL) - {c for c, _ in achados})
+    assert not mortas, (
+        "entrada de `_401_RENOVAVEL` sem sítio no código. Curinga órfão volta a "
+        "absorver o 401 novo da mesma função em silêncio, com a família velha — "
+        f"apague a entrada junto com o `raise`: {mortas}"
+    )
 
     sem_classificacao = sorted({c for c, _ in achados if c not in _401_RENOVAVEL})
     assert not sem_classificacao, (

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -340,47 +340,58 @@ def test_rotas_que_encerram_sessao_estao_no_auth_refresh():
     )
 
 
-# Classificação EXPLÍCITA de cada `raise HTTPException(status_code=401, ...)` de
+# Classificação EXPLÍCITA de cada resposta 401 de
 # `frontend/finance_bot_websocket_custom.py` + `frontend/routes/*.py`, por
-# `(arquivo, detail)`. `True` = falha de access/dashboard token, leva o
+# `(arquivo, função, detail)`. `True` = falha de access/dashboard token, leva o
 # `WWW_AUTHENTICATE_401` e o interceptor renova; `False` = 401 de aplicação, não
 # leva e não renova.
 #
+# A FUNÇÃO faz parte da chave porque `<str(exc)>` e `<NomeDaClasse>` são curingas:
+# com a chave só em `(arquivo, detail)`, um 401 novo de detail dinâmico herdava em
+# silêncio a classificação de outro sítio do mesmo arquivo e o gate ficava verde.
+#
 # `core/admin_dashboard.py` fica FORA por caminho: é outra árvore de auth (sessão
 # de admin, cookie próprio) e nenhuma página dela carrega o `auth-refresh.js`.
+_MONO = "frontend/finance_bot_websocket_custom.py"
 _401_RENOVAVEL = {
     # ── família A: o access/dashboard token falhou → renovar resolve ──────────
-    ("frontend/finance_bot_websocket_custom.py", "Token não fornecido."): True,
-    ("frontend/finance_bot_websocket_custom.py", "Token inválido ou expirado."): True,
-    ("frontend/finance_bot_websocket_custom.py", "Sessão encerrada. Faça login novamente."): True,
-    ("frontend/finance_bot_websocket_custom.py", "Sessão expirada. Faça login novamente."): True,
-    ("frontend/finance_bot_websocket_custom.py", "Token inválido"): True,
-    ("frontend/routes/shared.py", "Token de dashboard inválido ou expirado."): True,
-    ("frontend/routes/shared.py", "Sessão encerrada. Faça login novamente."): True,
+    (_MONO, "_get_current_user", "Token não fornecido."): True,
+    (_MONO, "_get_current_user", "Token inválido ou expirado."): True,
+    (_MONO, "_get_current_user", "Sessão encerrada. Faça login novamente."): True,
+    (_MONO, "_get_current_user", "Sessão expirada. Faça login novamente."): True,
+    (_MONO, "auth_validate", "Token inválido"): True,
+    ("frontend/routes/shared.py", "resolve_dashboard_user_id",
+     "Token de dashboard inválido ou expirado."): True,
+    ("frontend/routes/shared.py", "resolve_dashboard_user_id",
+     "Sessão encerrada. Faça login novamente."): True,
     # ── família B: 401 de aplicação, o token está ótimo ───────────────────────
     # Senha incorreta em MFA setup/disable, regenerar backup codes e export.
-    ("frontend/finance_bot_websocket_custom.py", "Senha incorreta."): False,
+    (_MONO, "auth_mfa_setup", "Senha incorreta."): False,
+    (_MONO, "auth_mfa_disable", "Senha incorreta."): False,
+    (_MONO, "auth_mfa_regenerate", "Senha incorreta."): False,
+    (_MONO, "auth_account_export_request", "Senha incorreta."): False,
     # Login: nem chega ao interceptor — login.html não carrega o auth-refresh.js.
-    ("frontend/finance_bot_websocket_custom.py", "E-mail ou senha incorretos."): False,
+    (_MONO, "auth_login", "E-mail ou senha incorretos."): False,
     # Magic link consumido/expirado. É a pegadinha da lista: parece autenticação
     # e NÃO é renovável — access token novo não ressuscita um link expirado.
-    ("frontend/finance_bot_websocket_custom.py", "Link de dashboard inválido ou expirado."): False,
+    (_MONO, "auth_dashboard_link", "Link de dashboard inválido ou expirado."): False,
     # `detail=str(exc)` de um PermissionError: senha errada no DELETE /auth/account
     # (monólito) e no reset de dados (settings.py). Dinâmico, daí o marcador.
-    ("frontend/finance_bot_websocket_custom.py", "<str(exc)>"): False,
-    ("frontend/routes/settings.py", "<str(exc)>"): False,
+    (_MONO, "auth_delete_account", "<str(exc)>"): False,
+    ("frontend/routes/settings.py", "account_reset_route", "<str(exc)>"): False,
     # Chave de API do lead engine e webhook server-to-server: sem sessão nenhuma.
-    ("frontend/routes/prospects.py", "Chave inválida."): False,
-    ("frontend/routes/open_finance.py", "Não autorizado."): False,
+    ("frontend/routes/prospects.py", "prospect_status", "Chave inválida."): False,
+    ("frontend/routes/open_finance.py", "open_finance_pluggy_webhook",
+     "Não autorizado."): False,
     # ── família C: 401 que o INTERCEPTOR nem alcança ──────────────────────────
     # Os dois do `POST /auth/refresh` (montados como `JSONResponse` porque o
     # `raise` descarta o Set-Cookie da limpeza, #175). O interceptor sai antes
     # deles, no `_isRefreshEndpoint`: renovar o refresh com o refresh é recursão.
-    ("frontend/finance_bot_websocket_custom.py", "missing_refresh_token"): False,
-    ("frontend/finance_bot_websocket_custom.py", "invalid_refresh_token"): False,
+    (_MONO, "auth_refresh", "missing_refresh_token"): False,
+    (_MONO, "auth_refresh", "invalid_refresh_token"): False,
     # Magic link expirado no `GET /d/{code}`: página HTML de NAVEGAÇÃO, não
     # resposta de `fetch`. O `window.fetch` do auth-refresh.js não vê navegação.
-    ("frontend/finance_bot_websocket_custom.py", "<HTMLResponse>"): False,
+    (_MONO, "dashboard_short_link", "<HTMLResponse>"): False,
 }
 
 
@@ -404,10 +415,20 @@ def _forma_do_header(no):
     O literal é separado do ausente de propósito: o código está CORRETO no
     comportamento e errado na §0.7 (duplica o valor da constante), e a mensagem
     que o autor recebe tem que ser essa, não "sem header nunca renova".
+
+    A constante conta nas três escritas que o repositório usa: o nome nu, o
+    apelido com `_` (o bloco de import do monólito apelida quase tudo assim —
+    `stamp_asset_versions as _stamp_asset_versions`) e o acesso por atributo
+    (`shared.WWW_AUTHENTICATE_401`). Sem isso o gate ficava VERMELHO em código
+    correto, mandando o autor procurar um header que está na linha.
     """
     import ast
 
-    if getattr(no, "id", None) == "WWW_AUTHENTICATE_401":
+    # ponytail: casa pelo nome final, não resolve o import. Um apelido sem
+    # relação (`as WWW`) passaria por ausente; resolver aliases exige ler o
+    # bloco de import — faça se alguém escrever um.
+    nome = getattr(no, "id", None) or getattr(no, "attr", None) or ""
+    if nome.lstrip("_") == "WWW_AUTHENTICATE_401":
         return "constante"
     if isinstance(no, ast.Dict) and any(
         isinstance(k, ast.Constant) and str(k.value).lower() == "www-authenticate"
@@ -427,14 +448,38 @@ def _varre_401(caminho, fonte):
         return JSONResponse(status_code=401, ...)           # e HTMLResponse etc
         status_code=status.HTTP_401_UNAUTHORIZED            # constante do FastAPI
 
-    `chave` é `(arquivo, detail)`. O `detail` sai do kwarg (HTTPException) ou do
-    `content={"detail": ...}` (JSONResponse); quando não é string constante vira
-    `<str(exc)>` no HTTPException e `<NomeDaClasse>` na resposta montada à mão.
+    `chave` é `(arquivo, função, detail)`. O `detail` sai do kwarg ou do 2º
+    posicional (HTTPException) ou do `content={"detail": ...}` (JSONResponse);
+    quando não é string constante vira `<str(exc)>` no HTTPException e
+    `<NomeDaClasse>` na resposta montada à mão.
+
+    A função que ENVOLVE o sítio entra na chave porque esses dois marcadores são
+    curingas: sem ela, um 401 novo cujo detail não é constante herda em silêncio
+    a classificação de um 401 velho do mesmo arquivo, e o gate — que é a única
+    rede de um interceptor que falha FECHADO — passa verde. Medido: três sítios
+    novos (dois `HTTPException` e um `HTMLResponse`) eram absorvidos pelas três
+    entradas curinga da tabela. Nome de função é estável; número de linha desliza
+    a cada edição acima.
+
+    E dois curingas IGUAIS na MESMA função ainda colidiriam, então o segundo
+    ganha `#2` no marcador e cai fora da tabela também. Detail constante não
+    recebe sufixo de propósito: ali a chave repetida é mesmo o mesmo caso.
     """
     import ast
 
+    arvore = ast.parse(fonte)
+    # `ast.walk` é BFS, então a função mais interna escreve por último e ganha.
+    # Sem isso um sítio dentro de closure levaria o nome da função de fora.
+    dono = {}
+    for no in ast.walk(arvore):
+        if isinstance(no, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for filho in ast.walk(no):
+                if isinstance(filho, ast.Call):
+                    dono[filho] = no.name
+
     achados = []
-    for chamada in ast.walk(ast.parse(fonte)):
+    vistos: dict[tuple, int] = {}
+    for chamada in ast.walk(arvore):
         if not isinstance(chamada, ast.Call):
             continue
         nome = getattr(chamada.func, "id", None) or getattr(chamada.func, "attr", None) or ""
@@ -449,17 +494,32 @@ def _varre_401(caminho, fonte):
         if not _e_401(status):
             continue
         detail = kw.get("detail")
+        # `HTTPException(401, "mensagem")` — detail é o 2º posicional, e lê-lo
+        # evita que uma mensagem constante nova caia no curinga `<str(exc)>`.
+        if detail is None and nome == "HTTPException" and len(chamada.args) > 1:
+            detail = chamada.args[1]
         if detail is None and isinstance(kw.get("content"), ast.Dict):
             detail = next(
                 (v for k, v in zip(kw["content"].keys, kw["content"].values)
                  if isinstance(k, ast.Constant) and k.value == "detail"),
                 None,
             )
-        chave = (
-            detail.value if isinstance(detail, ast.Constant) and isinstance(detail.value, str)
-            else "<str(exc)>" if nome == "HTTPException" else f"<{nome}>"
-        )
-        achados.append(((caminho, chave), _forma_do_header(kw.get("headers"))))
+        funcao = dono.get(chamada, "<módulo>")
+        if isinstance(detail, ast.Constant) and isinstance(detail.value, str):
+            # Detail constante é auto-descritivo: chave repetida = mesma mensagem,
+            # mesma família. Compartilhar a entrada aqui é certo (o `auth_login`
+            # levanta a mesma duas vezes).
+            marca = detail.value
+        else:
+            # Curinga (`<str(exc)>`, `<HTMLResponse>`): chave repetida NÃO quer
+            # dizer mesma coisa, então o segundo sítio da mesma função vira
+            # `...#2` e cai fora da tabela — o autor é obrigado a declará-lo.
+            marca = "<str(exc)>" if nome == "HTTPException" else f"<{nome}>"
+            n = vistos.get((funcao, marca), 0) + 1
+            vistos[(funcao, marca)] = n
+            if n > 1:
+                marca = f"{marca}#{n}"
+        achados.append(((caminho, funcao, marca), _forma_do_header(kw.get("headers"))))
     return achados
 
 

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -372,35 +372,94 @@ _401_RENOVAVEL = {
     # Chave de API do lead engine e webhook server-to-server: sem sessão nenhuma.
     ("frontend/routes/prospects.py", "Chave inválida."): False,
     ("frontend/routes/open_finance.py", "Não autorizado."): False,
+    # ── família C: 401 que o INTERCEPTOR nem alcança ──────────────────────────
+    # Os dois do `POST /auth/refresh` (montados como `JSONResponse` porque o
+    # `raise` descarta o Set-Cookie da limpeza, #175). O interceptor sai antes
+    # deles, no `_isRefreshEndpoint`: renovar o refresh com o refresh é recursão.
+    ("frontend/finance_bot_websocket_custom.py", "missing_refresh_token"): False,
+    ("frontend/finance_bot_websocket_custom.py", "invalid_refresh_token"): False,
+    # Magic link expirado no `GET /d/{code}`: página HTML de NAVEGAÇÃO, não
+    # resposta de `fetch`. O `window.fetch` do auth-refresh.js não vê navegação.
+    ("frontend/finance_bot_websocket_custom.py", "<HTMLResponse>"): False,
 }
 
 
-def _varre_401(caminho, fonte):
-    """Devolve (chave, tem_header) de cada `raise HTTPException(status_code=401)`.
+def _e_401(no):
+    """`401`, `status.HTTP_401_UNAUTHORIZED` ou `HTTP_401_UNAUTHORIZED` importado.
 
-    `chave` é `(arquivo, detail)`; `detail` dinâmico vira o marcador `<str(exc)>`.
+    A forma com a constante do FastAPI é a IDIOMÁTICA — a que um contribuidor
+    novo escreve —, e o gate era cego para ela.
+    """
+    import ast
+
+    if isinstance(no, ast.Constant):
+        return no.value == 401
+    return getattr(no, "attr", None) == "HTTP_401_UNAUTHORIZED" or \
+        getattr(no, "id", None) == "HTTP_401_UNAUTHORIZED"
+
+
+def _forma_do_header(no):
+    """`"constante"`, `"literal"` ou `None` — as três formas do `headers=`.
+
+    O literal é separado do ausente de propósito: o código está CORRETO no
+    comportamento e errado na §0.7 (duplica o valor da constante), e a mensagem
+    que o autor recebe tem que ser essa, não "sem header nunca renova".
+    """
+    import ast
+
+    if getattr(no, "id", None) == "WWW_AUTHENTICATE_401":
+        return "constante"
+    if isinstance(no, ast.Dict) and any(
+        isinstance(k, ast.Constant) and str(k.value).lower() == "www-authenticate"
+        for k in no.keys
+    ):
+        return "literal"
+    return None
+
+
+def _varre_401(caminho, fonte):
+    """Devolve (chave, forma_do_header) de cada resposta 401 do arquivo.
+
+    Quatro formas, todas medidas (o gate anterior só via a primeira):
+
+        raise HTTPException(status_code=401, ...)
+        raise HTTPException(401, ...)                       # posicional
+        return JSONResponse(status_code=401, ...)           # e HTMLResponse etc
+        status_code=status.HTTP_401_UNAUTHORIZED            # constante do FastAPI
+
+    `chave` é `(arquivo, detail)`. O `detail` sai do kwarg (HTTPException) ou do
+    `content={"detail": ...}` (JSONResponse); quando não é string constante vira
+    `<str(exc)>` no HTTPException e `<NomeDaClasse>` na resposta montada à mão.
     """
     import ast
 
     achados = []
-    for no in ast.walk(ast.parse(fonte)):
-        if not (isinstance(no, ast.Raise) and isinstance(no.exc, ast.Call)):
+    for chamada in ast.walk(ast.parse(fonte)):
+        if not isinstance(chamada, ast.Call):
             continue
-        chamada = no.exc
-        nome = getattr(chamada.func, "id", None) or getattr(chamada.func, "attr", None)
-        if nome != "HTTPException":
+        nome = getattr(chamada.func, "id", None) or getattr(chamada.func, "attr", None) or ""
+        if nome != "HTTPException" and not nome.endswith("Response"):
             continue
         kw = {k.arg: k.value for k in chamada.keywords}
+        # posicional: `HTTPException(401, ...)` e `JSONResponse(content, 401)`
+        pos = 0 if nome == "HTTPException" else 1
         status = kw.get("status_code")
-        if not (isinstance(status, ast.Constant) and status.value == 401):
+        if status is None and len(chamada.args) > pos:
+            status = chamada.args[pos]
+        if not _e_401(status):
             continue
         detail = kw.get("detail")
+        if detail is None and isinstance(kw.get("content"), ast.Dict):
+            detail = next(
+                (v for k, v in zip(kw["content"].keys, kw["content"].values)
+                 if isinstance(k, ast.Constant) and k.value == "detail"),
+                None,
+            )
         chave = (
             detail.value if isinstance(detail, ast.Constant) and isinstance(detail.value, str)
-            else "<str(exc)>"
+            else "<str(exc)>" if nome == "HTTPException" else f"<{nome}>"
         )
-        header = kw.get("headers")
-        achados.append(((caminho, chave), getattr(header, "id", None) == "WWW_AUTHENTICATE_401"))
+        achados.append(((caminho, chave), _forma_do_header(kw.get("headers"))))
     return achados
 
 
@@ -412,10 +471,18 @@ def test_401_de_autenticacao_declara_familia():
     de autenticação que alguém esqueça de marcar deixa de ser renovado e joga o
     usuário para o login, regressão PIOR que o bug original (uma request extra).
 
-    Duas direções, as duas vermelhas:
+    Direções, todas vermelhas:
       - 401 novo sem entrada em `_401_RENOVAVEL` → o autor é obrigado a decidir a
         família, em vez de herdar um default errado em silêncio;
-      - família declarada que não bate com o `headers=` do código.
+      - família declarada que não bate com o `headers=` do código, nas duas
+        direções (renovável sem header × de aplicação com header);
+      - `WWW-Authenticate` escrito como dict literal em vez da constante (§0.7).
+
+    A varredura cobre as QUATRO formas de responder 401 aqui — `status_code=401`,
+    `HTTPException(401, ...)` posicional, `JSONResponse/HTMLResponse(status_code=401)`
+    e `status.HTTP_401_UNAUTHORIZED`. Cobria só a primeira, e as outras três já
+    existiam no monólito (os dois do `/auth/refresh` e o do `/d/{code}`): a
+    promessa do docstring era falsa em 3 das 4.
 
     Fora do alcance por caminho: `core/admin_dashboard.py`, que é outra árvore de
     auth (sessão de admin) e cujas páginas não carregam o `auth-refresh.js`.
@@ -441,19 +508,35 @@ def test_401_de_autenticacao_declara_familia():
         f"login. Classifique em `_401_RENOVAVEL`: {sem_classificacao}"
     )
 
-    divergentes = sorted(
-        f"{c} código={tem} classificação={_401_RENOVAVEL[c]}"
-        for c, tem in achados
-        if _401_RENOVAVEL[c] != tem
+    literais = sorted({c for c, forma in achados if forma == "literal"})
+    assert not literais, (
+        "o `WWW-Authenticate` foi escrito como dict literal. O comportamento está "
+        "certo e a §0.7 não: use `headers=WWW_AUTHENTICATE_401` (importe de "
+        f"`frontend/routes/shared.py`), que é a fonte única do valor: {literais}"
     )
-    assert not divergentes, (
-        "o `headers=` do código não bate com a família declarada — renovável sem "
-        f"header nunca renova; de aplicação com header renova à toa: {divergentes}"
+
+    faltando = sorted({c for c, forma in achados if _401_RENOVAVEL[c] and not forma})
+    assert not faltando, (
+        "401 classificado como RENOVÁVEL e sem `headers=`. Acrescente "
+        "`headers=WWW_AUTHENTICATE_401` no `raise`/`Response` — sem ele o "
+        "interceptor não renova e o usuário cai no login. Se este 401 é de "
+        f"aplicação (o token está ótimo), troque a classificação para False: {faltando}"
+    )
+
+    sobrando = sorted({c for c, forma in achados if forma and not _401_RENOVAVEL[c]})
+    assert not sobrando, (
+        "401 classificado como DE APLICAÇÃO e com `WWW-Authenticate`. Ele vai "
+        "renovar o token à toa e gastar dois slots do rate limit. Tire o "
+        f"`headers=`, ou mude a classificação para True se ele é de autenticação: {sobrando}"
     )
 
     # Controle positivo: a família A não pode ter esvaziado. Se um refactor tirar
-    # o `headers=` de todos os sítios, as duas asserções acima continuariam verdes
+    # o `headers=` de todos os sítios, as três asserções acima continuariam verdes
     # caso a classificação fosse trocada junto — este número não.
-    assert sum(1 for _, tem in achados if tem) == 8, sorted(
-        c for c, tem in achados if tem
+    com_header = sorted(c for c, forma in achados if forma)
+    assert len(com_header) == 8, (
+        f"são {len(com_header)} sítios com `WWW-Authenticate`, e este controle "
+        "espera 8. Se você ADICIONOU um 401 de autenticação legítimo (já "
+        "classificado como True acima), atualize o 8 para o número novo. Se você "
+        f"não mexeu em nenhum 401, alguém apagou um `headers=`: {com_header}"
     )


### PR DESCRIPTION
Fecha #176.

## O dano real, medido (a issue estimou errado o lugar)

O `auth-refresh.js` renovava em QUALQUER 401 — o único critério era o status. Medido num Chromium com `POST /auth/mfa/setup` respondendo 401 `"Senha incorreta."`:

```
POST /auth/mfa/setup
POST /auth/refresh
POST /auth/mfa/setup      <- a senha errada vai DE NOVO
```

**A senha errada era enviada duas vezes**, consumindo DOIS slots do `@limiter.limit` da rota por digitação:

| rota | limite | efeito de 1 erro de digitação |
|---|---|---|
| `POST /auth/mfa/regenerate-backup-codes` | 3/hour | o 2º erro já toma **429** — usuário trancado por 1 hora |
| `POST /auth/account/export` | 3/hour | idem |
| `POST /auth/mfa/setup` | 5/hour | 2 tentativas reais em vez de 5 |
| `POST /auth/mfa/disable` | 5/hour | idem |
| `DELETE /auth/account` | 5/minute | idem, na janela do minuto |

Segundo dano: `auth_account_export_request` gravava `data_export_password_failed` **duas vezes por digitação errada**, num log de segurança.

O dano que a issue nomeava (apagar o estado do aparelho) **morreu com a #173** — senha errada → refresh → 200 → nada é apagado. Sobrava o gatilho, que é o que este PR conserta.

## O conserto

Quem classifica a família passa a ser o **servidor**, pelo mecanismo padrão: `WWW-Authenticate` nos 401 de autenticação. Constante única em `frontend/routes/shared.py` (§0.7 — um literal, não 8), aplicada nos **8 sítios** de falha de access/dashboard token:

- `finance_bot_websocket_custom.py` — os 4 de `_get_current_user` e o `auth_validate`
- `routes/shared.py` — os 3 de `resolve_dashboard_user_id`

São **22 sítios de 401** no alcance do gate (medido pela própria varredura), 8 com o header e **14 sem**. Incluindo a pegadinha da lista: **`auth_dashboard_link` é 401 e NÃO leva o header** — access token novo não ressuscita magic link expirado.

No JS, uma linha, **abaixo** do `const resp = await _requestComLimpeza(...)` e nunca acima: a limpeza central de fim de sessão roda ali e não pode ser pulada por um `return` antecipado. O retry continua passando por `_requestComLimpeza`, que é o que faz um `DELETE /auth/account` renovado limpar o aparelho.

**Descartadas** a allowlist de rotas no JS (opção 2 da issue) e a leitura do `detail`: as duas viram lista duplicada entre Python e JS e erram por omissão sem ninguém notar. O corpo, ainda por cima, já foi consumido pelo chamador.

**Nenhum bump de `?v=` foi preciso** — inventário, não memória: `stamp_asset_versions` já troca o `?v=` por um blake2b do conteúdo do arquivo em tempo de resposta, então editar o JS invalida o cache sozinho. O `?v=1` que está nos HTML é ignorado.

## O gate é obrigatório, não opcional

A mudança faz o gatilho **falhar FECHADO**: um 401 de autenticação que alguém esqueça de marcar deixa de ser renovado e joga o usuário para o login — regressão **pior** que o bug (que era uma request extra).

`test_401_de_autenticacao_declara_familia` (`tests/test_static_pages_routes.py`, ao lado do irmão `test_rotas_que_encerram_sessao_estao_no_auth_refresh`) varre por `ast` as **quatro** formas de responder 401 em `frontend/finance_bot_websocket_custom.py` + `frontend/routes/*.py` — `HTTPException(status_code=401, ...)`, `HTTPException(401, ...)` posicional, `JSONResponse`/`HTMLResponse(status_code=401)` e `status.HTTP_401_UNAUTHORIZED` — e compara com uma classificação explícita por `(arquivo, função, detail)`. A função entra na chave porque `<str(exc)>` e `<NomeDaClasse>` são curingas: sem ela, um 401 novo de detail dinâmico herdava a classificação de outro sítio do mesmo arquivo e o gate passava verde (três sítios novos absorvidos, medidos). E dois curingas IGUAIS na mesma função ainda colidiriam, então o **segundo ganha `#2`** no marcador (`<str(exc)>#2`) e também cai fora da tabela — o autor é obrigado a declarar o sítio novo em vez de herdar a família do velho. Detail constante não recebe sufixo de propósito: ali a chave repetida é mesmo o mesmo caso. O gate ainda afirma que a tabela não tem **entrada morta** (hoje 0): curinga órfão voltaria a absorver sítio novo em silêncio.

**401 novo sem classificação = vermelho**, e o autor é obrigado a decidir a família. `core/admin_dashboard.py` fica fora por caminho (outra árvore de auth, e nenhuma página dela carrega o `auth-refresh.js`) — a exclusão está escrita no docstring.

## Efeito colateral, declarado

Hoje um 401 de aplicação dispara `_doRefresh`, que chama `_comLimpeza("/auth/refresh", r, "POST")`. Parando de disparar, **perde-se essa limpeza naquele instante** — mas só quando o refresh teria dado 401, ou seja, com a sessão já morta. O próximo 401 de autenticação (≤15 min, quando o access token vence) dispara tudo. **Adiado, não perdido.**

## Testes

`tests/frontend/auth_refresh_gatilho.test.mjs` (novo, 4 casos, Playwright + `startServer()`):

| caso | asserção | papel |
|---|---|---|
| 401 **sem** header (senha errada) | 1× rota original, **0×** `/auth/refresh` | negativo |
| 401 **com** header (access vencido) | 1 refresh + 1 retry, e a resposta do **retry** chega ao caller | **positivo** |
| `DELETE /auth/account` 401-com-header → refresh OK → retry 200 | `caches.keys()` vazio e SW desregistrado | o retry ainda passa pelo `_requestComLimpeza` |
| `POST /auth/logout` com `route.abort()` | limpeza rodou **E** a rejeição subiu ao caller | não quebrou a limpeza central |

**Controles provados por mutação, não afirmados:**

- desligando a linha nova, o caso 1 fica vermelho com exatamente a sequência da issue: `["POST /auth/mfa/setup","POST /auth/refresh","POST /auth/mfa/setup"]`;
- trocando a linha por `if (true) return resp` (falha fechada), os casos 2 e 3 ficam vermelhos, mais **6** em `sw_cache_privado.test.mjs` (`tests 49 / pass 43 / fail 6` — os 6 call sites que prendem o refresh: linhas 501, 531, 557, 585, 603 e 624);
- tirando o `headers=` de um sítio de família A, o gate fica vermelho;
- acrescentando um 401 novo sem classificação, o gate fica vermelho — inclusive nas três formas que a chave antiga absorvia (`HTTPException(401, "...")` posicional no monólito e em `routes/settings.py`, `HTMLResponse(status_code=401)` no monólito), cada uma injetada na própria função dona do curinga;
- e o inverso, controle positivo do gate: escrevendo a constante como apelido (`WWW_AUTHENTICATE_401 as _WWW_AUTHENTICATE_401`, convenção do bloco de import do monólito) ou por atributo (`shared.WWW_AUTHENTICATE_401`), o gate fica **verde** — guarda prospectiva: os 8 sítios de hoje usam o nome nu, nenhuma das duas formas existe no repositório — código correto não trava PR; o dict literal continua vermelho (§0.7);
- tirando o `headers=` de `_get_current_user`, o teste de integração fica vermelho (`KeyError: 'www-authenticate'`).

**O gate também tem controle do próprio código.** `test_varredura_401_reconhece_as_formas` roda `_varre_401` sobre fonte sintética (dois curingas na mesma função, apelido, atributo, dict literal, detail no 2º posicional). Antes dele as três partes da varredura podiam ser **apagadas com a suíte verde** — medido em `0dc1f5c`: 18 passed com cada uma removida. Agora cada mutação fica vermelha:

| mutação | antes | agora |
|---|---|---|
| apaga o sufixo `#2` | 18 passed | `test_varredura_401_reconhece_as_formas` FAILED |
| casa só `ast.Name` nu (sem apelido/atributo) | 18 passed | idem |
| apaga a leitura do 2º posicional | 18 passed | idem |
| entrada morta na tabela | 18 passed | `test_401_de_autenticacao_declara_familia` FAILED |

Tetos do casamento por nome, medidos e escritos no `# ponytail:` da função: apelido sem relação (`as WWW`) passa por ausente (fail-closed); `qualquer_coisa.WWW_AUTHENTICATE_401` devolve `"constante"` (fail-open, qualquer atributo com esse nome final); e o header só é lido por kwarg, então `HTTPException(401, "m", WWW_AUTHENTICATE_401)` dá forma `None` (fail-closed, e ninguém escreve assim aqui).

O teste de navegador usa header que **ele mesmo escreve**, então a costura do lado servidor tem teste próprio: `test_401_de_autenticacao_manda_www_authenticate_e_o_de_aplicacao_nao` (`tests/test_auth_cookie.py`) afirma o header num 401 **real** de `_get_current_user`, e a ausência dele num 401 real de aplicação — o header só vale se DISCRIMINAR.

`tests/frontend/sw_cache_privado.test.mjs`: o duplo `fetchPorRota` ganhou `headers` (sem ele a linha nova estourava `TypeError`, porque `Response.headers` sempre existe no navegador e ali não existia) e a marca de família. Dois casos trocaram de rota porque o gatilho deles deixou de existir — a senha errada do MFA não renova mais; o invariante medido (#173: refresh 400 ≠ fim de sessão) é o mesmo, só mudou a porta de entrada. Um docstring de `test_error_pages.py` que afirmava "hoje nenhum 401 do produto manda WWW-Authenticate" foi atualizado.

## Medido aqui

- `pytest -q` completo: **5742 passed, 1 xfailed**, 0 falhas (149s) — 5741 era a baseline; o +1 é o controle do gate.
- `npm run test:frontend` completo: **302 passed, 0 fail**.

## Só se prova no aparelho, pós-deploy (§5)

O app carrega o site ao vivo, então nada disto vale antes do deploy:

1. **Errar a senha 3× em "Regenerar códigos de backup" e NÃO tomar 429** — é o ganho principal, e depende do rate limiter real do Railway, que a suíte não exercita.
2. **Deixar o app parado >15 min e conferir que ele ainda renova sozinho** — é exatamente o caso que a falha-fechada quebraria se algum 401 de autenticação tivesse ficado sem a marca.

Também não rodou aqui: o `eslint` (só o `playwright` está instalado no `node_modules` local; o CI roda o lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

