### PR TITLE
O modal de ajustar carteira volta a mostrar erro, e o gate do 5527f13 ganha teste

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,14 +78,26 @@ export default defineConfig([
           caughtErrorsIgnorePattern: "^_",
           // MUDANÇA DE CONFIG, não limpeza de código: `local` deixa de
           // reportar declaração do escopo GLOBAL. Os arquivos de frontend/ são
-          // scripts clássicos, e o que consome os nomes do topo são os 139
+          // scripts clássicos, e o que consome os nomes do topo são os 107
           // `onclick=` do dashboard.html (mais os gerados dentro de template
-          // string) — HTML que o ESLint não lê. Com o default `all` isso dava
-          // 73 avisos, todos falso positivo, e enterrava os de dentro de
-          // função. Quem cobre ESTA classe é tests/frontend/handlers_inline.test.mjs,
-          // que compara os nomes do HTML com os do JS. O preço: global morta de
-          // verdade deixa de aparecer aqui (as 3 achadas na medição de
-          // 2026-09-03 estão no relatório do burndown).
+          // string) — HTML que o ESLint não lê. Para remedir:
+          //   grep -oiE "onclick\s*=" frontend/dashboard.html | wc -l
+          // Com o default `all` isso dava 73 avisos: 70 falso positivo e 3
+          // código morto de VERDADE.
+          //
+          // NADA cobre esta classe. tests/frontend/handlers_inline.test.mjs roda
+          // só na direção HTML→JS (pergunta se todo `onclick` do HTML acha um
+          // nome no JS); a direção inversa — global declarada e SEM consumidor —
+          // não é verificada por teste nenhum, nem por lint. O preço desta
+          // config é exatamente essa: as 3 abaixo só existem registradas aqui, e
+          // este comentário é o único registro. Linhas MEDIDAS EM 2026-09-03 —
+          // remeça antes de reusar (CLAUDE.md §2), elas andam a cada edição:
+          //   grep -nE "^(async )?function (openPocketModal|confirmDeletePocket|computeDailyFromLaunches)\b" frontend/dashboard.js
+          //   openPocketModal          frontend/dashboard.js:8849
+          //   confirmDeletePocket      frontend/dashboard.js:9140
+          //   computeDailyFromLaunches frontend/dashboard.js:9973
+          // Remover função é decisão do dono, fora deste ciclo — as 3 seguem no
+          // arquivo de propósito.
           vars: "local",
         },
       ],
@@ -95,9 +107,9 @@ export default defineConfig([
       // 2026-09-03: as 3 eram `_fmtBRL`/`_fmtDateBR` declaradas 2× e 3× no
       // dashboard.js, com a última vencendo em todo o arquivo.
       "no-redeclare": ["error", { builtinGlobals: false }],
-      // 1 violação, e é bug de verdade: `errEl` em frontend/dashboard.js:9750
-      // está fora do escopo do `const errEl` da linha 9723.
-      "no-undef": "warn", // 1
+      // "error" torna verdade uma coisa nova: global de CDN nova usada sem
+      // entrar na lista `globals` deste arquivo REPROVA O CI, não avisa mais.
+      "no-undef": "error",
       // Orçamento de tamanho e complexidade: "warn" de propósito. São números
       // para conversa sobre fatoração, não portão. As contagens abaixo são a
       // LINHA DE BASE do burndown de 2026-09-03 (portão de decisão: corrigir o
@@ -151,7 +163,7 @@ export default defineConfig([
       // no arquivo do adaptador com um bloco DEPOIS deste.
       "quality/no-direct-console": [
         "warn", // 21
-        { logger: "um adaptador de log do frontend" },
+        { logger: "um adaptador de log do projeto" },
       ],
       // quality/no-direct-data-access foi removida: não existe módulo de dados
       // em JS aqui — o banco é acessado só pelo backend Python (db/).

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -9708,7 +9708,7 @@ function openAdjustWalletModal() {
   document.getElementById("adjust-wallet-banks").textContent = _fmtBRL(banks);
   const inp = document.getElementById("adjust-wallet-input");
   inp.value = carteira.toFixed(2);
-  document.getElementById("adjust-wallet-error").textContent = "";
+  _adjustWalletError("");  // texto E classe: só o textContent deixa a caixa vazia visível
   document.getElementById("adjust-wallet-overlay").classList.add("open");
   inp.oninput = _updateAdjustWalletTotal;
   _updateAdjustWalletTotal();
@@ -9747,7 +9747,7 @@ async function submitAdjustWallet() {
     showToast("✓ Carteira ajustada");
     sendRefresh();
   } catch (err) {
-    errEl.textContent = String(err.message || err);
+    _adjustWalletError(String(err.message || err));
   } finally {
     _adjustWalletState.submitting = false;
     btn.disabled = false;

--- a/tests/frontend/adjust_wallet_error.test.mjs
+++ b/tests/frontend/adjust_wallet_error.test.mjs
@@ -1,0 +1,176 @@
+/**
+ * "Ajustar carteira" falhou — o usuário tem que VER o erro.
+ *
+ * O `catch` de `submitAdjustWallet` escrevia em `errEl`, que só existe como
+ * `const` dentro de `_adjustWalletError` (dashboard.js:9723). Fora daquele
+ * escopo o nome não existe: qualquer falha do POST /adjust-balance virava
+ * `ReferenceError` DENTRO do catch — a promise rejeitava, o `finally` até
+ * destravava o botão, mas a mensagem nunca aparecia. E mesmo em escopo a linha
+ * original não mostraria nada: falta o `classList.toggle("show", …)` que
+ * `_adjustWalletError` faz, e `.modal-error` é `display:none` sem `.show`.
+ *
+ * Por isso o teste mede QUATRO coisas de uma vez: a promise não rejeita, o
+ * texto chega, a caixa fica VISÍVEL e o botão volta a clicável. Controle
+ * negativo: reverter a linha 9750 para `errEl.textContent = …` deixa
+ * `rejeitou: true` e `texto: ""`.
+ *
+ * "Visível" aqui é estilo COMPUTADO com a dashboard.css real carregada, não
+ * `classList.contains("show")` — pelo mesmo motivo de
+ * tests/frontend/onboarding_visibility.test.mjs: teste sem CSS é cego à metade
+ * do conserto. Renomear `.modal-error.show` (dashboard.css:1729) para
+ * `.modal-error.visivel` quebra a visibilidade em produção e deixa 3 destes 4
+ * testes vermelhos; medindo só o nome da classe, os 4 passavam.
+ *
+ * Como roda: mesmo padrão de dashboard_category_escape.test.mjs — o dashboard.js
+ * é script CLÁSSICO de 10 mil linhas, injetado inteiro numa página com o DOM
+ * mínimo que o topo dele exige. Zero `pageerror` no carregamento prova que o
+ * arquivo executou até o fim.
+ *
+ * Rodar:  npm run test:frontend
+ *         (ou só este: node --test tests/frontend/adjust_wallet_error.test.mjs)
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
+const DASHBOARD_JS = join(FRONTEND, "dashboard.js");
+const DASHBOARD_CSS = join(FRONTEND, "dashboard.css");
+
+/** IDs que o nível superior do dashboard.js acessa sem `?.` (grep:
+    `^document.getElementById("…").`) mais os que o `render()` toca. */
+const IDS = [
+  "grid", "bgt-overlay", "bgt-input", "investment-detail-overlay",
+  "investment-help-overlay", "edit-launch-overlay", "launch-overlay",
+  "launch-valor", "pocket-overlay", "pocket-name", "pocket-history-overlay",
+  "card-overlay", "card-name", "card-closing-day", "card-due-day",
+  "bill-detail-overlay", "pay-bill-overlay", "pay-bill-receipt-overlay",
+  "pay-bill-amount", "overview-heading", "launches-title", "launches-wrap",
+  "charts-title", "charts-grid", "alert-banner", "last-update",
+  "categories-distribution",
+  // O modal de ajustar carteira + o `#toast` que showToast() usa no sucesso.
+  "adjust-wallet-overlay", "adjust-wallet-submit", "toast",
+  "adjust-wallet-banks", "adjust-wallet-total",
+];
+
+let browser;
+before(async () => { browser = await chromium.launch(); });
+after(async () => { await browser?.close(); });
+
+async function carregar() {
+  const page = await browser.newPage();
+  const errs = [];
+  page.on("pageerror", (e) => errs.push(String(e)));
+  await page.setContent(
+    IDS.map((i) => `<div id="${i}"></div>`).join("") +
+    // .modal-error é display:none sem .show — a classe é metade do conserto,
+    // e quem a transforma em pixel é a CSS carregada logo abaixo.
+    `<div id="adjust-wallet-error" class="modal-error"></div>` +
+    // <input> de verdade, não <div>: openAdjustWalletModal() chama inp.select(),
+    // que só existe em input — e o teste de reabrir passa por lá.
+    `<input id="adjust-wallet-input">`,
+  );
+  // Promessa que nunca resolve: o IIFE de boot não pode navegar nem apagar o
+  // body (com fetch rejeitando, ele apaga — e o modal some antes do submit).
+  await page.evaluate(() => { window.fetch = () => new Promise(() => {}); });
+  await page.addStyleTag({ path: DASHBOARD_CSS });
+  await page.addScriptTag({ path: DASHBOARD_JS });
+  assert.deepEqual(errs, [], "dashboard.js não executou até o fim");
+  // DEPOIS do script, não antes: o dashboard.js DECLARA csrfHeaders (linha 78),
+  // e a declaração ganharia do stub. O original lê document.cookie, que em
+  // about:blank levanta SecurityError e mascararia o erro que estamos medindo.
+  await page.evaluate(() => { window.csrfHeaders = () => ({}); });
+  return page;
+}
+
+/**
+ * Troca o fetch pelo desfecho pedido, preenche o input, submete e devolve o
+ * estado observável do modal.
+ * @param {"ok"|"offline"|"http500"} desfecho
+ *   ok      = POST 200;
+ *   offline = o fetch REJEITA (rede caiu);
+ *   http500 = o fetch RESOLVE com !resp.ok — o outro ramo do catch, que passa
+ *             por `throw new Error(await readApiError(resp))`. É por onde caem
+ *             o 500 do servidor e o 403 de CSRF vencido, e ele não roda no
+ *             caso "offline".
+ */
+const submeter = (page, desfecho) => page.evaluate(async (responder) => {
+  window.fetch = () => ({
+    ok: Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    offline: Promise.reject(new Error("offline")),
+    // json() rejeitando = corpo não-JSON; readApiError cai no genérico com o status.
+    http500: Promise.resolve({ ok: false, status: 500, json: () => Promise.reject(new Error("não é JSON")) }),
+  })[responder];
+  document.getElementById("adjust-wallet-input").value = "10";
+  // O modal está aberto quando o usuário submete — sem isto, "fechou" passaria
+  // de graça, já que closeAdjustWalletModal() só remove a classe.
+  document.getElementById("adjust-wallet-overlay").classList.add("open");
+  let rejeitou = false;
+  try { await submitAdjustWallet(); } catch { rejeitou = true; }
+  const el = document.getElementById("adjust-wallet-error");
+  return {
+    rejeitou,
+    texto: el.textContent,
+    // O veredito é o estilo computado; `.show` fica como pista secundária.
+    visivel: getComputedStyle(el).display !== "none",
+    temShow: el.classList.contains("show"),
+    disabled: document.getElementById("adjust-wallet-submit").disabled,
+    aberto: document.getElementById("adjust-wallet-overlay").classList.contains("open"),
+    submitting: _adjustWalletState.submitting,
+  };
+}, desfecho);
+
+test("falha do POST mostra a mensagem no modal, visível e sem estourar", async () => {
+  const page = await carregar();
+  const r = await submeter(page, "offline");
+  assert.equal(r.rejeitou, false, "submitAdjustWallet rejeitou — o catch estourou");
+  assert.match(r.texto, /offline/, "a mensagem do erro não chegou ao modal");
+  assert.equal(r.visivel, true, "a caixa de erro ficou display:none — texto invisível");
+  assert.equal(r.temShow, true, "a classe .show é o mecanismo que a CSS usa");
+  assert.equal(r.disabled, false, "o finally tinha que destravar o botão");
+  await page.close();
+});
+
+test("erro HTTP (500) também aparece no modal, visível", async () => {
+  const page = await carregar();
+  const r = await submeter(page, "http500");
+  assert.equal(r.rejeitou, false, "submitAdjustWallet rejeitou — o catch estourou");
+  assert.match(r.texto, /erro 500/, "a mensagem do readApiError não chegou ao modal");
+  assert.equal(r.visivel, true, "a caixa de erro ficou display:none — texto invisível");
+  assert.equal(r.temShow, true, "a classe .show é o mecanismo que a CSS usa");
+  await page.close();
+});
+
+/**
+ * O espelho do bug de cima: lá, texto SEM `.show` (invisível); aqui, `.show`
+ * SEM texto — a caixa vazia fica VISÍVEL, uma barra vermelha de 18px no topo do
+ * modal (`.modal-error`, dashboard.css:1727). Controle negativo: trocar a linha
+ * 9711 de volta por `document.getElementById("adjust-wallet-error").textContent
+ * = ""` deixa a caixa acesa, com altura > 0.
+ */
+test("reabrir depois de uma falha não deixa caixa de erro vazia visível", async () => {
+  const page = await carregar();
+  const antes = await submeter(page, "offline");
+  assert.equal(antes.visivel, true, "pré-condição: a falha tinha que acender a caixa");
+  const depois = await page.evaluate(() => {
+    closeAdjustWalletModal();
+    openAdjustWalletModal();
+    const el = document.getElementById("adjust-wallet-error");
+    return { texto: el.textContent, altura: el.offsetHeight };
+  });
+  assert.equal(depois.texto, "", "o texto do erro anterior sobreviveu ao reabrir");
+  assert.equal(depois.altura, 0, "caixa vazia visível = barra vermelha no topo do modal");
+  await page.close();
+});
+
+test("sucesso fecha o modal e destrava o estado (controle positivo)", async () => {
+  const page = await carregar();
+  const r = await submeter(page, "ok");
+  assert.equal(r.rejeitou, false);
+  assert.equal(r.texto, "", "sucesso não pode escrever erro nenhum");
+  assert.equal(r.aberto, false, "o modal tinha que fechar no sucesso");
+  assert.equal(r.submitting, false, "o finally tinha que zerar o submitting");
+  await page.close();
+});

--- a/tests/frontend/eslint_max_lines_gate.test.mjs
+++ b/tests/frontend/eslint_max_lines_gate.test.mjs
@@ -1,0 +1,84 @@
+// Portão de tamanho: guarda o que o `5527f13` conquistou.
+//
+// A regra `quality/max-lines` vem copiada de um toolkit TypeScript, onde ela se
+// isentava sozinha por basename (`index`, `constants`, `types`, `dto`, `enum`,
+// `vo`, `*.config.*`, `*.stories.*`) e por diretório (`generated/`, `locales/`,
+// `fixtures/`, `mocks/`, `dist/`…). Aqui isso era buraco: `frontend/index.js` é
+// nome plausível num repo que já tem `frontend/index.html`, e passava com 404
+// linhas sem uma linha vermelha. As isenções foram encolhidas em
+// `eslint-rules/utils.cjs` para a única que este repo tem de verdade — os testes.
+//
+// Este arquivo existe para que ninguém as traga de volta sem perceber, e para
+// prender o NÚMERO: com uma sonda de 500 linhas, subir o teto para qualquer
+// valor até 499 passaria despercebido.
+//
+// Nada é escrito em disco: `lintText` resolve a config pelo caminho virtual,
+// então não sobra sonda esquecida em `frontend/` — e nem exige a rota que todo
+// arquivo novo de `frontend/` precisa em `frontend/routes/static_pages.py`.
+//
+// Rodar:  npm run test:frontend
+//         (ou só este: node --test tests/frontend/eslint_max_lines_gate.test.mjs)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
+
+const cwd = fileURLToPath(new URL("../..", import.meta.url));
+const eslint = new ESLint({ cwd });
+
+const LONGO = "x\n".repeat(500);
+// 351 linhas de conteúdo: uma acima do teto. É o que prende o 350.
+const UMA_ACIMA = "x\n".repeat(350) + "x";
+
+async function reports(filePath, texto = LONGO) {
+  const [res] = await eslint.lintText(texto, { filePath });
+  return res.messages.filter((m) => m.ruleId === "quality/max-lines");
+}
+
+test("basename que o toolkit isentava reprova: as isenções não podem voltar", async () => {
+  for (const nome of ["constants.js", "index.js", "types.js", "pb.config.js"]) {
+    const msgs = await reports(`frontend/${nome}`);
+    assert.equal(msgs.length, 1, `frontend/${nome} passou silencioso`);
+    assert.equal(msgs[0].severity, 2, `frontend/${nome} não está em error`);
+  }
+});
+
+test("diretório que o toolkit isentava reprova igual", async () => {
+  for (const caminho of ["frontend/mocks/m.js", "frontend/fixtures/f.js"]) {
+    const msgs = await reports(caminho);
+    assert.equal(msgs.length, 1, `${caminho} passou silencioso`);
+  }
+});
+
+test("arquivo comum de frontend/ reprova em error", async () => {
+  const msgs = await reports("frontend/nome_que_ninguem_isenta.js");
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].severity, 2);
+});
+
+test("legado da lista de escape não é reportado (o portão não reprova tudo)", async () => {
+  assert.deepEqual(await reports("frontend/dashboard.js"), []);
+});
+
+test("teste de frontend fica em warn, não error", async () => {
+  const msgs = await reports("tests/frontend/qualquer.test.mjs");
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].severity, 1);
+});
+
+test("351 linhas já reprovam: o teto guardado é 350, não 'algum teto'", async () => {
+  const msgs = await reports("frontend/nome_que_ninguem_isenta.js", UMA_ACIMA);
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].severity, 2);
+});
+
+test("350 linhas com \\n final passam limpo: o que prende a CONTAGEM", async () => {
+  // Simétrico do caso acima, e o único que enxerga o off-by-one: `sourceCode.lines`
+  // traz um elemento vazio depois do \n final. Sem o desconto do core-rules.cjs este
+  // arquivo reprova ("351 lines | max 350") enquanto o `wc -l` diz 350 — e baixar o
+  // teto de 350 também deixa de passar despercebido.
+  assert.deepEqual(
+    await reports("frontend/nome_que_ninguem_isenta.js", "x\n".repeat(350)),
+    [],
+  );
+});


### PR DESCRIPTION
Sobra de um ciclo de revisão do [#258](https://github.com/JapaLcK/Bot_Financeiro/pull/258) que o merge não levou junto. **Os dois defeitos de gate que aquele ciclo achou você já consertou no `5527f13`**, na origem — encolhendo as isenções no `utils.cjs` e acertando a contagem. Este PR não mexe nisso; traz o que ficou de fora.

## Bug de produção — 2 linhas

`submitAdjustWallet` escrevia num `errEl` que só existe dentro de outra função: **`ReferenceError`** quando o `POST /account/{id}/adjust-balance` falha, e o usuário via o clique sumir sem mensagem nenhuma. Mesmo em escopo não mostraria nada — falta o `classList.toggle("show")`, e `.modal-error` é `display:none` sem `.show`.

Varrendo a **categoria** em vez do caso, apareceu o simétrico 39 linhas acima: `openAdjustWalletModal` limpava o texto e **deixava** a classe, então reabrir depois de uma falha mostrava uma barra vermelha vazia de 18px — medido no navegador, com a `dashboard.css` real. Os dois agora chamam `_adjustWalletError`, que já existia. Os 5 modais irmãos foram conferidos um a um: todos já tinham o par `hide*Error()`/`show*Error()` chamado na abertura, o de carteira era o único fora do padrão.

Com isso o `no-undef` zera e sobe para `error` — e isso torna verdade uma coisa nova, escrita na config: **global de CDN usada sem entrar na lista `globals` passa a reprovar o CI**, não mais a avisar.

## Dois testes

**`adjust_wallet_error.test.mjs`** cobre os dois consertos. Ele nasceu verificando `classList.contains` — o *nome* da classe — e isso era cego à metade CSS do bug: renomeando `.modal-error.show` na folha de estilo, os 4 casos ficavam **verdes** com a caixa invisível. Agora carrega a `dashboard.css` real e mede `display` computado e `offsetHeight`; com a CSS quebrada, 3 dos 4 caem.

**`eslint_max_lines_gate.test.mjs`** guarda o seu conserto do `5527f13`, que hoje não tem rede nenhuma — é o único arquivo do repo que exercita `core-rules.cjs`/`utils.cjs`. As duas sondas guardam **direções opostas**, e isso é o desenho: 351 linhas reprovam (prende o teto por cima) e 350 linhas *com* `\n` final passam limpo (prende a contagem — e faz baixar o teto deixar de passar despercebido). Usa `lintText`, então não escreve arquivo em disco: nada de sonda esquecida em `frontend/`, nada de rota nova em `static_pages.py`.

## Quatro frases falsas no comentário da config

Diziam que `handlers_inline.test.mjs` cobre a classe "global morta" — não cobre, ele roda só HTML→JS. Que os 73 avisos eram "todos falso positivo" — são 70; os outros 3 são código morto real, agora nomeados com linha, data e o `grep` que remede. Que o `dashboard.html` tem 139 `onclick=` — tem 107. E citavam um "relatório do burndown" que não existe como arquivo.

## Verificação

| o quê | resultado |
|---|---|
| `npx eslint .` | 0 erros, 209 avisos, exit 0 |
| `npm run test:frontend` | **309/309** |
| reverter as 2 linhas do `dashboard.js` | 3 de 4 casos caem |
| desfazer o desconto da linha vazia no `core-rules.cjs` | o caso das 350 cai |
| baixar o teto para 100 | idem |
| reintroduzir as isenções por basename no `utils.cjs` | cai exatamente o caso que guarda isso |

## Não verificado

Nada disto passou pelo aparelho nem pós-deploy — o app carrega o site ao vivo. O `fetch` é stub nos 4 casos, então o servidor nunca respondeu; e o corpo real da API (`{"detail": …}`, tratado em três formas por `readApiError`) não é exercitado por nenhum deles.

Passou pelo ciclo completo Arquiteto → Coder → Tester → Manager, com o Tester atacando também o *port* nesta base nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)