### PR TITLE
A confirmação de fatura futura lê "hoje" em São Paulo, não em UTC

### DIFF
--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -533,6 +533,16 @@ function appTzWallClockToISO(localStr) {
   return new Date(asUTC - offsetMin * 60000).toISOString();
 }
 
+// "Hoje" em APP_TZ, como YYYY-MM-DD. Caminho OPOSTO ao de `appTzWallClockToISO`
+// (que vai de parede pra instante): aqui um instante vira o DIA de calendário em
+// São Paulo. `new Date().toISOString().slice(0,10)` dá o dia em UTC — das 21:00 às
+// 23:59 de SP isso já é amanhã, para TODO usuário; e `_isoDate(new Date())` dá o
+// dia do APARELHO, que erra para quem viaja. Issue #257.
+function appTodayIso(now = new Date()) {
+  const p = _wallPartsInTZ(now, APP_TZ);
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
 const fmtDate = iso => {
   const d = _isoToDate(iso);
   if (!d) return "—";
@@ -4470,7 +4480,7 @@ async function loadBillsView(_forceFresh = false, { background = false } = {}) {
   }
 }
 
-const _billToday = () => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; };
+const _billToday = () => new Date(appTodayIso() + "T00:00:00");
 const _billDate = (b) => { const d = new Date(b.due_date + "T00:00:00"); d.setHours(0, 0, 0, 0); return d; };
 const _billDaysUntil = (b) => Math.round((_billDate(b) - _billToday()) / 86400000);
 function _billOverdue(b) { return _billDaysUntil(b) < 0; }
@@ -9779,7 +9789,7 @@ async function submitPayBill() {
 
   // Confirmação extra ao antecipar fatura futura — comum em parcelamento
   // (paga 3/3 antes de 1/3 e 2/3). Não bloqueia, só avisa pra evitar erro.
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const todayIso = appTodayIso();
   if (b.period_end && b.period_end > todayIso) {
     const ok = await confirmModal(
       `${b.card_name} · ${b.label || ""} ainda não fechou (vence depois de hoje). ` +

--- a/tests/frontend/fatura_futura_app_tz.test.mjs
+++ b/tests/frontend/fatura_futura_app_tz.test.mjs
@@ -1,0 +1,183 @@
+/**
+ * "Hoje" na confirmação de antecipar fatura tem de ser o dia em APP_TZ
+ * (São Paulo), não o dia em UTC nem o do aparelho. Issue #257.
+ *
+ * O bug: `const todayIso = new Date().toISOString().slice(0, 10)` — `toISOString`
+ * devolve UTC. Às 21:30 de 02/09 em São Paulo (2026-09-03T00:30:00Z) o `todayIso`
+ * já vale "2026-09-03", então uma fatura que fecha AMANHÃ (`period_end`
+ * "2026-09-03") falha na comparação estrita `>` e o modal "Antecipar fatura?"
+ * NÃO abre. O usuário paga 3/3 antes de 1/3 sem a confirmação que existe
+ * justamente para isso. Erra para 100% dos usuários das 21:00 às 23:59 de SP,
+ * mesmo com o celular em Brasília — é a diferença desta ocorrência para as
+ * outras da mesma família no arquivo, que leem o fuso do APARELHO e só erram
+ * para quem está fora de São Paulo. A lista delas está na issue #257.
+ *
+ * Instante congelado: 2026-09-03T00:30:00Z.
+ *   SP  → 2026-09-02   |   UTC → 2026-09-03
+ *
+ * Controles NEGATIVOS — MEDIDOS um a um (04/09/2026), os três injetados em casos
+ * que estavam VERDES:
+ *  - `todayIso` de volta para `new Date().toISOString().slice(0, 10)` (o bug
+ *    original): 4 passam, 2 falham — o 1º E o 4º. O 4º entra junto porque em
+ *    Tóquio o dia UTC também é 03/09; não é o alvo dele, mas conta.
+ *  - a CHAMADA em `submitPayBill` (`frontend/dashboard.js`, o `const todayIso =`)
+ *    trocada de `appTodayIso()` para `_isoDate(new Date())` — a tentação óbvia,
+ *    "hoje" pelo fuso do APARELHO: 5 passam, falha SÓ o 4º. É a medição que
+ *    justifica o caso 4 existir: sem ele este arquivo aceitaria a correção errada.
+ *    O ponto de injeção importa: mutar o CORPO de `appTodayIso` (`return
+ *    _isoDate(now)`) é outra mutação, porque alcança os DOIS chamadores — medida
+ *    também, dá 3 passam / 3 falham (4º, 5º e 6º).
+ *  - `_billToday` de volta para `{ const d = new Date(); d.setHours(0,0,0,0);
+ *    return d; }`: 4 passam, falham o 5º e o 6º (em Tóquio já é 03/09, então a
+ *    fatura de hoje-em-SP aparece vencida e a de ontem conta -2 dias).
+ * Controles POSITIVOS: 2º e 3º provam que a confirmação NÃO passou a aparecer
+ * sempre (fatura de hoje e fatura velha seguem pagando direto — se ela virasse
+ * incondicional, os dois ficariam vermelhos); o 6º prova que `_billOverdue` não
+ * virou constante `false`.
+ *
+ * Como roda: mesma receita do edit_launch_patch_body.test.mjs — o `dashboard.js`
+ * é script CLÁSSICO, injetado inteiro numa página com o DOM mínimo que o topo
+ * dele exige. O modal NÃO é aberto: `payBillState` é `let` global, então dá para
+ * montar o estado e chamar `submitPayBill()` direto.
+ *
+ * Rodar:  npm run test:frontend
+ *         (ou só este: node --test tests/frontend/fatura_futura_app_tz.test.mjs)
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const FRONTEND = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "frontend");
+const DASHBOARD_JS = join(FRONTEND, "dashboard.js");
+
+/** 21:30 de 02/09 em São Paulo — dentro da janela 21:00-23:59 que o bug abre. */
+const AGORA = "2026-09-03T00:30:00.000Z";
+
+/** IDs que o nível superior do dashboard.js acessa sem `?.`, mais os três que o
+    `submitPayBill` toca no caminho de erro. */
+const IDS = [
+  "grid", "bgt-overlay", "bgt-input", "investment-detail-overlay",
+  "investment-help-overlay", "launch-overlay",
+  "launch-valor", "pocket-overlay", "pocket-name", "pocket-history-overlay",
+  "card-overlay", "card-name", "card-closing-day", "card-due-day",
+  "bill-detail-overlay", "pay-bill-overlay", "pay-bill-receipt-overlay",
+  "overview-heading", "launches-title", "launches-wrap",
+  "charts-title", "charts-grid", "alert-banner", "last-update",
+  "categories-distribution", "launch-success-toast",
+  "edit-launch-overlay", "pay-bill-error", "pay-bill-submit-btn",
+];
+
+let browser;
+before(async () => { browser = await chromium.launch(); });
+after(async () => { await browser?.close(); });
+
+async function abrir(timezoneId) {
+  const page = await browser.newPage({ timezoneId });
+  const errs = [];
+  page.on("pageerror", (e) => errs.push(String(e)));
+  // `setFixedTime` (e não `install`): congela só o relógio, sem parar os timers
+  // — com os timers parados o `await submitPayBill()` poderia nunca voltar.
+  // Antes do goto/addScriptTag, senão o `dashboard.js` já teria lido a hora real.
+  await page.clock.setFixedTime(new Date(AGORA));
+  await page.route("https://pigbank.test/**", (route) =>
+    route.fulfill({
+      contentType: "text/html",
+      body: IDS.map((i) => `<div id="${i}"></div>`).join("")
+        + `<input id="pay-bill-amount">`,
+    }),
+  );
+  await page.goto("https://pigbank.test/dashboard");
+  await page.evaluate(() => { window.fetch = () => new Promise(() => {}); });
+  await page.addScriptTag({ path: DASHBOARD_JS });
+  assert.deepEqual(errs, [], "dashboard.js não executou até o fim");
+
+  // SANIDADE DUPLA. Sem as duas, o arquivo inteiro é teatro: se o relógio não
+  // congelar, "hoje" é o dia real da máquina e nenhum caso mede o que diz medir;
+  // se o fuso não pegar, o caso 4 vira o caso 1 com outro nome.
+  const amb = await page.evaluate(() => ({
+    agora: new Date().toISOString(),
+    tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  }));
+  assert.equal(amb.agora, AGORA, "o relógio da página não ficou congelado");
+  assert.equal(amb.tz, timezoneId, "o Chromium não entrou no fuso pedido");
+  return page;
+}
+
+/** Monta `payBillState`, espiona o `confirmModal` (respondendo "não", para o
+    fluxo parar ali) e chama `submitPayBill`. Devolve quantas vezes perguntou. */
+const pagar = (page, periodEnd) => page.evaluate(async (pe) => {
+  payBillState = {
+    balance: 1000,
+    bills: [{
+      id: 1, due_amount: 100, period_end: pe,
+      card_name: "Nubank", label: "set",
+    }],
+    selectedId: 1,
+    submitting: false,
+  };
+  window.__perguntas = [];
+  confirmModal = (msg) => { window.__perguntas.push(msg); return Promise.resolve(false); };
+  window.fetch = () => Promise.reject(new Error("rede desligada no teste"));
+  document.getElementById("pay-bill-amount").value = "100";
+  await submitPayBill();
+  return {
+    perguntou: window.__perguntas.length,
+    erro: document.getElementById("pay-bill-error").textContent,
+  };
+}, periodEnd);
+
+test("21:30 em SP: fatura que fecha AMANHÃ ainda pede confirmação", async () => {
+  // O caso do bug. Em UTC já é 03/09, então "2026-09-03" > hoje dava false.
+  const page = await abrir("America/Sao_Paulo");
+  const r = await pagar(page, "2026-09-03");
+  assert.equal(r.perguntou, 1, "pagou fatura futura sem perguntar (o bug da #257)");
+  await page.close();
+});
+
+test("fatura que fecha HOJE em SP não pede confirmação (positivo)", async () => {
+  const page = await abrir("America/Sao_Paulo");
+  const r = await pagar(page, "2026-09-02");
+  assert.equal(r.perguntou, 0, "passou a perguntar em fatura que já fechou");
+  assert.match(r.erro, /rede desligada/, "nem chegou a tentar pagar");
+  await page.close();
+});
+
+test("fatura velha não pede confirmação (positivo)", async () => {
+  const page = await abrir("America/Sao_Paulo");
+  const r = await pagar(page, "2026-08-20");
+  assert.equal(r.perguntou, 0, "passou a perguntar em fatura vencida");
+  await page.close();
+});
+
+test("aparelho em Asia/Tokyo: 'hoje' continua sendo o de SÃO PAULO", async () => {
+  // No MESMO instante, em Tóquio já é 03/09. Um conserto que lesse o fuso do
+  // APARELHO (`_isoDate(new Date())`) deixaria "2026-09-03" > "2026-09-03"
+  // false e este caso VERMELHO — é ele que separa o conserto certo do errado.
+  const page = await abrir("Asia/Tokyo");
+  const r = await pagar(page, "2026-09-03");
+  assert.equal(r.perguntou, 1, "leu 'hoje' pelo fuso do aparelho, não por APP_TZ");
+  await page.close();
+});
+
+/** `_billToday` é o par disto na tela de faturas: mesmo defeito, mesmo remédio. */
+const diasAte = (page, dueDate) => page.evaluate(
+  (d) => ({
+    dias: _billDaysUntil({ due_date: d }),
+    vencida: _billOverdue({ due_date: d }),
+  }),
+  dueDate,
+);
+
+test("Asia/Tokyo: boleto que vence hoje-em-SP não aparece vencido", async () => {
+  const page = await abrir("Asia/Tokyo");
+  assert.deepEqual(await diasAte(page, "2026-09-02"), { dias: 0, vencida: false });
+  await page.close();
+});
+
+test("Asia/Tokyo: boleto de ontem-em-SP continua vencido (positivo)", async () => {
+  const page = await abrir("Asia/Tokyo");
+  assert.deepEqual(await diasAte(page, "2026-09-01"), { dias: -1, vencida: true });
+  await page.close();
+});


### PR DESCRIPTION
Refs #257 — **primeira fatia**, e a issue continua ABERTA de propósito: é ela
que carrega a tabela dos sítios restantes desta família, e não há outro
tracker para eles.

## O bug, e por que ele é de outra severidade

`frontend/dashboard.js`, em `submitPayBill`:

```js
const todayIso = new Date().toISOString().slice(0, 10);   // UTC
if (b.period_end && b.period_end > todayIso) { /* modal "Antecipar fatura?" */ }
```

`toISOString()` devolve **UTC**. Instante concreto, medido:

```
2026-09-03T00:30:00Z  ->  SP: 2026-09-02  |  UTC: 2026-09-03

"2026-09-03" > UTC hoje  -> false   (não abre o modal — o bug)
"2026-09-03" > SP  hoje  -> true    (abre — o correto)
```

Das **21:00 às 23:59 de São Paulo, todo dia**, uma fatura que fecha **amanhã**
perde a comparação estrita `>` e o modal não abre. O usuário paga uma fatura
futura — 3/3 antes de 1/3 — sem a confirmação que existe exatamente para
evitar isso.

**UTC × fuso do aparelho, e por que a distinção decide o escopo.** As outras
ocorrências da mesma família no arquivo (`const NOW = new Date()`,
`viewYear`/`viewMonth`, `todayY`/`todayM`, os defaults de recorrência…) leem o
**fuso do aparelho**: elas só erram para quem está fora de São Paulo. Esta lê
**UTC**, que não é o fuso de ninguém — ela erra para **100% dos usuários**
naquela janela, mesmo com o celular em Brasília. Outra população, outra
severidade, outro PR. **Elas estão declaradas fora de escopo aqui** e ficam
para a #257, que tem a tabela — exceto o `_billToday`, que é o **par direto**
desta ocorrência e entra junto (§2, edição 3 abaixo).

### O que a classe "dia em UTC" tem depois deste PR

Contagens **medidas em 04/09/2026 neste HEAD** — remeça antes de reusar (§2):

```
$ grep -c "new Date()" frontend/dashboard.js
25
$ grep -rn "toISOString()\.slice(0, *10)" frontend/
frontend/dashboard.js:538 e :539   <- só o comentário que explica o conserto
```

A classe **"dia em UTC" ficou fechada no `frontend/` inteiro**, não só neste
arquivo: sobra zero em código, e os dois hits são a prosa do comentário novo.
Os 25 `new Date()` restantes são a outra classe (fuso do aparelho), inventariada
na #257.

A fatura que fecha **hoje** não é caso afetado: não abre o modal nas duas
versões.

## O conserto — 3 edições em `frontend/dashboard.js`

1. **`appTodayIso(now = new Date())`**, junto dos irmãos de fuso, logo depois
   do `appTzWallClockToISO`. Sobre o `_wallPartsInTZ` que já existia (§0.1) —
   ele já devolve `year`/`month`/`day` em 2 dígitos via `en-CA`, só faltava
   concatenar. É o caminho **oposto** ao do `appTzWallClockToISO` (parede →
   instante); aqui é instante → dia de calendário em `APP_TZ`. Não havia irmão
   para isso: o `_isoDate` formata pelo fuso do **aparelho** e é da classe do
   problema, não a solução.
2. o `todayIso` de `submitPayBill` passa a usar `appTodayIso()`.
3. **`_billToday`** vira `new Date(appTodayIso() + "T00:00:00")`. É o **par**
   disto na tela de faturas (§2): mesmo defeito, mesmo remédio, e o mesmo
   idioma do `_billDate` da linha seguinte — então a aritmética do
   `_billDaysUntil` fica no mesmo frame. Para aparelho em SP o resultado é
   idêntico ao anterior; é conserto para quem viaja.

Diff: **12 inserções, 2 remoções** num arquivo só.

## O teste

`tests/frontend/fatura_futura_app_tz.test.mjs` — 6 casos, relógio congelado em
`2026-09-03T00:30:00Z` com `page.clock.setFixedTime` (e não `install`, que
pararia os timers e travaria o `await submitPayBill()`), `dashboard.js` inteiro
injetado num Chromium.

**Sanidade dupla antes de cada caso**, senão o arquivo seria teatro: dentro da
página, `new Date().toISOString()` tem de dar exatamente
`2026-09-03T00:30:00.000Z` **e** `Intl…resolvedOptions().timeZone` tem de ser o
fuso pedido.

| # | fuso | `period_end` | esperado | papel |
|---|---|---|---|---|
| 1 | `America/Sao_Paulo` | `2026-09-03` (amanhã em SP) | pergunta | **o bug** |
| 2 | `America/Sao_Paulo` | `2026-09-02` (hoje em SP) | não pergunta | positivo |
| 3 | `America/Sao_Paulo` | `2026-08-20` | não pergunta | positivo |
| 4 | **`Asia/Tokyo`** | `2026-09-03` | pergunta | **recusa o conserto ERRADO** |
| 5 | `Asia/Tokyo` | vence hoje-em-SP | `_billOverdue` false | o par `_billToday` |
| 6 | `Asia/Tokyo` | venceu ontem-em-SP | `-1 dia`, vencido | positivo |

O caso 4 é o que importa: em Tóquio, **no mesmo instante**, já é dia 03. Um
conserto que usasse o fuso do **aparelho** (`_isoDate(new Date())` — a tentação
óbvia) fica verde nos casos 1-3 e vermelho nele. Sem o caso 4, este arquivo
aceitaria a correção errada.

### Controles negativos — medidos um a um, injetados em casos que estavam verdes

| mutação | resultado medido |
|---|---|
| `todayIso` de volta para `new Date().toISOString().slice(0,10)` | **4 passam, falham o 1º e o 4º** |
| a **chamada** em `submitPayBill` (`const todayIso =`) → `_isoDate(new Date())` | **5 passam, falha SÓ o 4º** |
| `_billToday` de volta para `d.setHours(0,0,0,0)` | **4 passam, falham o 5º e o 6º** |

**O ponto de injeção da 2ª muda o resultado, e por isso está nomeado.** Mutar o
**corpo** de `appTodayIso` (`return _isoDate(now)`) alcança os **dois**
chamadores: medido, dá **3 passam / 3 falham** (4º, 5º e 6º). A linha da tabela
é a outra leitura — trocar só a chamada dentro de `submitPayBill`. As duas
foram rodadas; o cabeçalho do teste registra ambas.

Duas medições saíram **mais amplas** que a previsão do plano, e ficam
registradas como medidas: a 1ª derruba também o caso 4 (em Tóquio o dia UTC
também é 03/09), e a 3ª derruba também o caso 6 (com meia-noite do aparelho em
Tóquio, ontem-em-SP conta −2 dias e não −1).

**Controles positivos:** 2º e 3º provam que a confirmação não passou a aparecer
sempre — se ela virasse incondicional, os dois ficariam vermelhos; o 6º prova
que `_billOverdue` não virou constante `false`.

## Suítes — comparadas por NOME contra a baseline da mesma árvore

| | baseline (`origin/main`, 346270d) | depois |
|---|---|---|
| `pytest -q` | **5833 passed, 4 xfailed, 0 falhas** | **5833 passed, 4 xfailed, 0 falhas** |
| `npm run test:frontend` | 307 testes: **306 pass, 1 fail** | 313 testes: **312 pass, 1 fail** |

A única falha do frontend é a **mesma, pelo nome**, antes e depois:
`tests/frontend/eslint_max_lines_gate.test.mjs`, com
`ERR_MODULE_NOT_FOUND: Cannot find package 'eslint'` — o `eslint` não está
instalado no `node_modules` desta máquina. É ambiente, não regressão; no CI ele
roda. `dashboard.js` está na lista de escape da regra `quality/max-lines`, então
as 12 linhas novas não o alcançariam de qualquer forma.

Guarda **19.1** (`tests/test_fuso_do_app.py::test_o_app_tz_do_dashboard_e_o_mesmo_fuso_padrao_do_servidor`)
conferida isolada: **verde**. O helper novo só **lê** `APP_TZ` (não cria segunda
atribuição) e usa `_wallPartsInTZ(now, APP_TZ)` — nome de variável diferente dos
três `_APP_TZ_USOS` que a guarda exige, que continuam intactos.

## O que NÃO foi verificado

**O efeito na tela real.** O app carrega o site ao vivo (§5), então nada disto
aparece antes do deploy. A verificação no aparelho é: **entre 21:00 e 23:59 de
São Paulo**, abrir uma fatura que fecha **amanhã** e confirmar que o modal
"Antecipar fatura?" aparece.

## Nota de deploy

`stamp_asset_versions` re-hasheia o `dashboard.js` inteiro: **~517 KB são
rebaixados para todo cliente** neste deploy. Se houver outra mudança no arquivo
na fila, vale agrupar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

