### PR TITLE
O DDL para de mentir sobre a FK de system_event_logs, e o parâmetro morto sai do loadBillsView

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -119,7 +119,13 @@ async def ensure_admin_tables():
                     event_type TEXT NOT NULL,
                     message TEXT NOT NULL,
                     source TEXT,
-                    user_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+                    -- CASCADE (nao SET NULL): log de sistema e dado do titular
+                    -- e vai junto com a conta -- coerente com db/privacy.py, que
+                    -- ja faz `delete` puro nesta tabela. Quem VALE em runtime e o
+                    -- repair_user_fk_cascades (db/schema_repairs.py), que converge
+                    -- toda FK em users(id) a cada init_db; este DDL so precisava
+                    -- parar de declarar o oposto. Ver #221.
+                    user_id BIGINT REFERENCES users(id) ON DELETE CASCADE,
                     details JSONB,
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                 )

--- a/db/schema_repairs.py
+++ b/db/schema_repairs.py
@@ -33,6 +33,15 @@ _USER_FK_SET_NULL_TABLES: frozenset[str] = frozenset({
     # pessoas vivas — a conversão histórica não pode encolher quando uma conta
     # é excluída. O evento sobrevive anonimizado (user_id nulo).
     "checkout_funnel_events",
+    # Registro de compliance de acesso a PII: "alguém leu tal campo de tal
+    # titular, em tal data, com tal propósito" (purpose/actor/field). A coluna
+    # da FK é `subject_user_id` — o TITULAR cujo dado foi lido, não o autor do
+    # acesso —, então CASCADE apagaria a trilha justamente de quem pediu
+    # exclusão, destruindo a prova de que o acesso foi legítimo. O
+    # `db/privacy.py` não apaga esta tabela (nem no reset, nem no
+    # delete_user_data): a linha sobrevive anonimizada, com subject_user_id
+    # nulo.
+    "pii_access_log",
 })
 
 

--- a/frontend/dashboard.js
+++ b/frontend/dashboard.js
@@ -4151,7 +4151,7 @@ async function saveRecurring() {
                      : (isBill ? "✓ Conta a pagar cadastrada" : "✓ Gasto fixo cadastrado"));
     _recurringCache = null;
     loadFixedView(true);           // re-render gastos fixos (sem await)
-    if (isBill) loadBillsView(true);
+    if (isBill) loadBillsView();
     sendRefresh();
   } catch (err) {
     // Reabre modal com dados preservados pro user corrigir
@@ -4443,7 +4443,7 @@ async function _fetchBills({ force = false } = {}) {
   }, { force });
 }
 
-async function loadBillsView(_forceFresh = false, { background = false } = {}) {
+async function loadBillsView({ background = false } = {}) {
   const agendaEl = document.getElementById("recurring-bills-agenda");
   if (!agendaEl) return;
   loadForecast();  // independente dos boletos; o próprio gate cuida do não-Pro
@@ -4613,7 +4613,7 @@ async function payBill(billId, estimate, name, variavel) {
       throw new Error(await _errDetail(resp));
     }
     showToast(`✓ Boleto pago: ${_fmtBRL(amount)}`);
-    loadBillsView(true);
+    loadBillsView();
     sendRefresh();
   } catch (err) {
     await alertModal(String(err.message || err), { title: "Erro ao pagar" });
@@ -4655,7 +4655,7 @@ async function quickAddBoleto() {
     showToast("✓ Boleto adicionado");
     nameEl.value = ""; amtEl.value = "";  // mantém a data (costuma cadastrar vários próximos)
     nameEl.focus();
-    loadBillsView(true);
+    loadBillsView();
     sendRefresh();
   } catch (err) {
     await alertModal(String(err.message || err), { title: "Erro ao adicionar" });
@@ -4684,7 +4684,7 @@ async function editBoleto(id, name, amount, dueISO) {
       throw new Error(await _errDetail(resp));
     }
     showToast("✓ Boleto atualizado");
-    loadBillsView(true);
+    loadBillsView();
   } catch (err) {
     await alertModal(String(err.message || err), { title: "Erro ao editar" });
   }
@@ -4704,7 +4704,7 @@ async function deleteBoleto(id, name) {
       throw new Error(await _errDetail(resp));
     }
     showToast(" Boleto apagado");
-    loadBillsView(true);
+    loadBillsView();
   } catch (err) {
     await alertModal(String(err.message || err), { title: "Erro ao apagar" });
   }
@@ -11149,7 +11149,7 @@ function _pbDashboardRefresh() {
     case "fixed":
       if (_recurringTab === "overview") return loadRecurringOverview({ background: true });
       if (_recurringTab === "incomes")  return loadRecurringIncomeView(true, { background: true });
-      if (_recurringTab === "bills")    return loadBillsView(true, { background: true });
+      if (_recurringTab === "bills")    return loadBillsView({ background: true });
       return loadFixedView(true, { background: true });
     case "goals":        return loadGoalsView(true, { background: true });
     // Afiliado: o fetch-antes-de-render + preservação da chave Pix agora vive

--- a/tests/test_schema_repairs.py
+++ b/tests/test_schema_repairs.py
@@ -137,16 +137,6 @@ def _declared_user_fk_actions() -> dict[str, set[str]]:
     return declared
 
 
-# Divergência conhecida e AINDA SEM DECISÃO DO DONO. A #221 decidiu apenas
-# `system_event_logs`. `pii_access_log` declara SET NULL no DDL e roda CASCADE
-# (o repair converte a cada boot), e a escolha ali é genuinamente aberta: é um
-# audit de acesso a PII, e o irmão mais próximo (`auth_login_events`) é SET NULL
-# de propósito. Resolver exige decisão do dono, não o palpite de quem passou.
-# Ao decidir: ou o DDL vira CASCADE, ou a tabela entra em
-# _USER_FK_SET_NULL_TABLES — e esta linha sai junto.
-_PENDENTE_DECISAO_DO_DONO = frozenset({"pii_access_log"})
-
-
 def test_ddl_nao_contradiz_o_alvo_do_repair():
     """Nenhuma FK em users(id) pode declarar no DDL um `on delete` que o
     `repair_user_fk_cascades` vá sobrescrever no boot seguinte."""
@@ -163,10 +153,49 @@ def test_ddl_nao_contradiz_o_alvo_do_repair():
         if actions != {alvo}:
             divergentes[table] = {"ddl": sorted(actions), "repair": alvo}
 
-    inesperadas = set(divergentes) - _PENDENTE_DECISAO_DO_DONO
-    assert not inesperadas, (
+    assert not divergentes, (
         "DDL declara um `on delete` que o repair_user_fk_cascades sobrescreve: "
-        + repr({t: divergentes[t] for t in sorted(inesperadas)})
+        + repr({t: divergentes[t] for t in sorted(divergentes)})
         + ". Alinhe o DDL com _USER_FK_SET_NULL_TABLES (db/schema_repairs.py) — "
         "quem vale em runtime é o repair, não o `create table if not exists`."
     )
+
+
+def test_delete_user_preserva_linha_de_pii_access_log(user_id):
+    """Efeito da decisão do dono: `pii_access_log` é SET NULL, então apagar o
+    titular ANONIMIZA a linha de compliance em vez de destruí-la.
+
+    Controle negativo: tire "pii_access_log" de _USER_FK_SET_NULL_TABLES e o
+    repair converte a FK para CASCADE — o delete leva a linha junto e o
+    `select` abaixo não acha nada.
+    """
+    from conftest import _cleanup_user
+
+    with get_conn() as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            repair_user_fk_cascades(cur)  # aplica o alvo atual à FK real
+            assert _fk_action(cur, "pii_access_log") == "n"
+
+            cur.execute(
+                """
+                insert into pii_access_log (purpose, actor, subject_user_id, field)
+                values ('test_fk', 'system:test', %s, 'email')
+                returning id
+                """,
+                (user_id,),
+            )
+            row_id = cur.fetchone()["id"]
+            try:
+                _cleanup_user(user_id)  # o delete real da conta (users + filhos)
+
+                cur.execute(
+                    "select subject_user_id, purpose from pii_access_log where id = %s",
+                    (row_id,),
+                )
+                row = cur.fetchone()
+                assert row is not None, "CASCADE apagou a trilha de compliance"
+                assert row["subject_user_id"] is None
+                assert row["purpose"] == "test_fk"  # o resto do registro sobrevive
+            finally:
+                cur.execute("delete from pii_access_log where id = %s", (row_id,))

--- a/tests/test_schema_repairs.py
+++ b/tests/test_schema_repairs.py
@@ -1,8 +1,11 @@
 """
 Testa db/schema_repairs — migrations que corrigem FKs em users(id).
 """
+import re
+from pathlib import Path
+
 from db import get_conn
-from db.schema_repairs import repair_user_fk_cascades
+from db.schema_repairs import _USER_FK_SET_NULL_TABLES, repair_user_fk_cascades
 
 
 def _fk_action(cur, table_name: str, constraint_name: str | None = None) -> str | None:
@@ -88,3 +91,82 @@ def test_repair_is_idempotent():
             repair_user_fk_cascades(cur)  # garante estado correto
             second = repair_user_fk_cascades(cur)
             assert second == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §0.7: DDL × configuração do repair — duas fontes para a MESMA regra.
+#
+# `create table if not exists` nunca converge tabela que já existe, então o que
+# vale em runtime é sempre o `repair_user_fk_cascades`, chamado em todo
+# `init_db` (db/schema.py). Um DDL que declare o oposto do alvo do repair é
+# documentação que mente: ele é sobrescrito no boot seguinte.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DDL_FILES = ("db/schema.py", "core/admin_dashboard.py")
+
+_TABLE_RE = re.compile(
+    r"(?:create\s+table\s+(?:if\s+not\s+exists\s+)?|alter\s+table\s+)([a-z_][a-z0-9_]*)",
+    re.I,
+)
+_USER_FK_RE = re.compile(
+    r"references\s+users\s*\(\s*id\s*\)\s*(?:on\s+delete\s+(cascade|set\s+null|no\s+action))?",
+    re.I,
+)
+
+
+def _declared_user_fk_actions() -> dict[str, set[str]]:
+    """Lê o DDL do código: tabela -> {`on delete` declarado} de cada FK em users(id).
+
+    Sem cláusula explícita = `no action` (o default do Postgres).
+    """
+    declared: dict[str, set[str]] = {}
+    for rel in _DDL_FILES:
+        text = (_ROOT / rel).read_text(encoding="utf-8")
+        marks = [(m.start(), m.group(1).lower()) for m in _TABLE_RE.finditer(text)]
+        for fk in _USER_FK_RE.finditer(text):
+            table = None
+            for pos, name in marks:
+                if pos >= fk.start():
+                    break
+                table = name
+            if table is None:
+                continue
+            action = " ".join((fk.group(1) or "no action").lower().split())
+            declared.setdefault(table, set()).add(action)
+    return declared
+
+
+# Divergência conhecida e AINDA SEM DECISÃO DO DONO. A #221 decidiu apenas
+# `system_event_logs`. `pii_access_log` declara SET NULL no DDL e roda CASCADE
+# (o repair converte a cada boot), e a escolha ali é genuinamente aberta: é um
+# audit de acesso a PII, e o irmão mais próximo (`auth_login_events`) é SET NULL
+# de propósito. Resolver exige decisão do dono, não o palpite de quem passou.
+# Ao decidir: ou o DDL vira CASCADE, ou a tabela entra em
+# _USER_FK_SET_NULL_TABLES — e esta linha sai junto.
+_PENDENTE_DECISAO_DO_DONO = frozenset({"pii_access_log"})
+
+
+def test_ddl_nao_contradiz_o_alvo_do_repair():
+    """Nenhuma FK em users(id) pode declarar no DDL um `on delete` que o
+    `repair_user_fk_cascades` vá sobrescrever no boot seguinte."""
+    declared = _declared_user_fk_actions()
+
+    # Piso anti-tautologia: se o parser não achar o DDL (regex quebrada, arquivo
+    # movido), o teste passaria vazio afirmando nada. Estas tabelas TÊM de estar.
+    faltando = (_USER_FK_SET_NULL_TABLES | {"system_event_logs"}) - set(declared)
+    assert not faltando, f"parser não achou o DDL de {sorted(faltando)} — regex quebrada?"
+
+    divergentes = {}
+    for table, actions in declared.items():
+        alvo = "set null" if table in _USER_FK_SET_NULL_TABLES else "cascade"
+        if actions != {alvo}:
+            divergentes[table] = {"ddl": sorted(actions), "repair": alvo}
+
+    inesperadas = set(divergentes) - _PENDENTE_DECISAO_DO_DONO
+    assert not inesperadas, (
+        "DDL declara um `on delete` que o repair_user_fk_cascades sobrescreve: "
+        + repr({t: divergentes[t] for t in sorted(inesperadas)})
+        + ". Alinhe o DDL com _USER_FK_SET_NULL_TABLES (db/schema_repairs.py) — "
+        "quem vale em runtime é o repair, não o `create table if not exists`."
+    )


### PR DESCRIPTION
Fecha **#221** e **#268**. São duas issues pequenas, independentes e que não se cruzam (uma no schema Python, outra no `dashboard.js`) — por isso vieram num PR só.

---

## #221 — o diagnóstico da issue estava INVERTIDO

A issue afirma que `create table if not exists` nunca converge as duas versões, e pede migração explícita. **Medido, é o contrário.**

`repair_user_fk_cascades` (`db/schema_repairs.py`), chamado de `db/schema.py:2066` em **todo** `init_db`, varre `pg_constraint` por `confrelid = 'users'::regclass` e converge **toda** FK que referencia `users(id)`: as de `_USER_FK_SET_NULL_TABLES` viram `set null`, o resto vira `cascade`.

Medido no `pigbank_ci_test` — as únicas 3 FKs em `users(id)` que **não** são CASCADE são exatamente as 3 da configuração:

```
          tbl           |               conname               | confdeltype
------------------------+-------------------------------------+-------------
 auth_login_events      | auth_login_events_user_id_fkey      | n
 checkout_funnel_events | checkout_funnel_events_user_id_fkey | n
 plan_trials            | plan_trials_user_id_fkey            | n
```

`system_event_logs` está em `c` (CASCADE). **Isso não é deriva — é a configuração agindo.** Quem mentia era o DDL de `core/admin_dashboard.py:122`, que declarava `ON DELETE SET NULL` e era sobrescrito no boot seguinte.

### A decisão

**CASCADE está certo** — log de sistema é dado do titular e vai junto com a conta. Coerente com `db/privacy.py:837`, que já faz `delete` puro nessa tabela em vez de anonimizar.

### Este conserto é documentação executável, não migração

`create table if not exists` **não altera tabela existente**, e a tabela viva já estava em CASCADE antes deste PR. **Nada migra e nada muda de comportamento** — o DDL só para de declarar o oposto do que roda.

### O teste compara as duas fontes (§0.7)

`tests/test_schema_repairs.py::test_ddl_nao_contradiz_o_alvo_do_repair` lê o `on delete` declarado no DDL (`db/schema.py` + `core/admin_dashboard.py`, 55 tabelas com FK em `users(id)`) e o compara com o alvo do repair.

É sobre a **regra**, não sobre a lista de hoje:

| controle | como | resultado |
|---|---|---|
| **negativo** | DDL de volta em `SET NULL` | 🔴 `{'system_event_logs': {'ddl': ['set null'], 'repair': 'cascade'}}` |
| **tabela nova** | injetei `tabela_nova_de_amanha` com `on delete set null` | 🔴 `{'tabela_nova_de_amanha': ...}` |
| **positivo** | as 3 tabelas SET NULL legítimas | 🟢 continuam passando |

Tem também um piso anti-tautologia: se a regex quebrar e o parser não achar o DDL das tabelas conhecidas, o teste falha em vez de passar vazio.

### A varredura achou uma SEGUNDA divergência — e o dono DECIDIU: `SET NULL`

A issue previa uma; são **duas**:

```
{'auth_login_events': ['set null'],      # ok, está na config
 'checkout_funnel_events': ['set null'], # ok, está na config
 'plan_trials': ['set null'],            # ok, está na config
 'pii_access_log': ['set null']}         # ← DIVERGIA: rodava CASCADE
```

`pii_access_log` (`db/schema.py:1581`) declarava `SET NULL` e rodava `CASCADE`. A divergência foi levantada aqui e marcada como `_PENDENTE_DECISAO_DO_DONO` em vez de resolvida por palpite. **A decisão do dono saiu: `SET NULL`** — a tabela entra em `_USER_FK_SET_NULL_TABLES` (`db/schema_repairs.py:44`) e a marca de pendência sai do teste.

**A razão:** `pii_access_log` é registro de **compliance** — "alguém leu tal campo de tal titular, em tal data, com tal propósito" (`purpose`/`actor`/`field`). A coluna da FK é `subject_user_id`, o **titular cujo dado foi lido**, não o autor do acesso: CASCADE apagava a trilha justamente de quem pediu exclusão, destruindo a prova de que o acesso foi legítimo. Os dois sinais que a varredura já tinha levantado sustentam isso — o `db/privacy.py` **não** apaga essa tabela (diferente do `system_event_logs`, que ele apaga com `delete` puro), e o irmão mais próximo (`auth_login_events`) já era `SET NULL` de propósito.

#### ⚠️ Esta metade MUDA COMPORTAMENTO EM PRODUÇÃO

Diferente do `system_event_logs` — onde o conserto era só documentação executável e nada migrava —, aqui **a constraint da tabela viva vai ser alterada no próximo deploy**: hoje o repair converte a FK para CASCADE em todo boot, depois dele converte para SET NULL. É o efeito desejado, mas está dito com todas as letras.

**Busca por dependentes do CASCADE atual — nenhum:**

- `user_owned_tables` (`db/privacy.py:766`) não lista a tabela, e nem poderia: a coluna é `subject_user_id`, então a varredura de sobras (que filtra por `user_id`) nunca a alcança, nem no sweep nem na verificação pós-commit;
- a docstring do reset (`db/privacy.py:541`) já declara `pii_access_log` entre as tabelas **preservadas**;
- o listador do admin (`core/admin_dashboard.py:1822`) não faz join com `users` e tolera `subject_user_id` nulo;
- nenhum teste conta linhas ali (`grep -rn "pii_access_log" tests/` → só `test_crypto.py`, que mocka o insert, e este arquivo).

#### O gate perde a exceção, e um teste novo prova o EFEITO

`test_ddl_nao_contradiz_o_alvo_do_repair` passa a exigir convergência para as **duas** tabelas, sem exceção nomeada. E `test_delete_user_preserva_linha_de_pii_access_log` prova o que a lista faz de verdade: apagar o usuário **preserva** a linha, com `subject_user_id` nulo e o resto do registro intacto.

| controle | como | resultado |
|---|---|---|
| **negativo** | tirar `"pii_access_log"` da lista | 🔴 2 vermelhos: `test_ddl_nao_contradiz_o_alvo_do_repair` e `test_delete_user_preserva_linha_de_pii_access_log` (`assert 'c' == 'n'`) |
| **negativo (não-vácuo)** | idem, e desligando também o assert de FK do teste novo | 🔴 `AssertionError: CASCADE apagou a trilha de compliance` — a asserção de preservação mede mesmo |
| **positivo** | as 3 tabelas SET NULL que já estavam na lista | 🟢 continuam verdes |
| **positivo** | `test_repair_converts_no_action_to_cascade` | 🟢 tabela fora da lista continua indo para CASCADE |

---

## #268 — `loadBillsView(_forceFresh)`: parâmetro morto, apagado

O corpo chama `_fetchBills({ force: true })` incondicionalmente nos **dois** ramos (`background` e normal), então o parâmetro nunca fez nada.

Apagado, junto com os seis `true`. Confirmados por grep (as linhas da issue continuavam válidas): `4154`, `4616`, `4658`, `4687`, `4707` e o puxar-pra-atualizar em `11152`. **Não há sétimo chamador nem argumento diferente de `true`**, e `loadBillsView` não é exposto em `window` nem usado em handler inline.

**Comportamento idêntico**, o que significa que **não existe controle negativo aqui**: nenhum teste fica vermelho, porque nada mudou. O que vale é o frontend continuar no mesmo número.

---

## Medições

| | antes | depois |
|---|---|---|
| `pytest -q` | 5833 passed, 4 xfailed, **0 falhas** | 5835 passed, 4 xfailed, **0 falhas** |
| `npm run test:frontend` | 307 testes, 306 pass, 1 fail | 307 testes, 306 pass, 1 fail |

O `+2` no pytest são os dois testes novos (o gate do DDL e o da preservação da trilha). Comparado por **nome**: zero falhas dos dois lados.

A única falha de frontend é `eslint_max_lines_gate.test.mjs`, **antes e depois**, por `ERR_MODULE_NOT_FOUND: Cannot find package 'eslint'` — ambiente, não regressão.

### Não verificado aqui

- **`npm run lint` NÃO rodou**: não há `eslint` no `node_modules` local, nem no da raiz, nem no `npm root -g`. O CI cobre.
- **Nada foi medido em produção.** A medição do `confdeltype` acima é do `pigbank_ci_test`. Para o `system_event_logs` isso não bloqueia (o conserto não altera comportamento). Para o `pii_access_log` fica o registro explícito: a conversão da FK da tabela viva de CASCADE para SET NULL **só acontece no próximo boot em produção**, e não foi observada aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

