### PR TITLE
Porta 2: veto de catálogo quando a pergunta pede o nome (#185)

### DIFF
--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -760,18 +760,46 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> bool:
     # `_ja_tem_o_valor` moveria o outro chamador (`pedia_o_valor`, :1040), que
     # é o filtro de dano do #140.
     #
-    # TETO ACEITO pelo dono, e é o exemplo do título da issue: `saquei 200` +
+    # ── OS TRÊS TETOS, medidos. Esta é a ÚNICA cópia do texto: o comentário de
+    # `tests/test_perguntas_guardam_contexto.py` e o corpo do PR #280 apontam
+    # para cá em vez de repetir (§0.7 — a primeira redação errada teve de ser
+    # corrigida em três lugares).
+    #
+    # TETO 1, aceito pelo dono, e é o exemplo do título da issue: `saquei 200` +
     # `extrato` SEM caixinha chamada "extrato" continua abandonando, e os
     # R$ 200 se perdem. Fechar isso exigiria rodar o outro comando E re-armar a
     # pergunta no mesmo turno — padrão de UX novo, decisão adiada.
     #
-    # TETO INVERTIDO, também aceito: quem tem caixinha chamada exatamente
-    # `saldo`/`extrato`/`caixinhas` e quer o COMANDO enquanto uma pergunta de
-    # nome está de pé passa a executar o saque na caixinha. Troca consciente —
-    # o lado do dinheiro ganha.
+    # TETO 2 (invertido), também aceito, e MAIOR que "executa o saque": quem tem
+    # caixinha chamada exatamente `saldo`/`extrato`/`caixinhas` e quer o COMANDO
+    # enquanto uma pergunta de nome está de pé executa o comando PENDENTE no
+    # tamanho que o `orig_text` mandar — inclusive ESVAZIAMENTO INTEGRAL, quantia
+    # ilimitada, porque o handler lê `marcador_de_tudo(orig_text)` quando as
+    # entities não trazem `want_all` (`core/handlers/pockets.py:215-216`).
+    # Medido, caixinha `saldo` com R$ 300:
+    #   "esvaziar caixinha" -> "Qual caixinha?"   (falta=pocket_name, entities={})
+    #   "saldo"             -> "Caixinha *saldo* esvaziada: -R$ 300,00"  (300 -> 0)
+    #                          sem o veto: mostra a Conta Corrente, caixinha em 300
+    # E a mensagem que dispara isso é `classify("saldo")` -> `balance.check` com
+    # confiança 1.0. Troca consciente — o lado do dinheiro ganha. Prende este
+    # teto o `test_185_teto2_comando_pendente_esvazia_a_caixinha`.
+    #
+    # TETO 3, declarado depois da revisão do #280: o veto também dispara quando
+    # NÃO HÁ VALOR A PERDER, e aí a justificativa acima não se aplica.
+    # `tirar da caixinha` grava `entities={}` — o `falta="pocket_name"` vem ANTES
+    # da checagem de valor (`core/handlers/pockets.py:230-232`). Medido:
+    #   "tirar da caixinha" -> "Qual caixinha?"
+    #   "saldo"             -> "Qual o valor?"  (em vez do saldo)
+    # Custa UM turno: na volta o `falta` é `amount`, o veto não pega e o comando
+    # roda. Prende este teto o `test_185_teto3_veto_dispara_sem_valor_a_perder`.
     falta = payload.get("falta")
     intent = payload.get("intent")
-    if falta and falta == _CHAVE_DO_NOME.get(intent):
+    # `isinstance(intent, str)` pelo mesmo motivo do guard de payload não-dict lá
+    # em cima: `_CHAVE_DO_NOME.get([])` é `TypeError: unhashable type`, que vira
+    # "erro interno" com a pendência NUNCA consumida (o `consume_pending_action`
+    # só acontece depois, `core/handle_incoming.py:785`) — o loop que este
+    # guard existe para evitar. Nenhum produtor grava não-str hoje.
+    if falta and isinstance(intent, str) and falta == _CHAVE_DO_NOME.get(intent):
         resposta = limpa_pontuacao_final((text or "").strip())
         return not _eh_nome_do_catalogo(
             resposta, _alvos_existentes(user_id, intent))

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -120,7 +120,8 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
 #   porta 2  QUALQUER `clarification`  este arquivo, `_clarification_abandonada`
 #            no `route()` — não só a de `launches.add`: a de `recurring.add`, a
 #            de `funds.add_ask` e as genéricas da IA passam pela mesma escotilha.
-#            O filtro não é o intent da pergunta, é o `_ja_tem_o_valor`.
+#            O filtro não é o intent da pergunta, é o `_ja_tem_o_valor` — mais
+#            o veto de catálogo do #185, que só vale para as perguntas de NOME.
 #   porta 3  fila do multi-lançamento  core/handlers/launches.py::resolve_multi_launch_value
 #   porta 4  botão "✅ Já paguei"      adapters/whatsapp/wa_runtime.py (roda ANTES
 #                                      do handle_incoming, por isso importa daqui)
@@ -238,7 +239,7 @@ def route(result: IntentResult, msg: IncomingMessage, *,
     # -----------------------------------------------------------------------
     clarif = None if ignora_pendencias else h_pending.get_pending_clarification(user_id)
     if clarif:
-        if _clarification_abandonada(clarif, text):
+        if _clarification_abandonada(clarif, text, user_id):
             # Porta 2. Mesma escotilha de escape do `investment_pick` e do
             # `funding_source_choice` logo abaixo: outro comando claro abandona
             # a pergunta em vez de ser engolido por ela ("Quanto foi no *luz*?"
@@ -703,7 +704,7 @@ def _ja_tem_o_valor(entities: dict | None) -> bool:
         return True
 
 
-def _clarification_abandonada(clarif: dict, text: str) -> bool:
+def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> bool:
     """True quando a resposta é OUTRO comando claro, não a resposta à pergunta.
 
     Porta 2 do passo 1 (`abandona_pergunta_de_valor`). Quem decide é o INTENT,
@@ -712,7 +713,8 @@ def _clarification_abandonada(clarif: dict, text: str) -> bool:
     Vale para TODA `clarification`, não só a de `launches.add`: roda no
     `route()`, antes de o `_resolve_clarification` olhar o `intent` do payload,
     então a de `recurring.add`, a de `funds.add_ask` e as genéricas da IA
-    passam por aqui também. O único filtro por payload é o `_ja_tem_o_valor`.
+    passam por aqui também. Os filtros por payload são dois: o `_ja_tem_o_valor`
+    e o veto de catálogo lá embaixo (#185).
 
     Antes disso, uma condição que nada tem a ver com o classificador: **a
     pergunta ainda não pode ter o valor.** Toda `clarification` que pede a
@@ -733,7 +735,47 @@ def _clarification_abandonada(clarif: dict, text: str) -> bool:
         return False
     if _ja_tem_o_valor(payload.get("entities")):
         return False
-    return abandona_pergunta_de_valor(text)
+    if not abandona_pergunta_de_valor(text):
+        return False
+
+    # VETO DE CATÁLOGO (#185). Última palavra, e só no turno raro em que o
+    # classificador já disse "abandona": a pergunta pendente pede um NOME
+    # (`falta` é a chave de nome daquela intent) e a resposta é, literalmente,
+    # uma caixinha/investimento DESTE usuário. Aí "saldo" não é o comando de
+    # saldo — é o nome que a pergunta pediu, e abandonar descartaria o valor
+    # que ele já digitou ("saquei 200" → "de qual caixinha?" → "saldo").
+    #
+    # DEPOIS do `abandona_pergunta_de_valor`, não antes: o classificador
+    # determinístico decide o caso comum sozinho, e o catálogo custa I/O
+    # (`_alvos_existentes` chama `accrue_all_investments`, que ESCREVE
+    # accruals). Nesta ordem ele só roda quando a resposta já é um dos 6
+    # intents do `ABANDONA` e a pergunta viva é de nome.
+    #
+    # `_ja_tem_o_valor` fica INTOCADO de propósito. A one-liner da issue
+    # (ler `amount` além de `valor` ali) tem regressão medida: `saquei 200` +
+    # `saldo` SEM caixinha chamada "saldo" deixa de abandonar, cai no resolver,
+    # e `_funde_a_resposta` devolve `target_name="saldo"` — o bot responde
+    # "Não encontrei *saldo* nem em caixinhas nem em investimentos" e o comando
+    # nunca roda. Hoje o usuário ao menos vê o saldo. E mexer no
+    # `_ja_tem_o_valor` moveria o outro chamador (`pedia_o_valor`, :1040), que
+    # é o filtro de dano do #140.
+    #
+    # TETO ACEITO pelo dono, e é o exemplo do título da issue: `saquei 200` +
+    # `extrato` SEM caixinha chamada "extrato" continua abandonando, e os
+    # R$ 200 se perdem. Fechar isso exigiria rodar o outro comando E re-armar a
+    # pergunta no mesmo turno — padrão de UX novo, decisão adiada.
+    #
+    # TETO INVERTIDO, também aceito: quem tem caixinha chamada exatamente
+    # `saldo`/`extrato`/`caixinhas` e quer o COMANDO enquanto uma pergunta de
+    # nome está de pé passa a executar o saque na caixinha. Troca consciente —
+    # o lado do dinheiro ganha.
+    falta = payload.get("falta")
+    intent = payload.get("intent")
+    if falta and falta == _CHAVE_DO_NOME.get(intent):
+        resposta = limpa_pontuacao_final((text or "").strip())
+        return not _eh_nome_do_catalogo(
+            resposta, _alvos_existentes(user_id, intent))
+    return True
 
 
 _SO_NUMERO_RE = re.compile(r"[\d.,\s]+")

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -1761,15 +1761,21 @@ def test_negativo_pelo_botao_nao_paga(monkeypatch):
 
 
 def test_clarification_com_payload_torto_nao_estoura():
-    """`payload` não-dict virava AttributeError.
+    """`payload` não-dict virava AttributeError; `intent` não-hashável vira
+    `TypeError: unhashable type` no `_CHAVE_DO_NOME.get(intent)` do veto (#185).
 
-    Nenhum produtor grava isso hoje; o custo do guard é uma linha e o efeito
-    seria "erro interno" em loop, com a pendência nunca sendo limpa.
+    Nenhum produtor grava nenhum dos dois hoje; o custo dos guards é uma linha
+    cada e o efeito seria "erro interno" em loop, com a pendência nunca sendo
+    limpa — o `consume_pending_action` só acontece depois do `except`.
     """
     from core.intent_router import _clarification_abandonada
 
     assert _clarification_abandonada({"payload": "x"}, "saldo", 1) is False
     assert _clarification_abandonada({}, "saldo", 1) is False
+    # `falta` casa com a chave de nome, e o `intent` é o dado torto: sem o
+    # `isinstance(intent, str)` esta linha estoura antes de chegar ao return.
+    torto = {"payload": {"falta": "pocket_name", "intent": ["pockets.withdraw"]}}
+    assert _clarification_abandonada(torto, "saldo", 1) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -1768,8 +1768,8 @@ def test_clarification_com_payload_torto_nao_estoura():
     """
     from core.intent_router import _clarification_abandonada
 
-    assert _clarification_abandonada({"payload": "x"}, "saldo") is False
-    assert _clarification_abandonada({}, "saldo") is False
+    assert _clarification_abandonada({"payload": "x"}, "saldo", 1) is False
+    assert _clarification_abandonada({}, "saldo", 1) is False
 
 
 # ---------------------------------------------------------------------------
@@ -1945,8 +1945,8 @@ def test_escotilha_da_clarification_nao_apaga_pergunta_de_outra_tarefa(monkeypat
     real = IR._clarification_abandonada
     nova = {"bill_id": 99, "name": "Internet"}
 
-    def com_corrida(clarif, texto):
-        decidiu = real(clarif, texto)
+    def com_corrida(clarif, texto, uid_):
+        decidiu = real(clarif, texto, uid_)
         if decidiu:
             # outra tarefa chegou primeiro e já perguntou outra coisa. É um
             # `bill_pay_amount` de propósito: o `route()` não o consome (quem

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -830,16 +830,24 @@ def test_p3_nota_nao_mente_quando_nao_havia_alvo_guardado(uid):
 # `saquei 200` + `saldo` abandonava a pergunta e os R$ 200 sumiam, mesmo com
 # uma caixinha chamada `saldo` para receber o saque.
 #
-# O conserto NÃO é a one-liner da issue (fazer `_ja_tem_o_valor` ler `amount`).
-# Medido: com ela, `saquei 200` + `saldo` SEM caixinha chamada "saldo" deixa de
-# abandonar, cai no resolver, e o bot responde "Não encontrei *saldo* nem em
-# caixinhas nem em investimentos" — o comando `saldo` nunca roda e a pendência
-# morre do mesmo jeito. É estritamente pior que hoje. Quem prende isso é o
-# `test_185_abandono_comum_continua_vivo` abaixo.
+# POR QUE NÃO A ONE-LINER DA ISSUE, e OS TRÊS TETOS do conserto: o texto mora
+# UMA VEZ SÓ, no comentário do veto em `core/intent_router.py`
+# (`_clarification_abandonada`, bloco `VETO DE CATÁLOGO (#185)`). Não repita
+# aqui — a primeira redação errada custou correção em três lugares (§0.7).
+# Quem prende cada teto:
+#   teto 1 (`extrato` sem caixinha)  -> test_185_abandono_comum_continua_vivo
+#   teto 2 (comando vira comando pendente, esvaziamento integral)
+#                                    -> test_185_nome_do_catalogo_vence_o_comando
+#                                       test_185_teto2_comando_pendente_esvazia_a_caixinha
+#   teto 3 (dispara sem valor a perder)
+#                                    -> test_185_teto3_veto_dispara_sem_valor_a_perder
 #
 # CONTROLES NEGATIVOS (medidos, cada um injetado num caso que estava VERDE):
-#   remover o bloco `if falta and falta == _CHAVE_DO_NOME.get(intent)` de
-#   `_clarification_abandonada` -> test_185_nome_do_catalogo_vence_o_comando
+#   remover o bloco `if falta and isinstance(intent, str) and falta ==
+#   _CHAVE_DO_NOME.get(intent)` de `_clarification_abandonada`
+#     -> test_185_nome_do_catalogo_vence_o_comando,
+#        test_185_teto2_comando_pendente_esvazia_a_caixinha,
+#        test_185_teto3_veto_dispara_sem_valor_a_perder
 #   trocar o `return not _eh_nome_do_catalogo(...)` daquele bloco por
 #   `return False`                -> test_185_abandono_comum_continua_vivo
 #
@@ -847,14 +855,6 @@ def test_p3_nota_nao_mente_quando_nao_havia_alvo_guardado(uid):
 # só são alcançáveis via LLM, que não roda nos testes. O que esta seção prova é
 # a rota `funds.withdraw` (`classify("saquei 200")` -> `funds.withdraw
 # {'amount': 200.0}`, determinístico).
-#
-# TETO ACEITO, e é o exemplo do título da issue: `saquei 200` + `extrato`, sem
-# caixinha chamada "extrato", continua abandonando e perdendo os R$ 200 —
-# fechar isso exigiria rodar o comando E re-armar a pergunta no mesmo turno.
-# TETO INVERTIDO: quem TEM caixinha `saldo` e quer o COMANDO enquanto a
-# pergunta de nome está viva passa a sacar da caixinha. É o `test_185_nome_do_
-# catalogo_vence_o_comando`: troca consciente, o lado do dinheiro ganha.
-
 
 def test_185_nome_do_catalogo_vence_o_comando(uid):
     """O caso da issue: a resposta É uma caixinha do usuário, não um comando."""
@@ -891,6 +891,35 @@ def test_185_saque_legitimo_pelo_nome_ainda_funciona(uid):
               "saquei 100", "viagem")
 
     assert _saldos(uid)["viagem"] == 200.00
+
+
+def test_185_teto2_comando_pendente_esvazia_a_caixinha(uid):
+    """TETO 2 no tamanho medido: não é "executa o saque", é esvaziamento
+    integral. `esvaziar caixinha` deixa `entities={}` e o handler lê o `tudo` do
+    `orig_text`, então a resposta `saldo` — que o classificador lê como
+    `balance.check` com confiança 1.0 — zera a caixinha inteira."""
+    _caixinhas_com_saldo(uid, "saldo")
+
+    respostas = _conversa(uid, "esvaziar caixinha", "saldo")
+
+    assert "Qual caixinha" in respostas[0], respostas[0]
+    assert "esvaziada" in respostas[-1], respostas[-1]
+    assert _saldos(uid)["saldo"] == 0.00, \
+        f"o teto 2 é maior que um saque: a caixinha inteira foi: {respostas[-1]!r}"
+
+
+def test_185_teto3_veto_dispara_sem_valor_a_perder(uid):
+    """TETO 3: `tirar da caixinha` grava `entities={}` (o `falta` vem antes da
+    checagem de valor), então o veto segura a pergunta sem ter valor nenhum a
+    proteger. Custa UM turno — a pergunta vira a de valor e nada se move."""
+    _caixinhas_com_saldo(uid, "saldo")
+
+    respostas = _conversa(uid, "tirar da caixinha", "saldo")
+
+    assert "Qual o valor" in respostas[-1], \
+        f"sem o veto aqui viria o saldo; com ele, a pergunta de valor: {respostas[-1]!r}"
+    assert "Conta Corrente" not in respostas[-1], respostas[-1]
+    assert _saldos(uid)["saldo"] == 300.00, "nada podia se mover neste turno"
 
 
 def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -821,3 +821,88 @@ def test_p3_nota_nao_mente_quando_nao_havia_alvo_guardado(uid):
     assert _saldos(uid)["viagem"] == 200.00
     assert "esvaziar" not in (saque.get("nota") or "").lower(), \
         f"a nota diz esvaziar num saque de 100: {saque.get('nota')!r}"
+
+
+# ── #185: o veto de catálogo na porta 2 ─────────────────────────────────────
+#
+# A pergunta de NOME já carrega o valor em `entities["amount"]`, que o
+# `_ja_tem_o_valor` (porta 2) não lê — ele só conhece `valor`. Então
+# `saquei 200` + `saldo` abandonava a pergunta e os R$ 200 sumiam, mesmo com
+# uma caixinha chamada `saldo` para receber o saque.
+#
+# O conserto NÃO é a one-liner da issue (fazer `_ja_tem_o_valor` ler `amount`).
+# Medido: com ela, `saquei 200` + `saldo` SEM caixinha chamada "saldo" deixa de
+# abandonar, cai no resolver, e o bot responde "Não encontrei *saldo* nem em
+# caixinhas nem em investimentos" — o comando `saldo` nunca roda e a pendência
+# morre do mesmo jeito. É estritamente pior que hoje. Quem prende isso é o
+# `test_185_abandono_comum_continua_vivo` abaixo.
+#
+# CONTROLES NEGATIVOS (medidos, cada um injetado num caso que estava VERDE):
+#   remover o bloco `if falta and falta == _CHAVE_DO_NOME.get(intent)` de
+#   `_clarification_abandonada` -> test_185_nome_do_catalogo_vence_o_comando
+#   trocar o `return not _eh_nome_do_catalogo(...)` daquele bloco por
+#   `return False`                -> test_185_abandono_comum_continua_vivo
+#
+# CLASSE CEGA: as portas de caixinha/investimento cujo payload guarda `amount`
+# só são alcançáveis via LLM, que não roda nos testes. O que esta seção prova é
+# a rota `funds.withdraw` (`classify("saquei 200")` -> `funds.withdraw
+# {'amount': 200.0}`, determinístico).
+#
+# TETO ACEITO, e é o exemplo do título da issue: `saquei 200` + `extrato`, sem
+# caixinha chamada "extrato", continua abandonando e perdendo os R$ 200 —
+# fechar isso exigiria rodar o comando E re-armar a pergunta no mesmo turno.
+# TETO INVERTIDO: quem TEM caixinha `saldo` e quer o COMANDO enquanto a
+# pergunta de nome está viva passa a sacar da caixinha. É o `test_185_nome_do_
+# catalogo_vence_o_comando`: troca consciente, o lado do dinheiro ganha.
+
+
+def test_185_nome_do_catalogo_vence_o_comando(uid):
+    """O caso da issue: a resposta É uma caixinha do usuário, não um comando."""
+    _caixinhas_com_saldo(uid, "saldo")
+
+    respostas = _conversa(uid, "saquei 200", "saldo")
+
+    assert "retirar de qual" in respostas[0], respostas[0]
+    assert _saldos(uid)["saldo"] == 100.00, \
+        f"o saque de R$ 200 na caixinha 'saldo' não fechou: {respostas[-1]!r}"
+
+
+def test_185_abandono_comum_continua_vivo(uid):
+    """CONTROLE POSITIVO, e é ele que separa este conserto do proposto na issue.
+
+    Sem caixinha chamada "saldo", `saldo` continua sendo o COMANDO de saldo. A
+    one-liner da issue derruba exatamente este caso (medido: o bot passa a
+    responder "Não encontrei *saldo*..."); o veto de catálogo o mantém.
+    """
+    respostas = _conversa(uid, "saquei 200", "saldo")
+
+    assert "Conta Corrente" in respostas[-1], respostas[-1]
+    assert _saldos(uid) == {}, "não havia caixinha nenhuma para mover"
+
+
+def test_185_saque_legitimo_pelo_nome_ainda_funciona(uid):
+    """CONTROLE POSITIVO 2: o caminho normal da pergunta de nome, com um nome
+    que não colide com comando nenhum."""
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False)
+
+    _conversa(uid, "criar caixinha viagem", "coloquei 300 na caixinha viagem",
+              "saquei 100", "viagem")
+
+    assert _saldos(uid)["viagem"] == 200.00
+
+
+def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
+    """O veto vale SÓ quando a pergunta pede o NOME. Com `falta == "amount"` a
+    resposta `saldo` não responde nada que a pergunta pediu, e a escotilha do
+    comando continua valendo — mesmo com uma caixinha chamada `saldo` no
+    catálogo, que é o que faz este caso discriminar o veto."""
+    _caixinhas_com_saldo(uid, "viagem", "saldo")
+
+    respostas = _conversa(uid, "tirar da caixinha viagem", "viagem", "saldo")
+
+    assert "Qual o valor" in respostas[1], respostas[1]
+    assert "Conta Corrente" in respostas[-1], respostas[-1]
+    assert _saldos(uid) == {"viagem": 300.00, "saldo": 300.00}, \
+        "sacou sem que o valor fosse dito"


### PR DESCRIPTION
Fecha #185.

## O problema, medido

`_clarification_abandonada` (porta 2) protege a pergunta que JÁ tem o valor —
mas quem implementa isso, `_ja_tem_o_valor`, só lê `entities["valor"]`. As nove
perguntas de handler do #184 guardam o valor em `entities["amount"]`, então toda
pergunta de NOME que já carrega o valor ficava fora da proteção.

Medido na `main` (`346270d`), sem IA no caminho (`classify("saquei 200")` →
`funds.withdraw {'amount': 200.0}`, determinístico):

```
criar caixinha saldo + 500 de depósito
saquei 200   -> "Você quer retirar de qual caixinha ou investimento?"
saldo        -> 🏦 Conta Corrente: R$ 500,00
                caixinha 'saldo' segue em 500,00, pendência = None
```

Os R$ 200 somem, e havia uma caixinha chamada `saldo` esperando o saque.

## Por que NÃO a one-liner da issue

A issue propõe `_ja_tem_o_valor` passar a ler `amount` além de `valor`. **Tem
regressão medida** (mesma árvore, o predicado trocado em runtime):

```
sem caixinha chamada "saldo":
saquei 200   -> "Você quer retirar de qual caixinha ou investimento?"
saldo        -> "Não encontrei *saldo* nem em caixinhas nem em investimentos.
                 Use *listar caixinhas* ou *listar investimentos*..."
                pendência = None
```

A pergunta deixa de ser abandonada, cai no resolver, e
`_funde_a_resposta('funds.withdraw', {'amount':200,'want_all':False}, 'saldo', [])`
devolve `({'amount':200,'want_all':False,'target_name':'saldo'}, None)` — `falta`
é `target_name`, então não entra no ramo de re-armar: **a pendência morre do
mesmo jeito E o comando `saldo` nunca roda**. Hoje o usuário ao menos vê o
saldo. É estritamente pior.

E `_ja_tem_o_valor` tem um segundo chamador: `pedia_o_valor`
(`core/intent_router.py:1040`), que alimenta o ramo `launches.add` (`:1210`).
Mexer ali reabre por uma fresta o #140 — uma clarification genérica da IA com
`{amount: 200}` reclassificada para `launches.add` passaria a ser lida como "a
resposta é a DESCRIÇÃO", pulando o `valor_perigoso`. O comentário de
`:1027-1039` documenta o que isso custou em produção (R$ 10,00 gravado de "-10",
R$ 13.250,00 de "132 50").

## O conserto: veto de catálogo na porta 2

`_ja_tem_o_valor` fica **intocado**. A porta 2 ganha uma última palavra, na
ordem em que o classificador determinístico decide primeiro:

1. payload não-dict → não abandona (como hoje)
2. `_ja_tem_o_valor(entities)` → não abandona (como hoje, **inalterado**)
3. `not abandona_pergunta_de_valor(text)` → não abandona (como hoje)
4. **novo:** se `payload["falta"] == _CHAVE_DO_NOME[payload["intent"]]`, a
   resposta (via `limpa_pontuacao_final`) é um alvo do catálogo do usuário?
   Se sim, **não abandona** — a resposta é o nome que a pergunta pediu.
5. abandona

Reusa o que já existe (§0.1), **nenhuma constante nova**: `_CHAVE_DO_NOME`,
`_eh_nome_do_catalogo`, `_alvos_existentes` e o mesmo `limpa_pontuacao_final`
que o resolver usa em `:1085`.

Assinatura mudou para `_clarification_abandonada(clarif, text, user_id)`. Um
chamador de produção (`route()`, que já tinha o `user_id`) e três sítios de
teste — `tests/test_bill_amount_pending.py:1771`, `:1772` e o monkeypatch
`com_corrida` de `:1948`, que estouraria `TypeError` com dois parâmetros.
Confirmado por grep: não há outros.

Depois do conserto, mesma conversa:

```
saquei 200 + saldo (COM caixinha 'saldo')  -> 📤 Caixinha *saldo*: -R$ 200,00
                                              caixinha 500,00 -> 300,00
saquei 200 + saldo (SEM caixinha 'saldo')  -> 🏦 Conta Corrente (inalterado)
```

## Os TRÊS tetos — o texto mora no código, não aqui

Para não corrigir a mesma redação em três lugares de novo (§0.7), o texto
completo está **uma vez só**, em `core/intent_router.py`
(`_clarification_abandonada`, bloco `VETO DE CATÁLOGO (#185)`). O resumo, com o
tamanho **medido**:

1. **`saquei 200` + `extrato`, sem caixinha chamada "extrato", continua
   abandonando e perdendo os R$ 200.** É o exemplo do título da issue e fica de
   fora **de propósito**: não abandonar ali é a regressão medida acima.
2. **Teto invertido, e ele é MAIOR do que este PR dizia.** A redação anterior
   ("passa a executar o saque na caixinha") subdimensionava: quem tem caixinha
   chamada exatamente `saldo`/`extrato`/`caixinhas` executa o comando
   **pendente** no tamanho que o `orig_text` mandar — inclusive **esvaziamento
   integral, quantia ilimitada**, porque o handler lê `marcador_de_tudo(orig_text)`
   quando as entities não trazem `want_all` (`core/handlers/pockets.py:215-216`).
   Medido, caixinha `saldo` com R$ 300:

   ```
   "esvaziar caixinha" -> "Qual caixinha?"   (falta=pocket_name, entities={})
   "saldo"             -> COM o veto:  "Caixinha *saldo* esvaziada: -R$ 300,00"  300 -> 0
                          SEM o veto:  mostra a Conta Corrente, caixinha em 300
   ```

   E `classify("saldo")` é `balance.check` com **confiança 1.0**. O dono
   reconfirmou a troca com o tamanho real: comportamento mantido, texto corrigido.
3. **Teto novo, que nenhuma das três cópias declarava:** o veto também dispara
   **quando não há valor a perder**, e aí a justificativa escrita ("descartaria o
   valor que ele já digitou") não se aplica. `tirar da caixinha` grava
   `entities={}` — o `falta="pocket_name"` vem antes da checagem de valor
   (`core/handlers/pockets.py:230-232`). Medido: `tirar da caixinha` + `saldo`
   deixa de mostrar o saldo e devolve `"Qual o valor?"`. Custa **um turno** (na
   volta o `falta` é `amount`, o veto não pega e o comando roda).

## Efeito colateral, medido

`_alvos_existentes` chama `db.accrue_all_investments`, que **escreve**. O passo
4 é um caminho novo para essa chamada (só quando há clarification de NOME
pendente **e** o texto cai num dos 6 intents do `ABANDONA`). Contado com um spy
em `psycopg.Cursor.execute`, no turno da resposta `saldo`:

| cenário | statements | escritas | `investments` |
|---|---|---|---|
| sem o veto, usuário sem investimento | 22 | 10 | 0 |
| com o veto, usuário sem investimento | 32 | 16 | 0 |
| sem o veto, usuário com 1 investimento | 22 | 10 | 0 |
| com o veto, usuário com 1 investimento | 37 | 17 | 1 (`update investments set balance=0 ...`) |

As escritas extras são `ensure_user` (`users`/`accounts`, `ON CONFLICT DO
NOTHING`) das consultas de catálogo, mais o accrual idempotente — a mesma
chamada que o caminho irmão já faz em `:1092`. Nenhum teste existente conta
statements nesta família (o `test_inferencia_nao_escreve_no_banco` é do
`infer_category`, outro caminho, e segue verde).

## `intent` não-hashável (achado da revisão)

`_CHAVE_DO_NOME.get(intent)` estoura `TypeError: unhashable type` se
`payload["intent"]` vier lista ou dict — cai no `except` de
`core/handle_incoming.py:785` → "erro interno" **com a pendência nunca
consumida** (o `consume_pending_action` só acontece depois): exatamente o laço
que o guard de payload não-dict, três linhas acima, existe para evitar.
Inalcançável hoje (todos os produtores gravam `str`), mas o
`test_clarification_com_payload_torto_nao_estoura` prometia cobrir isso pelo
nome e não cobria. Escolhido o mesmo remédio do irmão — `isinstance(intent, str)`,
uma linha — em vez de só renomear o teste, porque o teste sem o guard não tem o
que afirmar. Controle negativo: remover o `isinstance` derruba o teste com
`TypeError: unhashable type: 'list'` em `core/intent_router.py:802`.

## Testes

Quatro casos novos em `tests/test_perguntas_guardam_contexto.py`, todos pela
conversa (`handle_incoming`, estado real no banco), todos sem IA:

- `test_185_nome_do_catalogo_vence_o_comando` — o caso da issue: o saque de
  R$ 200 na caixinha `saldo` fecha (300,00 no `db.list_pockets`);
- `test_185_abandono_comum_continua_vivo` — **controle positivo, e é ele que
  separa este conserto do proposto**: sem caixinha chamada "saldo", `saldo`
  continua sendo o comando. A one-liner da issue derruba exatamente este caso;
- `test_185_saque_legitimo_pelo_nome_ainda_funciona` — controle positivo 2, o
  caminho normal (`criar caixinha viagem` → 300 → `saquei 100` → `viagem` → 200);
- `test_185_pergunta_de_valor_continua_abandonando` — `falta == "amount"`
  inalterado, com a caixinha `saldo` no catálogo para o caso discriminar.

Mais dois, que prendem os tetos no tamanho medido (foi a falta deles que deixou
o texto divergir do código):

- `test_185_teto2_comando_pendente_esvazia_a_caixinha` — `esvaziar caixinha` +
  `saldo` zera a caixinha de R$ 300 (300,00 -> 0,00);
- `test_185_teto3_veto_dispara_sem_valor_a_perder` — `tirar da caixinha` +
  `saldo` devolve "Qual o valor?" e nada se move (caixinha segue em 300,00).

`test_escotilha_outro_comando_abandona` (a escotilha do caso comum) segue verde.

**Controles negativos, medidos** (cada um injetado num caso que estava VERDE):

- remover o bloco do passo 4 → `test_185_nome_do_catalogo_vence_o_comando`,
  `test_185_teto2_comando_pendente_esvazia_a_caixinha` e
  `test_185_teto3_veto_dispara_sem_valor_a_perder` FALHAM (3 failed, 4 passed);
- trocar o `return not _eh_nome_do_catalogo(...)` por `return False` →
  `test_185_abandono_comum_continua_vivo` FALHA (1 failed, 6 passed);
- remover o `isinstance(intent, str)` →
  `test_clarification_com_payload_torto_nao_estoura` FALHA (1 failed, 6 passed).

**Classe cega declarada:** as portas de caixinha/investimento cujo payload
guarda `amount` só são alcançáveis via LLM, que não roda nos testes. O que a
suíte prova é a rota `funds.withdraw`.

## Suíte

Baseline em worktree limpo de `origin/main` (346270d): **5833 passed, 4 xfailed,
0 failed** (228s). Branch: **5839 passed, 4 xfailed, 0 failed** (167s) — o delta
de 6 são exatamente os testes novos (4 do conserto + 2 dos tetos). Comparado por nome: nenhuma falha dos dois
lados.

**Não verificado aqui:** WhatsApp real e caminho com LLM — os testes mockam o
classificador de IA e o envio. Só no aparelho, depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

