### PR TITLE
ONDA 1: tira a cara de template das páginas públicas

### DIFF
--- a/frontend/agents.html
+++ b/frontend/agents.html
@@ -106,9 +106,9 @@
   <div class="wrap">
 
     <section class="section">
-      <div class="section-head">
+      <div class="section-head center">
         <div class="pill" style="margin:0 auto 18px"><span class="tag-novo">NOVO</span> Sua equipe financeira no automático</div>
-        <h2>Os <span class="grad">Agentes</span><br>do Piggy</h2>
+        <h1>Os <span class="grad">Agentes</span><br>do Piggy</h1>
         <p>Pequenos assistentes que trabalham por você nos bastidores. Cada um cuida de uma parte do seu dinheiro, vigiando gastos, avisando de boletos e caçando desperdício, sem você precisar pedir.</p>
       </div>
 

--- a/frontend/changelog.html
+++ b/frontend/changelog.html
@@ -41,9 +41,8 @@
   <div class="wrap">
 
     <section class="section">
-      <div class="section-head">
-        <div class="eyebrow">PigBank+</div>
-        <h2>Notícias do <span class="grad">mercado</span></h2>
+      <div class="section-head center">
+        <h1>Notícias do <span class="grad">mercado</span></h1>
         <p>Resumos do mercado financeiro feitos pela Piggy, atualizados ao longo do dia. Exclusivo pra assinantes.</p>
       </div>
 

--- a/frontend/comandos.html
+++ b/frontend/comandos.html
@@ -36,7 +36,6 @@
   <div class="wrap cmds-page">
 
     <section class="hero">
-      <div class="eyebrow">O que pedir</div>
       <h1>Pergunta do jeito que <span class="grad">sair na cabeça</span></h1>
       <p>O Piggy não tem comando decorado: você fala português corrido e ele entende. Aqui em baixo tem algumas das coisas que dá pra pedir, pra você ter ideia. Clica em qualquer exemplo pra copiar.</p>
     </section>

--- a/frontend/como-funciona.html
+++ b/frontend/como-funciona.html
@@ -37,27 +37,34 @@
 
     <section class="section">
       <div class="section-head">
-        <h2>Simples, rápido e<br>no seu <span class="grad">WhatsApp</span></h2>
-        <p>Em poucos minutos você já está no controle do seu dinheiro, sem planilha, sem app pra baixar.</p>
+        <h1>Do primeiro “oi” até<br>o mês fechado</h1>
+        <p>Só o primeiro acontece fora do WhatsApp — nos outros três você só digita.</p>
+      </div>
+
+      <div class="section-head" style="margin-bottom:30px">
+        <h2>Quatro passos</h2>
       </div>
 
       <div class="how-grid">
-        <div class="steps">
+        <div class="steps steps-typed">
           <div class="step">
             <div class="step-num">1</div>
             <div><h3>Crie sua conta</h3><p>Em segundos, entrando com o Google. Depois você ativa 15 dias grátis pra testar tudo.</p></div>
           </div>
           <div class="step">
             <div class="step-num">2</div>
-            <div><h3>Conecte o WhatsApp</h3><p>Fale com a Piggy pelo número do bot. É onde tudo acontece. Nada pra instalar.</p></div>
+            <div><h3>Conecte o WhatsApp</h3><p>Salve o número da Piggy e mande a primeira mensagem. É onde tudo acontece, nada pra instalar.</p>
+              <span class="phrase cmd">oi</span></div>
           </div>
           <div class="step">
             <div class="step-num">3</div>
-            <div><h3>Registre falando</h3><p>"Gastei R$ 50 no mercado" e pronto: a IA entende, categoriza e salva na hora.</p></div>
+            <div><h3>Registre falando</h3><p>Conte o gasto como contaria pra um amigo: a IA entende, categoriza e salva na hora.</p>
+              <span class="phrase cmd">gastei 50 no mercado</span></div>
           </div>
           <div class="step">
             <div class="step-num">4</div>
-            <div><h3>Acompanhe tudo</h3><p>Saldo, gastos, caixinhas e metas no dashboard, atualizados em tempo real.</p></div>
+            <div><h3>Acompanhe tudo</h3><p>Pergunte pela conversa ou abra o dashboard: saldo, gastos, caixinhas e metas, atualizados em tempo real.</p>
+              <span class="phrase cmd">quanto sobrou</span></div>
           </div>
         </div>
 
@@ -69,15 +76,15 @@
           </div>
           <div class="bubble user">Gastei 32 no uber</div>
           <div class="bubble bot">Anotado!<br>Categoria: <b>Transporte</b><br>Saldo atual: <b>R$ 1.218,00</b></div>
-          <div class="bubble user">quanto sobrou esse mês?</div>
+          <div class="bubble user">quanto sobrou</div>
           <div class="bubble bot">Você tem <b>R$ 1.218,00</b><br>Já guardou <b>R$ 300</b> na caixinha "Viagem". Bora?</div>
         </div>
       </div>
 
       <div class="cta-band">
-        <h2>Pronto para começar?</h2>
-        <p>Sua vida financeira resolvida no WhatsApp, a partir de agora.</p>
-        <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora →</a>
+        <h2>O passo 1 leva alguns segundos</h2>
+        <p>Do 2 em diante é só conversa — e você já sabe usar o WhatsApp.</p>
+        <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
     </section>
 

--- a/frontend/funcionalidades.html
+++ b/frontend/funcionalidades.html
@@ -37,8 +37,12 @@
 
     <section class="section">
       <div class="section-head">
-        <h2>Recursos que fazem<br>a <span class="grad">diferença</span></h2>
-        <p>Tudo que você precisa pra organizar sua vida financeira, sem planilha, sem app pra baixar, direto no WhatsApp.</p>
+        <h1>Tudo o que a Piggy faz</h1>
+        <p>A home mostra o que a Piggy faz. Aqui está como pedir cada uma — do jeito que a frase sairia numa conversa.</p>
+      </div>
+
+      <div class="section-head" style="margin-bottom:30px">
+        <h2>Cada recurso, e a frase<br>que faz ele acontecer</h2>
       </div>
 
       <div class="grid-3">
@@ -46,163 +50,55 @@
           <div class="icon-box"><i class="ph ph-chat-circle" aria-hidden="true"></i></div>
           <h3>Registro por conversa</h3>
           <p>Fale como você fala. A IA entende, categoriza e registra o gasto na hora, em segundos.</p>
+          <span class="phrase cmd">gastei 32 no almoço</span>
         </div>
         <div class="card feature-card">
           <div class="icon-box neon"><i class="ph ph-tag" aria-hidden="true"></i></div>
           <h3>Categorização automática</h3>
           <p>Cada gasto cai na categoria certa sozinho. Você não precisa marcar nada manualmente.</p>
+          <span class="phrase cmd">gastei 89 na farmácia</span>
         </div>
         <div class="card feature-card">
           <div class="icon-box"><i class="ph ph-piggy-bank" aria-hidden="true"></i></div>
           <h3>Caixinhas & metas</h3>
           <p>Separe dinheiro por objetivo e acompanhe o progresso de cada meta que você criar.</p>
+          <span class="phrase cmd">guarda 300 na caixinha Viagem</span>
         </div>
         <div class="card feature-card">
           <div class="icon-box neon"><i class="ph ph-credit-card" aria-hidden="true"></i></div>
           <h3>Cartões & faturas</h3>
           <p>Limite, fatura aberta e parcelamentos de todos os seus cartões num lugar só.</p>
+          <span class="phrase cmd">minha fatura do Nubank</span>
         </div>
         <div class="card feature-card">
           <div class="icon-box"><i class="ph ph-bell" aria-hidden="true"></i></div>
-          <h3>Alertas inteligentes</h3>
-          <p>A Piggy te avisa quando um gasto foge do padrão ou o orçamento começa a apertar.</p>
+          <h3>Orçamentos e alertas</h3>
+          <p>Você põe o limite da categoria; a Piggy avisa quando o gasto foge do padrão ou o orçamento aperta.</p>
+          <span class="phrase cmd">define orçamento de 500 em lazer</span>
         </div>
         <div class="card feature-card">
-          <div class="icon-box neon"><i class="ph ph-lock" aria-hidden="true"></i></div>
-          <h3>Segurança & privacidade</h3>
-          <p>Seus dados sensíveis são cifrados. Você fica no controle das suas informações, sempre.</p>
+          <div class="icon-box neon"><i class="ph ph-chart-bar" aria-hidden="true"></i></div>
+          <h3>Resumos e relatórios</h3>
+          <p>Onde o dinheiro foi, o fechamento do mês e a comparação com o anterior, sem abrir planilha.</p>
+          <span class="phrase cmd">resumo mensal</span>
         </div>
       </div>
-    </section>
 
-    <section class="tech-split">
-      <div class="tech-copy">
-        <div class="eyebrow">Tecnologia</div>
-        <h2>A inteligência que<br><span class="grad">facilita sua vida</span></h2>
-        <ul class="tech-list">
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> IA que entende português do dia a dia</li>
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização que aprende com você</li>
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard atualizado em tempo real</li>
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp, zero apps pra baixar</li>
-        </ul>
-        <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora →</a>
-      </div>
-      <div class="tech-visual">
-        <div class="hologram" aria-label="Cubo AI holográfico em wireframe">
-          <div class="floating">
-            <svg viewBox="0 0 800 800" role="img" aria-labelledby="holoTitle holoDesc">
-              <title id="holoTitle">Cubo AI holográfico com texto em relevo</title>
-              <desc id="holoDesc">Cubo isométrico em wireframe rosa neon, com letras AI em perspectiva e extrusão tridimensional sobre a face superior.</desc>
-
-              <defs>
-                <linearGradient id="edgeGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stop-color="#ff2d75" /><stop offset="52%" stop-color="#ec1758" /><stop offset="100%" stop-color="#b10c42" />
-                </linearGradient>
-                <linearGradient id="hotGradient" x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="0%" stop-color="#ff86b1" /><stop offset="28%" stop-color="#ff2d75" /><stop offset="100%" stop-color="#ec1758" />
-                </linearGradient>
-                <linearGradient id="aiGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stop-color="#ff79aa" /><stop offset="38%" stop-color="#ff2d75" /><stop offset="100%" stop-color="#e31455" />
-                </linearGradient>
-                <filter id="neonGlow" x="-100%" y="-100%" width="300%" height="300%">
-                  <feGaussianBlur stdDeviation="3.5" result="a" /><feGaussianBlur stdDeviation="8.5" result="b" />
-                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="softGlow" x="-100%" y="-100%" width="300%" height="300%">
-                  <feGaussianBlur stdDeviation="2.5" result="a" /><feMerge><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="nodeGlow" x="-200%" y="-200%" width="500%" height="500%">
-                  <feGaussianBlur stdDeviation="4" result="a" /><feGaussianBlur stdDeviation="8" result="b" />
-                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="textGlow" x="-100%" y="-100%" width="300%" height="300%">
-                  <feGaussianBlur stdDeviation="4" result="a" /><feGaussianBlur stdDeviation="12" result="b" />
-                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="particleGlow" x="-250%" y="-250%" width="600%" height="600%">
-                  <feGaussianBlur stdDeviation="2.2" result="a" /><feMerge><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <clipPath id="topClip"><polygon points="400,148 648,292 400,436 152,292" /></clipPath>
-              </defs>
-
-              <g aria-hidden="true">
-                <path class="circuit" d="M66 332 H165 L212 379 H276" /><path class="circuit" d="M70 546 H170 L222 494 H282" />
-                <path class="circuit" d="M734 332 H635 L588 379 H524" /><path class="circuit" d="M730 546 H630 L578 494 H518" />
-                <path class="circuit" d="M400 58 V118 L366 152" /><path class="circuit" d="M400 744 V684 L435 649" />
-                <path class="circuit" d="M116 228 H186 L221 263" /><path class="circuit" d="M684 228 H614 L579 263" />
-                <path class="circuit" d="M95 642 H176 L226 592" /><path class="circuit" d="M705 642 H624 L574 592" />
-                <circle class="circuit-dot" cx="66" cy="332" r="2.2"/><circle class="circuit-dot" cx="70" cy="546" r="2.2"/>
-                <circle class="circuit-dot" cx="734" cy="332" r="2.2"/><circle class="circuit-dot" cx="730" cy="546" r="2.2"/>
-                <circle class="circuit-dot" cx="400" cy="58" r="2.2"/><circle class="circuit-dot" cx="400" cy="744" r="2.2"/>
-              </g>
-
-              <g aria-hidden="true">
-                <circle class="particle" cx="126" cy="275" r="2.2" style="--duration:5.4s;--delay:-1.1s"/>
-                <circle class="particle soft" cx="174" cy="421" r="1.7" style="--duration:6.2s;--delay:-3.5s"/>
-                <circle class="particle dim" cx="124" cy="554" r="2.8" style="--duration:7s;--delay:-2.4s"/>
-                <circle class="particle" cx="235" cy="655" r="1.9" style="--duration:5s;--delay:-.8s"/>
-                <circle class="particle soft" cx="340" cy="706" r="2.2" style="--duration:5.8s;--delay:-4.1s"/>
-                <circle class="particle dim" cx="478" cy="691" r="2.5" style="--duration:6.8s;--delay:-1.8s"/>
-                <circle class="particle soft" cx="588" cy="626" r="1.8" style="--duration:5.1s;--delay:-2.3s"/>
-                <circle class="particle" cx="684" cy="518" r="2.5" style="--duration:6.4s;--delay:-4.7s"/>
-                <circle class="particle dim" cx="692" cy="363" r="2.7" style="--duration:7.2s;--delay:-3s"/>
-                <circle class="particle" cx="637" cy="218" r="1.8" style="--duration:5.7s;--delay:-1.5s"/>
-                <circle class="particle soft" cx="530" cy="115" r="2.2" style="--duration:6.5s;--delay:-4.4s"/>
-                <circle class="particle dim" cx="365" cy="82" r="2.5" style="--duration:7.3s;--delay:-2.9s"/>
-                <circle class="particle soft" cx="247" cy="125" r="1.8" style="--duration:5.3s;--delay:-.5s"/>
-              </g>
-
-              <g class="cube">
-                <g class="face-grid top-grid">
-                  <path d="M214 256 L462 400"/><path d="M276 220 L524 364"/><path d="M338 184 L586 328"/>
-                  <path d="M586 256 L338 400"/><path d="M524 220 L276 364"/><path d="M462 184 L214 328"/>
-                </g>
-                <g class="face-grid">
-                  <path d="M214 328 L400 436 L400 690"/><path d="M276 364 L400 436"/><path d="M338 400 L400 436"/>
-                  <path d="M152 356 L400 500"/><path d="M152 420 L400 564"/><path d="M152 484 L400 628"/>
-                  <path d="M586 328 L400 436 L400 690"/><path d="M524 364 L400 436"/><path d="M462 400 L400 436"/>
-                  <path d="M648 356 L400 500"/><path d="M648 420 L400 564"/><path d="M648 484 L400 628"/>
-                </g>
-
-                <path class="inner" d="M400 148 L400 436 L400 690"/>
-                <path class="inner" d="M152 292 L400 436 L648 292"/>
-                <path class="inner" d="M152 548 L400 436 L648 548"/>
-                <path class="inner" d="M276 364 L276 620"/><path class="inner" d="M524 364 L524 620"/>
-
-                <path class="edge back" d="M400 148 L152 292"/><path class="edge back" d="M400 148 L648 292"/><path class="edge back" d="M400 148 L400 436"/>
-                <path class="edge strong" d="M400 148 L648 292 L400 436 L152 292 Z"/>
-                <path class="edge" d="M152 292 L400 436 L400 690 L152 548 Z"/>
-                <path class="edge strong" d="M648 292 L400 436 L400 690 L648 548 Z"/>
-                <path class="edge" d="M152 548 L400 690 L648 548"/>
-                <path class="edge" d="M152 292 L152 548"/><path class="edge strong" d="M400 436 L400 690"/><path class="edge strong" d="M648 292 L648 548"/>
-
-                <g clip-path="url(#topClip)" aria-label="AI">
-                  <g transform="translate(0 18)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-deep" x="-36" y="0">A</text><text class="ai-text ai-depth-deep" x="36" y="0">I</text></g></g>
-                  <g transform="translate(0 12)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-mid" x="-36" y="0">A</text><text class="ai-text ai-depth-mid" x="36" y="0">I</text></g></g>
-                  <g transform="translate(0 6)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-mid" x="-36" y="0">A</text><text class="ai-text ai-depth-mid" x="36" y="0">I</text></g></g>
-                  <g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-letter-top" x="-36" y="0">A</text><text class="ai-text ai-letter-top" x="36" y="0">I</text></g>
-                </g>
-
-                <path class="scan" d="M232 363 L400 460 L568 363"/>
-
-                <circle class="node" cx="400" cy="148" r="4.2"/><circle class="node" cx="152" cy="292" r="4.2"/><circle class="node" cx="648" cy="292" r="4.2"/>
-                <circle class="node" cx="400" cy="436" r="4.8"/><circle class="node" cx="152" cy="548" r="4.1"/><circle class="node" cx="648" cy="548" r="4.1"/>
-                <circle class="node" cx="400" cy="690" r="4.8"/>
-                <circle class="node small" cx="276" cy="220" r="2.2"/><circle class="node small" cx="524" cy="220" r="2.2"/>
-                <circle class="node small" cx="276" cy="364" r="2.2"/><circle class="node small" cx="524" cy="364" r="2.2"/>
-                <circle class="node small" cx="152" cy="420" r="2.1"/><circle class="node small" cx="648" cy="420" r="2.1"/>
-                <circle class="node small" cx="400" cy="564" r="2.3"/><circle class="node small" cx="276" cy="620" r="2.1"/><circle class="node small" cx="524" cy="620" r="2.1"/>
-
-                <circle class="particle" cx="330" cy="340" r="1.8" style="--duration:4.7s;--delay:-1.1s"/>
-                <circle class="particle soft" cx="474" cy="350" r="2" style="--duration:5.7s;--delay:-3.4s"/>
-                <circle class="particle dim" cx="316" cy="468" r="2.3" style="--duration:6.5s;--delay:-2.1s"/>
-                <circle class="particle" cx="484" cy="494" r="1.7" style="--duration:5.1s;--delay:-4.1s"/>
-                <circle class="particle soft" cx="365" cy="575" r="2" style="--duration:6s;--delay:-.9s"/>
-                <circle class="particle" cx="442" cy="610" r="1.8" style="--duration:4.8s;--delay:-2.8s"/>
-              </g>
-            </svg>
-          </div>
+      <!-- Segurança em bloco próprio: era uma oração subordinada no subtítulo
+           do CTA, a única menção do assunto na página. Copy igual à do FAQ da
+           home, que é a fonte dessa resposta. -->
+      <div class="card sec-note">
+        <div class="icon-box"><i class="ph ph-lock-key" aria-hidden="true"></i></div>
+        <div>
+          <h3>Segurança &amp; privacidade</h3>
+          <p>Seus dados sensíveis são cifrados e o controle das informações continua sendo seu. A PigBank não é banco nem corretora: <strong>nunca movimenta, transfere ou guarda</strong> o seu dinheiro. Se você conectar um banco, é via Open Finance oficial, <strong>só de leitura</strong> e autorizado por você — e você revoga o acesso quando quiser.</p>
         </div>
+      </div>
+
+      <div class="cta-band">
+        <h2>Crie a conta e mande a primeira frase</h2>
+        <p>São frases reais, do jeito que você digitaria. A conta leva alguns segundos; daí em diante é tudo pelo WhatsApp.</p>
+        <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
     </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,9 +139,9 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
           <a class="btn btn-outline btn-lg" href="#como-funciona">Ver como funciona</a>
         </div>
         <div class="trust">
-          <span><i class="dot"></i> Seguro e confiável</span>
-          <span><i class="dot"></i> Rápido e prático</span>
-          <span><i class="dot"></i> Privacidade garantida</span>
+          <span><i class="dot"></i> Texto, áudio ou foto do comprovante</span>
+          <span><i class="dot"></i> Sem instalar nada</span>
+          <span><i class="dot"></i> Dados criptografados</span>
         </div>
       </div>
 
@@ -205,7 +205,11 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
 
     <!-- ─── VSL ──────────────────────────────────────────────────── -->
     <section class="section" id="vsl">
-      <div class="section-head" data-reveal>
+      <!-- .center: o conteúdo desta seção é bloco estreito centrado (.vsl-frame,
+           860px de 1152) mais o CTA centrado. Sem a classe o cabeçalho caía em
+           404 contra 640 do vídeo — 236px fora do eixo. As outras seções desta
+           página apresentam grade de largura cheia e ficam alinhadas à esquerda. -->
+      <div class="section-head center" data-reveal>
         <div class="eyebrow">Assista antes de começar</div>
         <h2>Em 1 minuto você entende<br><span class="grad">tudo que a Piggy faz</span></h2>
       </div>
@@ -249,9 +253,8 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     <!-- ─── Funcionalidades ───────────────────────────────────────── -->
     <section class="section" id="funcionalidades">
       <div class="section-head" data-reveal>
-        <div class="eyebrow">Funcionalidades</div>
-        <h2>Recursos que fazem<br>a <span class="grad">diferença</span></h2>
-        <p>Tudo que você precisa pra organizar sua vida financeira, sem planilha, sem app pra baixar, direto no WhatsApp.</p>
+        <h2>O que a Piggy faz enquanto<br>você só conversa</h2>
+        <p>Você manda o gasto como mandaria pra um amigo. Ela categoriza, atualiza o saldo e guarda o histórico — sem planilha, sem app pra baixar.</p>
       </div>
 
       <div class="grid-3" data-reveal>
@@ -270,21 +273,11 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
           <h3>Caixinhas &amp; metas</h3>
           <p>Separe dinheiro por objetivo e acompanhe o progresso de cada meta que você criar.</p>
         </div>
-        <div class="card feature-card">
-          <div class="icon-box neon"><i class="ph ph-credit-card" aria-hidden="true"></i></div>
-          <h3>Cartões &amp; faturas</h3>
-          <p>Limite, fatura aberta e parcelamentos de todos os seus cartões num lugar só.</p>
-        </div>
-        <div class="card feature-card">
-          <div class="icon-box"><i class="ph ph-bell" aria-hidden="true"></i></div>
-          <h3>Alertas inteligentes</h3>
-          <p>A Piggy te avisa quando um gasto foge do padrão ou o orçamento começa a apertar.</p>
-        </div>
-        <div class="card feature-card">
-          <div class="icon-box neon"><i class="ph ph-lock" aria-hidden="true"></i></div>
-          <h3>Segurança &amp; privacidade</h3>
-          <p>Seus dados sensíveis são cifrados. Você fica no controle das suas informações, sempre.</p>
-        </div>
+      </div>
+
+      <div class="sec-more" data-reveal>
+        <p>Cartões, alertas e o resto: cada um com a frase que aciona.</p>
+        <a class="btn btn-outline" href="/funcionalidades">Ver todas as funcionalidades <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
     </section>
 
@@ -293,14 +286,14 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     <!-- ─── Como funciona ─────────────────────────────────────────── -->
     <section class="section" id="como-funciona">
       <div class="section-head" data-reveal>
-        <div class="eyebrow">Como funciona</div>
-        <h2>Simples, rápido e<br>no seu <span class="grad">WhatsApp</span></h2>
+        <h2>De “gastei 32 no almoço”<br>até o saldo atualizado</h2>
+        <p>Três passos, um minuto, dentro de uma conversa que você já usa todo dia.</p>
       </div>
 
       <div class="hiw-rail">
 
         <article class="hiw-card is-open" tabindex="0" aria-current="step">
-          <div class="hiw-head"><span class="hiw-num">01</span><h3>Conexão</h3></div>
+          <div class="hiw-head"><span class="hiw-num">1</span><h3>Conexão</h3></div>
           <div class="hiw-stage">
             <div class="hiw-state hiw-demo">
               <div class="hiw-panel">
@@ -322,7 +315,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
             </div>
             <div class="hiw-state hiw-idle">
               <div class="hiw-ring"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"/></svg></div>
-              <span>passo 1 de 3</span>
+              <span>salve o número, mande um “oi”</span>
             </div>
           </div>
           <div class="hiw-foot">
@@ -331,7 +324,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         </article>
 
         <article class="hiw-card is-idle" tabindex="0">
-          <div class="hiw-head"><span class="hiw-num">02</span><h3>Resposta</h3></div>
+          <div class="hiw-head"><span class="hiw-num">2</span><h3>Resposta</h3></div>
           <div class="hiw-stage">
             <div class="hiw-state hiw-demo">
               <div class="hiw-panel">
@@ -356,7 +349,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
             </div>
             <div class="hiw-state hiw-idle">
               <div class="hiw-ring"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"/></svg></div>
-              <span>passo 2 de 3</span>
+              <span>conte o gasto, ela anota</span>
             </div>
           </div>
           <div class="hiw-foot">
@@ -365,7 +358,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
         </article>
 
         <article class="hiw-card is-idle" tabindex="0">
-          <div class="hiw-head"><span class="hiw-num">03</span><h3>Painel</h3></div>
+          <div class="hiw-head"><span class="hiw-num">3</span><h3>Painel</h3></div>
           <div class="hiw-stage">
             <div class="hiw-state hiw-demo">
               <div class="hiw-charts">
@@ -408,7 +401,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
             </div>
             <div class="hiw-state hiw-idle">
               <div class="hiw-ring"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"/></svg></div>
-              <span>passo 3 de 3</span>
+              <span>gráficos e saldo em tempo real</span>
             </div>
           </div>
           <div class="hiw-foot">
@@ -428,132 +421,68 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     <!-- ─── IA / Tecnologia ───────────────────────────────────────── -->
     <section class="tech-split">
       <div class="tech-copy" data-reveal>
-        <div class="eyebrow">Tecnologia</div>
-        <h2>A inteligência que<br><span class="grad">facilita sua vida</span></h2>
+        <h2>Ela entende português<br>do jeito que você escreve</h2>
         <ul class="tech-list">
-          <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> IA que entende português do dia a dia</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Categorização que aprende com você</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Dashboard atualizado em tempo real</li>
           <li><span class="tick"><i class="ph ph-check" aria-hidden="true"></i></span> Tudo no WhatsApp, zero apps pra baixar</li>
         </ul>
         <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
+      <!-- Prova do título ao lado: o vocabulário real que a Piggy aceita.
+           Substituiu um cubo wireframe com as letras "AI" — decoração que não
+           explicava nada e é o visual mais genérico possível de IA. As oito
+           frases foram passadas pelo classify(..., allow_ai=False) e todas
+           resolvem SEM IA. Seis estão literais no catálogo
+           (core/commands_catalog.py, espelhado em /comandos); as outras duas —
+           "gastei 32 no almoço" e "quanto sobrou" — saem do
+           core/intent_classifier.py. Não acrescente frase aqui sem rodar o
+           classificador nela: "quanto sobrou esse mês?" já esteve aqui e dava
+           out_of_scope 0.0, porque o :70 é dicionário de match EXATO. -->
       <div class="tech-visual" data-reveal>
-        <div class="hologram" aria-label="Cubo AI holográfico em wireframe">
-          <div class="floating">
-            <svg viewBox="0 0 800 800" role="img" aria-labelledby="holoTitle holoDesc">
-              <title id="holoTitle">Cubo AI holográfico com texto em relevo</title>
-              <desc id="holoDesc">Cubo isométrico em wireframe rosa neon, com letras AI em perspectiva e extrusão tridimensional sobre a face superior.</desc>
-
-              <defs>
-                <linearGradient id="edgeGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stop-color="#ff2d75" /><stop offset="52%" stop-color="#ec1758" /><stop offset="100%" stop-color="#b10c42" />
-                </linearGradient>
-                <linearGradient id="hotGradient" x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="0%" stop-color="#ff86b1" /><stop offset="28%" stop-color="#ff2d75" /><stop offset="100%" stop-color="#ec1758" />
-                </linearGradient>
-                <linearGradient id="aiGradient" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="0%" stop-color="#ff79aa" /><stop offset="38%" stop-color="#ff2d75" /><stop offset="100%" stop-color="#e31455" />
-                </linearGradient>
-                <filter id="neonGlow" x="-100%" y="-100%" width="300%" height="300%">
-                  <feGaussianBlur stdDeviation="3.5" result="a" /><feGaussianBlur stdDeviation="8.5" result="b" />
-                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="softGlow" x="-100%" y="-100%" width="300%" height="300%">
-                  <feGaussianBlur stdDeviation="2.5" result="a" /><feMerge><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="nodeGlow" x="-200%" y="-200%" width="500%" height="500%">
-                  <feGaussianBlur stdDeviation="4" result="a" /><feGaussianBlur stdDeviation="8" result="b" />
-                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="textGlow" x="-100%" y="-100%" width="300%" height="300%">
-                  <feGaussianBlur stdDeviation="4" result="a" /><feGaussianBlur stdDeviation="12" result="b" />
-                  <feMerge><feMergeNode in="b" /><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="particleGlow" x="-250%" y="-250%" width="600%" height="600%">
-                  <feGaussianBlur stdDeviation="2.2" result="a" /><feMerge><feMergeNode in="a" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <clipPath id="topClip"><polygon points="400,148 648,292 400,436 152,292" /></clipPath>
-              </defs>
-
-              <g aria-hidden="true">
-                <path class="circuit" d="M66 332 H165 L212 379 H276" /><path class="circuit" d="M70 546 H170 L222 494 H282" />
-                <path class="circuit" d="M734 332 H635 L588 379 H524" /><path class="circuit" d="M730 546 H630 L578 494 H518" />
-                <path class="circuit" d="M400 58 V118 L366 152" /><path class="circuit" d="M400 744 V684 L435 649" />
-                <path class="circuit" d="M116 228 H186 L221 263" /><path class="circuit" d="M684 228 H614 L579 263" />
-                <path class="circuit" d="M95 642 H176 L226 592" /><path class="circuit" d="M705 642 H624 L574 592" />
-                <circle class="circuit-dot" cx="66" cy="332" r="2.2"/><circle class="circuit-dot" cx="70" cy="546" r="2.2"/>
-                <circle class="circuit-dot" cx="734" cy="332" r="2.2"/><circle class="circuit-dot" cx="730" cy="546" r="2.2"/>
-                <circle class="circuit-dot" cx="400" cy="58" r="2.2"/><circle class="circuit-dot" cx="400" cy="744" r="2.2"/>
-              </g>
-
-              <g aria-hidden="true">
-                <circle class="particle" cx="126" cy="275" r="2.2" style="--duration:5.4s;--delay:-1.1s"/>
-                <circle class="particle soft" cx="174" cy="421" r="1.7" style="--duration:6.2s;--delay:-3.5s"/>
-                <circle class="particle dim" cx="124" cy="554" r="2.8" style="--duration:7s;--delay:-2.4s"/>
-                <circle class="particle" cx="235" cy="655" r="1.9" style="--duration:5s;--delay:-.8s"/>
-                <circle class="particle soft" cx="340" cy="706" r="2.2" style="--duration:5.8s;--delay:-4.1s"/>
-                <circle class="particle dim" cx="478" cy="691" r="2.5" style="--duration:6.8s;--delay:-1.8s"/>
-                <circle class="particle soft" cx="588" cy="626" r="1.8" style="--duration:5.1s;--delay:-2.3s"/>
-                <circle class="particle" cx="684" cy="518" r="2.5" style="--duration:6.4s;--delay:-4.7s"/>
-                <circle class="particle dim" cx="692" cy="363" r="2.7" style="--duration:7.2s;--delay:-3s"/>
-                <circle class="particle" cx="637" cy="218" r="1.8" style="--duration:5.7s;--delay:-1.5s"/>
-                <circle class="particle soft" cx="530" cy="115" r="2.2" style="--duration:6.5s;--delay:-4.4s"/>
-                <circle class="particle dim" cx="365" cy="82" r="2.5" style="--duration:7.3s;--delay:-2.9s"/>
-                <circle class="particle soft" cx="247" cy="125" r="1.8" style="--duration:5.3s;--delay:-.5s"/>
-              </g>
-
-              <g class="cube">
-                <g class="face-grid top-grid">
-                  <path d="M214 256 L462 400"/><path d="M276 220 L524 364"/><path d="M338 184 L586 328"/>
-                  <path d="M586 256 L338 400"/><path d="M524 220 L276 364"/><path d="M462 184 L214 328"/>
-                </g>
-                <g class="face-grid">
-                  <path d="M214 328 L400 436 L400 690"/><path d="M276 364 L400 436"/><path d="M338 400 L400 436"/>
-                  <path d="M152 356 L400 500"/><path d="M152 420 L400 564"/><path d="M152 484 L400 628"/>
-                  <path d="M586 328 L400 436 L400 690"/><path d="M524 364 L400 436"/><path d="M462 400 L400 436"/>
-                  <path d="M648 356 L400 500"/><path d="M648 420 L400 564"/><path d="M648 484 L400 628"/>
-                </g>
-
-                <path class="inner" d="M400 148 L400 436 L400 690"/>
-                <path class="inner" d="M152 292 L400 436 L648 292"/>
-                <path class="inner" d="M152 548 L400 436 L648 548"/>
-                <path class="inner" d="M276 364 L276 620"/><path class="inner" d="M524 364 L524 620"/>
-
-                <path class="edge back" d="M400 148 L152 292"/><path class="edge back" d="M400 148 L648 292"/><path class="edge back" d="M400 148 L400 436"/>
-                <path class="edge strong" d="M400 148 L648 292 L400 436 L152 292 Z"/>
-                <path class="edge" d="M152 292 L400 436 L400 690 L152 548 Z"/>
-                <path class="edge strong" d="M648 292 L400 436 L400 690 L648 548 Z"/>
-                <path class="edge" d="M152 548 L400 690 L648 548"/>
-                <path class="edge" d="M152 292 L152 548"/><path class="edge strong" d="M400 436 L400 690"/><path class="edge strong" d="M648 292 L648 548"/>
-
-                <g clip-path="url(#topClip)" aria-label="AI">
-                  <g transform="translate(0 18)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-deep" x="-36" y="0">A</text><text class="ai-text ai-depth-deep" x="36" y="0">I</text></g></g>
-                  <g transform="translate(0 12)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-mid" x="-36" y="0">A</text><text class="ai-text ai-depth-mid" x="36" y="0">I</text></g></g>
-                  <g transform="translate(0 6)"><g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-depth-mid" x="-36" y="0">A</text><text class="ai-text ai-depth-mid" x="36" y="0">I</text></g></g>
-                  <g transform="matrix(0.78 0.45 -0.78 0.45 400 276)"><text class="ai-text ai-letter-top" x="-36" y="0">A</text><text class="ai-text ai-letter-top" x="36" y="0">I</text></g>
-                </g>
-
-                <path class="scan" d="M232 363 L400 460 L568 363"/>
-
-                <circle class="node" cx="400" cy="148" r="4.2"/><circle class="node" cx="152" cy="292" r="4.2"/><circle class="node" cx="648" cy="292" r="4.2"/>
-                <circle class="node" cx="400" cy="436" r="4.8"/><circle class="node" cx="152" cy="548" r="4.1"/><circle class="node" cx="648" cy="548" r="4.1"/>
-                <circle class="node" cx="400" cy="690" r="4.8"/>
-                <circle class="node small" cx="276" cy="220" r="2.2"/><circle class="node small" cx="524" cy="220" r="2.2"/>
-                <circle class="node small" cx="276" cy="364" r="2.2"/><circle class="node small" cx="524" cy="364" r="2.2"/>
-                <circle class="node small" cx="152" cy="420" r="2.1"/><circle class="node small" cx="648" cy="420" r="2.1"/>
-                <circle class="node small" cx="400" cy="564" r="2.3"/><circle class="node small" cx="276" cy="620" r="2.1"/><circle class="node small" cx="524" cy="620" r="2.1"/>
-
-                <circle class="particle" cx="330" cy="340" r="1.8" style="--duration:4.7s;--delay:-1.1s"/>
-                <circle class="particle soft" cx="474" cy="350" r="2" style="--duration:5.7s;--delay:-3.4s"/>
-                <circle class="particle dim" cx="316" cy="468" r="2.3" style="--duration:6.5s;--delay:-2.1s"/>
-                <circle class="particle" cx="484" cy="494" r="1.7" style="--duration:5.1s;--delay:-4.1s"/>
-                <circle class="particle soft" cx="365" cy="575" r="2" style="--duration:6s;--delay:-.9s"/>
-                <circle class="particle" cx="442" cy="610" r="1.8" style="--duration:4.8s;--delay:-2.8s"/>
-              </g>
-            </svg>
-          </div>
+        <div class="phrasebook" role="list" aria-label="Exemplos de mensagens que a Piggy entende">
+          <span class="phrase" role="listitem">gastei 32 no almoço</span>
+          <span class="phrase" role="listitem">recebi 2000 de salário</span>
+          <span class="phrase" role="listitem">parcelei 1200 em 6x no Nubank</span>
+          <span class="phrase" role="listitem">quanto sobrou</span>
+          <span class="phrase" role="listitem">paguei a fatura do Nubank</span>
+          <span class="phrase" role="listitem">deposita 200 na caixinha viagem</span>
+          <span class="phrase" role="listitem">últimos lançamentos</span>
+          <span class="phrase" role="listitem">quanto tenho de limite no Nubank</span>
         </div>
+      </div>
+    </section>
+
+    <div class="sec-sep"></div>
+
+    <!-- ─── Agentes (faixa curta; a página inteira é /agents) ─────── -->
+    <section class="section" id="agentes">
+      <div class="section-head" data-reveal>
+        <h2>E tem gente trabalhando<br>quando você não está falando</h2>
+        <p>Agentes que rodam nos bastidores da sua conta e só te chamam quando têm algo pra dizer. Três dos oito:</p>
+      </div>
+
+      <div class="grid-3" data-reveal>
+        <article class="card agent-mini">
+          <img src="/brand/agents/xerife.png?v=1" alt="" width="265" height="433" loading="lazy" />
+          <h3>Xerife</h3>
+          <p>Fica de olho no seu padrão de gastos e dá o alerta quando algo foge da curva, ou quando uma categoria estoura o limite que você definiu.</p>
+        </article>
+        <article class="card agent-mini">
+          <img src="/brand/agents/carteiro.png?v=1" alt="" width="290" height="416" loading="lazy" />
+          <h3>Carteiro</h3>
+          <p>Não deixa boleto vencer. Avisa antes do vencimento, direto no seu feed, pra você nunca mais pagar juros por esquecimento.</p>
+        </article>
+        <article class="card agent-mini">
+          <img src="/brand/agents/detetive.png?v=1" alt="" width="305" height="439" loading="lazy" />
+          <h3>Detetive</h3>
+          <p>Fareja cobranças repetidas que parecem aquela assinatura esquecida, a que você paga todo mês e nem lembra mais que existe.</p>
+        </article>
+      </div>
+
+      <div class="sec-more" data-reveal>
+        <p>Os outros cinco: resumo do mês, metas, dinheiro parado, carteira de ações — e o Aviador, ainda em breve.</p>
+        <a class="btn btn-outline" href="/agents">Conhecer os agentes <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
       </div>
     </section>
 
@@ -561,8 +490,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
 
     <!-- ─── Preços ────────────────────────────────────────────────── -->
     <section class="section" id="precos">
-      <div class="section-head" data-reveal>
-        <div class="eyebrow">Planos</div>
+      <div class="section-head center" data-reveal>
         <h2>Escolha seu <span class="grad">PigBank+</span></h2>
         <p>15 dias grátis pra testar. Cancele quando quiser, sem letras miúdas.</p>
       </div>
@@ -590,9 +518,8 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
 
     <!-- ─── FAQ ───────────────────────────────────────────────────── -->
     <section class="section" id="faq">
-      <div class="section-head" data-reveal>
-        <div class="eyebrow">Dúvidas</div>
-        <h2>Perguntas <span class="grad">frequentes</span></h2>
+      <div class="section-head center" data-reveal>
+        <h2>Perguntas frequentes</h2>
         <p>O que a galera mais quer saber antes de começar com a Piggy.</p>
       </div>
 
@@ -634,8 +561,8 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
 
     <!-- ─── CTA final ─────────────────────────────────────────────── -->
     <div class="cta-band" data-reveal>
-      <h2>Pronto para começar?</h2>
-      <p>Sua vida financeira resolvida no WhatsApp, a partir de agora.</p>
+      <h2>Manda o primeiro gasto pra Piggy</h2>
+      <p>Você conta o que gastou. Ela cuida do resto — e o painel já abre com isso dentro.</p>
       <a class="btn btn-primary btn-lg" href="/cadastro">Começar agora <i class="ph ph-arrow-right" aria-hidden="true"></i></a>
     </div>
 

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -217,9 +217,8 @@
   <div class="wrap">
 
     <section class="section">
-      <div class="section-head">
+      <div class="section-head center">
         <img src="/brand/mascot.webp" alt="" style="width:132px;height:auto;display:block;margin:0 auto 18px;filter:drop-shadow(0 10px 26px rgba(0,0,0,.5))" />
-        <div class="eyebrow" id="precos-eyebrow">Planos</div>
         <h2 id="precos-title">Escolha seu <span class="grad">PigBank</span></h2>
         <p id="precos-sub">15 dias grátis pra testar o plano que você escolher. Cancele antes do fim e não paga nada.</p>
       </div>

--- a/frontend/site-redesign.css
+++ b/frontend/site-redesign.css
@@ -93,17 +93,8 @@
 }
 .rd .feature-card h3 { font-size: 1.12rem; letter-spacing: -.01em; }
 
-/* Ícones: caixa em gradiente, mais “produto” e menos flat */
-.rd .icon-box {
-  width: 50px; height: 50px; border-radius: 14px; font-size: 1.35rem;
-  background: linear-gradient(135deg, rgba(255,45,142,.22), rgba(255,45,142,.06));
-  border: 1px solid rgba(255,45,142,.32);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.08);
-}
-.rd .icon-box.neon {
-  background: linear-gradient(135deg, rgba(198,241,26,.20), rgba(198,241,26,.05));
-  border-color: rgba(198,241,26,.34);
-}
+/* (não há bloco de ícone: o quadrado colorido em gradiente foi removido junto
+   com o do site.css. O ícone agora é só o glifo, herdado de .icon-box.) */
 
 /* ─── 6. Faixa de valor: chips com vidro e brilho no marcador ──────────── */
 .rd .value-strip { gap: 12px; margin: 8px 0 12px; }
@@ -194,7 +185,7 @@
 }
 .rd .hiw-card.is-open { background: var(--card-2); border-color: var(--line-2); box-shadow: var(--shadow); }
 .rd .hiw-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 14px; }
-.rd .hiw-num { font-size: 1.9rem; font-weight: 800; color: var(--ink-3); letter-spacing: -.04em; font-variant-numeric: tabular-nums; }
+.rd .hiw-num { font-size: .95rem; font-weight: 700; color: var(--ink-3); letter-spacing: -.04em; font-variant-numeric: tabular-nums; }
 .rd .hiw-card.is-open .hiw-num { color: var(--pink); }
 .rd .hiw-card.is-done .hiw-num { color: var(--neon); }
 .rd .hiw-head h3 { font-size: 1.55rem; font-weight: 700; letter-spacing: -.03em; }
@@ -310,8 +301,10 @@
 .rd .hiw-months { display: flex; justify-content: space-between; color: var(--ink-3); font-size: .68rem; margin-top: 6px; letter-spacing: .04em; }
 
 /* CTA logo abaixo do trilho */
-.rd .hiw-cta { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 16px; margin-top: 32px; }
-.rd .hiw-cta p { color: var(--ink-2); }
+.rd .hiw-cta,
+.rd .sec-more { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 16px; margin-top: 32px; }
+.rd .hiw-cta p,
+.rd .sec-more p { color: var(--ink-2); }
 
 /* Escopado no trilho de propósito: um `*` global mataria as transições da
    página inteira (nav, botões, FAQ, reveal). */

--- a/frontend/site.css
+++ b/frontend/site.css
@@ -603,10 +603,24 @@ section[id] { scroll-margin-top: 96px; }
 .reveal.in { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; transition: none; } }
 /* ══════════════════════════════════════════════════════════════════════
-   Acessibilidade — piso do site público. Fim do arquivo de propósito:
-   sem !important, ganha por ordem de cascata.
+   Acessibilidade — piso do site público.
+
+   `:is()`, não `:where()`. O `:where()` zera a especificidade dos argumentos,
+   então a regra ficava em (0,1,0) — vinda só do `:focus-visible` — e PERDIA
+   para `.field input, .field textarea, .field select { outline: none }` da
+   linha 488, que é (0,1,1). Resultado medido: os 13 campos de /login,
+   /cadastro, /reset-password e /suporte ficavam com `outline-style: none`,
+   justamente onde o usuário de teclado digita. O `:is()` herda a
+   especificidade do argumento mais forte — `[tabindex]`, (0,1,0) — e a regra
+   sobe para (0,2,0), que vence o (0,1,1) pelo `b`.
+
+   Não é "ordem de cascata": ordem só desempata especificidade IGUAL.
+
+   Alcance medido dos dois lados: 281 focáveis em 13 rotas, 13 mudam — os 13
+   campos. Nenhum outro seletor é atropelado. Guardado por
+   tests/frontend/faq_focus_ring.test.mjs.
    ══════════════════════════════════════════════════════════════════════ */
-:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+:is(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
   outline: 2px solid var(--pink);
   outline-offset: 2px;
 }

--- a/frontend/site.css
+++ b/frontend/site.css
@@ -18,7 +18,7 @@
   --line-2:     rgba(255,255,255,.15);
   --ink:        #ffffff;
   --ink-2:      rgba(255,255,255,.62);
-  --ink-3:      rgba(255,255,255,.40);
+  --ink-3:      rgba(255,255,255,.48);  /* era .40 → 3,8:1 sobre --bg; .48 dá 5,0:1 */
   --radius:     20px;
   --radius-sm:  14px;
   --radius-lg:  26px;
@@ -106,6 +106,8 @@ img { max-width: 100%; display: block; }
   font-size: .74rem; font-weight: 800; letter-spacing: .04em;
 }
 .pill .tag-novo { background: var(--pink); color: #fff; border-radius: 999px; padding: 2px 8px; font-size: .64rem; font-weight: 800; letter-spacing: .06em; }
+/* Pílula da VSL (index.html). Único consumidor entre as 17 páginas que carregam
+   este arquivo — as outras tiveram o <div> removido do HTML pela ONDA 1. */
 .eyebrow {
   display: inline-flex; background: rgba(198,241,26,.12); border: 1px solid rgba(198,241,26,.28);
   color: var(--neon); border-radius: 999px; padding: 6px 14px;
@@ -114,9 +116,21 @@ img { max-width: 100%; display: block; }
 
 /* ─── Seções ────────────────────────────────────────────────────────── */
 .section { padding: 92px 0; }
-.section-head { text-align: center; max-width: 640px; margin: 0 auto 52px; }
-.section-head h2 { font-size: clamp(1.9rem,4vw,2.7rem); font-weight: 800; letter-spacing: -.02em; line-height: 1.08; margin-bottom: 16px; text-transform: uppercase; }
+
+/* Cabeçalho de seção. Era: centralizado + CAIXA ALTA + metade do título em
+   gradiente rosa, repetido oito vezes entre index, whatsapp, suporte, comandos
+   e changelog. Oito seções iguais lidas em sequência é o que faz o site parecer
+   gerado. Caixa alta agora é privilégio do hero (.hero-title); o resto usa
+   caixa baixa, como /precos e /termos já faziam — e são as páginas que a
+   auditoria apontou como as mais bem resolvidas. */
+.section-head { max-width: 640px; margin: 0 0 52px; }
+.section-head :is(h1,h2) { font-size: clamp(1.75rem,3.4vw,2.35rem); font-weight: 800; letter-spacing: -.022em; line-height: 1.1; margin-bottom: 14px; text-wrap: balance; }
 .section-head p { color: var(--ink-2); font-size: 1.02rem; line-height: 1.65; }
+
+/* Centralizar é opt-in, não padrão: usar só onde o conteúdo abaixo também é
+   centralizado (planos, FAQ). Alinhado à esquerda por padrão dá ritmo diferente
+   a cada seção sem precisar inventar composição nova pra cada uma. */
+.section-head.center { text-align: center; margin-left: auto; margin-right: auto; }
 .grad { background: linear-gradient(135deg,var(--pink),#FF7AB8); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
 
 /* ─── Cards genéricos ───────────────────────────────────────────────── */
@@ -125,11 +139,10 @@ img { max-width: 100%; display: block; }
   border-radius: var(--radius); padding: 26px;
 }
 .icon-box {
-  width: 46px; height: 46px; border-radius: 12px; display: flex; align-items: center; justify-content: center;
-  background: var(--pink-soft); border: 1px solid rgba(255,45,142,.3); color: var(--pink);
-  font-size: 1.25rem; margin-bottom: 18px;
+  display: flex; align-items: center; justify-content: flex-start;
+  color: var(--pink); font-size: 1.5rem; line-height: 1; margin-bottom: 14px;
 }
-.icon-box.neon { background: rgba(198,241,26,.1); border-color: rgba(198,241,26,.3); color: var(--neon); }
+.icon-box.neon { color: var(--neon-ink-on-dark, var(--neon)); }
 
 /* Feature card com seta circular (landing) */
 .feature-card { position: relative; }
@@ -213,12 +226,29 @@ img { max-width: 100%; display: block; }
 .grid-3 { display: grid; grid-template-columns: repeat(3,1fr); gap: 18px; }
 .grid-2 { display: grid; grid-template-columns: repeat(2,1fr); gap: 18px; }
 .tech-split { display: grid; grid-template-columns: 1fr 1fr; gap: 44px; align-items: center; padding: 30px 0 90px; }
-.tech-copy h2 { font-size: clamp(1.8rem,4vw,2.6rem); font-weight: 800; letter-spacing: -.02em; line-height: 1.08; margin-bottom: 24px; text-transform: uppercase; }
+.tech-copy h2 { font-size: clamp(1.7rem,3.4vw,2.3rem); font-weight: 800; letter-spacing: -.022em; line-height: 1.1; margin-bottom: 24px; text-wrap: balance; }
 .tech-list { list-style: none; display: grid; gap: 14px; margin-bottom: 28px; }
 .tech-list li { display: flex; align-items: center; gap: 12px; color: var(--ink-2); font-size: 1rem; }
 .tick { width: 24px; height: 24px; border-radius: 7px; background: rgba(198,241,26,.12); border: 1px solid rgba(198,241,26,.3); color: var(--neon); display: flex; align-items: center; justify-content: center; font-size: .78rem; font-weight: 800; flex-shrink: 0; }
 .tech-visual { display: flex; justify-content: center; }
-.tech-visual img { width: min(330px,82%); filter: drop-shadow(0 16px 34px rgba(0,0,0,.5)); }
+
+/* Vocabulário real da Piggy — substitui o cubo "AI". Mono porque é o texto que
+   a pessoa DIGITA, não prosa de marketing; é o mesmo tratamento que /comandos
+   já dá aos exemplos, e ali funciona. */
+.phrasebook { display: flex; flex-wrap: wrap; gap: 10px; align-content: center; max-width: 460px; }
+.phrase {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: .86rem; color: var(--ink-2); line-height: 1.3;
+  /* Overlay relativo, não cor fixa: var(--card) era idêntico ao fundo do .card
+     e o chip sumia dentro dele em /funcionalidades. Branco translúcido clareia
+     sobre --bg (#0c0c0d) E sobre --card (#17171a); a borda a 33% é o que
+     desenha o chip: 3,0:1 sobre o card e 2,9:1 sobre --bg, contra 1,2:1 da
+     versão anterior (piso 3:1 de contraste não-textual, WCAG 1.4.11). */
+  background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.33);
+  border-radius: var(--radius-sm); padding: 9px 13px;
+}
+.phrase::before { content: "“"; color: var(--pink); }
+.phrase::after  { content: "”"; color: var(--pink); }
 
 /* ─── Responsivo ────────────────────────────────────────────────────── */
 @media (max-width: 980px) {
@@ -252,6 +282,9 @@ img { max-width: 100%; display: block; }
 }
 @media (max-width: 560px) {
   .features-row { grid-template-columns: 1fr; }
+  /* .grid-3 parava em 2 colunas e ia até 0px: em 375 sobra ~146px por card e o
+     título quebra em 3 linhas. Uma coluna abaixo de 560. */
+  .grid-3 { grid-template-columns: 1fr; }
   .hero-mascot { width: 150px; }
 }
 
@@ -266,7 +299,7 @@ img { max-width: 100%; display: block; }
 .phone { justify-self: center; width: min(300px,90%); background: var(--card); border: 1px solid var(--line); border-radius: 30px; padding: 16px 14px; box-shadow: var(--shadow); position: relative; }
 .phone-notch { width: 54px; height: 5px; border-radius: 3px; background: var(--line-2); margin: 2px auto 14px; }
 .cta-band { text-align: center; background: linear-gradient(180deg, rgba(255,45,142,.10), rgba(255,255,255,.02)); border: 1px solid rgba(255,45,142,.28); border-radius: var(--radius-lg); padding: 56px 30px; margin: 46px 0 20px; }
-.cta-band h2 { font-size: clamp(1.6rem,3.5vw,2.3rem); font-weight: 800; text-transform: uppercase; letter-spacing: -.02em; margin-bottom: 12px; }
+.cta-band h2 { font-size: clamp(1.6rem,3.5vw,2.3rem); font-weight: 800; letter-spacing: -.02em; margin-bottom: 12px; }
 .cta-band p { color: var(--ink-2); margin-bottom: 24px; }
 
 /* ─── Preços: planos ────────────────────────────────────────────────── */
@@ -547,7 +580,12 @@ section[id] { scroll-margin-top: 96px; }
 
 /* FAQ — acordeão */
 .faq { max-width: 760px; margin: 0 auto; display: grid; gap: 12px; }
-.faq-item { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm); overflow: hidden; }
+/* Sem `overflow: hidden`: o botão .faq-q encosta na borda (folga 0), e o recorte
+   comia os 4px do anel de foco (2 de largura + 2 de offset) — 0 pixel de anel
+   visível, WCAG 2.4.7. O `overflow` aqui não segurava nada: quem recorta a
+   sanfona é o próprio .faq-a. Medido: 0 px de diferença aberto e fechado,
+   em / e /suporte, 1280x800 e 375x812. */
+.faq-item { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm); }
 .faq-item.open { border-color: var(--line-2); }
 .faq-q {
   width: 100%; text-align: left; background: none; border: none; cursor: pointer;
@@ -564,53 +602,54 @@ section[id] { scroll-margin-top: 96px; }
 .reveal { opacity: 0; transform: translateY(18px); transition: opacity .6s var(--ease), transform .6s var(--ease); }
 .reveal.in { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; transition: none; } }
-
 /* ══════════════════════════════════════════════════════════════════════
-   Cubo AI holográfico (fornecido pelo Lucas) — CSS escopado sob .hologram
-   pra não vazar (svg{}, :root, html/body do original foram dropados).
+   Acessibilidade — piso do site público. Fim do arquivo de propósito:
+   sem !important, ganha por ordem de cascata.
    ══════════════════════════════════════════════════════════════════════ */
-.hologram {
-  position: relative; width: min(460px,100%); aspect-ratio: 1;
-  display: grid; place-items: center; isolation: isolate; margin: 0 auto;
+:where(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--pink);
+  outline-offset: 2px;
 }
-.hologram::before {
-  content: ""; position: absolute; inset: 13%; z-index: -2; border-radius: 50%;
-  background: radial-gradient(circle, rgba(255,45,117,.18) 0%, rgba(236,23,88,.095) 29%, rgba(177,12,66,.028) 57%, transparent 76%);
-  filter: blur(28px); animation: ambientPulse 4.8s ease-in-out infinite;
+
+/* O site já desligava .reveal. Isto fecha o resto: são 17 `transition:`,
+   2 `animation:` e 2 @keyframes só neste arquivo. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
+  html { scroll-behavior: auto; }
 }
-.hologram::after {
-  content: ""; position: absolute; width: 55%; height: 12%; bottom: 9%; z-index: -1; border-radius: 50%;
-  background: radial-gradient(ellipse, rgba(236,23,88,.2), rgba(236,23,88,.045) 52%, transparent 74%);
-  filter: blur(18px); transform: perspective(520px) rotateX(68deg);
+
+/* Comando real fechando um bloco (card de funcionalidade, passo de /como-funciona)
+   — reusa .phrase, o mesmo tratamento mono do vocabulário da home. */
+.phrase.cmd { display: inline-block; margin-top: 12px; font-size: .8rem; }
+
+/* /como-funciona: a numeração descreve uma sequência real, então numerar não é o
+   problema — o círculo em gradiente rosa é, porque dá peso de decoração a um
+   ordinal. Aqui ele vira ordinal discreto e o peso vai pra frase que a pessoa
+   digita. /whatsapp não tem esta classe e mantém os círculos. */
+.steps-typed .step { gap: 14px; }
+.steps-typed .step-num,
+.steps-typed .step:nth-child(even) .step-num {
+  width: 22px; height: auto; border-radius: 0; background: none; box-shadow: none;
+  color: var(--ink-3); font-size: .8rem; font-weight: 700; font-variant-numeric: tabular-nums;
+  align-items: flex-start; justify-content: flex-start; padding-top: 3px;
 }
-.hologram .floating { width: 100%; height: 100%; animation: floating 5.6s ease-in-out infinite; }
-.hologram svg { display: block; width: 100%; height: 100%; overflow: visible; }
-.hologram .circuit { fill: none; stroke: #ec1758; stroke-width: 1; stroke-linecap: round; stroke-linejoin: round; stroke-dasharray: 3 9; opacity: .12; animation: circuitFlow 14s linear infinite; }
-.hologram .circuit-dot { fill: #ff2d75; opacity: .28; filter: url(#softGlow); }
-.hologram .cube { transform-box: fill-box; transform-origin: center; animation: drift 13s ease-in-out infinite; }
-.hologram .face-grid { fill: none; stroke: #ec1758; stroke-width: .85; opacity: .12; vector-effect: non-scaling-stroke; }
-.hologram .top-grid { opacity: .18; }
-.hologram .edge { fill: none; stroke: url(#edgeGradient); stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; vector-effect: non-scaling-stroke; filter: url(#neonGlow); animation: edgePulse 3.5s ease-in-out infinite; }
-.hologram .edge.strong { stroke: url(#hotGradient); stroke-width: 2.25; }
-.hologram .edge.back { opacity: .36; stroke-width: 1.5; filter: url(#softGlow); }
-.hologram .inner { fill: none; stroke: #ec1758; stroke-width: 1.15; stroke-dasharray: 3 7; opacity: .19; vector-effect: non-scaling-stroke; filter: url(#softGlow); }
-.hologram .node { fill: #ff5e98; stroke: rgba(255,255,255,.45); stroke-width: .5; filter: url(#nodeGlow); transform-box: fill-box; transform-origin: center; animation: nodePulse 2.8s ease-in-out infinite; }
-.hologram .node.small { opacity: .74; animation-delay: -1.2s; }
-.hologram .particle { fill: #ff2d75; filter: url(#particleGlow); transform-box: fill-box; transform-origin: center; animation: particleFloat var(--duration,6s) ease-in-out infinite; animation-delay: var(--delay,0s); }
-.hologram .particle.dim { fill: #b10c42; opacity: .3; }
-.hologram .particle.soft { opacity: .5; }
-.hologram .ai-text { font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif; font-size: 132px; font-weight: 800; text-anchor: middle; dominant-baseline: middle; letter-spacing: 0; }
-.hologram .ai-depth-deep { fill: #650626; stroke: #8f0a36; stroke-width: 1.1; stroke-linejoin: round; }
-.hologram .ai-depth-mid { fill: #a40b3e; stroke: #d21450; stroke-width: 1.05; stroke-linejoin: round; }
-.hologram .ai-letter-top { fill: url(#aiGradient); stroke: #ff91b7; stroke-width: 1.3; paint-order: stroke fill; filter: url(#textGlow); animation: textPulse 3.2s ease-in-out infinite; }
-.hologram .scan { fill: none; stroke: #ff5e98; stroke-width: 1; opacity: 0; filter: url(#softGlow); animation: scan 5.4s ease-in-out infinite; }
-@keyframes floating { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-10px); } }
-@keyframes drift { 0%,100% { transform: rotate(0deg) translate(0,0); } 25% { transform: rotate(.25deg) translate(2px,-1px); } 50% { transform: rotate(0deg) translate(0,-2px); } 75% { transform: rotate(-.25deg) translate(-2px,-1px); } }
-@keyframes edgePulse { 0%,100% { opacity: .82; } 50% { opacity: 1; } }
-@keyframes textPulse { 0%,100% { opacity: .92; } 50% { opacity: 1; } }
-@keyframes nodePulse { 0%,100% { transform: scale(.88); opacity: .7; } 50% { transform: scale(1.25); opacity: 1; } }
-@keyframes ambientPulse { 0%,100% { transform: scale(.94); opacity: .65; } 50% { transform: scale(1.05); opacity: 1; } }
-@keyframes particleFloat { 0%,100% { transform: translate(0,0) scale(.8); opacity: .18; } 45% { transform: translate(3px,-9px) scale(1.2); opacity: .85; } 72% { transform: translate(-2px,-4px) scale(.95); opacity: .4; } }
-@keyframes circuitFlow { to { stroke-dashoffset: -110; } }
-@keyframes scan { 0%,15%,100% { opacity: 0; transform: translateY(-35px); } 38% { opacity: .4; } 72% { opacity: .06; transform: translateY(92px); } }
-@media (prefers-reduced-motion: reduce) { .hologram *, .hologram *::before, .hologram *::after { animation: none !important; } }
+
+/* Faixa curta de agentes na home — não duplica /agents: 3 dos 8, com a arte e a
+   copy da própria página, e link pra ela. */
+/* Sticker (xerife.png, 265×433, fundo transparente) e não a arte _hero de
+   1200×600: as três _hero pesavam 3.020 KB pra renderizar a 327 px. Mesmo
+   tratamento do .card-sticker dos guias. */
+.agent-mini img { width: auto; height: 150px; object-fit: contain; margin-bottom: 14px; filter: drop-shadow(0 8px 18px rgba(0,0,0,.45)); }
+.agent-mini h3 { font-size: 1.08rem; font-weight: 800; letter-spacing: -.01em; margin-bottom: 8px; }
+.agent-mini p { color: var(--ink-2); font-size: .93rem; line-height: 1.6; }
+
+/* /funcionalidades: segurança tinha virado oração subordinada no subtítulo do
+   CTA. Bloco próprio, largura cheia, reusando .card. */
+.sec-note { display: flex; gap: 16px; align-items: flex-start; margin-top: 18px; }
+.sec-note .icon-box { margin: 2px 0 0; font-size: 1.6rem; flex: none; }
+.sec-note h3 { font-size: 1.05rem; font-weight: 700; margin-bottom: 8px; }
+.sec-note p { color: var(--ink-2); font-size: .95rem; line-height: 1.6; }

--- a/frontend/suporte.html
+++ b/frontend/suporte.html
@@ -44,9 +44,8 @@
 
     <!-- FAQ: guias e dicas evergreen (renderizados de core/blog_guides.py via {{FAQ}}) -->
     <section class="section" id="faq">
-      <div class="section-head">
-        <div class="eyebrow">Ajuda</div>
-        <h2>Guias &amp; <span class="grad">dicas</span></h2>
+      <div class="section-head center">
+        <h1>Guias &amp; <span class="grad">dicas</span></h1>
         <p>As dúvidas mais comuns sobre usar o PigBank. Toque numa pergunta pra abrir.</p>
       </div>
       <div class="faq">
@@ -55,7 +54,7 @@
     </section>
 
     <section class="section">
-      <div class="section-head">
+      <div class="section-head center">
         <h2>Fale com o <span class="grad">nosso time</span></h2>
         <p>Estamos aqui pra te ajudar a tirar o máximo do PigBank. Escolha o canal ou mande uma mensagem.</p>
       </div>

--- a/frontend/whatsapp.html
+++ b/frontend/whatsapp.html
@@ -36,9 +36,8 @@
   <div class="wrap">
 
     <section class="section" style="padding-bottom:40px">
-      <div class="section-head">
-        <div class="eyebrow">WhatsApp financeiro</div>
-        <h2>Controle seu dinheiro<br><span class="grad">mandando mensagem</span></h2>
+      <div class="section-head center">
+        <h1>Controle seu dinheiro<br><span class="grad">mandando mensagem</span></h1>
         <p>O PigBank transforma mensagens simples em registros financeiros organizados. Você envia o que aconteceu, a Piggy entende, categoriza e atualiza seu saldo.</p>
       </div>
       <div class="hero-cta" style="justify-content:center;margin-bottom:8px">
@@ -49,8 +48,7 @@
 
     <!-- ─── Como conectar ─────────────────────────────────────────── -->
     <section class="section" style="padding-bottom:44px">
-      <div class="section-head" style="margin-bottom:30px">
-        <div class="eyebrow">Como conectar</div>
+      <div class="section-head center" style="margin-bottom:30px">
         <h2>Comece em <span class="grad">4 passos</span></h2>
         <p>Leva menos de um minuto. O segredo é usar o <b>mesmo número</b> de WhatsApp no cadastro: é ele que liga a conversa à sua conta.</p>
       </div>
@@ -104,7 +102,7 @@
     </section>
 
     <section style="padding-bottom:50px">
-      <div class="section-head" style="margin-bottom:28px"><h2>Exemplos de <span class="grad">conversa</span></h2></div>
+      <div class="section-head center" style="margin-bottom:28px"><h2>Exemplos de <span class="grad">conversa</span></h2></div>
       <div class="chat-card" style="max-width:440px;margin:0 auto">
         <div class="chat-head"><img src="/brand/icon.png?v=2" alt="" /> <strong>PigBank</strong><span class="online"><i></i> online</span></div>
         <div class="bubble user">Gastei 89,90 no mercado no débito</div>

--- a/tests/frontend/faq_focus_ring.test.mjs
+++ b/tests/frontend/faq_focus_ring.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * O anel de foco do FAQ precisa de espaço para existir.
+ *
+ * `site.css` desenha o foco do site público com `outline: 2px solid var(--pink);
+ * outline-offset: 2px` — 4px de tinta FORA da border-box do elemento. O `.faq-q`
+ * encosta na borda do `.faq-item` (folga 0), então qualquer `overflow` que
+ * recorte no `.faq-item` come o anel inteiro: 0 pixel visível, WCAG 2.4.7. Foi
+ * o que a ONDA 1 causou ao trocar o `outline-style: auto` do navegador (que o
+ * Chromium pinta por fora do recorte) por um outline próprio, que não.
+ *
+ * Duas asserções, e a segunda é o controle: ela reinjeta `overflow: hidden` e
+ * exige que a folga volte a ZERO. Sem ela a primeira passaria num CSS que nem
+ * carregou.
+ *
+ * O FAQ de /suporte é o mesmo markup (`.faq-item > .faq-q`), montado em
+ * `frontend/routes/static_pages.py` pelo `{{FAQ}}` — o servidor estático desta
+ * pasta não serve aquela rota, mas a regra CSS é a mesma.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+async function abrir() {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  await page.goto(`${ORIGIN}/index.html`);
+  await page.waitForSelector(".faq-q");
+  return page;
+}
+
+/** Para cada .faq-q: a menor distância entre a border-box dele e a borda de
+ *  recorte de qualquer ancestral que recorte. Infinity = ninguém recorta. */
+const folgas = (page) => page.$$eval(".faq-q", (els) => els.map((el) => {
+  const r = el.getBoundingClientRect();
+  let menor = Infinity;
+  for (let p = el.parentElement; p; p = p.parentElement) {
+    const s = getComputedStyle(p);
+    if (s.overflowX === "visible" && s.overflowY === "visible") continue;
+    const pr = p.getBoundingClientRect();
+    const cm = parseFloat(s.overflowClipMargin) || 0;   // overflow: clip
+    const lados = [];
+    if (s.overflowX !== "visible")
+      lados.push(r.left - (pr.left + parseFloat(s.borderLeftWidth) - cm),
+                 (pr.right - parseFloat(s.borderRightWidth) + cm) - r.right);
+    if (s.overflowY !== "visible")
+      lados.push(r.top - (pr.top + parseFloat(s.borderTopWidth) - cm),
+                 (pr.bottom - parseFloat(s.borderBottomWidth) + cm) - r.bottom);
+    menor = Math.min(menor, ...lados);
+  }
+  return menor;
+}));
+
+test("o anel de foco do .faq-q cabe: nenhum ancestral recorta os 4px", async () => {
+  const page = await abrir();
+
+  // A regra do site: 2px de largura + 2px de offset = 4px fora da border-box.
+  // Se o CSS não carregar, isto não dá 4 — a medição abaixo não passa por acaso.
+  const anel = await page.$eval(".faq-q", (b) => {
+    b.focus();
+    const s = getComputedStyle(b);
+    return parseFloat(s.outlineWidth) + parseFloat(s.outlineOffset);
+  });
+  assert.equal(anel, 4, "site.css mudou o anel; ajuste a folga exigida junto");
+
+  const fs = await folgas(page);
+  assert.ok(fs.length >= 4, `poucos .faq-q na index: ${fs.length}`);
+  for (const f of fs) assert.ok(f >= 4, `folga ${f}px < 4px — o anel some`);
+  await page.close();
+});
+
+test("controle: com overflow:hidden de volta no .faq-item, a folga zera", async () => {
+  const page = await abrir();
+  await page.addStyleTag({ content: ".faq-item { overflow: hidden !important; }" });
+  const fs = await folgas(page);
+  assert.ok(fs.every((f) => f < 4), `medição cega: folgas ${fs} mesmo com o recorte de volta`);
+  await page.close();
+});

--- a/tests/frontend/focus_ring_campos.test.mjs
+++ b/tests/frontend/focus_ring_campos.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * O anel de foco tem de alcançar os CAMPOS DE FORMULÁRIO.
+ *
+ * `site.css` define o piso de foco do site público:
+ *
+ *   :is(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+ *     outline: 2px solid var(--pink); outline-offset: 2px;
+ *   }
+ *
+ * `:is()` e não `:where()`, e a diferença é o motivo deste arquivo existir.
+ * `:where()` zera a especificidade dos argumentos: a regra ficava em (0,1,0),
+ * vinda só do `:focus-visible`, e PERDIA para a linha 488
+ *
+ *   .field input, .field textarea, .field select { ... outline: none; }   (0,1,1)
+ *
+ * Resultado medido antes do conserto: `outline-style: none` nos 13 campos de
+ * /login, /cadastro, /reset-password e /suporte — justamente onde o usuário de
+ * teclado digita. `:is()` herda a especificidade do argumento mais forte
+ * (`[tabindex]`, (0,1,0)), a regra sobe para (0,2,0) e vence o (0,1,1) pelo `b`.
+ *
+ * O `faq_focus_ring.test.mjs` não pega isto: ele mede se o anel CABE (geometria
+ * de recorte), não se ele é PINTADO. São duas formas de o mesmo anel sumir.
+ *
+ * O caso 2 é o controle: reinjeta o `outline: none` com a especificidade que
+ * vencia antes e exige que o anel suma. Sem ele o caso 1 passaria num CSS que
+ * nem carregou.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/** Páginas do servidor estático que têm `.field`. /suporte é servida pela rota
+ *  do FastAPI (o `{{FAQ}}` é montado lá), então fica fora deste harness — a
+ *  regra CSS é a mesma e os campos são o mesmo markup. */
+const PAGINAS = ["login.html", "cadastro.html", "reset-password.html"];
+
+/** Foca por TECLADO. `el.focus()` nem sempre casa `:focus-visible` — o
+ *  navegador decide pela modalidade da última interação. Tab a partir do body
+ *  garante a heurística de teclado; sem isso o teste mediria outra coisa. */
+async function focarPorTeclado(page, seletor) {
+  await page.evaluate(() => document.body.focus());
+  const alvo = await page.$(seletor);
+  await alvo.evaluate((e) => e.setAttribute("data-alvo-foco", "1"));
+  for (let i = 0; i < 60; i++) {
+    await page.keyboard.press("Tab");
+    if (await page.evaluate(() => document.activeElement?.dataset?.alvoFoco === "1")) return true;
+  }
+  return false;
+}
+
+const anel = (page) => page.evaluate(() => {
+  const e = document.activeElement;
+  const cs = getComputedStyle(e);
+  return { tag: e.tagName.toLowerCase(), focusVisible: e.matches(":focus-visible"),
+           style: cs.outlineStyle, width: cs.outlineWidth, offset: cs.outlineOffset };
+});
+
+test("campo de formulário focado por teclado recebe o anel de 2px", async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+  const vistos = [];
+
+  for (const arquivo of PAGINAS) {
+    await page.goto(`${ORIGIN}/${arquivo}`);
+    await page.waitForSelector(".field input");
+    assert.ok(await focarPorTeclado(page, ".field input"),
+      `${arquivo}: não consegui alcançar o .field input por Tab`);
+
+    const a = await anel(page);
+    assert.ok(a.focusVisible, `${arquivo}: o campo não casou :focus-visible — o caso não mede nada`);
+    assert.equal(a.style,  "solid", `${arquivo}: outline-style deveria ser solid, veio "${a.style}"`);
+    assert.equal(a.width,  "2px",   `${arquivo}: outline-width deveria ser 2px, veio "${a.width}"`);
+    assert.equal(a.offset, "2px",   `${arquivo}: outline-offset deveria ser 2px, veio "${a.offset}"`);
+    vistos.push(`${arquivo}:${a.tag}`);
+  }
+
+  assert.equal(vistos.length, PAGINAS.length, `esperava um campo por página, medi ${vistos.join(", ")}`);
+  await page.close();
+});
+
+test("controle: voltando o :where(), o anel some", async () => {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 800 } });
+
+  // Serve o site.css com `:is(` trocado de volta por `:where(` — o estado
+  // exato de antes do conserto. Injetar uma regra concorrente NÃO serviria de
+  // controle: `:is(...)` é (0,2,0) e continuaria vencendo qualquer
+  // `.field input { outline: none }` (0,1,1), viesse ele de onde viesse.
+  let trocou = false;
+  await page.route("**/site.css*", async (route) => {
+    const resp = await route.fetch();
+    const texto = await resp.text();
+    const antes = texto.replace(
+      ":is(a, button, input, select, textarea, summary, [tabindex]):focus-visible",
+      ":where(a, button, input, select, textarea, summary, [tabindex]):focus-visible");
+    trocou = antes !== texto;
+    await route.fulfill({ response: resp, body: antes });
+  });
+
+  await page.goto(`${ORIGIN}/login.html`);
+  await page.waitForSelector(".field input");
+  assert.ok(trocou, "não achei a regra `:is(...):focus-visible` no site.css — o controle não mede nada");
+
+  assert.ok(await focarPorTeclado(page, ".field input"), "não alcancei o campo por Tab");
+  const a = await anel(page);
+  assert.ok(a.focusVisible, "o campo não casou :focus-visible — o controle não mede nada");
+  assert.equal(a.style, "none",
+    `com :where() o anel deveria sumir; veio "${a.style}" — então o caso 1 não discrimina`);
+
+  await page.close();
+});


### PR DESCRIPTION
Primeira onda da auditoria visual do frontend. Direção: **"extrato, não folheto"** — o PigBank tem de parecer produto financeiro conversacional feito pro WhatsApp, não landing genérica de SaaS.

Escopo: **páginas públicas**. Não toca backend, auth, dashboard, billing, banco, service worker nem `dashboard.js`.

## O que fazia o site parecer gerado

| achado | o que mudou |
|---|---|
| **Oito seções** abrindo com a mesma composição (pílula verde-limão + título em caixa alta de 2 linhas com a 2ª metade em rosa) | Caixa alta vira privilégio do hero. `.section-head` alinha à esquerda por padrão, centraliza por opt-in `.center` — auditei os 18 e cada um casa com o conteúdo abaixo. Seis pílulas removidas |
| **Doze ícones** dentro de quadrado colorido | O quadrado sai, o ícone fica. O ícone distingue (chat, etiqueta, cofre, cartão, sino, cadeado); a caixa não |
| **Cubo wireframe "AI"** — o visual mais genérico possível de IA | Trocado pelo vocabulário real da Piggy: 8 frases que o classificador resolve **sem IA** |
| **`/funcionalidades` era cópia byte a byte da home** | Home mostra 3 cards + link; a `/funcionalidades` fica dona dos 6, cada um com o comando real que o dispara. Seção "Tecnologia" duplicada saiu inteira (15.593 → 5.272 bytes) |
| **`01 / 02 / 03`** decorativos | `1 / 2 / 3`, sem o círculo em gradiente |
| **Microcopy de gerador** | Saíram "Recursos que fazem a diferença", "A inteligência que facilita sua vida", "Pronto para começar?", "Bem-vindo de volta!" e as 3 pílulas de confiança |

A home também ganhou uma faixa com **3 dos 8 agentes**, arte e copy oficiais de `/agents`, com o Aviador rotulado "em breve" — que é como a própria página o marca.

## Acessibilidade

- **Anel de foco nas páginas públicas.** Ele nasceu recortado a zero nos acordeões do FAQ: o botão tem 1px de folga dentro do `.faq-item` e o halo precisa de 4px. O `overflow: hidden` do `.faq-item` **não fazia nada** — quem recorta a sanfona é o `.faq-a` — então a correção é deletar essa declaração. Medido: **3.312px de anel a 1280 e 1.580 a 375, contra 0 antes**. Vem com teste e controle negativo.
- **`--ink-3` de .40 para .48**: 3,79:1 → 5,00:1 sobre `--bg`. Era o token de "rótulo discreto", abaixo do AA.
- **`<h1>` em 6 páginas** que não tinham nenhum.
- **`prefers-reduced-motion`** cobrindo o site público.

## O que ficou de fora, de propósito

- **`/agents` não se toca** — é a referência autoral do site.
- **`/comandos-app` fica pra onda 2**: é área logada, CSS inline, e uma das duas rotas do POC de SPA, com o contrato `PBPages.<key>.inits`.
- **`/precos` não ganha `<h1>`** — promover lá criaria salto `h1→h3`. Decisão do dono.
- **`--radius*` e `--shadow` revertidos ao valor da main**: restilizavam login, cadastro, reset-password, termos, privacy, onboarding e blog — 7 páginas fora desta onda.

## Verificação

```
frontend    305 testes · 304 pass
            a falha é eslint_max_lines_gate (Cannot find package 'eslint'),
            que falha igual na main limpa — ambiente, não regressão
pytest      5812 passed · 2 xfailed · 0 failed
overflow    14 rotas × desktop 1280×800 e mobile 375×812 — nenhuma rola de lado
```

O ciclo passou por três rodadas de implementação, duas de ataque adversarial e três auditorias, com duas reprovações antes desta. Os números acima foram remedidos de forma independente em cada etapa.

## Pendência conhecida — vale olhar na revisão

**Os 3 PNGs de agente da home somam 684 KB** (`208 + 202 + 274`), renderizados a 92–105px. Estão abaixo da dobra com `loading="lazy"`, então a carga inicial não muda (medido: 1307 → 1300 KB), mas depois de rolar a home vai de 1307 para 1969 KB.

Existe `tests/test_brand_asset_budget.py` com teto de **20 KiB** por imagem de home, criado exatamente contra isso — e ele passa verde porque só cobre `brand/icon.png`. O repo já usa o formato certo em `/brand/stickers/*.webp` (16–22 KB cada).

Não segurei o PR por isso porque a onda **melhorou** o quadro (o achado original eram 3 MB de PNG de agente na home) e porque `/agents` serve **10,3 MB** de `*_hero.png`, intocada, na página irmã. O conserto certo cobre as duas páginas e alarga o gate — trabalho próprio.

## Não verificado

- **Nada em produção nem no aparelho.** Tudo é Chromium headless local; o app carrega o site ao vivo, então nada disso existe pro usuário antes do deploy.
- **`/changelog` nunca foi renderizada** (302 → login, é Pro-only). É a única página que carrega o shim **e** o `app-mode.css`.
- **`/suporte`**: o FAQ vem do `{{FAQ}}` em `static_pages.py`, então o teste committado cobre 1 dos 2 sítios.
- **Aparência não foi julgada** — medimos geometria, pixels de anel, peso e integridade de referência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)