### PR TITLE
Os cinco leitores que mostravam o tipo legado a menos

### DIFF
--- a/core/handlers/balance.py
+++ b/core/handlers/balance.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from datetime import date
 import db
+from db.accounts import _TIPO_ALIASES
 from utils_text import fmt_brl
 from utils_date import today_tz
 
@@ -29,8 +30,9 @@ def check(user_id: int) -> str:
     today_launches = db.get_launches_by_period(user_id, today, today)
     despesas_hoje = [
         l for l in today_launches
-        # as duas formas de `tipo`: só a moderna some com a linha legada do dia
-        if l["tipo"] in ("despesa", "saida") and not l.get("is_internal_movement")
+        # As duas formas de `tipo` vêm de `_TIPO_ALIASES` (db/accounts.py), o dono
+        # da regra em Python: literal aqui deriva no dia em que a tabela mudar.
+        if l["tipo"] in _TIPO_ALIASES["despesa"] and not l.get("is_internal_movement")
     ]
     if despesas_hoje:
         lines.append("")

--- a/core/handlers/balance.py
+++ b/core/handlers/balance.py
@@ -29,7 +29,8 @@ def check(user_id: int) -> str:
     today_launches = db.get_launches_by_period(user_id, today, today)
     despesas_hoje = [
         l for l in today_launches
-        if l["tipo"] == "despesa" and not l.get("is_internal_movement")
+        # as duas formas de `tipo`: só a moderna some com a linha legada do dia
+        if l["tipo"] in ("despesa", "saida") and not l.get("is_internal_movement")
     ]
     if despesas_hoje:
         lines.append("")

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -554,6 +554,14 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
         total_receitas = sum(float(r["valor"]) for r in rows
                              if r.get("tipo") in _TIPO_ALIASES["receita"]
                              and not r.get("is_internal_movement"))
+        # E a soma parcial DIZ o que ficou fora — mesma forma de `_total_despesa`
+        # logo abaixo. Sem isto, o dia com pagamento de fatura (`db/cards.py`,
+        # despesa interna, mensal e todo usuário de cartão) mostra a linha e um
+        # "Gastos" menor, sem dizer por quê. As duas pernas: saldo inicial,
+        # ajuste e estorno de fatura entram como RECEITA interna.
+        internos = sum(float(r["valor"]) for r in rows
+                       if r.get("is_internal_movement")
+                       and r.get("tipo") in _TIPO_ALIASES["despesa"] + _TIPO_ALIASES["receita"])
 
         lines = []
         for r in rows:
@@ -570,6 +578,12 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
             summary_parts.append(f"💸 Gastos: {fmt_brl(total_despesas)}")
         if total_receitas > 0:
             summary_parts.append(f"💰 Receitas: {fmt_brl(total_receitas)}")
+        if internos > 0:
+            # Sem o "Mais" do `_total_despesa`: aqui a linha pode ser a ÚNICA
+            # (dia só de pagamento de fatura), e são dois totais acima, não um.
+            summary_parts.append(
+                f"🔁 {fmt_brl(internos)} em movimentação interna (não entra nos totais)."
+            )
         summary = "\n".join(summary_parts)
 
         return f"{header}:\n" + "\n".join(lines) + (f"\n\n{summary}" if summary else "")
@@ -794,11 +808,15 @@ def _total_despesa(
     Nenhum número do dashboard muda: "você gastou" continua sendo o filtrado.
 
     ponytail: a diferença é atribuída a movimentação interna, e é a única causa
-    que sobra — as duas pernas leem `TIPO_DESPESA_SQL` (db/budgets.py:272 e
-    db/accounts.py:822 via `_TIPO_ALIASES`), então a linha legada com
-    tipo='saida' entra nas DUAS e não produz divergência. Se um dia as duas
-    deixarem de falar dos mesmos aliases, o rótulo volta a ficar impreciso — é o
-    que `test_o_sql_e_o_python_falam_dos_mesmos_aliases` guarda.
+    que sobra — as duas pernas somam por `TIPO_DESPESA_SQL`
+    (`sum_spent_in_category_period`, db/budgets.py; e o `tot_despesa` de
+    `list_launches_by_category`, db/accounts.py), então a linha legada com
+    tipo='saida' entra nas DUAS e não produz divergência. O `_TIPO_ALIASES` da
+    mesma função filtra as LINHAS, não soma: enquanto o somatório era literal,
+    um terceiro alias deixava a linha entrar sem ser somada e o `fora` sumia
+    calado. Quem guarda hoje: `test_o_sql_e_o_python_falam_dos_mesmos_aliases`
+    (as duas fontes entre si) e
+    `test_o_resumo_da_lista_de_categoria_acompanha_a_fonte_unica` (o somatório).
     """
     total = db.sum_spent_in_category_period(user_id, categoria, start, end)
     # limit=1: o resumo vem de window aggregates, calculados ANTES do LIMIT.

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -6,6 +6,7 @@ import re
 from datetime import date, timedelta
 
 import db
+from db.accounts import _TIPO_ALIASES
 from utils_text import (
     fmt_brl, is_internal_category, canonicalize_category_label, normalize_text,
     merchant_key, RECURRING_SUGGESTION_BLOCKLIST, CATEGORY_LABELS,
@@ -542,16 +543,17 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
             return f"Nenhum lançamento encontrado em **{label}**."
 
         # calcula totais
-        # As duas formas de `tipo`, igual ao rodapé da lista sem data logo abaixo
-        # (`("despesa", "saida")` / `("receita", "entrada")`): só a moderna
-        # SUBCONTA o rodapé de um dia que tenha linha legada.
-        # TODO: ao contrário do irmão, estes dois somatórios não descartam
-        # `is_internal_movement` — transferência entra no rodapé do dia. Outra
-        # classe de bug, fora do escopo deste PR.
+        # Mesma regra do rodapé da lista sem data logo abaixo, e a mesma fonte:
+        # `_TIPO_ALIASES` (db/accounts.py). Só a forma moderna SUBCONTA o rodapé
+        # de um dia que tenha linha legada; literal aqui deriva da tabela.
+        # O `is_internal_movement` também iguala o irmão: sem o guard, uma
+        # transferência entrava no "Gastos" do dia e não no dos últimos N.
         total_despesas = sum(float(r["valor"]) for r in rows
-                             if r.get("tipo") in ("despesa", "saida"))
+                             if r.get("tipo") in _TIPO_ALIASES["despesa"]
+                             and not r.get("is_internal_movement"))
         total_receitas = sum(float(r["valor"]) for r in rows
-                             if r.get("tipo") in ("receita", "entrada"))
+                             if r.get("tipo") in _TIPO_ALIASES["receita"]
+                             and not r.get("is_internal_movement"))
 
         lines = []
         for r in rows:
@@ -652,12 +654,12 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
     total_despesas = sum(
         float(r["valor"])
         for r in rows
-        if r.get("tipo") in ("despesa", "saida") and not r.get("is_internal_movement")
+        if r.get("tipo") in _TIPO_ALIASES["despesa"] and not r.get("is_internal_movement")
     )
     total_receitas = sum(
         float(r["valor"])
         for r in rows
-        if r.get("tipo") in ("receita", "entrada") and not r.get("is_internal_movement")
+        if r.get("tipo") in _TIPO_ALIASES["receita"] and not r.get("is_internal_movement")
     )
 
     summary_parts = []
@@ -762,7 +764,7 @@ def _total_despesa(
 
     Duas fontes, de propósito diferentes:
       - `sum_spent_in_category_period` (db/budgets.py) filtra
-        `is_internal_movement = false` e `tipo = 'despesa'` → é o número do
+        `is_internal_movement = false` e `TIPO_DESPESA_SQL` → é o número do
         DASHBOARD, e continua sendo o que sai como "você gastou".
       - o `resumo` de `list_launches_by_category` NÃO filtra nada disso → é o
         número que a LISTA da mesma categoria mostra.
@@ -791,11 +793,12 @@ def _total_despesa(
 
     Nenhum número do dashboard muda: "você gastou" continua sendo o filtrado.
 
-    ponytail: a diferença é atribuída a movimentação interna, que é a causa em
-    todo escritor acima. Uma linha LEGADA com tipo='saida' (que a lista conta e
-    o `sum_spent_...` não, porque ele fixa `tipo = 'despesa'`) cairia no mesmo
-    rótulo. Separar as duas causas pede uma 3ª query; enquanto não houver
-    escritor de 'saida' (não há), a soma é a mesma e só o rótulo seria impreciso.
+    ponytail: a diferença é atribuída a movimentação interna, e é a única causa
+    que sobra — as duas pernas leem `TIPO_DESPESA_SQL` (db/budgets.py:272 e
+    db/accounts.py:822 via `_TIPO_ALIASES`), então a linha legada com
+    tipo='saida' entra nas DUAS e não produz divergência. Se um dia as duas
+    deixarem de falar dos mesmos aliases, o rótulo volta a ficar impreciso — é o
+    que `test_o_sql_e_o_python_falam_dos_mesmos_aliases` guarda.
     """
     total = db.sum_spent_in_category_period(user_id, categoria, start, end)
     # limit=1: o resumo vem de window aggregates, calculados ANTES do LIMIT.

--- a/core/handlers/launches.py
+++ b/core/handlers/launches.py
@@ -542,8 +542,16 @@ def list_launches(user_id: int, limit: int = 10, entities: dict | None = None, o
             return f"Nenhum lançamento encontrado em **{label}**."
 
         # calcula totais
-        total_despesas = sum(float(r["valor"]) for r in rows if r.get("tipo") == "despesa")
-        total_receitas = sum(float(r["valor"]) for r in rows if r.get("tipo") == "receita")
+        # As duas formas de `tipo`, igual ao rodapé da lista sem data logo abaixo
+        # (`("despesa", "saida")` / `("receita", "entrada")`): só a moderna
+        # SUBCONTA o rodapé de um dia que tenha linha legada.
+        # TODO: ao contrário do irmão, estes dois somatórios não descartam
+        # `is_internal_movement` — transferência entra no rodapé do dia. Outra
+        # classe de bug, fora do escopo deste PR.
+        total_despesas = sum(float(r["valor"]) for r in rows
+                             if r.get("tipo") in ("despesa", "saida"))
+        total_receitas = sum(float(r["valor"]) for r in rows
+                             if r.get("tipo") in ("receita", "entrada"))
 
         lines = []
         for r in rows:

--- a/core/services/piggy_agents.py
+++ b/core/services/piggy_agents.py
@@ -24,7 +24,7 @@ import sys
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
-from db.connection import get_conn
+from db.connection import TIPO_DESPESA_SQL, TIPO_RECEITA_SQL, get_conn
 
 # ── Config ───────────────────────────────────────────────────────────────────
 
@@ -192,12 +192,15 @@ def run_xerife_once(today: date | None = None, user_id: int | None = None) -> di
 # ── Repórter: a manchete do mês ──────────────────────────────────────────────
 
 def _month_stats(cur, user_id: int, first: date, nxt: date) -> dict[str, float]:
+    # f-string por causa de `TIPO_RECEITA_SQL`/`TIPO_DESPESA_SQL`: `entrou` lia
+    # só `tipo = 'receita'` enquanto `saiu` já lia as duas formas, então uma linha
+    # legada 'entrada' sumia da manchete e o "sobrou" saía MENOR do que é.
     cur.execute(
-        """
+        f"""
         select
-          coalesce(sum(valor) filter (where tipo = 'receita'
+          coalesce(sum(valor) filter (where {TIPO_RECEITA_SQL}
                                         and is_internal_movement = false), 0)      as entrou,
-          coalesce(sum(valor) filter (where tipo in ('despesa', 'saida')
+          coalesce(sum(valor) filter (where {TIPO_DESPESA_SQL}
                                         and is_internal_movement = false), 0)      as saiu,
           -- aportes vêm de deposito/saque_caixinha, que db/pockets.py grava SEMPRE
           -- como is_internal_movement=true. Por isso o guard de movimento interno

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -993,7 +993,7 @@ def get_top_expense_categories(
     """Top N categorias de gasto no período.
 
     Agrega:
-      - despesas reais em launches (tipo='despesa', is_internal_movement=false),
+      - despesas reais em launches (`TIPO_DESPESA_SQL`, is_internal_movement=false),
         pela data do lançamento (criado_em)
       - compras no cartão (credit_transactions, is_refund=false)
 

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -1034,7 +1034,7 @@ def get_top_expense_categories(
                     select categoria, valor
                     from launches
                     where user_id = %s
-                      and tipo = 'despesa'
+                      and {TIPO_DESPESA_SQL}
                       and is_internal_movement = false
                       and criado_em >= %s and criado_em < %s
                     union all

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -894,10 +894,16 @@ def list_launches_by_category(
                        posted_at, has_time, fonte,
                        user_seq, id, ord_id, is_internal_movement,
                        count(*) over () as n_total,
+                       -- A fonte única, não o literal: o `resumo` daqui é o
+                       -- número que o `_total_despesa` (core/handlers/launches.py)
+                       -- SUBTRAI do total do dashboard pra dizer o que ficou de
+                       -- fora. Com um terceiro alias só no filtro de linhas
+                       -- (`_TIPO_ALIASES`, logo abaixo) a linha entrava e não era
+                       -- somada — a explicação sumia calada.
                        coalesce(sum(valor) filter (
-                           where tipo in ('despesa', 'saida')) over (), 0) as tot_despesa,
+                           where {TIPO_DESPESA_SQL}) over (), 0) as tot_despesa,
                        coalesce(sum(valor) filter (
-                           where tipo in ('receita', 'entrada')) over (), 0) as tot_receita
+                           where {TIPO_RECEITA_SQL}) over (), 0) as tot_receita
                 from (
                     select tipo,
                            valor,

--- a/db_support.py
+++ b/db_support.py
@@ -60,14 +60,24 @@ def get_summary_by_period_impl(
     start_dt = datetime.combine(start_date, datetime.min.time())
     end_excl = datetime.combine(end_date + timedelta(days=1), datetime.min.time())
 
-    sql = """
-        select tipo, coalesce(sum(valor), 0) as total
+    # Import local, não no topo: `db/__init__` importa `db.reports`, que lê
+    # atributos de `db_support` na carga — topo aqui fecha o ciclo (mesmo motivo
+    # do `from db_support import ...` local em db/users.py:167).
+    from db.connection import TIPO_CANON_SQL
+
+    # `TIPO_CANON_SQL` colapsa a forma legada na moderna AQUI, no SQL: com
+    # `group by tipo` cru a linha 'saida' vira chave própria e o `if tipo in out`
+    # abaixo a descarta sem erro e sem log — a despesa do mês sai menor do que é.
+    # `group by 1` e não `group by tipo`: com o alias e a coluna com o mesmo nome,
+    # o Postgres resolve o GROUP BY pela coluna de ENTRADA e o CASE não agruparia.
+    sql = f"""
+        select {TIPO_CANON_SQL} as tipo, coalesce(sum(valor), 0) as total
         from launches
         where user_id=%s
           and criado_em >= %s
           and criado_em < %s
           and is_internal_movement = false
-        group by tipo
+        group by 1
     """
 
     with get_conn() as conn:

--- a/tests/test_tipo_legado_na_cauda.py
+++ b/tests/test_tipo_legado_na_cauda.py
@@ -42,6 +42,16 @@ Controle NEGATIVO — um por conserto, todos injetados em caso que estava VERDE:
 Controle POSITIVO: `test_base_sem_linha_legada_nao_muda_nenhum_numero` — a MESMA
 base só com a forma moderna responde exatamente o mesmo nos cinco pontos. Sem
 ele o grupo passaria num código que somasse a mesma linha DUAS vezes.
+
+Os cinco acima provam que os sites contam a linha legada de HOJE — não provam
+que eles LEEM a fonte única, e literal copiado passa igual. Quem mede isso é
+`test_ampliar_a_fonte_unica_alcanca_os_cinco_sites`: amplia a fonte com um
+terceiro alias e cobra que os cinco acompanhem (50 × 150).
+
+E `test_rodape_do_dia_nao_conta_movimento_interno` guarda o guard de
+`is_internal_movement` do rodapé do dia, que igualou o irmão de :654/659 —
+somar as duas formas de `tipo` tinha deixado a transferência LEGADA entrar no
+"Gastos" do dia, que o `== "despesa"` escondia por acidente.
 """
 from __future__ import annotations
 
@@ -201,3 +211,89 @@ def test_base_sem_linha_legada_nao_muda_nenhum_numero(uid_wa):
     saldo = _diga(uid_wa, "saldo")
     assert len(_linhas_do_hoje(saldo)) == 2, saldo
     assert "R$ 150,00" in saldo, saldo
+
+
+# ── a fonte única tem que ALCANÇAR os cinco sites ───────────────────────────
+#
+# Os 6 testes acima provam que os cinco sites contam a linha legada de HOJE.
+# Nenhum deles prova que os sites LEEM a fonte única — literal copiado passa
+# igual, e é assim que a deriva volta: ampliar a regra numa ponta e os literais
+# ficarem para trás, sem erro e sem log. `test_o_sql_e_o_python_falam_dos_mesmos
+# _aliases` (irmão do dashboard) compara as DUAS fontes entre si e também não
+# alcança cópia nenhuma.
+
+_ALIAS_NOVO = "egresso"  # um terceiro alias que não existe em lugar nenhum
+
+
+@pytest.fixture
+def fonte_ampliada(monkeypatch):
+    """Amplia a fonte ÚNICA (as duas pernas dela) com um terceiro alias.
+
+    `setitem` e não `setattr`: `core/handlers/*` fazem `from db.accounts import
+    _TIPO_ALIASES` na carga, então quem tem que mudar é o CONTEÚDO do dict, que
+    é o mesmo objeto nos três módulos. O SQL é string interpolada em f-string,
+    e cada módulo guarda a sua cópia do nome — daí os três `setattr`.
+    """
+    import core.services.piggy_agents as PA
+    import db.accounts as ACC
+    import db.connection as CONN
+    from db.accounts import _TIPO_ALIASES
+
+    despesa_sql = f"tipo IN ('despesa', 'saida', '{_ALIAS_NOVO}')"
+    canon_sql = (
+        f"CASE WHEN {despesa_sql} THEN 'despesa' "
+        f"WHEN {CONN.TIPO_RECEITA_SQL} THEN 'receita' ELSE tipo END"
+    )
+    monkeypatch.setitem(_TIPO_ALIASES, "despesa", ("despesa", "saida", _ALIAS_NOVO))
+    monkeypatch.setattr(ACC, "TIPO_DESPESA_SQL", despesa_sql)
+    monkeypatch.setattr(PA, "TIPO_DESPESA_SQL", despesa_sql)
+    monkeypatch.setattr(CONN, "TIPO_CANON_SQL", canon_sql)
+
+
+def test_ampliar_a_fonte_unica_alcanca_os_cinco_sites(uid_wa, fonte_ampliada):
+    """Controle da DERIVA: com um terceiro alias na fonte única, os cinco sites
+    têm que acompanhar. Qualquer um deles de volta ao literal
+    (`("despesa","saida")` em Python, `tipo = 'despesa'` no SQL) devolve 50 no
+    lugar de 150 e deixa este teste VERMELHO."""
+    db.add_launch_and_update_balance(
+        uid_wa, "despesa", 50, "mercado", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    _grava_tipo_legado(uid_wa, _ALIAS_NOVO, 100, "mercado")
+
+    assert _resumo(uid_wa)["despesa"] == 150.0, _resumo(uid_wa)      # db_support
+    assert _stats_do_mes(uid_wa)["saiu"] == 150.0, _stats_do_mes(uid_wa)  # piggy_agents
+    assert _top_categorias(uid_wa) == {"mercado": 150.0}             # db/accounts
+
+    lista = _diga(uid_wa, "lancamentos de hoje")                     # launches.py
+    assert "💸 Gastos: R$ 150,00" in lista, lista
+    # o rodapé SEM data é o irmão na mesma função, e é a 4ª cópia em Python:
+    # sem ele aqui, revertê-lo ao literal não deixaria nada vermelho.
+    ultimos = _diga(uid_wa, "meus lancamentos")
+    assert "💸 Gastos: R$ 150,00" in ultimos, ultimos
+
+    saldo = _diga(uid_wa, "saldo")                                   # balance.py
+    assert len(_linhas_do_hoje(saldo)) == 2, saldo
+
+
+# ── o guard de movimento interno no rodapé do DIA ───────────────────────────
+
+def test_rodape_do_dia_nao_conta_movimento_interno(uid_wa):
+    """O rodapé do dia não descartava `is_internal_movement`, ao contrário do
+    irmão de :654/659 na MESMA função. Antes do conserto do tipo legado o
+    `== "despesa"` escondia isso por acidente; somar as duas formas passou a
+    deixar a transferência LEGADA entrar no "Gastos" do dia.
+
+    Controle NEGATIVO: sem o `and not r.get("is_internal_movement")` de
+    launches.py:551-554 a resposta vira "R$ 138,00"."""
+    db.add_launch_and_update_balance(
+        uid_wa, "despesa", 50, "mercado", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    _grava_tipo_legado(uid_wa, "saida", 88, "transferencia", interno=True)
+
+    lista = _diga(uid_wa, "lancamentos de hoje")
+    assert "💸 Gastos: R$ 50,00" in lista, lista
+    assert "R$ 138,00" not in lista, lista
+    # a linha continua APARECENDO na lista; o que muda é o total do rodapé
+    assert "legado-interno" in lista, lista

--- a/tests/test_tipo_legado_na_cauda.py
+++ b/tests/test_tipo_legado_na_cauda.py
@@ -20,9 +20,9 @@ Os dois primeiros vinham do SQL (`TIPO_DESPESA_SQL`/`TIPO_RECEITA_SQL`/
 
 Os dois meio-consertos que provam que a categoria estava aberta, não a folha:
 `_month_stats` já lia `('despesa','saida')` em `saiu` e só `'receita'` em
-`entrou` — sinal do "sobrou" INVERTIDO; e o rodapé do dia (launches.py:545) lia
-só a moderna dentro da MESMA função cujo rodapé sem data (launches.py:647) já
-lia as duas.
+`entrou` — sinal do "sobrou" INVERTIDO; e o rodapé do dia (`list_launches`,
+ramo COM data) lia só a moderna dentro da MESMA função cujo rodapé sem data
+(o ramo dos últimos N) já lia as duas.
 
 Incidência: a produção deu ZERO linhas legadas em 27/08/2026 (mesma medição do
 cabeçalho do irmão do dashboard). Isto fecha a classe; não muda número de
@@ -35,9 +35,10 @@ Controle NEGATIVO — um por conserto, todos injetados em caso que estava VERDE:
       → `test_resumo_do_periodo_nao_descarta_a_linha_legada` (despesa 150 × 50)
   • `get_top_expense_categories` de volta a `and tipo = 'despesa'`
       → `test_quanto_gastei_soma_a_linha_legada` (mercado 150 × 50)
-  • `launches.py:545-546` de volta a `== "despesa"` / `== "receita"`
+  • os dois somatórios do ramo COM data de `list_launches` de volta a
+    `== "despesa"` / `== "receita"`
       → `test_rodape_do_dia_soma_a_linha_legada` ("R$ 150,00" × "R$ 50,00")
-  • `balance.py:32` de volta a `== "despesa"`
+  • o filtro de `balance.py::check` de volta a `== "despesa"`
       → `test_hoje_do_saldo_mostra_a_linha_legada` (2 linhas × 1)
 Controle POSITIVO: `test_base_sem_linha_legada_nao_muda_nenhum_numero` — a MESMA
 base só com a forma moderna responde exatamente o mesmo nos cinco pontos. Sem
@@ -45,11 +46,12 @@ ele o grupo passaria num código que somasse a mesma linha DUAS vezes.
 
 Os cinco acima provam que os sites contam a linha legada de HOJE — não provam
 que eles LEEM a fonte única, e literal copiado passa igual. Quem mede isso é
-`test_ampliar_a_fonte_unica_alcanca_os_cinco_sites`: amplia a fonte com um
-terceiro alias e cobra que os cinco acompanhem (50 × 150).
+`test_ampliar_a_fonte_unica_alcanca_os_seis_sites`: amplia as DUAS pernas da
+fonte com um terceiro alias e cobra que os seis acompanhem (50 × 150). São seis
+e não cinco porque o rodapé sem data é a 6ª cópia, na mesma função da 4ª.
 
 E `test_rodape_do_dia_nao_conta_movimento_interno` guarda o guard de
-`is_internal_movement` do rodapé do dia, que igualou o irmão de :654/659 —
+`is_internal_movement` do rodapé do dia, que igualou o irmão dos últimos N —
 somar as duas formas de `tipo` tinha deixado a transferência LEGADA entrar no
 "Gastos" do dia, que o `== "despesa"` escondia por acidente.
 """
@@ -207,22 +209,28 @@ def test_base_sem_linha_legada_nao_muda_nenhum_numero(uid_wa):
     lista = _diga(uid_wa, "lancamentos de hoje")
     assert "💸 Gastos: R$ 150,00" in lista, lista
     assert "💰 Receitas: R$ 300,00" in lista, lista
+    # POSITIVO do item 0: dia SEM movimento interno não ganha linha nenhuma a
+    # mais. Sem isto, a explicação podia aparecer sempre e ninguém veria.
+    assert "🔁" not in lista, lista
 
     saldo = _diga(uid_wa, "saldo")
     assert len(_linhas_do_hoje(saldo)) == 2, saldo
     assert "R$ 150,00" in saldo, saldo
 
 
-# ── a fonte única tem que ALCANÇAR os cinco sites ───────────────────────────
+# ── a fonte única tem que ALCANÇAR os seis sites ────────────────────────────
 #
-# Os 6 testes acima provam que os cinco sites contam a linha legada de HOJE.
+# Os 6 testes acima provam que os cinco sites da tabela contam a linha legada de
+# HOJE (o 6º, o rodapé sem data, já contava antes do PR).
 # Nenhum deles prova que os sites LEEM a fonte única — literal copiado passa
 # igual, e é assim que a deriva volta: ampliar a regra numa ponta e os literais
 # ficarem para trás, sem erro e sem log. `test_o_sql_e_o_python_falam_dos_mesmos
 # _aliases` (irmão do dashboard) compara as DUAS fontes entre si e também não
 # alcança cópia nenhuma.
 
-_ALIAS_NOVO = "egresso"  # um terceiro alias que não existe em lugar nenhum
+_ALIAS_NOVO = "egresso"    # um terceiro alias de DESPESA que não existe
+_ALIAS_NOVO_REC = "ingresso"  # e o de RECEITA: sem ele, a perna de receita de
+                              # cada site podia voltar ao literal em VERDE
 
 
 @pytest.fixture
@@ -232,7 +240,7 @@ def fonte_ampliada(monkeypatch):
     `setitem` e não `setattr`: `core/handlers/*` fazem `from db.accounts import
     _TIPO_ALIASES` na carga, então quem tem que mudar é o CONTEÚDO do dict, que
     é o mesmo objeto nos três módulos. O SQL é string interpolada em f-string,
-    e cada módulo guarda a sua cópia do nome — daí os três `setattr`.
+    e cada módulo guarda a sua cópia do nome — daí os cinco `setattr`.
     """
     import core.services.piggy_agents as PA
     import db.accounts as ACC
@@ -240,52 +248,88 @@ def fonte_ampliada(monkeypatch):
     from db.accounts import _TIPO_ALIASES
 
     despesa_sql = f"tipo IN ('despesa', 'saida', '{_ALIAS_NOVO}')"
+    receita_sql = f"tipo IN ('receita', 'entrada', '{_ALIAS_NOVO_REC}')"
     canon_sql = (
         f"CASE WHEN {despesa_sql} THEN 'despesa' "
-        f"WHEN {CONN.TIPO_RECEITA_SQL} THEN 'receita' ELSE tipo END"
+        f"WHEN {receita_sql} THEN 'receita' ELSE tipo END"
     )
     monkeypatch.setitem(_TIPO_ALIASES, "despesa", ("despesa", "saida", _ALIAS_NOVO))
+    monkeypatch.setitem(_TIPO_ALIASES, "receita", ("receita", "entrada", _ALIAS_NOVO_REC))
     monkeypatch.setattr(ACC, "TIPO_DESPESA_SQL", despesa_sql)
+    monkeypatch.setattr(ACC, "TIPO_RECEITA_SQL", receita_sql)
     monkeypatch.setattr(PA, "TIPO_DESPESA_SQL", despesa_sql)
+    monkeypatch.setattr(PA, "TIPO_RECEITA_SQL", receita_sql)
     monkeypatch.setattr(CONN, "TIPO_CANON_SQL", canon_sql)
 
 
-def test_ampliar_a_fonte_unica_alcanca_os_cinco_sites(uid_wa, fonte_ampliada):
-    """Controle da DERIVA: com um terceiro alias na fonte única, os cinco sites
-    têm que acompanhar. Qualquer um deles de volta ao literal
-    (`("despesa","saida")` em Python, `tipo = 'despesa'` no SQL) devolve 50 no
-    lugar de 150 e deixa este teste VERMELHO."""
+def test_ampliar_a_fonte_unica_alcanca_os_seis_sites(uid_wa, fonte_ampliada):
+    """Controle da DERIVA: com um terceiro alias em CADA perna da fonte única,
+    os seis sites têm que acompanhar. Qualquer um deles de volta ao literal
+    (`("despesa","saida")` / `("receita","entrada")` em Python, `tipo =
+    'despesa'` no SQL) devolve 50 no lugar de 150 (ou 0 no lugar de 300) e
+    deixa este teste VERMELHO.
+
+    A perna de RECEITA está aqui porque sem ela não estava: reverter os dois
+    `_TIPO_ALIASES["receita"]` de `list_launches` ao literal deixava o arquivo
+    inteiro VERDE (medido, 8 passed)."""
+    db.add_launch_and_update_balance(
+        uid_wa, "despesa", 50, "mercado", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    _grava_tipo_legado(uid_wa, _ALIAS_NOVO, 100, "mercado")
+    _grava_tipo_legado(uid_wa, _ALIAS_NOVO_REC, 300, "rendimentos")
+
+    assert _resumo(uid_wa)["despesa"] == 150.0, _resumo(uid_wa)      # db_support
+    assert _resumo(uid_wa)["receita"] == 300.0, _resumo(uid_wa)
+    assert _stats_do_mes(uid_wa)["saiu"] == 150.0, _stats_do_mes(uid_wa)  # piggy_agents
+    assert _stats_do_mes(uid_wa)["entrou"] == 300.0, _stats_do_mes(uid_wa)
+    assert _top_categorias(uid_wa) == {"mercado": 150.0}             # db/accounts
+
+    lista = _diga(uid_wa, "lancamentos de hoje")                     # launches.py
+    assert "💸 Gastos: R$ 150,00" in lista, lista
+    assert "💰 Receitas: R$ 300,00" in lista, lista
+    # o rodapé SEM data é o irmão na mesma função, e é a 6ª cópia em Python:
+    # sem ele aqui, revertê-lo ao literal não deixaria nada vermelho.
+    ultimos = _diga(uid_wa, "meus lancamentos")
+    assert "💸 Gastos: R$ 150,00" in ultimos, ultimos
+    assert "💰 Receitas: R$ 300,00" in ultimos, ultimos
+
+    saldo = _diga(uid_wa, "saldo")                                   # balance.py
+    assert len(_linhas_do_hoje(saldo)) == 2, saldo
+
+
+def test_o_resumo_da_lista_de_categoria_acompanha_a_fonte_unica(uid_wa, fonte_ampliada):
+    """O `tot_despesa` de `list_launches_by_category` (db/accounts.py) era
+    literal enquanto o FILTRO de linhas da MESMA query já lia `_TIPO_ALIASES`:
+    com um terceiro alias a linha entrava na lista e não era somada.
+
+    Não é cosmético — é o número que `_total_despesa`
+    (core/handlers/launches.py) subtrai do total do dashboard para escrever
+    "🔁 Mais R$ X em movimentação interna". Subcontado, a explicação some
+    calada. Negativo: literal de volta → 50,00 no lugar de 150,00."""
+    hoje = today_tz()
     db.add_launch_and_update_balance(
         uid_wa, "despesa", 50, "mercado", None,
         categoria="mercado", criado_em=_hoje_as(10),
     )
     _grava_tipo_legado(uid_wa, _ALIAS_NOVO, 100, "mercado")
 
-    assert _resumo(uid_wa)["despesa"] == 150.0, _resumo(uid_wa)      # db_support
-    assert _stats_do_mes(uid_wa)["saiu"] == 150.0, _stats_do_mes(uid_wa)  # piggy_agents
-    assert _top_categorias(uid_wa) == {"mercado": 150.0}             # db/accounts
-
-    lista = _diga(uid_wa, "lancamentos de hoje")                     # launches.py
-    assert "💸 Gastos: R$ 150,00" in lista, lista
-    # o rodapé SEM data é o irmão na mesma função, e é a 4ª cópia em Python:
-    # sem ele aqui, revertê-lo ao literal não deixaria nada vermelho.
-    ultimos = _diga(uid_wa, "meus lancamentos")
-    assert "💸 Gastos: R$ 150,00" in ultimos, ultimos
-
-    saldo = _diga(uid_wa, "saldo")                                   # balance.py
-    assert len(_linhas_do_hoje(saldo)) == 2, saldo
+    _, resumo = db.list_launches_by_category(
+        uid_wa, "mercado", hoje, hoje, tipo="despesa", limit=1,
+    )
+    assert resumo["despesa"] == 150.0, resumo
 
 
 # ── o guard de movimento interno no rodapé do DIA ───────────────────────────
 
 def test_rodape_do_dia_nao_conta_movimento_interno(uid_wa):
     """O rodapé do dia não descartava `is_internal_movement`, ao contrário do
-    irmão de :654/659 na MESMA função. Antes do conserto do tipo legado o
+    irmão dos últimos N na MESMA função. Antes do conserto do tipo legado o
     `== "despesa"` escondia isso por acidente; somar as duas formas passou a
     deixar a transferência LEGADA entrar no "Gastos" do dia.
 
-    Controle NEGATIVO: sem o `and not r.get("is_internal_movement")` de
-    launches.py:551-554 a resposta vira "R$ 138,00"."""
+    Controle NEGATIVO: sem o `and not r.get("is_internal_movement")` dos dois
+    somatórios do ramo COM data a resposta vira "R$ 138,00"."""
     db.add_launch_and_update_balance(
         uid_wa, "despesa", 50, "mercado", None,
         categoria="mercado", criado_em=_hoje_as(10),
@@ -297,3 +341,32 @@ def test_rodape_do_dia_nao_conta_movimento_interno(uid_wa):
     assert "R$ 138,00" not in lista, lista
     # a linha continua APARECENDO na lista; o que muda é o total do rodapé
     assert "legado-interno" in lista, lista
+
+
+def test_rodape_do_dia_explica_o_pagamento_de_fatura(uid_wa):
+    """A MESMA regra na forma que existe em produção: linha MODERNA
+    (`tipo='despesa'`) com `is_internal_movement`, categoria pagamento_fatura —
+    quem grava é `db/cards.py::mark_bill_paid`, uma vez por mês por cartão. O
+    irmão acima prova o guard com linha LEGADA, e a produção tem ZERO delas:
+    sem este teste, o único número que o PR muda hoje não tinha caso.
+
+    E o rodapé DIZ o que ficou de fora (a forma de `_total_despesa`). Sem a
+    linha "🔁", o dia com fatura paga mostra o lançamento de R$ 88,00 na lista e
+    "Gastos: R$ 50,00" embaixo, sem dizer por quê.
+
+    Controle NEGATIVO, dois: sem o guard vira "R$ 138,00"; sem o `internos` o
+    "🔁" some."""
+    db.add_launch_and_update_balance(
+        uid_wa, "despesa", 50, "mercado", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    db.add_launch_and_update_balance(
+        uid_wa, "despesa", 88, "fatura:nubank", "Pagamento de fatura (Nubank)",
+        categoria="pagamento_fatura", is_internal_movement=True,
+        criado_em=_hoje_as(9),
+    )
+
+    lista = _diga(uid_wa, "lancamentos de hoje")
+    assert "💸 Gastos: R$ 50,00" in lista, lista
+    assert "R$ 138,00" not in lista, lista
+    assert "🔁 R$ 88,00 em movimentação interna" in lista, lista

--- a/tests/test_tipo_legado_na_cauda.py
+++ b/tests/test_tipo_legado_na_cauda.py
@@ -1,0 +1,203 @@
+"""A cauda do `tipo` legado: os cinco leitores que mostravam número errado.
+
+Mesma armadilha dos irmãos `test_tipo_legado_no_dashboard.py` e
+`test_tipo_legado_na_tendencia.py`, agora fora do dashboard. `launches.tipo` tem
+duas formas para a mesma coisa — a moderna ('despesa', 'receita') e a legada
+('saida', 'entrada'). Nenhum escritor de hoje grava a legada, mas quem filtra só
+a moderna DESCARTA ou SUBCONTA a linha antiga, sem erro e sem log:
+
+| número na tela                  | quem lia                                  |
+|---------------------------------|-------------------------------------------|
+| "Gastos em <mês>" do saldo      | `get_summary_by_period_impl` (db_support) |
+| manchete do Repórter            | `_month_stats` (core/services/piggy_agents)|
+| "quanto gastei" / top categorias| `get_top_expense_categories` (db/accounts)|
+| rodapé da lista de UM DIA       | `core/handlers/launches.py` (list_launches)|
+| "📋 Hoje" do saldo              | `core/handlers/balance.py::check`          |
+
+Os dois primeiros vinham do SQL (`TIPO_DESPESA_SQL`/`TIPO_RECEITA_SQL`/
+`TIPO_CANON_SQL`, db/connection.py — a fonte única, não se cria outra); os três
+últimos, de comparação em Python.
+
+Os dois meio-consertos que provam que a categoria estava aberta, não a folha:
+`_month_stats` já lia `('despesa','saida')` em `saiu` e só `'receita'` em
+`entrou` — sinal do "sobrou" INVERTIDO; e o rodapé do dia (launches.py:545) lia
+só a moderna dentro da MESMA função cujo rodapé sem data (launches.py:647) já
+lia as duas.
+
+Incidência: a produção deu ZERO linhas legadas em 27/08/2026 (mesma medição do
+cabeçalho do irmão do dashboard). Isto fecha a classe; não muda número de
+usuário nenhum hoje.
+
+Controle NEGATIVO — um por conserto, todos injetados em caso que estava VERDE:
+  • `_month_stats` de volta a `tipo = 'receita'`
+      → `test_manchete_do_reporter_nao_inverte_o_sinal` (sobrou +150 × −150)
+  • `get_summary_by_period_impl` de volta a `select tipo ... group by tipo`
+      → `test_resumo_do_periodo_nao_descarta_a_linha_legada` (despesa 150 × 50)
+  • `get_top_expense_categories` de volta a `and tipo = 'despesa'`
+      → `test_quanto_gastei_soma_a_linha_legada` (mercado 150 × 50)
+  • `launches.py:545-546` de volta a `== "despesa"` / `== "receita"`
+      → `test_rodape_do_dia_soma_a_linha_legada` ("R$ 150,00" × "R$ 50,00")
+  • `balance.py:32` de volta a `== "despesa"`
+      → `test_hoje_do_saldo_mostra_a_linha_legada` (2 linhas × 1)
+Controle POSITIVO: `test_base_sem_linha_legada_nao_muda_nenhum_numero` — a MESMA
+base só com a forma moderna responde exatamente o mesmo nos cinco pontos. Sem
+ele o grupo passaria num código que somasse a mesma linha DUAS vezes.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+
+import pytest
+
+import db
+import core.handle_incoming as HI
+from core.services.piggy_agents import _month_stats
+from core.types import IncomingMessage
+from db.connection import get_conn
+from utils_date import today_tz
+
+# §0.1: o INSERT da linha legada já existe no irmão — importa, não recria.
+from tests.test_tipo_legado_no_dashboard import _grava_tipo_legado, _hoje_as
+
+
+@pytest.fixture
+def uid_wa():
+    """Usuário com id CURTO (< 1e9), que é o que o caminho do WhatsApp aceita —
+    mesmo molde de `tests/test_categoria_frase_estado_vazio.py`."""
+    from tests.conftest import promote_to_pro
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    yield promote_to_pro(uid)
+
+
+def _base(uid, *, legado: bool) -> None:
+    """A MESMA base nas duas formas: 50 + 100 de despesa e 300 de receita.
+
+    Com `legado=True` a segunda despesa entra como 'saida' e a receita como
+    'entrada' — a base que existe numa instalação antiga. Com `legado=False`,
+    tudo moderno: é 100% da produção de hoje, e é o controle positivo.
+    """
+    db.add_launch_and_update_balance(
+        uid, "despesa", 50, "mercado", None,
+        categoria="mercado", criado_em=_hoje_as(10),
+    )
+    if legado:
+        _grava_tipo_legado(uid, "saida", 100, "mercado")
+        _grava_tipo_legado(uid, "entrada", 300, "rendimentos")
+    else:
+        db.add_launch_and_update_balance(
+            uid, "despesa", 100, "feira", None,
+            categoria="mercado", criado_em=_hoje_as(9),
+        )
+        db.add_launch_and_update_balance(
+            uid, "receita", 300, "freela", None,
+            categoria="rendimentos", criado_em=_hoje_as(9),
+        )
+
+
+# ── os cinco pontos, cada um lido como o usuário lê ─────────────────────────
+
+def _resumo(uid) -> dict:
+    hoje = today_tz()
+    return db.get_summary_by_period(uid, hoje.replace(day=1), hoje)
+
+
+def _stats_do_mes(uid) -> dict:
+    hoje = today_tz()
+    first = hoje.replace(day=1)
+    nxt = (first + timedelta(days=32)).replace(day=1)
+    with get_conn() as conn, conn.cursor() as cur:
+        return _month_stats(cur, uid, first, nxt)
+
+
+def _top_categorias(uid) -> dict[str, float]:
+    hoje = today_tz()
+    rows = db.get_top_expense_categories(
+        uid, hoje.replace(day=1), hoje, limit=1000, by_bill_month=True
+    )
+    return {r["categoria"]: r["total"] for r in rows}
+
+
+def _diga(uid, texto: str) -> str:
+    msg = IncomingMessage(platform="whatsapp", user_id=uid, text=texto,
+                          message_id="m", attachments=[], external_id="e", raw={})
+    saida = HI.handle_incoming(msg)
+    return saida[0].text if saida else ""
+
+
+def _linhas_do_hoje(resposta: str) -> list[str]:
+    """Os bullets sob "📋 *Hoje*" da resposta do `saldo`."""
+    linhas = resposta.splitlines()
+    i = next(n for n, l in enumerate(linhas) if l.startswith("📋 *Hoje*"))
+    return [l for l in linhas[i + 1:] if l.startswith("  • ")]
+
+
+# ── um teste por conserto ───────────────────────────────────────────────────
+
+def test_resumo_do_periodo_nao_descarta_a_linha_legada(uid_wa):
+    """`group by tipo` cru devolve 'saida' como CHAVE PRÓPRIA, e o `if tipo in
+    out` a joga fora sem exceção e sem log: o "Gastos em <mês>" sai menor."""
+    _base(uid_wa, legado=True)
+    r = _resumo(uid_wa)
+    assert r["despesa"] == 150.0, r
+    assert r["receita"] == 300.0, r
+
+
+def test_manchete_do_reporter_nao_inverte_o_sinal(uid_wa):
+    """Meio-conserto: `saiu` já lia as duas formas e `entrou` só a moderna, o
+    que não subconta — INVERTE o sinal do "sobrou" da manchete do mês."""
+    _base(uid_wa, legado=True)
+    s = _stats_do_mes(uid_wa)
+    assert s["entrou"] == 300.0, s
+    assert s["saiu"] == 150.0, s
+    assert s["sobrou"] == 150.0, s
+
+
+def test_quanto_gastei_soma_a_linha_legada(uid_wa):
+    """As top categorias do "quanto gastei" saem do mesmo `and tipo='despesa'`."""
+    _base(uid_wa, legado=True)
+    assert _top_categorias(uid_wa) == {"mercado": 150.0}
+
+
+def test_rodape_do_dia_soma_a_linha_legada(uid_wa):
+    """Pela CONVERSA: o rodapé da lista de UM DIA discordava do rodapé da lista
+    sem data, que é a mesma função e já somava as duas formas."""
+    _base(uid_wa, legado=True)
+    resposta = _diga(uid_wa, "lancamentos de hoje")
+    assert "💸 Gastos: R$ 150,00" in resposta, resposta
+    assert "💰 Receitas: R$ 300,00" in resposta, resposta
+
+
+def test_hoje_do_saldo_mostra_a_linha_legada(uid_wa):
+    """Pela CONVERSA: no `saldo`, a linha legada SUMIA da lista "📋 Hoje"."""
+    _base(uid_wa, legado=True)
+    resposta = _diga(uid_wa, "saldo")
+    assert len(_linhas_do_hoje(resposta)) == 2, resposta
+    assert "R$ 150,00" in resposta, resposta  # "Gastos em <mês>", via db_support
+
+
+# ── controle POSITIVO ───────────────────────────────────────────────────────
+
+def test_base_sem_linha_legada_nao_muda_nenhum_numero(uid_wa):
+    """A base de 100% da produção de hoje (zero linhas legadas) responde
+    EXATAMENTE o mesmo nos cinco pontos. É o que prova que canonizar não passou
+    a contar a mesma linha duas vezes."""
+    _base(uid_wa, legado=False)
+
+    r = _resumo(uid_wa)
+    assert (r["despesa"], r["receita"]) == (150.0, 300.0), r
+
+    s = _stats_do_mes(uid_wa)
+    assert (s["entrou"], s["saiu"], s["sobrou"]) == (300.0, 150.0, 150.0), s
+
+    assert _top_categorias(uid_wa) == {"mercado": 150.0}
+
+    lista = _diga(uid_wa, "lancamentos de hoje")
+    assert "💸 Gastos: R$ 150,00" in lista, lista
+    assert "💰 Receitas: R$ 300,00" in lista, lista
+
+    saldo = _diga(uid_wa, "saldo")
+    assert len(_linhas_do_hoje(saldo)) == 2, saldo
+    assert "R$ 150,00" in saldo, saldo

--- a/tests/test_tipo_legado_no_dashboard.py
+++ b/tests/test_tipo_legado_no_dashboard.py
@@ -45,14 +45,18 @@ def _hoje_as(hora: int):
     return datetime.combine(today_tz(), time(hora, 0))
 
 
-def _grava_tipo_legado(user_id, tipo, valor, categoria):
+def _grava_tipo_legado(user_id, tipo, valor, categoria, interno: bool = False):
     """`add_launch_and_update_balance` não grava a forma legada (nem deve): a
-    linha antiga entra por SQL, que é como ela existe numa base de verdade."""
+    linha antiga entra por SQL, que é como ela existe numa base de verdade.
+
+    `interno=True` marca `is_internal_movement` — a transferência antiga, que é
+    linha legada E movimento interno ao mesmo tempo."""
     with db.get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "insert into launches (user_id, tipo, valor, categoria, nota, "
-            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,false)",
-            (user_id, tipo, valor, categoria, "legado", _hoje_as(9)),
+            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, tipo, valor, categoria,
+             "legado-interno" if interno else "legado", _hoje_as(9), interno),
         )
         conn.commit()
 


### PR DESCRIPTION
> **Isto fecha classe, não apaga incêndio.** Produção deu **zero** linhas legadas em 27/08/2026 (`count(*) filter (where tipo='saida')` = 0, idem `'entrada'`), e a medição está sendo refeita. Nenhum número de usuário muda por causa do tipo legado hoje. **Muda um número por outro motivo** — ver §3, e é a única coisa deste PR com efeito imediato.

## O problema

`launches.tipo` tem **duas formas para a mesma coisa**: a moderna (`'despesa'`, `'receita'`) e a legada (`'saida'`, `'entrada'`). Nenhum escritor de hoje grava a legada, mas leitores que filtram só a moderna **descartam ou subcontam** a linha — número errado na tela, sem erro nenhum.

A classe foi fechada em vários leitores nos #158 e #165. **Sobrou uma cauda**, e este é o PR 1 dela: os cinco que mostram número ao usuário.

## 1. Os cinco sites

| # | site | consumidor | sintoma antes |
|---|---|---|---|
| 1 | `db_support.py` `get_summary_by_period_impl` | relatório diário do WhatsApp, `/saldo`, e 4 tools do chat da IA | **descartava em silêncio** — `group by tipo` devolvia `'saida'` como chave própria e o `if tipo in out` a jogava fora |
| 2 | `core/services/piggy_agents.py` `_month_stats` | manchete do agente Repórter | **meio-consertado**: `saiu` já tinha o par, `entrou` não → `sobrou` menor, **podendo inverter o sinal** com o usuário no azul |
| 3 | `db/accounts.py` `get_top_expense_categories` | "quanto gastei em X" do WhatsApp e a tool `get_top_categories` | subcontava a categoria; o ranking podia trocar de ordem |
| 4 | `core/handlers/launches.py` rodapé de "lançamentos de hoje" | WhatsApp | **o meio-conserto estava na mesma função** que a versão certa — alguém arrumou o rodapé sem data e não o do dia |
| 5 | `core/handlers/balance.py` "📋 Hoje" do `/saldo` | WhatsApp | descartava a linha legada da lista |

Todos passaram a ler a fonte única que **já existia** (`TIPO_DESPESA_SQL`, `TIPO_RECEITA_SQL`, `TIPO_CANON_SQL` em `db/connection.py`; `_TIPO_ALIASES` para os que filtram em Python).

**Ressalva honesta:** a fonte é única para **estes seis sites**, não para o repositório. Um `grep` do par literal fora de testes devolve ~28 ocorrências, todas **corretas hoje** (contêm as duas formas). Não são bug — são superfície de deriva, e este PR não as toca.

## 2. Duas armadilhas de implementação que teriam feito o conserto parecer funcionar

**`group by tipo` anularia o conserto em silêncio.** Com o alias de saída e a coluna de entrada de mesmo nome, o Postgres resolve o `GROUP BY` pela **coluna de entrada**: o `CASE` projeta certo e agrupa errado, `'saida'` volta a ser chave própria, e o Python de `db_support` faz atribuição (não acumulação), então a última linha vence. Medido:
```
group by tipo : [receita 7.0, despesa 50.0, receita 300.0, despesa 100.0]
group by 1    : [despesa 150.0, receita 307.0]
```

**O import no topo fecha ciclo**, reproduzido:
```
db_support.py from db.connection import TIPO_CANON_SQL
  -> db/__init__.py from .reports import ...
    -> db/reports.py AccountAlreadyExistsError = _db_support.AccountAlreadyExistsError
AttributeError: module 'db_support' has no attribute 'AccountAlreadyExistsError'
```
Import dentro da função, padrão já usado no repo. Custo medido: **0,095 µs/chamada**, contra um roundtrip de banco; `EXPLAIN ANALYZE` idêntico.

## 3. A ÚNICA mudança de número visível hoje — leia antes de aprovar

O rodapé de "lançamentos de hoje" **deixa de somar movimento interno**. Em base moderna isso é **pagamento de fatura** (`db/cards.py`), **saldo inicial**, **ajuste** e transferências importadas. **Não é caso raro: é mensal e é todo usuário de cartão.**

Medido: base com despesa moderna 50 + linha interna 88 → `💸 Gastos: R$ 138,00` antes, `R$ 50,00` depois.

Por que entrou: o PR **causou** a regressão. Antes, o `== "despesa"` excluía a linha interna **por acidente**; ao aceitar a forma legada, ela passaria a entrar. O guard iguala o rodapé do dia ao irmão sem data e ao dashboard, que já o tinham.

E o total deixou de ser mudo — a soma parcial passa a **dizer o que ficou de fora**, copiando a forma que o repo já usa em `_total_despesa`:
```
🔁 R$ 88,00 em movimentação interna (não entra nos totais).
```
Dia sem movimento interno não ganha linha nenhuma a mais (controle positivo).

## 4. Dois sites que a varredura derrubou

`db/open_finance.py:1922` e `:1984` **não procedem**: filtram `coalesce(source,'')='open_finance'` **antes** do tipo, e o único escritor desse `source` grava a forma moderna incondicionalmente. Não existe caminho que produza `source='open_finance'` com `tipo='saida'`. Diff sem efeito.

## 5. Controles

**Negativos, um por site, cada um injetado num caso que estava VERDE** — os seis ficam vermelhos: `db_support` (incluindo a variante `group by tipo`), `piggy_agents`, `get_top_expense_categories`, o rodapé do dia, o rodapé sem data, e `balance.py`. Mais dois: sem o guard de `is_internal_movement`, e sem a linha `🔁`.

**Positivo** — `test_base_sem_linha_legada_nao_muda_nenhum_numero`: a mesma base em forma 100% moderna (que é 100% da produção hoje) responde **exatamente o mesmo** nos cinco pontos. Ele foi provado **não-vazio**: forçando contagem dupla nos cinco sites, ficou vermelho nos cinco.

**Anti-deriva** — `test_ampliar_a_fonte_unica_alcanca_os_seis_sites` amplia a fonte única (as duas pernas, despesa e receita) e prova que os seis acompanham. Sem ele, um ataque anterior conseguiu deixar **26 testes verdes** com a fonte ampliada e a mesma tela se contradizendo.

Sites 4, 5 e o rodapé sem data entram pela **conversa** (`handle_incoming`, banco real), não pela função com `db` mockado.

## 6. O que fica fora, e onde

- **PR 2** — os três "quietos" (`db/recurring.py`, `db/categories.py`, `db/accounts.py` `get_internal_movement_total`): ausência de sugestão, não número errado. Mais apagar `monthly_summary_credit_debit` (`db/cards.py`), que tem **zero chamadores**.
- **PR 3** — `frontend/home.html`: `isReceita` sem o par enquanto `isDespesa` tem, então uma linha `'entrada'` renderiza como **despesa vermelha com sinal de menos**. **Sinal invertido**, não subcontagem. Separado por ser só verificável **depois do deploy**.
- **`_CONTA_CORRENTE_LAUNCH_FILTER`** — é escopo de *delete*, não leitor de número. Ampliá-lo muda **o que é apagado**, e o teto do #214 é que `kept_unsafe` é **permanente**. Fora.
- **`_TIPO_ALIASES` continua fonte separada** dos gêmeos SQL, guardada pelo teste que compara as duas. Descer para `db/connection.py` é possível (a seta de import permite) — **adiado por escopo**, não por ciclo. E este PR é a primeira vez que esse nome privado é importado em `core/handlers/`: o underscore agora mente.
- **O rodapé sem data não ganhou a linha `🔁`** — mesma mudez, mas pré-existente e com até 10 lançamentos de dias variados, onde a soma é menos legível. Decisão de produto, não fiz.

## Onde foi provado

`pigbank_ci_test`, com `handle_incoming` e banco real nos sites de conversa. **Nada verificado no WhatsApp real nem pós-deploy** — os testes de WhatsApp mockam LLM e envio, então o verde cobre a lógica intermediária, não o comando ponta a ponta. A remedição de incidência em produção está pendente.

Suíte após integrar a `main`: **5843 passed, 4 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
