### PR TITLE
Porta 2: a tabela das 16 células do #281 (quinto sinal + desempate)

### DIFF
--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -255,14 +255,19 @@ def abandona_pergunta_de_valor(text: str) -> bool:
 # para o "tudo"/"esvaziar"/"zerar", que é a outra forma de preencher o MESMO
 # campo (ver o docstring de lá).
 #
-# TETO MEDIDO, e é o preço de não ter lista: a UNIDADE conta como cauda.
-#   "paguei 100 reais"  -> pergunta   (era resolve; "reais" é a última palavra)
-#   "paguei 2 mil"      -> resolve    ("mil" É valor para o `_extract_valor`)
-#   "100 reais"         -> resolve    (começa pelo valor, sai antes daqui)
-# Custa UM turno numa forma comum, e nunca custa dinheiro — perguntar não
-# escreve. Fechar isso exigiria a lista de unidades, que é a lista que este
-# desenho existe para não ter. ponytail: se o turno a mais incomodar, o conserto
-# é reusar o `h_bills._UNIDADE` AQUI, num predicado só, não espalhar palavras.
+# A UNIDADE do valor NÃO é cauda — e é ela que separa a regra 2 da regra 3 do
+# dono sem precisar de lista de cauda:
+#   "100 reais"      -> `reais` é o próprio valor dito por extenso, não um alvo
+#                       -> a quantidade é a última coisa -> RESPONDE
+#   "50 no mercado"  -> depois do número vem um ALVO
+#                       -> a quantidade não é a última coisa -> PERGUNTA
+# O vocabulário é o `h_bills._UNIDADE` da porta 1 (§0.7 — reusado, não copiado).
+# `centavos` e `k` ficam SÓ aqui: medido, pô-los lá dentro faria o `_VALOR_RE`
+# aceitar "132 centavos" (a porta 1 PAGARIA R$ 132,00 no lugar de R$ 1,32) e
+# "132k" (R$ 132,00 no lugar de R$ 132.000,00 — o `_extract_valor` já lê 132 daí,
+# e consertar isso é outra issue). O `k` chega aqui separado porque o
+# `limpa_pontuacao_final` recorta o bloco numérico: "132k" vira "132 k".
+# (a regex mora logo abaixo, junto do `_INVISIVEL`)
 #
 # CONSEQUÊNCIA ACEITA PELO DONO, e é a única linha que sai da tabela anterior:
 # `gastei tudo mesmo` passa a PERGUNTAR em vez de esvaziar. Esvaziar é a
@@ -274,6 +279,9 @@ def abandona_pergunta_de_valor(text: str) -> bool:
 # "paguei 132 \u200b" são os dois RESPOSTA. Sem isto o mesmo caractere decidia
 # coisas diferentes conforme viesse colado no número ou separado por espaço.
 _INVISIVEL = str.maketrans("", "", "\u200b\u200c\u200d\ufeff")
+
+# A unidade do valor, que NÃO é cauda — ver o bloco acima.
+_UNIDADE_DE_VALOR_RE = re.compile(rf"(?:{h_bills._UNIDADE}|centavos?|k)", re.I)
 
 
 def _tem_quantidade(text: str) -> bool:
@@ -293,6 +301,8 @@ def _quantidade_fecha(text: str) -> bool:
     """
     palavras = limpa_pontuacao_final(
         (text or "").translate(_INVISIVEL).strip()).split()
+    while palavras and _UNIDADE_DE_VALOR_RE.fullmatch(palavras[-1]):
+        palavras.pop()
     return bool(palavras) and _tem_quantidade(palavras[-1])
 
 
@@ -305,10 +315,17 @@ def _quantidade_fecha(text: str) -> bool:
 # (`clarif`), junto com o texto que ficou pendurado (`texto`): sem os dois, "era
 # o valor" não teria para onde voltar. Mesmo desenho do `funding_source_choice`
 # e do `investment_pick`, que também guardam o contexto no payload.
+#
+# O texto do usuário aparece UMA vez, e cortado. Medido na versão anterior (duas
+# interpolações, sem corte): 2.021 chars de entrada viravam 4.234 de resposta —
+# e o `wa_client.send_text` manda o body cru, sem split nem truncagem
+# (adapters/whatsapp/). Que a Cloud API recuse acima de 4.096 é limite de
+# plataforma e NÃO foi exercitado aqui. O texto inteiro continua no payload, que
+# é quem o registra quando o usuário escolhe 2.
 _PERGUNTA_DE_DESEMPATE = (
     "Não sei se *{texto}* responde a pergunta ou é um lançamento novo.\n\n"
     "1️⃣ *responder* — {pergunta}\n"
-    "2️⃣ *registrar* — trata *{texto}* como comando novo\n\n"
+    "2️⃣ *registrar* — trata como comando novo\n\n"
     "Ou *cancela*."
 )
 
@@ -323,18 +340,11 @@ def _resolve_desempate(pending: dict, msg: IncomingMessage, user_id: int) -> str
     para a linha e sai por `None` — o `route()` reentra na tabela com a mensagem
     NOVA, como se o desempate nunca tivesse existido.
 
-    O cancelamento tem ramo próprio, e isso NÃO é duplicação do
-    `_resolve_clarification` (que já trata "nao"/"cancelar"): com o desempate
-    armado, "cancelar" nunca chega ao `route()`. O
-    `handle_billing_command` (core/services/billing_commands.py:296) responde
-    antes — "🐷 Você tá no plano Free, não tem o que cancelar" — porque a
-    guarda dele consulta o `ai_pending_actions` (a mesa da IA) e não o
-    `pending_actions`, que é onde moram a `clarification`, este desempate e as
-    confirmações de delete que o comentário de lá diz proteger.
-    HOLE PRÉ-EXISTENTE, medido, e NÃO consertado aqui: mexer naquela guarda
-    move o `cancelar` de toda pendência determinística do produto, o que é
-    outro PR. O texto da pergunta oferece *cancela*, que chega até aqui; o ramo
-    aceita as quatro formas assim mesmo, para quem digitar de outro jeito.
+    O cancelamento NÃO tem ramo próprio: ele é a "qualquer outra coisa" acima —
+    a pergunta volta para a linha, o `route()` reentra e o
+    `_resolve_clarification` (que já trata "cancela"/"nao") responde
+    "❌ Cancelado." e mata as duas. Medido: com um ramo dedicado a saída era
+    byte a byte a mesma nas quatro palavras.
 
     O CAS é o de sempre: se a linha já não é este desempate, outra tarefa a
     substituiu e o texto do usuário responde a OUTRA pergunta.
@@ -342,14 +352,6 @@ def _resolve_desempate(pending: dict, msg: IncomingMessage, user_id: int) -> str
     payload  = pending.get("payload") or {}
     guardado = payload.get("texto") or ""
     escolha  = limpa_pontuacao_final((msg.text or "").strip().lower())
-
-    if escolha in ("cancelar", "cancela", "nao", "não"):
-        # Mata as DUAS: o texto pendurado e a pergunta que ele desalojou. Ramo
-        # próprio porque o `_resolve_clarification` (que já trata "cancelar")
-        # nunca é alcançado — a inferência de ajuda responde antes, ver o
-        # comentário no `route()`.
-        db.consume_pending_action(user_id, pending)
-        return "❌ Cancelado."
 
     if escolha in ("2", "2️⃣", "registrar"):
         if not db.consume_pending_action(user_id, pending):
@@ -373,6 +375,12 @@ def _resolve_desempate(pending: dict, msg: IncomingMessage, user_id: int) -> str
     return None
 
 
+# O abandono da via nova (C1) descarta uma pergunta que o usuário acabou de ver
+# na tela. O comando roda; o aviso é para ele não ficar esperando a resposta da
+# pergunta que morreu.
+_AVISO_PERGUNTA_CANCELADA = "🔕 Cancelei a pergunta anterior.\n\n"
+
+
 def route(result: IntentResult, msg: IncomingMessage, *,
           ignora_pendencias: bool = False) -> str:
     """
@@ -380,12 +388,17 @@ def route(result: IntentResult, msg: IncomingMessage, *,
     Retorna o texto de resposta (ainda não formatado por plataforma).
 
     `ignora_pendencias=True`: roteia a mensagem como comando novo SEM olhar a
-    linha de `pending_actions`. Um chamador só — a porta 4
+    linha de `pending_actions`. Dois chamadores. O primeiro é a porta 4
     (`adapters/whatsapp/wa_runtime.py`), quando o CAS de abandono dela falha:
     aí a linha já é de OUTRA tarefa, com uma pergunta que o usuário acabou de
     ver na tela, e deixar as guardas abaixo rodarem faria o comando velho
     abandoná-la (o `resolve_bill_amount` a apaga; o `resolve_multi_launch_value`
     apaga a fila inteira). Ver o mesmo tratamento na porta 2, logo abaixo.
+
+    O segundo é este próprio `route()`, uma vez, no `abandona_avisa`: a linha
+    ACABOU de ser consumida, e a reentrada existe só para pôr o aviso na frente
+    da resposta do comando. Recursão de um nível — o segundo passe não pode
+    reabrir o ramo, porque a `clarification` já não está lá.
     """
     user_id  = int(msg.user_id)
     text     = (msg.text or "").strip()
@@ -440,6 +453,13 @@ def route(result: IntentResult, msg: IncomingMessage, *,
             # turno — nem o valor na pergunta viva, nem o comando novo. O CAS é
             # o mesmo do abandono logo abaixo, e pela mesma razão: se a linha já
             # é de outra tarefa, o desempate não pode atropelá-la.
+            #
+            # E quando ele FALHA a saída NÃO é o roteamento normal, que é o que
+            # o abandono faz: lá o texto é um comando que o usuário deu de
+            # propósito; aqui é o que este desenho acabou de declarar ambíguo.
+            # Medido com o CAS forçado a False, a saída anterior gravava
+            # "💸 Despesa registrada: R$ 50,00" e perdia a pergunta original.
+            # Ambíguo não escreve, nem no caminho de exceção.
             if db.advance_pending_action(
                     user_id, "clarification", clarif.get("payload") or {},
                     {"clarif": clarif.get("payload") or {}, "texto": text},
@@ -449,11 +469,11 @@ def route(result: IntentResult, msg: IncomingMessage, *,
                     new_action_type="value_or_command_choice",
                     old_created_at=clarif.get("created_at")):
                 return _PERGUNTA_DE_DESEMPATE.format(
-                    texto=text,
+                    texto=text[:300] + ("…" if len(text) > 300 else ""),
                     pergunta=(clarif.get("payload") or {}).get("question")
                              or "a pergunta anterior")
-            ignora_pendencias = True
-        elif veredito == "abandona":
+            return NOT_UNDERSTOOD_MSG
+        elif veredito.startswith("abandona"):
             # Porta 2. Mesma escotilha de escape do `investment_pick` e do
             # `funding_source_choice` logo abaixo: outro comando claro abandona
             # a pergunta em vez de ser engolido por ela ("Quanto foi no *luz*?"
@@ -469,7 +489,17 @@ def route(result: IntentResult, msg: IncomingMessage, *,
             # `get_pending_action` abaixo a recarregava e o comando velho
             # ("saldo") ia parar no `resolve_bill_amount` dela — deixando
             # órfã exatamente a pergunta que o CAS protegeu.
-            ignora_pendencias = not db.consume_pending_action(user_id, clarif)
+            #
+            # `abandona_avisa` (C1, a via nova): o comando roda, mas a pergunta
+            # que ele descartou é ANUNCIADA. Reentra com `ignora_pendencias`
+            # porque a linha acabou de ficar livre — é o mesmo caminho de baixo,
+            # com o aviso na frente.
+            if db.consume_pending_action(user_id, clarif):
+                if veredito == "abandona_avisa":
+                    return _AVISO_PERGUNTA_CANCELADA + route(
+                        result, msg, ignora_pendencias=True)
+            else:
+                ignora_pendencias = True
         else:
             return _resolve_clarification(clarif, text, user_id, platform, external_id)
 
@@ -952,18 +982,23 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     está no corpo do PR #288 e nos testes; aqui fica o predicado, nesta ordem:
 
       A0  intent de LEITURA ("saldo", "extrato")            -> abandona
-      D11 começa pelo valor ("50 no mercado", "100 reais")  -> resolve
       D10 o reroteamento leria OUTRO valor                  -> resolve
       D9  valor perigoso ("paguei, 132 50", "-10")          -> resolve
       D4/D6/C2 a quantidade FECHA a mensagem                -> resolve
       D4b/D5/D7/D8 a quantidade tem cauda                   -> PERGUNTA
-      C1  comando SEM quantidade ("fatura")                 -> abandona
+      C1  comando SEM quantidade ("fatura")                 -> abandona_avisa
       D1/D2/D3/B0 o resto (sem quantidade nenhuma)          -> resolve
 
     O classificador decide DUAS células (A0 e C1); as outras são posicionais —
     ver o quinto sinal, em `_quantidade_fecha`. Foi a tentativa de decidir tudo
     pelo intent que produziu as rodadas anteriores: `launches.add` 0.95 é o
     mesmo veredito para `gastei 50 no mercado` e para `100 reais`.
+
+    `"abandona_avisa"` é o abandono da via NOVA (C1) e só muda o TEXTO: a
+    pergunta viva morre igual, mas o bot diz que a cancelou. Na `main` "fatura"
+    respondendo "Qual o valor?" mantinha a pergunta; agora ela é descartada, e
+    descartar em silêncio é o que o dono recusou. O A0 (`saldo`, `extrato`)
+    segue calado, como sempre foi.
 
     `"pergunta"` NUNCA escreve — quem a recebe é o desempate do `route()`, que
     guarda a pergunta original e o texto e devolve as duas opções ao usuário.
@@ -998,7 +1033,7 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     o valor, recusa o valor perigoso ou re-pergunta — a pergunta continua viva
     em todos os três casos.
     """
-    from parsers import _STARTS_WITH_VALUE_RE, _extract_valor
+    from parsers import _extract_valor
 
     payload = clarif.get("payload")
     if not isinstance(payload, dict):
@@ -1023,11 +1058,6 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     # É o mesmo bug que o #185 fechou, por outra porta — e os testes do #185
     # não viam porque `saldo` (do `ABANDONA`) continuava passando pelo veto.
     if intent_da_resposta not in ABANDONA:
-        # D11: começa pelo valor. "50 no mercado" e "100 reais" classificam
-        # `launches.add` 0.95 igual a `gastei 50 no mercado`, e são a resposta
-        # que o bot pediu com o nome junto. Sem esta linha, `100 reais` e
-        # `30 reais e 50 centavos` viram pergunta de desempate.
-        #
         # D10 e D9, o FILTRO DE DANO antes de largar a pergunta. Abandonar e
         # perguntar passam por FORA do `valor_perigoso` (ele mora no
         # `_resolve_clarification`), então o texto com pontuação de prosa ou com
@@ -1040,8 +1070,7 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
         # a pendência viva — o comportamento da `main`. Estritamente
         # conservadores: só fazem esta via abandonar (e perguntar) MENOS.
         bruto = (text or "").strip()
-        if (_STARTS_WITH_VALUE_RE.match(bruto)
-                or not _o_reroteamento_le_o_mesmo_valor(bruto)
+        if (not _o_reroteamento_le_o_mesmo_valor(bruto)
                 or valor_perigoso(bruto, _extract_valor(bruto))):
             return "resolve"
         if _tem_quantidade(bruto):
@@ -1132,7 +1161,7 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
         resposta = limpa_pontuacao_final((text or "").strip())
         if _eh_nome_do_catalogo(resposta, _alvos_existentes(user_id, intent)):
             return "resolve"
-    return "abandona"
+    return "abandona" if intent_da_resposta in ABANDONA else "abandona_avisa"
 
 
 _SO_NUMERO_RE = re.compile(r"[\d.,\s]+")

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -276,12 +276,33 @@ def abandona_pergunta_de_valor(text: str) -> bool:
 #
 # A unidade é obrigatória em cada iteração externa: sem isso o `PT_VALUE`
 # aninhado num segundo `*` dá backtracking catastrófico (medido: 40 grupos de
-# "2 mil e " não terminaram em 120s; com esta forma, 0,09 ms).
+# "2 mil e " não terminaram em 120s; com esta forma, termina). O "0,09 ms" que
+# estava escrito aqui era de UMA seed de `PYTHONHASHSEED` — o tempo varia com
+# a ordenação da alternância, e é o que a nota de ordenação abaixo trata. O
+# `test_281_so_o_valor_nao_estoura_com_texto_longo` mede exponencial × não
+# exponencial, não milissegundos.
 #
 # "centavos" entra além do `_UNIDADE` da porta 1 porque aqui a mensagem é uma
 # frase falada inteira ("30 reais e 50 centavos"), e lá é só o número.
+#
+# A ordenação tem DUAS chaves de propósito. `_SEM_CONTEUDO` é um `frozenset`,
+# então `key=len` sozinho desempata pela ordem de iteração — que muda com o
+# `PYTHONHASHSEED`. O resultado do `fullmatch` é o mesmo (medido: md5 idêntico
+# sobre 7 seeds), mas o TEMPO não é: `_so_o_valor("um "*1365 + "x")` mediu de
+# 463 ms a 6,1 s conforme a seed, e é alcançável por mensagem de usuário
+# ("gastei " + "um "*1362 + "x" → 1,3–1,5 s). O `-len` mantém a alternância mais
+# longa primeiro (é o que evita o casamento parcial de "um" dentro de "umas") e
+# o alfabético torna o custo reprodutível. REMEDIDO em 2026-09-04 com a segunda
+# chave, nas mesmas 7 seeds (0 1 2 3 7 42 12345):
+#     PYTHONHASHSEED=$S .venv/bin/python -c "…md5(_SEM_CONTEUDO_ALT); _so_o_valor('um '*1365+'x')"
+# md5 idêntico nas 7 e 392–443 ms — remedir antes de reusar o número.
+#
+# ponytail: o teto que SOBRA é o custo linear-com-constante-alta do próprio
+# `_SO_O_VALOR_RE` (≈400 ms para 1365 palavras de enchimento). É o mesmo da
+# `main`, agora só previsível. Se virar problema, o conserto é cortar a
+# mensagem por tamanho antes do `fullmatch`, não mexer na alternância.
 _SEM_CONTEUDO_ALT = "|".join(
-    sorted((re.escape(w) for w in _SEM_CONTEUDO), key=len, reverse=True))
+    sorted((re.escape(w) for w in _SEM_CONTEUDO), key=lambda w: (-len(w), w)))
 _SO_O_VALOR_RE = re.compile(
     rf"(?:(?:{_SEM_CONTEUDO_ALT})\s+)*(?:-\s*)?"
     rf"(?:{PT_VALUE}"
@@ -311,10 +332,45 @@ def _so_o_valor(text: str) -> bool:
     é "foi - 10" voltar a pagar R$ 10,00 positivo. Um turno a mais é barato;
     aquilo não é.
     """
-    dobrado = unicodedata.normalize(
+    return bool(_SO_O_VALOR_RE.fullmatch(_dobrado(text)))
+
+
+# Verbo de lançamento (prefixo SEM conteúdo) e MAIS NADA além de UMA palavra.
+# O `_so_o_valor` acima cobre o caso em que essa palavra é o valor; este cobre
+# o caso em que ela não é — e o veredito é o mesmo, porque a razão é a mesma:
+# a mensagem não nomeia alvo nenhum, então não compete com a pergunta viva.
+#
+# É a via EXPLÍCITO abandonando para um comando que NÃO PODE RODAR: sem valor e
+# sem alvo, o `launches.add` só faz a sua própria pergunta, com a palavra do
+# usuário no lugar do alvo — a classe que o
+# `test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta` existe para impedir.
+# Medido contra a `main`, respondendo "Qual o valor?" de um saque da caixinha
+# `viagem` (R$ 300):
+#   "gastei tudo"    main: esvaziada -R$ 300,00   sem esta guarda: "Quanto foi no *tudo*?"
+#   "paguei tudo"    main: esvaziada -R$ 300,00   sem esta guarda: "Quanto foi no *tudo*?"
+#   "gastei metade"  main: "Não entendi o valor" (pergunta VIVA)
+#                                                 sem esta guarda: "Quanto foi no *metade*?"
+#
+# UMA palavra, não N: "gastei 50 no mercado" nomeia alvo e segue EXPLÍCITO.
+# E só os 12 `_VERBOS_LANCAMENTO` (mais o enchimento) são prefixo sem conteúdo,
+# então `retirei tudo`, `saquei tudo`, `tirei tudo` e `esvaziar caixinha viagem`
+# não passam por aqui — os quatro seguem abandonando, como na `main`.
+_VERBO_E_UMA_PALAVRA_RE = re.compile(
+    rf"(?:(?:{_SEM_CONTEUDO_ALT})\s+)+\S+", re.I)
+
+
+def _verbo_e_uma_palavra(text: str) -> bool:
+    """A mensagem é prefixo sem conteúdo + UMA palavra ("gastei tudo")."""
+    return bool(_VERBO_E_UMA_PALAVRA_RE.fullmatch(_dobrado(text)))
+
+
+def _dobrado(text: str) -> str:
+    """A dobra da porta 1: `lower` + NFKD sem combining + `_TRACOS` +
+    `limpa_pontuacao_final`. Compartilhada pelos dois portões acima."""
+    d = unicodedata.normalize(
         "NFKD", (text or "").strip().lower().translate(_TRACOS))
-    dobrado = "".join(c for c in dobrado if not unicodedata.combining(c))
-    return bool(_SO_O_VALOR_RE.fullmatch(limpa_pontuacao_final(dobrado)))
+    return limpa_pontuacao_final(
+        "".join(c for c in d if not unicodedata.combining(c)))
 
 
 def route(result: IntentResult, msg: IncomingMessage, *,
@@ -880,6 +936,14 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     Não é `bool` de propósito: o PR B acrescenta uma via, e um `bool` obrigaria
     o chamador a adivinhar qual dos dois "False" ele recebeu.
 
+    TETO DECLARADO, não verificável neste ambiente: quando a via `ESCRITA`
+    abandona, o turno sai daqui pelo roteamento normal e o
+    `classify_with_context` — que só roda dentro do `_resolve_clarification` —
+    NÃO roda. Para a conta Pro, isso significa que a IA não vê aquele turno. A
+    suíte não cobre: os testes de WhatsApp mockam o LLM (`CLAUDE.md §3`), e um
+    `classify` determinístico com `allow_ai=False` é o que decide aqui. Só se
+    observa em produção, com conta Pro.
+
     UMA chamada de `classify` por turno. O `abandona_pergunta_de_valor` faria
     a segunda com a mesma entrada e o mesmo `allow_ai=False` — a linha dele
     está inlinada abaixo, e o docstring dele continua sendo a explicação de
@@ -902,7 +966,7 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     o valor, recusa o valor perigoso ou re-pergunta — a pergunta continua viva
     em todos os três casos.
     """
-    from parsers import _STARTS_WITH_VALUE_RE
+    from parsers import _STARTS_WITH_VALUE_RE, _extract_valor
 
     payload = clarif.get("payload")
     if not isinstance(payload, dict):
@@ -915,18 +979,39 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
 
     intent_da_resposta = classify((text or "").strip(), allow_ai=False).intent
 
-    # Via ESCRITA (#281), ANTES do `ABANDONA`: os dois conjuntos são disjuntos
-    # (o `test_281_escrita_e_abandona_sao_disjuntos` prende isso), então a
-    # ordem não muda resultado — ela está aqui porque o veto de catálogo
-    # abaixo é sobre o `ABANDONA`, e misturar os dois blocos confunde.
-    if intent_da_resposta in ESCRITA and not _so_o_valor(text):
+    # As DUAS vias caem no veto de catálogo abaixo — `elif`, não dois `return`.
+    # Ser disjunto do `ABANDONA` (o `test_281_escrita_e_abandona_sao_disjuntos`)
+    # NÃO bastava: o que tornava o veto inalcançável não era um intent nos dois
+    # conjuntos, era o `return "abandona"` que esta via tinha antes dele.
+    # Medido, caixinha chamada `fatura` com R$ 300 e "saquei 200" pendente:
+    #   "fatura" -> classify `credit.handle` 1.0, que está no ESCRITA
+    #            -> abandonava: "Você ainda não tem cartões cadastrados",
+    #               caixinha INTACTA, pendência consumida, R$ 200 perdidos, e
+    #               repetir "fatura" re-abandonava para sempre.
+    # É o mesmo bug que o #185 fechou, por outra porta — e os testes do #185
+    # não viam porque `saldo` (do `ABANDONA`) continuava passando pelo veto.
+    if (intent_da_resposta in ESCRITA
+            and not _so_o_valor(text) and not _verbo_e_uma_palavra(text)):
         if _STARTS_WITH_VALUE_RE.match((text or "").strip()):
             return "resolve"   # AMBÍGUO — desempate é o PR B da #281
         if not _o_reroteamento_le_o_mesmo_valor(text):
             return "resolve"
-        return "abandona"      # EXPLÍCITO — verbo próprio, comando novo
-
-    if intent_da_resposta not in ABANDONA:
+        # FILTRO DE DANO antes de largar a pergunta. Abandonar passa por FORA
+        # do `valor_perigoso` (ele mora no `_resolve_clarification`), então
+        # todo texto cuja pontuação de prosa impede o `_so_o_valor` de casar
+        # entrava no roteamento normal SEM filtro. Não é lista de formas de
+        # mensagem — é a mesma pergunta que o resolver faz, feita antes:
+        #   "paguei, 132 50" / "paguei 132 50 ok" -> R$ 13.250,00
+        #   "gastei 132 50 no mercado"            -> R$ 13.250,00
+        #   "gastei -10 no mercado"               -> R$ 10,00 POSITIVOS
+        #   "gastei " + "1"*400 + " no mercado"   -> "erro interno" (inf)
+        # Com ele, os quatro voltam a `"resolve"` e o resolver re-pergunta com
+        # a pendência viva — que é o comportamento da `main`. Estritamente
+        # conservador: só faz esta via abandonar MENOS.
+        if valor_perigoso(text, _extract_valor((text or "").strip())):
+            return "resolve"
+        # EXPLÍCITO — verbo próprio, comando novo. Segue para o veto.
+    elif intent_da_resposta not in ABANDONA:
         return "resolve"
 
     # VETO DE CATÁLOGO (#185). Última palavra, e só no turno raro em que o
@@ -936,18 +1021,18 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     # saldo — é o nome que a pergunta pediu, e abandonar descartaria o valor
     # que ele já digitou ("saquei 200" → "de qual caixinha?" → "saldo").
     #
-    # DEPOIS do classificador, não antes: o determinístico decide o caso comum
-    # sozinho, e o catálogo custa I/O (`_alvos_existentes` chama
-    # `accrue_all_investments`, que ESCREVE accruals). Nesta ordem ele só roda
-    # quando a resposta já é um dos 6 intents do `ABANDONA` e a pergunta viva
-    # é de nome.
+    # DEPOIS do classificador e dos dois portões da via `ESCRITA`, não antes: o
+    # determinístico decide o caso comum sozinho, e o catálogo custa I/O
+    # (`_alvos_existentes` chama `accrue_all_investments`, que ESCREVE
+    # accruals). Nesta ordem ele só roda quando UMA DAS DUAS vias já disse
+    # "abandona" e a pergunta viva é de nome — os `return "resolve"` de cima
+    # (AMBÍGUO, guarda de entrega, valor perigoso) saem sem pagar o catálogo.
     #
-    # A via `ESCRITA` do #281 foi posta ACIMA deste bloco pelo mesmo motivo, e
-    # é o que mantém a frase anterior verdadeira: se ela caísse aqui, o turno
-    # raro do veto viraria o turno comum ("gastei 50 no mercado" é
-    # `launches.add`), e cada mensagem sequestrada pagaria as 6 chamadas de
-    # catálogo — inclusive a que escreve. Medido no #280: 6 chamadas no turno
-    # do veto contra 2 no turno que abandona.
+    # O #281 tinha posto a via `ESCRITA` acima deste bloco COM `return` próprio,
+    # justamente para não pagar essa I/O. O preço era o veto ficar inalcançável
+    # para os 9 intents de escrita — ver o comentário da via, e o custo em
+    # dinheiro na caixinha chamada `fatura`. A I/O passa a ser paga também no
+    # turno que abandona por escrita; é o lado barato da troca.
     #
     # `_ja_tem_o_valor` fica INTOCADO de propósito. A one-liner da issue
     # (ler `amount` além de `valor` ali) tem regressão medida: `saquei 200` +

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -12,12 +12,14 @@ from __future__ import annotations
 
 import logging
 import re
+import unicodedata
 
 import db
 from core.intent_classifier import IntentResult, classify
 from core.types import IncomingMessage
-from utils_text import (contains_word, limpa_pontuacao_final, marcador_de_tudo,
-                        normalize_text, valor_perigoso)
+from utils_text import (PT_VALUE, _ENCHIMENTO, _TRACOS, contains_word,
+                        limpa_pontuacao_final, marcador_de_tudo, normalize_text,
+                        valor_perigoso)
 
 # handlers
 from core.handlers import (
@@ -122,6 +124,11 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
 #            de `funds.add_ask` e as genéricas da IA passam pela mesma escotilha.
 #            O filtro não é o intent da pergunta, é o `_ja_tem_o_valor` — mais
 #            o veto de catálogo do #185, que só vale para as perguntas de NOME.
+#            É a única das quatro que tem uma SEGUNDA via de abandono, a do
+#            #281: intent de ESCRITA cuja mensagem inteira não é o valor
+#            pedido ("gastei 50 no mercado" respondendo "Qual o valor?"). Ela
+#            é só daqui — as portas 3 e 4 seguem lendo o `ABANDONA` pelo
+#            `abandona_pergunta_de_valor`, que não mudou.
 #   porta 3  fila do multi-lançamento  core/handlers/launches.py::resolve_multi_launch_value
 #   porta 4  botão "✅ Já paguei"      adapters/whatsapp/wa_runtime.py (roda ANTES
 #                                      do handle_incoming, por isso importa daqui)
@@ -146,36 +153,72 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
 #   pockets.list         "caixinhas"             1.0
 #   report.monthly       "resumo do mes"         1.0
 #
-# `credit.handle` ficou de FORA por medição, não por esquecimento: "fatura" é
-# 1.0 e "132 no cartao" é 0.95 — mesmo intent, e o segundo é uma resposta
-# legítima ("foram 132, no cartão"). O único corte por confiança que os separa
-# (== 1.0) também derrubaria "fatura do cartao" (0.95), então não é corte
-# limpo.
+# `credit.handle` ficou de FORA **deste conjunto** por medição, não por
+# esquecimento: "fatura" é 1.0 e "132 no cartao" é 0.95 — mesmo intent, e o
+# segundo é uma resposta legítima ("foram 132, no cartão"). O único corte por
+# confiança que os separa (== 1.0) também derrubaria "fatura do cartao"
+# (0.95), então não é corte limpo.
 #
-# O PREÇO de deixá-lo fora, MEDIDO nas quatro portas com "fatura",
+# ELE SEGUE FORA DO `ABANDONA` — e desde o #281 está no `ESCRITA` logo abaixo,
+# por decisão do dono. O que mudou não foi a medição, foi a peça disponível: o
+# `_STARTS_WITH_VALUE_RE` (parsers.py:176) separa limpo o que nenhum corte de
+# confiança separava. Medido com `allow_ai=False`:
+#   "fatura"        sv=0, e não é só-o-valor  -> EXPLÍCITO: abandona a porta 2
+#   "132 no cartao" sv=1                      -> AMBÍGUO: NÃO abandona (PR A)
+# A resposta legítima continua protegida, e o comando de cartão deixa de ficar
+# preso. A via nova é SÓ da porta 2: as portas 3 e 4 consultam o
+# `abandona_pergunta_de_valor`, que lê este conjunto e não mudou.
+#
+# O PREÇO de deixá-lo fora daqui, MEDIDO nas quatro portas com "fatura",
 # "fatura do cartao", "meus cartoes" e "cartao nubank" — não é "o usuário
 # repete o comando", e é diferente em cada porta:
 #
 #   porta 1  custo ZERO: o `_VALOR_RE` não casa, a pergunta é abandonada e o
 #            comando de cartão roda normalmente.
 #   porta 3  custo ZERO: o `_extract_valor` não acha valor, mesmo efeito.
-#   porta 2  LAÇO INDEFINIDO **medido com a IA desligada**: a pergunta volta
-#            ("Quanto foi no *luz*?") e a pendência é RE-ARMADA a cada turno
-#            (medido: `expires_at` cresce em cada resposta), então ela nunca
-#            expira e o comando de cartão nunca roda enquanto o usuário
-#            insistir nele. Em produção o `classify_with_context` roda ANTES do
-#            re-armar (no `_resolve_clarification`) e pode despachar o comando,
-#            encurtando ou eliminando o laço — saída de LLM, não mensurável
-#            aqui.
+#   porta 2  ERA um LAÇO INDEFINIDO **medido com a IA desligada**: a pergunta
+#            voltava ("Quanto foi no *luz*?") e a pendência era RE-ARMADA a
+#            cada turno (medido: `expires_at` cresce em cada resposta), então
+#            nunca expirava. FECHADO pelo #281: "fatura" entra pela via
+#            EXPLÍCITO do `ESCRITA` e abandona.
 #   porta 4  laço, mas com saída: a pergunta volta ("Não peguei o valor") e a
 #            pendência NÃO é reescrita (`expires_at` não muda), então o laço
 #            morre nos 10 min contados da pergunta original.
 #
-# Ainda assim o cartão fica fora: o laço da porta 2 custa turnos, e apagar a
-# fila de quem respondeu "132 no cartao" custa o lançamento do usuário.
+# Nas portas 3 e 4 o preço continua de pé, e é o que se quis proteger: quem
+# responde "132 no cartao" a uma pergunta de valor não perde o lançamento (a
+# fila não é apagada).
 ABANDONA = {
     "balance.check", "launches.list", "launches.delete",
     "launches.spend_query", "pockets.list", "report.monthly",
+}
+
+# Intents de ESCRITA. Mundo fechado como o `ABANDONA` acima, pela mesma razão
+# (blacklist sobre oráculo ilimitado faz todo intent novo nascer destrutivo),
+# e com o mesmo rigor: cada entrada abaixo veio de uma medição, e a string que
+# a produziu está do lado. `classify(..., allow_ai=False)`:
+#   launches.add         "gastei 50 no mercado", "paguei 120 de luz"    0.95
+#   pockets.deposit      "guardei 100 na caixinha viagem"               0.95
+#   pockets.withdraw     "retirei 100 da caixinha viagem"               0.95
+#   investments.deposit  "aportei 200 no CDB"                           0.95
+#   investments.withdraw "resgatei 200 do CDB"                          0.95
+#   funds.withdraw       "saquei 200", "tirei 200 do tesouro direto"    0.95
+#   pockets.create       "criar caixinha viagem"                        0.95
+#   pockets.delete       "apagar caixinha viagem"                       0.95
+#   credit.handle        "fatura" 1.0, "132 no cartao" 0.95  (ver acima)
+#
+# SÓ a porta 2 lê este conjunto (`_clarification_abandonada`). O
+# `abandona_pergunta_de_valor` — compartilhado com as portas 3 e 4 — continua
+# lendo apenas o `ABANDONA`, de propósito: mexer nele moveria três portas de
+# uma vez.
+#
+# E ele NUNCA decide sozinho. O portão de admissão é o `_so_o_valor` logo
+# abaixo: "100 reais" também classifica `launches.add` 0.95, e é a resposta
+# que o bot pediu. Sem esse portão, nenhuma pergunta do bot funcionaria mais.
+ESCRITA = {
+    "launches.add", "pockets.deposit", "pockets.withdraw",
+    "investments.deposit", "investments.withdraw", "funds.withdraw",
+    "pockets.create", "pockets.delete", "credit.handle",
 }
 
 
@@ -194,6 +237,53 @@ def abandona_pergunta_de_valor(text: str) -> bool:
       nunca abandonam nada, que é exatamente o comportamento da `main`.
     """
     return classify((text or "").strip(), allow_ai=False).intent in ABANDONA
+
+
+# PORTÃO DE ADMISSÃO da via de escrita da porta 2 (#281). "A resposta tem de
+# consumir a mensagem INTEIRA" é uma pergunta sobre a mensagem, não sobre o
+# parser: o contrato do `_funde_a_resposta` ("leia número e alvo desta
+# resposta") está certo — ele só estava errado quando a mensagem não era uma
+# resposta. Por isso o portão mora aqui e o `_funde_a_resposta` não muda.
+#
+# Reusa o `PT_VALUE` e o `_ENCHIMENTO` do `utils_text` e o `_UNIDADE` da porta
+# 1 (`core/handlers/bills.py`) — as três já são fonte única compartilhada. A
+# unidade é obrigatória em cada iteração externa: sem isso o `PT_VALUE`
+# aninhado num segundo `*` dá backtracking catastrófico (medido: 40 grupos de
+# "2 mil e " não terminaram em 120s; com esta forma, 0,09 ms).
+#
+# "centavos" entra além do `_UNIDADE` da porta 1 porque aqui a mensagem é uma
+# frase falada inteira ("30 reais e 50 centavos"), e lá é só o número.
+_SO_O_VALOR_RE = re.compile(
+    rf"(?:{_ENCHIMENTO}\s+)*{PT_VALUE}"
+    rf"(?:\s+(?:e\s+)?(?:{h_bills._UNIDADE}|centavos?)(?:\s+(?:e\s+)?{PT_VALUE})?)*",
+    re.I)
+
+
+def _so_o_valor(text: str) -> bool:
+    """A mensagem INTEIRA é o valor que o bot pediu ("100 reais", "2 mil").
+
+    True aqui = a mensagem responde a pergunta, mesmo que o classificador a
+    tenha lido como comando de escrita ("100 reais" é `launches.add` 0.95).
+    É o controle positivo do #281 virado código: sem ele a via de escrita
+    abandonaria a pergunta para toda resposta falada com "reais"/"mil", e
+    nenhuma pergunta do bot funcionaria mais.
+
+    NÃO usa `normalize_text`: ele apaga `$` e `,`, e aí "R$ 100" e
+    "R$ 1.200,00" deixam de consumir a mensagem — medido. A dobra abaixo é a
+    da porta 1 (`lower` + NFKD sem combining + `_TRACOS` +
+    `limpa_pontuacao_final`), que preserva os dois.
+
+    TETO medido, e é a razão de "100 reais mesmo" cair em AMBÍGUO: o
+    `_ENCHIMENTO_PALAVRAS` só vale ANTES do número. Crescer aquela lista para
+    acomodar o enchimento depois do número move o `_sinal_negativo` e o
+    `_VALOR_RE` da porta 1 junto (utils_text.py:947), e o preço registrado lá
+    é "foi - 10" voltar a pagar R$ 10,00 positivo. Um turno a mais é barato;
+    aquilo não é.
+    """
+    dobrado = unicodedata.normalize(
+        "NFKD", (text or "").strip().lower().translate(_TRACOS))
+    dobrado = "".join(c for c in dobrado if not unicodedata.combining(c))
+    return bool(_SO_O_VALOR_RE.fullmatch(limpa_pontuacao_final(dobrado)))
 
 
 def route(result: IntentResult, msg: IncomingMessage, *,
@@ -239,7 +329,8 @@ def route(result: IntentResult, msg: IncomingMessage, *,
     # -----------------------------------------------------------------------
     clarif = None if ignora_pendencias else h_pending.get_pending_clarification(user_id)
     if clarif:
-        if _clarification_abandonada(clarif, text, user_id):
+        # `"resolve"` | `"abandona"` — ver `_clarification_abandonada`.
+        if _clarification_abandonada(clarif, text, user_id) == "abandona":
             # Porta 2. Mesma escotilha de escape do `investment_pick` e do
             # `funding_source_choice` logo abaixo: outro comando claro abandona
             # a pergunta em vez de ser engolido por ela ("Quanto foi no *luz*?"
@@ -704,11 +795,37 @@ def _ja_tem_o_valor(entities: dict | None) -> bool:
         return True
 
 
-def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> bool:
-    """True quando a resposta é OUTRO comando claro, não a resposta à pergunta.
+def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
+    """Decide o que a mensagem é: `"resolve"` a pergunta, ou a `"abandona"`.
 
     Porta 2 do passo 1 (`abandona_pergunta_de_valor`). Quem decide é o INTENT,
     não a forma do texto: "gastei 132" e "apagar 42" têm os dois um número.
+
+    Duas vias levam a `"abandona"`, e as duas leem a MESMA classificação:
+
+      ABANDONA   os 6 intents de LEITURA ("saldo", "extrato"), como sempre,
+                 mais o veto de catálogo do #185 lá embaixo.
+      ESCRITA    comando de escrita EXPLÍCITO — verbo próprio e a mensagem
+                 inteira não é o valor pedido ("gastei 50 no mercado"). #281.
+
+    A via `ESCRITA` tem dois portões, nesta ordem:
+
+      1. `_so_o_valor` — "100 reais" classifica `launches.add` 0.95 e É a
+         resposta que o bot pediu. Ele resolve, nunca abandona.
+      2. `_STARTS_WITH_VALUE_RE` (parsers.py:176) — sobra o ATALHO sem verbo
+         ("50 no mercado", "120 de luz", "100 na caixinha viagem"), que é
+         genuinamente ambíguo: pode ser o gasto ou pode ser o valor com o
+         nome junto. Hoje ele cai em `"resolve"`, que é o comportamento da
+         `main`. A pergunta de desempate é o PR B da #281 — quando ela vier,
+         é aqui que nasce o terceiro valor de retorno, sem tocar no resto.
+
+    Não é `bool` de propósito: o PR B acrescenta uma via, e um `bool` obrigaria
+    o chamador a adivinhar qual dos dois "False" ele recebeu.
+
+    UMA chamada de `classify` por turno. O `abandona_pergunta_de_valor` faria
+    a segunda com a mesma entrada e o mesmo `allow_ai=False` — a linha dele
+    está inlinada abaixo, e o docstring dele continua sendo a explicação de
+    por que a IA fica fora.
 
     Vale para TODA `clarification`, não só a de `launches.add`: roda no
     `route()`, antes de o `_resolve_clarification` olhar o `intent` do payload,
@@ -727,16 +844,30 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> bool:
     o valor, recusa o valor perigoso ou re-pergunta — a pergunta continua viva
     em todos os três casos.
     """
+    from parsers import _STARTS_WITH_VALUE_RE
+
     payload = clarif.get("payload")
     if not isinstance(payload, dict):
         # Nenhum produtor grava payload não-dict hoje; sem esta linha um dado
         # torto viraria AttributeError → "erro interno" em loop, com a
         # pendência nunca sendo limpa.
-        return False
+        return "resolve"
     if _ja_tem_o_valor(payload.get("entities")):
-        return False
-    if not abandona_pergunta_de_valor(text):
-        return False
+        return "resolve"
+
+    intent_da_resposta = classify((text or "").strip(), allow_ai=False).intent
+
+    # Via ESCRITA (#281), ANTES do `ABANDONA`: os dois conjuntos são disjuntos
+    # (o `test_281_escrita_e_abandona_sao_disjuntos` prende isso), então a
+    # ordem não muda resultado — ela está aqui porque o veto de catálogo
+    # abaixo é sobre o `ABANDONA`, e misturar os dois blocos confunde.
+    if intent_da_resposta in ESCRITA and not _so_o_valor(text):
+        if _STARTS_WITH_VALUE_RE.match((text or "").strip()):
+            return "resolve"   # AMBÍGUO — desempate é o PR B da #281
+        return "abandona"      # EXPLÍCITO — verbo próprio, comando novo
+
+    if intent_da_resposta not in ABANDONA:
+        return "resolve"
 
     # VETO DE CATÁLOGO (#185). Última palavra, e só no turno raro em que o
     # classificador já disse "abandona": a pergunta pendente pede um NOME
@@ -745,11 +876,18 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> bool:
     # saldo — é o nome que a pergunta pediu, e abandonar descartaria o valor
     # que ele já digitou ("saquei 200" → "de qual caixinha?" → "saldo").
     #
-    # DEPOIS do `abandona_pergunta_de_valor`, não antes: o classificador
-    # determinístico decide o caso comum sozinho, e o catálogo custa I/O
-    # (`_alvos_existentes` chama `accrue_all_investments`, que ESCREVE
-    # accruals). Nesta ordem ele só roda quando a resposta já é um dos 6
-    # intents do `ABANDONA` e a pergunta viva é de nome.
+    # DEPOIS do classificador, não antes: o determinístico decide o caso comum
+    # sozinho, e o catálogo custa I/O (`_alvos_existentes` chama
+    # `accrue_all_investments`, que ESCREVE accruals). Nesta ordem ele só roda
+    # quando a resposta já é um dos 6 intents do `ABANDONA` e a pergunta viva
+    # é de nome.
+    #
+    # A via `ESCRITA` do #281 foi posta ACIMA deste bloco pelo mesmo motivo, e
+    # é o que mantém a frase anterior verdadeira: se ela caísse aqui, o turno
+    # raro do veto viraria o turno comum ("gastei 50 no mercado" é
+    # `launches.add`), e cada mensagem sequestrada pagaria as 6 chamadas de
+    # catálogo — inclusive a que escreve. Medido no #280: 6 chamadas no turno
+    # do veto contra 2 no turno que abandona.
     #
     # `_ja_tem_o_valor` fica INTOCADO de propósito. A one-liner da issue
     # (ler `amount` além de `valor` ali) tem regressão medida: `saquei 200` +
@@ -801,9 +939,9 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> bool:
     # guard existe para evitar. Nenhum produtor grava não-str hoje.
     if falta and isinstance(intent, str) and falta == _CHAVE_DO_NOME.get(intent):
         resposta = limpa_pontuacao_final((text or "").strip())
-        return not _eh_nome_do_catalogo(
-            resposta, _alvos_existentes(user_id, intent))
-    return True
+        if _eh_nome_do_catalogo(resposta, _alvos_existentes(user_id, intent)):
+            return "resolve"
+    return "abandona"
 
 
 _SO_NUMERO_RE = re.compile(r"[\d.,\s]+")

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -17,7 +17,7 @@ import unicodedata
 import db
 from core.intent_classifier import IntentResult, classify
 from core.types import IncomingMessage
-from utils_text import (PT_VALUE, _ENCHIMENTO, _TRACOS, contains_word,
+from utils_text import (PT_VALUE, _SEM_CONTEUDO, _TRACOS, contains_word,
                         limpa_pontuacao_final, marcador_de_tudo, normalize_text,
                         valor_perigoso)
 
@@ -245,17 +245,48 @@ def abandona_pergunta_de_valor(text: str) -> bool:
 # resposta") está certo — ele só estava errado quando a mensagem não era uma
 # resposta. Por isso o portão mora aqui e o `_funde_a_resposta` não muda.
 #
-# Reusa o `PT_VALUE` e o `_ENCHIMENTO` do `utils_text` e o `_UNIDADE` da porta
-# 1 (`core/handlers/bills.py`) — as três já são fonte única compartilhada. A
-# unidade é obrigatória em cada iteração externa: sem isso o `PT_VALUE`
+# Tudo aqui é peça já existente e compartilhada — nada foi inventado:
+#
+#   `_SEM_CONTEUDO`  (utils_text) o prefixo que NÃO carrega conteúdo. É o
+#                    `_ENCHIMENTO` ("foi", "uns", "acho que") MAIS os 12
+#                    verbos de lançamento MAIS "r$"/"rs". A lista já existe
+#                    com exatamente este significado: é ela que decide, no
+#                    `_sinal_negativo`, se o que vem antes de um traço é
+#                    conteúdo.
+#   `PT_VALUE`       (utils_text) dígitos ou número por extenso, encadeado.
+#   `_UNIDADE`       (porta 1) "reais", "pila", "conto"…
+#   `_NUMERO_AMBIGUO_RE` (porta 1) só dígitos/separadores/espaço, mas
+#                    malformado: "132 50", "1.23.456", ",50", "1"×400.
+#
+# O VERBO É PREFIXO SEM CONTEÚDO, e isto é o oposto de um detalhe. "paguei
+# 132" não nomeia alvo nenhum, então não compete com a pergunta pendente — ele
+# É a resposta, com um verbo na frente. Tratá-lo como comando novo tem preço
+# MEDIDO, porque o filtro de dano (`valor_perigoso`) mora no
+# `_resolve_clarification` e o abandono passa por fora dele:
+#   "paguei 132 50"           -> R$ 13.250,00 registrados (o bug que o filtro existe para matar)
+#   "paguei 132,50. foi isso" -> R$ 13.250,00
+#   "paguei -10"              -> R$ 10,00 POSITIVOS
+#   "paguei " + "1"*400       -> "erro interno" (Infinity no JSON da pendência)
+# Com o verbo como prefixo, os quatro voltam ao `valor_perigoso` — que é o
+# comportamento de HOJE e recusa os quatro. `gastei 50 no mercado` segue
+# EXPLÍCITO: sobra "no mercado", e sobra é alvo.
+#
+# O SINAL e o `_NUMERO_AMBIGUO_RE` estão aqui pela mesma razão, não por
+# completude: sem eles "paguei -10" e "paguei ,50" escapam do filtro.
+#
+# A unidade é obrigatória em cada iteração externa: sem isso o `PT_VALUE`
 # aninhado num segundo `*` dá backtracking catastrófico (medido: 40 grupos de
 # "2 mil e " não terminaram em 120s; com esta forma, 0,09 ms).
 #
 # "centavos" entra além do `_UNIDADE` da porta 1 porque aqui a mensagem é uma
 # frase falada inteira ("30 reais e 50 centavos"), e lá é só o número.
+_SEM_CONTEUDO_ALT = "|".join(
+    sorted((re.escape(w) for w in _SEM_CONTEUDO), key=len, reverse=True))
 _SO_O_VALOR_RE = re.compile(
-    rf"(?:{_ENCHIMENTO}\s+)*{PT_VALUE}"
-    rf"(?:\s+(?:e\s+)?(?:{h_bills._UNIDADE}|centavos?)(?:\s+(?:e\s+)?{PT_VALUE})?)*",
+    rf"(?:(?:{_SEM_CONTEUDO_ALT})\s+)*(?:-\s*)?"
+    rf"(?:{PT_VALUE}"
+    rf"(?:\s+(?:e\s+)?(?:{h_bills._UNIDADE}|centavos?)(?:\s+(?:e\s+)?{PT_VALUE})?)*"
+    rf"|{h_bills._NUMERO_AMBIGUO_RE.pattern})",
     re.I)
 
 
@@ -795,6 +826,33 @@ def _ja_tem_o_valor(entities: dict | None) -> bool:
         return True
 
 
+def _o_reroteamento_le_o_mesmo_valor(text: str) -> bool:
+    """Guarda de entrega da via EXPLÍCITO: só larga a pergunta se o roteamento
+    normal for ler o MESMO número que esta porta lê.
+
+    As quatro portas limpam a pontuação de prosa (`limpa_pontuacao_final`); o
+    roteamento normal NÃO — o furo é do `parse_money` e tem issue própria (ver
+    `_cola_separador_decimal`). Enquanto ele existir, entregar a mensagem ao
+    roteamento normal pode MUDAR o valor. Medido, e é a diferença entre
+    R$ 132,50 e R$ 13.250,00:
+
+        "paguei 132,50. foi isso"  porta: 132.5   roteamento normal: 13250.0
+        "1.234,56, foi isso"       porta: 1234.56 roteamento normal: None
+
+    Nas outras 14 formas EXPLÍCITO medidas (`gastei 50 no mercado`,
+    `paguei 120 de luz`, `guardei 100 na caixinha viagem`, `aportei 200 no
+    CDB`, `fatura`…) os dois leem o mesmo, então a guarda não custa nada.
+
+    Estritamente CONSERVADORA: ela só faz a porta abandonar MENOS. O caso que
+    ela segura continua exatamente no comportamento de hoje — o resolver, com
+    o filtro de dano.
+    """
+    from utils_text import parse_money
+
+    bruto = (text or "").strip()
+    return parse_money(bruto) == parse_money(limpa_pontuacao_final(bruto))
+
+
 def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     """Decide o que a mensagem é: `"resolve"` a pergunta, ou a `"abandona"`.
 
@@ -864,6 +922,8 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     if intent_da_resposta in ESCRITA and not _so_o_valor(text):
         if _STARTS_WITH_VALUE_RE.match((text or "").strip()):
             return "resolve"   # AMBÍGUO — desempate é o PR B da #281
+        if not _o_reroteamento_le_o_mesmo_valor(text):
+            return "resolve"
         return "abandona"      # EXPLÍCITO — verbo próprio, comando novo
 
     if intent_da_resposta not in ABANDONA:

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -16,6 +16,7 @@ from dataclasses import replace
 
 import db
 from core.intent_classifier import IntentResult, classify
+from core.response_formatter import wrap_wa_markup
 from core.types import IncomingMessage
 from utils_text import (contains_word, limpa_pontuacao_final, marcador_de_tudo,
                         normalize_text, valor_perigoso)
@@ -323,7 +324,7 @@ def _quantidade_fecha(text: str) -> bool:
 # plataforma e NÃO foi exercitado aqui. O texto inteiro continua no payload, que
 # é quem o registra quando o usuário escolhe 2.
 _PERGUNTA_DE_DESEMPATE = (
-    "Não sei se *{texto}* responde a pergunta ou é um lançamento novo.\n\n"
+    "Não sei se {texto} responde a pergunta ou é um lançamento novo.\n\n"
     "1️⃣ *responder* — {pergunta}\n"
     "2️⃣ *registrar* — trata como comando novo\n\n"
     "Ou *cancela*."
@@ -469,7 +470,14 @@ def route(result: IntentResult, msg: IncomingMessage, *,
                     new_action_type="value_or_command_choice",
                     old_created_at=clarif.get("created_at")):
                 return _PERGUNTA_DE_DESEMPATE.format(
-                    texto=text[:300] + ("…" if len(text) > 300 else ""),
+                    # `wrap_wa_markup` e não `*{texto}*` no molde: texto CRU
+                    # do usuário dentro de `*...*` faz o bot ABRIR um par que o
+                    # `*` do usuário fecha no meio (`gastei 50 no *mercado`
+                    # virava `*gastei 50 no *mercado*` na tela). Mesma fonte
+                    # única do `core/handlers/pending.py` (#270). O total ímpar
+                    # que SOBRA é a #276, e é outro desenho.
+                    texto=wrap_wa_markup(
+                        text[:300] + ("…" if len(text) > 300 else "")),
                     pergunta=(clarif.get("payload") or {}).get("question")
                              or "a pergunta anterior")
             return NOT_UNDERSTOOD_MSG

--- a/core/intent_router.py
+++ b/core/intent_router.py
@@ -12,14 +12,13 @@ from __future__ import annotations
 
 import logging
 import re
-import unicodedata
+from dataclasses import replace
 
 import db
 from core.intent_classifier import IntentResult, classify
 from core.types import IncomingMessage
-from utils_text import (PT_VALUE, _SEM_CONTEUDO, _TRACOS, contains_word,
-                        limpa_pontuacao_final, marcador_de_tudo, normalize_text,
-                        valor_perigoso)
+from utils_text import (contains_word, limpa_pontuacao_final, marcador_de_tudo,
+                        normalize_text, valor_perigoso)
 
 # handlers
 from core.handlers import (
@@ -124,10 +123,12 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
 #            de `funds.add_ask` e as genéricas da IA passam pela mesma escotilha.
 #            O filtro não é o intent da pergunta, é o `_ja_tem_o_valor` — mais
 #            o veto de catálogo do #185, que só vale para as perguntas de NOME.
-#            É a única das quatro que tem uma SEGUNDA via de abandono, a do
-#            #281: intent de ESCRITA cuja mensagem inteira não é o valor
-#            pedido ("gastei 50 no mercado" respondendo "Qual o valor?"). Ela
-#            é só daqui — as portas 3 e 4 seguem lendo o `ABANDONA` pelo
+#            É a única das quatro com uma SEGUNDA via (#281): o comando sem
+#            quantidade (`COMANDO_SEM_QUANTIDADE`) também abandona, e a
+#            mensagem com quantidade que NÃO fecha ("gastei 50 no mercado"
+#            respondendo "Qual o valor?") não abandona nem resolve — ela
+#            PERGUNTA (`_quantidade_fecha`, e o desempate no `route()`). As
+#            duas são só daqui: as portas 3 e 4 seguem lendo o `ABANDONA` pelo
 #            `abandona_pergunta_de_valor`, que não mudou.
 #   porta 3  fila do multi-lançamento  core/handlers/launches.py::resolve_multi_launch_value
 #   porta 4  botão "✅ Já paguei"      adapters/whatsapp/wa_runtime.py (roda ANTES
@@ -159,12 +160,13 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
 # confiança que os separa (== 1.0) também derrubaria "fatura do cartao"
 # (0.95), então não é corte limpo.
 #
-# ELE SEGUE FORA DO `ABANDONA` — e desde o #281 está no `ESCRITA` logo abaixo,
-# por decisão do dono. O que mudou não foi a medição, foi a peça disponível: o
-# `_STARTS_WITH_VALUE_RE` (parsers.py:176) separa limpo o que nenhum corte de
-# confiança separava. Medido com `allow_ai=False`:
-#   "fatura"        sv=0, e não é só-o-valor  -> EXPLÍCITO: abandona a porta 2
-#   "132 no cartao" sv=1                      -> AMBÍGUO: NÃO abandona (PR A)
+# ELE SEGUE FORA DO `ABANDONA` — e desde o #281 está no
+# `COMANDO_SEM_QUANTIDADE` logo abaixo, por decisão do dono. O que mudou não foi
+# a medição, foi a peça disponível: a QUANTIDADE separa limpo o que nenhum corte
+# de confiança separava. Medido com `allow_ai=False`:
+#   "fatura"        sem quantidade  -> COMANDO: abandona a porta 2
+#   "fatura 132"    quantidade que fecha a mensagem -> RESPOSTA: não abandona
+#   "132 no cartao" começa pelo valor               -> RESPOSTA: não abandona
 # A resposta legítima continua protegida, e o comando de cartão deixa de ficar
 # preso. A via nova é SÓ da porta 2: as portas 3 e 4 consultam o
 # `abandona_pergunta_de_valor`, que lê este conjunto e não mudou.
@@ -179,8 +181,8 @@ def _should_redirect_launches_list_to_help(text: str) -> bool:
 #   porta 2  ERA um LAÇO INDEFINIDO **medido com a IA desligada**: a pergunta
 #            voltava ("Quanto foi no *luz*?") e a pendência era RE-ARMADA a
 #            cada turno (medido: `expires_at` cresce em cada resposta), então
-#            nunca expirava. FECHADO pelo #281: "fatura" entra pela via
-#            EXPLÍCITO do `ESCRITA` e abandona.
+#            nunca expirava. FECHADO pelo #281: "fatura" é comando SEM
+#            quantidade e abandona.
 #   porta 4  laço, mas com saída: a pergunta volta ("Não peguei o valor") e a
 #            pendência NÃO é reescrita (`expires_at` não muda), então o laço
 #            morre nos 10 min contados da pergunta original.
@@ -193,32 +195,26 @@ ABANDONA = {
     "launches.spend_query", "pockets.list", "report.monthly",
 }
 
-# Intents de ESCRITA. Mundo fechado como o `ABANDONA` acima, pela mesma razão
-# (blacklist sobre oráculo ilimitado faz todo intent novo nascer destrutivo),
-# e com o mesmo rigor: cada entrada abaixo veio de uma medição, e a string que
-# a produziu está do lado. `classify(..., allow_ai=False)`:
-#   launches.add         "gastei 50 no mercado", "paguei 120 de luz"    0.95
-#   pockets.deposit      "guardei 100 na caixinha viagem"               0.95
-#   pockets.withdraw     "retirei 100 da caixinha viagem"               0.95
-#   investments.deposit  "aportei 200 no CDB"                           0.95
-#   investments.withdraw "resgatei 200 do CDB"                          0.95
-#   funds.withdraw       "saquei 200", "tirei 200 do tesouro direto"    0.95
-#   pockets.create       "criar caixinha viagem"                        0.95
-#   pockets.delete       "apagar caixinha viagem"                       0.95
-#   credit.handle        "fatura" 1.0, "132 no cartao" 0.95  (ver acima)
+# Comandos que NÃO carregam quantidade. Único abandono NOVO do #281, e o único
+# lugar onde o classificador ainda decide alguma coisa além do `ABANDONA` acima
+# — o resto da tabela é posicional (ver `_quantidade_fecha`).
 #
-# SÓ a porta 2 lê este conjunto (`_clarification_abandonada`). O
-# `abandona_pergunta_de_valor` — compartilhado com as portas 3 e 4 — continua
-# lendo apenas o `ABANDONA`, de propósito: mexer nele moveria três portas de
-# uma vez.
+# Medidos um a um com `classify(..., allow_ai=False)`:
+#   credit.handle    "fatura" 1.0, "meus cartoes" 1.0
+#   pockets.create   "criar caixinha viagem" 0.95
+#   pockets.delete   "apagar caixinha viagem" 0.95
 #
-# E ele NUNCA decide sozinho. O portão de admissão é o `_so_o_valor` logo
-# abaixo: "100 reais" também classifica `launches.add` 0.95, e é a resposta
-# que o bot pediu. Sem esse portão, nenhuma pergunta do bot funcionaria mais.
-ESCRITA = {
-    "launches.add", "pockets.deposit", "pockets.withdraw",
-    "investments.deposit", "investments.withdraw", "funds.withdraw",
-    "pockets.create", "pockets.delete", "credit.handle",
+# Os SEIS verbos de lançamento (`launches.add`, `pockets.deposit`,
+# `pockets.withdraw`, `investments.deposit`, `investments.withdraw`,
+# `funds.withdraw`) ficam de FORA: sem quantidade nenhuma eles não conseguem
+# rodar — `gastei`, `gastei no mercado` e `guardei na caixinha viagem` só fariam
+# a própria pergunta, com a palavra do usuário no lugar do alvo. Estes três
+# rodam: "fatura" mostra a fatura, "criar caixinha viagem" cria a caixinha.
+#
+# COM quantidade eles voltam a ser resposta ("fatura 132", "fatura tudo",
+# "criar caixinha 2028") — quem decide é o portão posicional, não este conjunto.
+COMANDO_SEM_QUANTIDADE = {
+    "credit.handle", "pockets.create", "pockets.delete",
 }
 
 
@@ -239,138 +235,142 @@ def abandona_pergunta_de_valor(text: str) -> bool:
     return classify((text or "").strip(), allow_ai=False).intent in ABANDONA
 
 
-# PORTÃO DE ADMISSÃO da via de escrita da porta 2 (#281). "A resposta tem de
-# consumir a mensagem INTEIRA" é uma pergunta sobre a mensagem, não sobre o
-# parser: o contrato do `_funde_a_resposta` ("leia número e alvo desta
-# resposta") está certo — ele só estava errado quando a mensagem não era uma
-# resposta. Por isso o portão mora aqui e o `_funde_a_resposta` não muda.
+# O QUINTO SINAL do #281, e o portão inteiro da via de comando da porta 2:
+# **a quantidade é a ÚLTIMA coisa da mensagem?**
 #
-# Tudo aqui é peça já existente e compartilhada — nada foi inventado:
+#   fecha  -> é RESPOSTA. A pessoa está respondendo "Qual o valor?".
+#             "paguei 132", "gastei tudo", "fatura 132", "cem".
+#   sobrou -> é AMBÍGUO, e aí ninguém escreve: a porta PERGUNTA.
+#             "paguei 132 ok", "gastei 50 no mercado", "gastei tudo mesmo".
 #
-#   `_SEM_CONTEUDO`  (utils_text) o prefixo que NÃO carrega conteúdo. É o
-#                    `_ENCHIMENTO` ("foi", "uns", "acho que") MAIS os 12
-#                    verbos de lançamento MAIS "r$"/"rs". A lista já existe
-#                    com exatamente este significado: é ela que decide, no
-#                    `_sinal_negativo`, se o que vem antes de um traço é
-#                    conteúdo.
-#   `PT_VALUE`       (utils_text) dígitos ou número por extenso, encadeado.
-#   `_UNIDADE`       (porta 1) "reais", "pila", "conto"…
-#   `_NUMERO_AMBIGUO_RE` (porta 1) só dígitos/separadores/espaço, mas
-#                    malformado: "132 50", "1.23.456", ",50", "1"×400.
+# POSICIONAL, não lexical, e isso é a decisão — não um detalhe de implementação.
+# As três rodadas anteriores morreram tentando listar o que pode vir depois do
+# número ("ok", "sim", "hoje", "no debito", "mesmo"…): a lista nunca fecha, e
+# cada palavra esquecida vira dinheiro no lugar errado. Aqui não há lista: o que
+# vier depois da quantidade é cauda, seja qual for a palavra.
 #
-# O VERBO É PREFIXO SEM CONTEÚDO, e isto é o oposto de um detalhe. "paguei
-# 132" não nomeia alvo nenhum, então não compete com a pergunta pendente — ele
-# É a resposta, com um verbo na frente. Tratá-lo como comando novo tem preço
-# MEDIDO, porque o filtro de dano (`valor_perigoso`) mora no
-# `_resolve_clarification` e o abandono passa por fora dele:
-#   "paguei 132 50"           -> R$ 13.250,00 registrados (o bug que o filtro existe para matar)
-#   "paguei 132,50. foi isso" -> R$ 13.250,00
-#   "paguei -10"              -> R$ 10,00 POSITIVOS
-#   "paguei " + "1"*400       -> "erro interno" (Infinity no JSON da pendência)
-# Com o verbo como prefixo, os quatro voltam ao `valor_perigoso` — que é o
-# comportamento de HOJE e recusa os quatro. `gastei 50 no mercado` segue
-# EXPLÍCITO: sobra "no mercado", e sobra é alvo.
+# `quantidade` são as DUAS formas de dizer quanto, pelas peças que já existem —
+# nada foi inventado: `_extract_valor` (parsers.py) para o número em qualquer
+# grafia ("132", "cem", "2 mil", "1.234,56") e `marcador_de_tudo` (utils_text)
+# para o "tudo"/"esvaziar"/"zerar", que é a outra forma de preencher o MESMO
+# campo (ver o docstring de lá).
 #
-# O SINAL e o `_NUMERO_AMBIGUO_RE` estão aqui pela mesma razão, não por
-# completude: sem eles "paguei -10" e "paguei ,50" escapam do filtro.
+# TETO MEDIDO, e é o preço de não ter lista: a UNIDADE conta como cauda.
+#   "paguei 100 reais"  -> pergunta   (era resolve; "reais" é a última palavra)
+#   "paguei 2 mil"      -> resolve    ("mil" É valor para o `_extract_valor`)
+#   "100 reais"         -> resolve    (começa pelo valor, sai antes daqui)
+# Custa UM turno numa forma comum, e nunca custa dinheiro — perguntar não
+# escreve. Fechar isso exigiria a lista de unidades, que é a lista que este
+# desenho existe para não ter. ponytail: se o turno a mais incomodar, o conserto
+# é reusar o `h_bills._UNIDADE` AQUI, num predicado só, não espalhar palavras.
 #
-# A unidade é obrigatória em cada iteração externa: sem isso o `PT_VALUE`
-# aninhado num segundo `*` dá backtracking catastrófico (medido: 40 grupos de
-# "2 mil e " não terminaram em 120s; com esta forma, termina). O "0,09 ms" que
-# estava escrito aqui era de UMA seed de `PYTHONHASHSEED` — o tempo varia com
-# a ordenação da alternância, e é o que a nota de ordenação abaixo trata. O
-# `test_281_so_o_valor_nao_estoura_com_texto_longo` mede exponencial × não
-# exponencial, não milissegundos.
+# CONSEQUÊNCIA ACEITA PELO DONO, e é a única linha que sai da tabela anterior:
+# `gastei tudo mesmo` passa a PERGUNTAR em vez de esvaziar. Esvaziar é a
+# operação que zera a caixinha inteira; quando a mensagem é ambígua, o lado
+# seguro de uma operação irreversível é o que não escreve. Decisão, não acidente.
 #
-# "centavos" entra além do `_UNIDADE` da porta 1 porque aqui a mensagem é uma
-# frase falada inteira ("30 reais e 50 centavos"), e lá é só o número.
-#
-# A ordenação tem DUAS chaves de propósito. `_SEM_CONTEUDO` é um `frozenset`,
-# então `key=len` sozinho desempata pela ordem de iteração — que muda com o
-# `PYTHONHASHSEED`. O resultado do `fullmatch` é o mesmo (medido: md5 idêntico
-# sobre 7 seeds), mas o TEMPO não é: `_so_o_valor("um "*1365 + "x")` mediu de
-# 463 ms a 6,1 s conforme a seed, e é alcançável por mensagem de usuário
-# ("gastei " + "um "*1362 + "x" → 1,3–1,5 s). O `-len` mantém a alternância mais
-# longa primeiro (é o que evita o casamento parcial de "um" dentro de "umas") e
-# o alfabético torna o custo reprodutível. REMEDIDO em 2026-09-04 com a segunda
-# chave, nas mesmas 7 seeds (0 1 2 3 7 42 12345):
-#     PYTHONHASHSEED=$S .venv/bin/python -c "…md5(_SEM_CONTEUDO_ALT); _so_o_valor('um '*1365+'x')"
-# md5 idêntico nas 7 e 392–443 ms — remedir antes de reusar o número.
-#
-# ponytail: o teto que SOBRA é o custo linear-com-constante-alta do próprio
-# `_SO_O_VALOR_RE` (≈400 ms para 1365 palavras de enchimento). É o mesmo da
-# `main`, agora só previsível. Se virar problema, o conserto é cortar a
-# mensagem por tamanho antes do `fullmatch`, não mexer na alternância.
-_SEM_CONTEUDO_ALT = "|".join(
-    sorted((re.escape(w) for w in _SEM_CONTEUDO), key=lambda w: (-len(w), w)))
-_SO_O_VALOR_RE = re.compile(
-    rf"(?:(?:{_SEM_CONTEUDO_ALT})\s+)*(?:-\s*)?"
-    rf"(?:{PT_VALUE}"
-    rf"(?:\s+(?:e\s+)?(?:{h_bills._UNIDADE}|centavos?)(?:\s+(?:e\s+)?{PT_VALUE})?)*"
-    rf"|{h_bills._NUMERO_AMBIGUO_RE.pattern})",
-    re.I)
+# RESÍDUO INVISÍVEL (ZWSP, BOM — o que o teclado do celular e o copiar-e-colar
+# deixam) conta como NADA, não como cauda: "paguei 132\u200b" e
+# "paguei 132 \u200b" são os dois RESPOSTA. Sem isto o mesmo caractere decidia
+# coisas diferentes conforme viesse colado no número ou separado por espaço.
+_INVISIVEL = str.maketrans("", "", "\u200b\u200c\u200d\ufeff")
 
 
-def _so_o_valor(text: str) -> bool:
-    """A mensagem INTEIRA é o valor que o bot pediu ("100 reais", "2 mil").
+def _tem_quantidade(text: str) -> bool:
+    """O texto diz QUANTO — por número ou pelo marcador de tudo."""
+    from parsers import _extract_valor
 
-    True aqui = a mensagem responde a pergunta, mesmo que o classificador a
-    tenha lido como comando de escrita ("100 reais" é `launches.add` 0.95).
-    É o controle positivo do #281 virado código: sem ele a via de escrita
-    abandonaria a pergunta para toda resposta falada com "reais"/"mil", e
-    nenhuma pergunta do bot funcionaria mais.
+    return _extract_valor(text) is not None or marcador_de_tudo(text)
 
-    NÃO usa `normalize_text`: ele apaga `$` e `,`, e aí "R$ 100" e
-    "R$ 1.200,00" deixam de consumir a mensagem — medido. A dobra abaixo é a
-    da porta 1 (`lower` + NFKD sem combining + `_TRACOS` +
-    `limpa_pontuacao_final`), que preserva os dois.
 
-    TETO medido, e é a razão de "100 reais mesmo" cair em AMBÍGUO: o
-    `_ENCHIMENTO_PALAVRAS` só vale ANTES do número. Crescer aquela lista para
-    acomodar o enchimento depois do número move o `_sinal_negativo` e o
-    `_VALOR_RE` da porta 1 junto (utils_text.py:947), e o preço registrado lá
-    é "foi - 10" voltar a pagar R$ 10,00 positivo. Um turno a mais é barato;
-    aquilo não é.
+def _quantidade_fecha(text: str) -> bool:
+    """A quantidade é a última coisa da mensagem? — o quinto sinal, acima.
+
+    `limpa_pontuacao_final` porque "paguei 132." é resposta, não cauda. Ele NÃO
+    tira `?`, `,` nem `:` (utils_text.py) — e não é esquecimento aqui: o que ele
+    deixar preso na última palavra faz a mensagem cair no lado que PERGUNTA, que
+    é o lado que não escreve.
     """
-    return bool(_SO_O_VALOR_RE.fullmatch(_dobrado(text)))
+    palavras = limpa_pontuacao_final(
+        (text or "").translate(_INVISIVEL).strip()).split()
+    return bool(palavras) and _tem_quantidade(palavras[-1])
 
 
-# Verbo de lançamento (prefixo SEM conteúdo) e MAIS NADA além de UMA palavra.
-# O `_so_o_valor` acima cobre o caso em que essa palavra é o valor; este cobre
-# o caso em que ela não é — e o veredito é o mesmo, porque a razão é a mesma:
-# a mensagem não nomeia alvo nenhum, então não compete com a pergunta viva.
+# O DESEMPATE do #281. A mensagem tem quantidade e cauda: pode ser a resposta
+# da pergunta viva ("era o valor") ou um comando novo. Ninguém escreve até o
+# usuário dizer qual — perguntar é a única saída que não move dinheiro.
 #
-# É a via EXPLÍCITO abandonando para um comando que NÃO PODE RODAR: sem valor e
-# sem alvo, o `launches.add` só faz a sua própria pergunta, com a palavra do
-# usuário no lugar do alvo — a classe que o
-# `test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta` existe para impedir.
-# Medido contra a `main`, respondendo "Qual o valor?" de um saque da caixinha
-# `viagem` (R$ 300):
-#   "gastei tudo"    main: esvaziada -R$ 300,00   sem esta guarda: "Quanto foi no *tudo*?"
-#   "paguei tudo"    main: esvaziada -R$ 300,00   sem esta guarda: "Quanto foi no *tudo*?"
-#   "gastei metade"  main: "Não entendi o valor" (pergunta VIVA)
-#                                                 sem esta guarda: "Quanto foi no *metade*?"
-#
-# UMA palavra, não N: "gastei 50 no mercado" nomeia alvo e segue EXPLÍCITO.
-# E só os 12 `_VERBOS_LANCAMENTO` (mais o enchimento) são prefixo sem conteúdo,
-# então `retirei tudo`, `saquei tudo`, `tirei tudo` e `esvaziar caixinha viagem`
-# não passam por aqui — os quatro seguem abandonando, como na `main`.
-_VERBO_E_UMA_PALAVRA_RE = re.compile(
-    rf"(?:(?:{_SEM_CONTEUDO_ALT})\s+)+\S+", re.I)
+# `pending_actions` é UMA LINHA POR USUÁRIO, então armar o desempate DESALOJA a
+# pergunta original. Por isso o payload dela viaja DENTRO do payload daqui
+# (`clarif`), junto com o texto que ficou pendurado (`texto`): sem os dois, "era
+# o valor" não teria para onde voltar. Mesmo desenho do `funding_source_choice`
+# e do `investment_pick`, que também guardam o contexto no payload.
+_PERGUNTA_DE_DESEMPATE = (
+    "Não sei se *{texto}* responde a pergunta ou é um lançamento novo.\n\n"
+    "1️⃣ *responder* — {pergunta}\n"
+    "2️⃣ *registrar* — trata *{texto}* como comando novo\n\n"
+    "Ou *cancela*."
+)
 
 
-def _verbo_e_uma_palavra(text: str) -> bool:
-    """A mensagem é prefixo sem conteúdo + UMA palavra ("gastei tudo")."""
-    return bool(_VERBO_E_UMA_PALAVRA_RE.fullmatch(_dobrado(text)))
+def _resolve_desempate(pending: dict, msg: IncomingMessage, user_id: int) -> str | None:
+    """As três saídas do desempate. `None` = desembrulhou, o turno segue.
 
+    INVÓLUCRO FINO de propósito: não há transição nova aqui. `2` roteia o texto
+    guardado como comando novo (o mesmo `route`, com a linha já livre); `1`
+    devolve a pergunta original para a linha e resolve com o texto guardado (o
+    mesmo `_resolve_clarification`); QUALQUER outra coisa devolve a pergunta
+    para a linha e sai por `None` — o `route()` reentra na tabela com a mensagem
+    NOVA, como se o desempate nunca tivesse existido.
 
-def _dobrado(text: str) -> str:
-    """A dobra da porta 1: `lower` + NFKD sem combining + `_TRACOS` +
-    `limpa_pontuacao_final`. Compartilhada pelos dois portões acima."""
-    d = unicodedata.normalize(
-        "NFKD", (text or "").strip().lower().translate(_TRACOS))
-    return limpa_pontuacao_final(
-        "".join(c for c in d if not unicodedata.combining(c)))
+    O cancelamento tem ramo próprio, e isso NÃO é duplicação do
+    `_resolve_clarification` (que já trata "nao"/"cancelar"): com o desempate
+    armado, "cancelar" nunca chega ao `route()`. O
+    `handle_billing_command` (core/services/billing_commands.py:296) responde
+    antes — "🐷 Você tá no plano Free, não tem o que cancelar" — porque a
+    guarda dele consulta o `ai_pending_actions` (a mesa da IA) e não o
+    `pending_actions`, que é onde moram a `clarification`, este desempate e as
+    confirmações de delete que o comentário de lá diz proteger.
+    HOLE PRÉ-EXISTENTE, medido, e NÃO consertado aqui: mexer naquela guarda
+    move o `cancelar` de toda pendência determinística do produto, o que é
+    outro PR. O texto da pergunta oferece *cancela*, que chega até aqui; o ramo
+    aceita as quatro formas assim mesmo, para quem digitar de outro jeito.
+
+    O CAS é o de sempre: se a linha já não é este desempate, outra tarefa a
+    substituiu e o texto do usuário responde a OUTRA pergunta.
+    """
+    payload  = pending.get("payload") or {}
+    guardado = payload.get("texto") or ""
+    escolha  = limpa_pontuacao_final((msg.text or "").strip().lower())
+
+    if escolha in ("cancelar", "cancela", "nao", "não"):
+        # Mata as DUAS: o texto pendurado e a pergunta que ele desalojou. Ramo
+        # próprio porque o `_resolve_clarification` (que já trata "cancelar")
+        # nunca é alcançado — a inferência de ajuda responde antes, ver o
+        # comentário no `route()`.
+        db.consume_pending_action(user_id, pending)
+        return "❌ Cancelado."
+
+    if escolha in ("2", "2️⃣", "registrar"):
+        if not db.consume_pending_action(user_id, pending):
+            return NOT_UNDERSTOOD_MSG
+        return route(classify(guardado, user_id=user_id),
+                     replace(msg, text=guardado), ignora_pendencias=True)
+
+    if not db.advance_pending_action(
+            user_id, "value_or_command_choice", payload,
+            payload.get("clarif") or {}, new_action_type="clarification",
+            old_created_at=pending.get("created_at")):
+        return NOT_UNDERSTOOD_MSG
+
+    if escolha in ("1", "1️⃣", "responder"):
+        clarif = h_pending.get_pending_clarification(user_id)
+        if clarif is None:
+            return NOT_UNDERSTOOD_MSG
+        return _resolve_clarification(
+            clarif, guardado, user_id, msg.platform,
+            getattr(msg, "external_id", None) or "")
+    return None
 
 
 def route(result: IntentResult, msg: IncomingMessage, *,
@@ -396,6 +396,22 @@ def route(result: IntentResult, msg: IncomingMessage, *,
     confidence = result.confidence
     entities   = result.entities or {}
 
+    # Desempate do #281 armado no turno anterior. ANTES DE TUDO, inclusive do
+    # `infer_help_from_text` logo abaixo: as respostas dele são `1`, `2` e o
+    # cancelamento, e nenhuma delas pode ser lida como pedido de ajuda.
+    #
+    # Enquanto ele está armado, a pergunta original mora DENTRO do payload dele
+    # (`pending_actions` é UMA linha por usuário) e só volta para a linha por
+    # aqui. `None` = o usuário mandou uma TERCEIRA coisa, a pergunta original já
+    # voltou para a linha e o turno segue abaixo como sempre — inclusive pela
+    # inferência de ajuda.
+    if not ignora_pendencias:
+        desempate = db.get_pending_action(user_id)
+        if desempate and desempate.get("action_type") == "value_or_command_choice":
+            resp = _resolve_desempate(desempate, msg, user_id)
+            if resp is not None:
+                return resp
+
     inferred_help = h_help.infer_help_from_text(text, platform)
     if inferred_help is not None:
         norm = normalize_text(text)
@@ -416,8 +432,28 @@ def route(result: IntentResult, msg: IncomingMessage, *,
     # -----------------------------------------------------------------------
     clarif = None if ignora_pendencias else h_pending.get_pending_clarification(user_id)
     if clarif:
-        # `"resolve"` | `"abandona"` — ver `_clarification_abandonada`.
-        if _clarification_abandonada(clarif, text, user_id) == "abandona":
+        # `"resolve"` | `"abandona"` | `"pergunta"` — ver
+        # `_clarification_abandonada`.
+        veredito = _clarification_abandonada(clarif, text, user_id)
+        if veredito == "pergunta":
+            # AMBÍGUO: a quantidade não fecha a mensagem. Ninguém escreve neste
+            # turno — nem o valor na pergunta viva, nem o comando novo. O CAS é
+            # o mesmo do abandono logo abaixo, e pela mesma razão: se a linha já
+            # é de outra tarefa, o desempate não pode atropelá-la.
+            if db.advance_pending_action(
+                    user_id, "clarification", clarif.get("payload") or {},
+                    {"clarif": clarif.get("payload") or {}, "texto": text},
+                    # Literal, e não uma constante: o varredor do
+                    # `tests/test_pending_registry.py` lê o `ast` e só confere
+                    # tipo que aparece como string aqui.
+                    new_action_type="value_or_command_choice",
+                    old_created_at=clarif.get("created_at")):
+                return _PERGUNTA_DE_DESEMPATE.format(
+                    texto=text,
+                    pergunta=(clarif.get("payload") or {}).get("question")
+                             or "a pergunta anterior")
+            ignora_pendencias = True
+        elif veredito == "abandona":
             # Porta 2. Mesma escotilha de escape do `investment_pick` e do
             # `funding_source_choice` logo abaixo: outro comando claro abandona
             # a pergunta em vez de ser engolido por ela ("Quanto foi no *luz*?"
@@ -910,33 +946,29 @@ def _o_reroteamento_le_o_mesmo_valor(text: str) -> bool:
 
 
 def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
-    """Decide o que a mensagem é: `"resolve"` a pergunta, ou a `"abandona"`.
+    """O que a mensagem é: `"resolve"` a pergunta, `"abandona"`, ou `"pergunta"`.
 
-    Porta 2 do passo 1 (`abandona_pergunta_de_valor`). Quem decide é o INTENT,
-    não a forma do texto: "gastei 132" e "apagar 42" têm os dois um número.
+    Porta 2 do passo 1 (`abandona_pergunta_de_valor`). A TABELA das 16 células
+    está no corpo do PR #288 e nos testes; aqui fica o predicado, nesta ordem:
 
-    Duas vias levam a `"abandona"`, e as duas leem a MESMA classificação:
+      A0  intent de LEITURA ("saldo", "extrato")            -> abandona
+      D11 começa pelo valor ("50 no mercado", "100 reais")  -> resolve
+      D10 o reroteamento leria OUTRO valor                  -> resolve
+      D9  valor perigoso ("paguei, 132 50", "-10")          -> resolve
+      D4/D6/C2 a quantidade FECHA a mensagem                -> resolve
+      D4b/D5/D7/D8 a quantidade tem cauda                   -> PERGUNTA
+      C1  comando SEM quantidade ("fatura")                 -> abandona
+      D1/D2/D3/B0 o resto (sem quantidade nenhuma)          -> resolve
 
-      ABANDONA   os 6 intents de LEITURA ("saldo", "extrato"), como sempre,
-                 mais o veto de catálogo do #185 lá embaixo.
-      ESCRITA    comando de escrita EXPLÍCITO — verbo próprio e a mensagem
-                 inteira não é o valor pedido ("gastei 50 no mercado"). #281.
+    O classificador decide DUAS células (A0 e C1); as outras são posicionais —
+    ver o quinto sinal, em `_quantidade_fecha`. Foi a tentativa de decidir tudo
+    pelo intent que produziu as rodadas anteriores: `launches.add` 0.95 é o
+    mesmo veredito para `gastei 50 no mercado` e para `100 reais`.
 
-    A via `ESCRITA` tem dois portões, nesta ordem:
+    `"pergunta"` NUNCA escreve — quem a recebe é o desempate do `route()`, que
+    guarda a pergunta original e o texto e devolve as duas opções ao usuário.
 
-      1. `_so_o_valor` — "100 reais" classifica `launches.add` 0.95 e É a
-         resposta que o bot pediu. Ele resolve, nunca abandona.
-      2. `_STARTS_WITH_VALUE_RE` (parsers.py:176) — sobra o ATALHO sem verbo
-         ("50 no mercado", "120 de luz", "100 na caixinha viagem"), que é
-         genuinamente ambíguo: pode ser o gasto ou pode ser o valor com o
-         nome junto. Hoje ele cai em `"resolve"`, que é o comportamento da
-         `main`. A pergunta de desempate é o PR B da #281 — quando ela vier,
-         é aqui que nasce o terceiro valor de retorno, sem tocar no resto.
-
-    Não é `bool` de propósito: o PR B acrescenta uma via, e um `bool` obrigaria
-    o chamador a adivinhar qual dos dois "False" ele recebeu.
-
-    TETO DECLARADO, não verificável neste ambiente: quando a via `ESCRITA`
+    TETO DECLARADO, não verificável neste ambiente: quando a via de comando
     abandona, o turno sai daqui pelo roteamento normal e o
     `classify_with_context` — que só roda dentro do `_resolve_clarification` —
     NÃO roda. Para a conta Pro, isso significa que a IA não vê aquele turno. A
@@ -979,40 +1011,50 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
 
     intent_da_resposta = classify((text or "").strip(), allow_ai=False).intent
 
-    # As DUAS vias caem no veto de catálogo abaixo — `elif`, não dois `return`.
-    # Ser disjunto do `ABANDONA` (o `test_281_escrita_e_abandona_sao_disjuntos`)
-    # NÃO bastava: o que tornava o veto inalcançável não era um intent nos dois
-    # conjuntos, era o `return "abandona"` que esta via tinha antes dele.
+    # As DUAS vias de abandono caem no veto de catálogo abaixo — o bloco não tem
+    # `return "abandona"` próprio, ele CAI para lá. Ser disjunto do `ABANDONA`
+    # não bastava: o que tornava o veto inalcançável era o `return` que a via de
+    # comando tinha antes dele.
     # Medido, caixinha chamada `fatura` com R$ 300 e "saquei 200" pendente:
-    #   "fatura" -> classify `credit.handle` 1.0, que está no ESCRITA
+    #   "fatura" -> classify `credit.handle` 1.0, comando sem quantidade
     #            -> abandonava: "Você ainda não tem cartões cadastrados",
     #               caixinha INTACTA, pendência consumida, R$ 200 perdidos, e
     #               repetir "fatura" re-abandonava para sempre.
     # É o mesmo bug que o #185 fechou, por outra porta — e os testes do #185
     # não viam porque `saldo` (do `ABANDONA`) continuava passando pelo veto.
-    if (intent_da_resposta in ESCRITA
-            and not _so_o_valor(text) and not _verbo_e_uma_palavra(text)):
-        if _STARTS_WITH_VALUE_RE.match((text or "").strip()):
-            return "resolve"   # AMBÍGUO — desempate é o PR B da #281
-        if not _o_reroteamento_le_o_mesmo_valor(text):
-            return "resolve"
-        # FILTRO DE DANO antes de largar a pergunta. Abandonar passa por FORA
-        # do `valor_perigoso` (ele mora no `_resolve_clarification`), então
-        # todo texto cuja pontuação de prosa impede o `_so_o_valor` de casar
-        # entrava no roteamento normal SEM filtro. Não é lista de formas de
-        # mensagem — é a mesma pergunta que o resolver faz, feita antes:
+    if intent_da_resposta not in ABANDONA:
+        # D11: começa pelo valor. "50 no mercado" e "100 reais" classificam
+        # `launches.add` 0.95 igual a `gastei 50 no mercado`, e são a resposta
+        # que o bot pediu com o nome junto. Sem esta linha, `100 reais` e
+        # `30 reais e 50 centavos` viram pergunta de desempate.
+        #
+        # D10 e D9, o FILTRO DE DANO antes de largar a pergunta. Abandonar e
+        # perguntar passam por FORA do `valor_perigoso` (ele mora no
+        # `_resolve_clarification`), então o texto com pontuação de prosa ou com
+        # valor torto entrava no roteamento normal SEM filtro:
+        #   "paguei 132,50. foi isso"             -> R$ 13.250,00
         #   "paguei, 132 50" / "paguei 132 50 ok" -> R$ 13.250,00
-        #   "gastei 132 50 no mercado"            -> R$ 13.250,00
         #   "gastei -10 no mercado"               -> R$ 10,00 POSITIVOS
         #   "gastei " + "1"*400 + " no mercado"   -> "erro interno" (inf)
-        # Com ele, os quatro voltam a `"resolve"` e o resolver re-pergunta com
-        # a pendência viva — que é o comportamento da `main`. Estritamente
-        # conservador: só faz esta via abandonar MENOS.
-        if valor_perigoso(text, _extract_valor((text or "").strip())):
+        # Com eles, os quatro voltam a `"resolve"` e o resolver re-pergunta com
+        # a pendência viva — o comportamento da `main`. Estritamente
+        # conservadores: só fazem esta via abandonar (e perguntar) MENOS.
+        bruto = (text or "").strip()
+        if (_STARTS_WITH_VALUE_RE.match(bruto)
+                or not _o_reroteamento_le_o_mesmo_valor(bruto)
+                or valor_perigoso(bruto, _extract_valor(bruto))):
             return "resolve"
-        # EXPLÍCITO — verbo próprio, comando novo. Segue para o veto.
-    elif intent_da_resposta not in ABANDONA:
-        return "resolve"
+        if _tem_quantidade(bruto):
+            # O QUINTO SINAL. Fechou a mensagem: é resposta. Sobrou cauda: é
+            # ambíguo, e ambíguo não escreve — nem o valor da pergunta, nem o
+            # comando novo.
+            return "resolve" if _quantidade_fecha(bruto) else "pergunta"
+        if intent_da_resposta not in COMANDO_SEM_QUANTIDADE:
+            # Verbo sem quantidade nenhuma (`gastei`, `gastei no mercado`): o
+            # comando não teria como rodar — só faria a própria pergunta, com a
+            # palavra do usuário no lugar do alvo. A pergunta viva continua.
+            return "resolve"
+        # C1 — comando SEM quantidade. Segue para o veto.
 
     # VETO DE CATÁLOGO (#185). Última palavra, e só no turno raro em que o
     # classificador já disse "abandona": a pergunta pendente pede um NOME
@@ -1021,18 +1063,22 @@ def _clarification_abandonada(clarif: dict, text: str, user_id: int) -> str:
     # saldo — é o nome que a pergunta pediu, e abandonar descartaria o valor
     # que ele já digitou ("saquei 200" → "de qual caixinha?" → "saldo").
     #
-    # DEPOIS do classificador e dos dois portões da via `ESCRITA`, não antes: o
+    # DEPOIS do classificador e dos portões da via de comando, não antes: o
     # determinístico decide o caso comum sozinho, e o catálogo custa I/O
     # (`_alvos_existentes` chama `accrue_all_investments`, que ESCREVE
     # accruals). Nesta ordem ele só roda quando UMA DAS DUAS vias já disse
-    # "abandona" e a pergunta viva é de nome — os `return "resolve"` de cima
-    # (AMBÍGUO, guarda de entrega, valor perigoso) saem sem pagar o catálogo.
+    # "abandona" e a pergunta viva é de nome — os `return` de cima (resolve em
+    # todas as suas formas, e `pergunta`) saem sem pagar o catálogo.
     #
-    # O #281 tinha posto a via `ESCRITA` acima deste bloco COM `return` próprio,
-    # justamente para não pagar essa I/O. O preço era o veto ficar inalcançável
-    # para os 9 intents de escrita — ver o comentário da via, e o custo em
-    # dinheiro na caixinha chamada `fatura`. A I/O passa a ser paga também no
-    # turno que abandona por escrita; é o lado barato da troca.
+    # O #281 tinha posto a via de comando acima deste bloco COM `return`
+    # próprio, justamente para não pagar essa I/O. O preço era o veto ficar
+    # inalcançável para os intents de escrita — ver o comentário da via, e o
+    # custo em dinheiro na caixinha chamada `fatura`. A I/O passa a ser paga
+    # também no turno que abandona por comando; é o lado barato da troca.
+    #
+    # E ela ficou MAIS rara com o quinto sinal: só o comando SEM quantidade
+    # chega aqui pela via nova. `fatura 132` e `gastei 50 no mercado` saem
+    # antes, sem catálogo — era exatamente a I/O que a rodada anterior evitava.
     #
     # `_ja_tem_o_valor` fica INTOCADO de propósito. A one-liner da issue
     # (ler `amount` além de `valor` ali) tem regressão medida: `saquei 200` +

--- a/db/pending.py
+++ b/db/pending.py
@@ -273,6 +273,15 @@ _REGISTRO: dict[str, _Pendencia] = {
     # suprime a IA (a resposta é "1"/"2", que o classificador lê como
     # `out_of_scope` e a IA do Pro sequestraria); e sobrevive a áudio (perder a
     # linha perde a pergunta original E o texto pendurado).
+    #
+    # A 3ª coluna é a única DEFENSIVA das três, e isso é medido: mutá-la não
+    # deixa nenhum teste vermelho porque o estado não é alcançável. Com o
+    # desempate de pé, todo áudio passa antes pelo `_resolve_desempate` do
+    # `route()` — nos quatro turnos medidos ("1", "2", um terceiro assunto e um
+    # comando), o `core/handle_incoming.py:332` consultou a coluna com
+    # `recategorize_launch_offer` e com `None`, nunca com este tipo: quando o
+    # desempate sobrevive, o turno não insere lançamento e o check nem roda.
+    # Fica `True` por coerência com a `clarification` que ele embrulha.
     "value_or_command_choice":   _Pendencia(   False,   True,      True),
 
     # ── perguntas respondidas com "sim"/"não" (classificador reconhece) ───

--- a/db/pending.py
+++ b/db/pending.py
@@ -266,6 +266,14 @@ _REGISTRO: dict[str, _Pendencia] = {
     # ficava sem valor). Já estava na lista do áudio, o que mostra que a
     # ausência era esquecimento, não decisão.
     "multi_launch_values":       _Pendencia(   False,   True,      True),
+    # Desempate do #281 ("era o valor" x "é um lançamento novo"). As TRÊS
+    # colunas copiadas da `clarification`, porque ele É uma `clarification`
+    # embrulhada: não é oferta (não pode ser desalojado por outra pergunta,
+    # senão a pergunta original — que mora no payload dele — some junto);
+    # suprime a IA (a resposta é "1"/"2", que o classificador lê como
+    # `out_of_scope` e a IA do Pro sequestraria); e sobrevive a áudio (perder a
+    # linha perde a pergunta original E o texto pendurado).
+    "value_or_command_choice":   _Pendencia(   False,   True,      True),
 
     # ── perguntas respondidas com "sim"/"não" (classificador reconhece) ───
     "confirm_recurring_offer":   _Pendencia(   False,   False,     True),

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from unittest.mock import Mock
 
@@ -1494,16 +1496,21 @@ def test_claim_perdido_nao_anuncia_comando_que_paga_o_lancamento_errado(ia_espia
     `clarification` antes, e o 132,50 vira o valor do lançamento VELHO — a
     conta fica sem pagar e o dinheiro entra na descrição errada.
 
-    O #281 INVERTEU a segunda metade, e este teste passou a medir o contrário:
-    "paguei luz 132,50" é `launches.add` 0.95, não é só-o-valor e não começa
-    por valor — via EXPLÍCITO. A `clarification` é abandonada e a conta É paga.
-    Medido: `✅ Conta paga: *Luz* — R$ 132,50`, um único lançamento
-    (`conta:Luz`, 132,50) e a pendência limpa.
+    A rodada da TABELA do #281 devolveu este caso ao comportamento da `main`, e
+    é uma medição, não uma escolha nova: em "paguei luz 132,50" a QUANTIDADE
+    FECHA A MENSAGEM (célula D6), então ela é lida como resposta — o valor vai
+    para o lançamento velho e a conta segue pendente. O quinto sinal olha o que
+    vem DEPOIS do número; o alvo aqui vem ANTES, e nenhum sinal da tabela o vê.
 
-    A primeira metade continua valendo como está: o texto degradado não voltou
-    a sugerir a forma completa. Reverter o texto é decisão de produto separada
-    (o sequestro que motivou a degradação acabou de morrer), e NÃO é o PR A —
-    ele não muda nenhuma mensagem.
+    Medido nas três árvores, com a `clarification` de "gastei no mercado" viva:
+      main     -> resolve a pergunta, conta PENDENTE
+      b543228  -> abandona pela via EXPLÍCITO, conta PAGA
+      aqui     -> resolve a pergunta, conta PENDENTE  (= main)
+
+    Nada se perde no turno (o valor vira o lançamento que a pergunta pediu) e a
+    conta continua pagável no turno seguinte, mas o texto degradado que a
+    primeira metade prende segue sendo necessário — e é por isso que ele NÃO
+    voltou a sugerir a forma completa.
     """
     import uuid
     import db
@@ -1525,14 +1532,18 @@ def test_claim_perdido_nao_anuncia_comando_que_paga_o_lancamento_errado(ia_espia
     assert "132,50" not in texto, texto
     assert "Qual foi o valor?" in texto, texto
 
-    # O motivo do texto degradado MORREU no #281: a forma completa não é mais
-    # engolida pela `clarification` — ela abandona a pergunta e paga a conta.
+    # A forma completa continua sendo engolida pela `clarification`, como na
+    # `main`: o 132,50 fecha a mensagem, então é a resposta da pergunta viva.
     _diga(uid, "paguei luz 132,50")
 
-    assert B.list_bills(uid, include_paid=True)[0]["status"] == "paid"
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending", \
+        "a conta não podia ser paga por um texto que respondeu outra pergunta"
+    # UM lançamento, o da pergunta velha, com o texto inteiro na descrição —
+    # exatamente o dano que a primeira metade deste teste existe para não
+    # anunciar. R$ 132,50 é o valor certo; o alvo é que é o do outro assunto.
     lancamentos = db.list_launches(uid, limit=10)
-    assert [(l.get("alvo"), abs(float(l["valor"]))) for l in lancamentos] == \
-        [("conta:Luz", 132.5)], lancamentos
+    assert [abs(float(l["valor"])) for l in lancamentos] == [132.5], lancamentos
+    assert "mercado" in (lancamentos[0].get("alvo") or ""), lancamentos
 
 
 def test_valor_invalido_continua_sugerindo_a_forma_completa(ia_espia):
@@ -2632,7 +2643,13 @@ def test_recusa_da_porta_2_nao_apaga_pergunta_de_outra_tarefa(monkeypatch, respo
 
     def com_corrida(texto, valor):
         perigo = real(texto, valor)
-        if perigo:
+        # A corrida tem de nascer na chamada do RESOLVER — é ele que re-arma a
+        # pergunta, e é o primitivo do re-armamento que este par mede. Desde o
+        # #281 o PORTÃO da porta 2 (`_clarification_abandonada`) também chama o
+        # `valor_perigoso`, antes de decidir; injetar ali faria o
+        # `consume_pending_action` do resolver falhar no CAS e o par passaria a
+        # medir outra coisa (medido: o controle negativo ficava verde sozinho).
+        if perigo and sys._getframe(1).f_code.co_name != "_clarification_abandonada":
             db.set_pending_action(uid, "bill_pay_amount", nova)
         return perigo
 
@@ -2689,7 +2706,13 @@ def test_controle_negativo_upsert_incondicional_atropela_a_pergunta_nova(monkeyp
 
     def com_corrida(texto, valor):
         perigo = real(texto, valor)
-        if perigo:
+        # A corrida tem de nascer na chamada do RESOLVER — é ele que re-arma a
+        # pergunta, e é o primitivo do re-armamento que este par mede. Desde o
+        # #281 o PORTÃO da porta 2 (`_clarification_abandonada`) também chama o
+        # `valor_perigoso`, antes de decidir; injetar ali faria o
+        # `consume_pending_action` do resolver falhar no CAS e o par passaria a
+        # medir outra coisa (medido: o controle negativo ficava verde sozinho).
+        if perigo and sys._getframe(1).f_code.co_name != "_clarification_abandonada":
             db.set_pending_action(uid, "bill_pay_amount", nova)
         return perigo
 
@@ -3126,130 +3149,16 @@ def test_cas_perdido_na_porta_3_ja_nao_tocava_a_pergunta_nova(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# #281 — a tabela do predicado da porta 2, input -> via. Unidade, sem banco:
-# o que a conversa prova está em `tests/test_perguntas_guardam_contexto.py`,
-# que é onde moram os controles negativos e a classe cega.
+# #281 — a porta 2 pela CONVERSA. A tabela das 16 células mora em
+# `tests/test_perguntas_guardam_contexto.py` (§0.7 — uma cópia só), com os
+# controles negativos e a classe cega. Aqui ficam as duas guardas que a via de
+# comando atravessa ANTES de decidir: a de entrega e o filtro de dano.
 #
-#   i = classify(texto, allow_ai=False).intent
-#   i in ABANDONA                     -> ABANDONA-6 (+ veto de catálogo, #280)
-#   i in ESCRITA and not _so_o_valor:
-#           começa por valor          -> AMBÍGUO (no PR A cai em COMPATÍVEL)
-#           reroteamento leria OUTRO
-#             número                  -> COMPATÍVEL (guarda de entrega)
-#           senão                     -> EXPLÍCITO
-#   senão                             -> COMPATÍVEL
+# A tabela de UNIDADE que existia aqui foi apagada junto com o vocabulário que
+# ela media (EXPLÍCITO/AMBÍGUO/COMPATÍVEL, `_so_o_valor`,
+# `_verbo_e_uma_palavra`): o predicado deixou de ser decidido pelo intent — só
+# `ABANDONA` e `COMANDO_SEM_QUANTIDADE` ainda o consultam, o resto é posicional.
 # ---------------------------------------------------------------------------
-
-_VIAS_281 = [
-    # EXPLÍCITO — verbo próprio, e a mensagem inteira não é o valor pedido.
-    ("gastei 50 no mercado", "EXPLICITO"),
-    ("paguei 120 de luz", "EXPLICITO"),
-    ("gastei 25,90 na farmácia ontem", "EXPLICITO"),
-    ("guardei 100 na caixinha viagem", "EXPLICITO"),
-    ("transferi 80 pro joão", "EXPLICITO"),
-    ("aportei 200 no CDB", "EXPLICITO"),
-    ("resgatei 200 do CDB", "EXPLICITO"),
-    ("saquei 200", "EXPLICITO"),
-    ("investi 80", "EXPLICITO"),
-    ("criar caixinha viagem", "EXPLICITO"),
-    ("apagar caixinha viagem", "EXPLICITO"),
-    ("fatura", "EXPLICITO"),
-    # AMBÍGUO — atalho sem verbo. No PR A tem o MESMO destino do COMPATÍVEL.
-    ("50 no mercado", "AMBIGUO"),
-    ("120 de luz", "AMBIGUO"),
-    ("100 na caixinha viagem", "AMBIGUO"),
-    ("132 no cartao", "AMBIGUO"),
-    ("100 reais mesmo", "AMBIGUO"),
-    # COMPATÍVEL por FORMA — `launches.add` 0.95, mas consome a mensagem toda.
-    ("100 reais", "COMPATIVEL"),
-    ("2 mil", "COMPATIVEL"),
-    ("10 mil", "COMPATIVEL"),
-    ("2,5 mil", "COMPATIVEL"),
-    ("30 reais e 50 centavos", "COMPATIVEL"),
-    # COMPATÍVEL pelo VERBO: os 12 do `_VERBOS_LANCAMENTO` são prefixo SEM
-    # conteúdo (`_SEM_CONTEUDO`) — a mesma operação que a pergunta já fazia, e
-    # nenhum alvo nomeado. Sem isto eles pulam o `valor_perigoso`, e os quatro
-    # de baixo viravam R$ 13.250,00 / R$ 10,00 positivos / "erro interno".
-    ("paguei 132", "COMPATIVEL"),
-    ("gastei 132", "COMPATIVEL"),
-    ("recebi 1000", "COMPATIVEL"),
-    ("paguei 132 50", "COMPATIVEL"),
-    ("paguei -10", "COMPATIVEL"),
-    ("paguei ,50", "COMPATIVEL"),
-    ("paguei " + "1" * 400, "COMPATIVEL"),
-    # COMPATÍVEL pela GUARDA DE ENTREGA: o roteamento normal leria 13250.0
-    # onde a porta lê 132.5, porque só as portas limpam a pontuação de prosa.
-    ("paguei 132,50. foi isso", "COMPATIVEL"),
-    # COMPATÍVEL por INTENT — `out_of_scope`, nem chega ao portão de forma.
-    ("100", "COMPATIVEL"),
-    ("R$ 100", "COMPATIVEL"),
-    ("132,50", "COMPATIVEL"),
-    ("cem", "COMPATIVEL"),
-    ("cento e vinte", "COMPATIVEL"),
-    ("tudo", "COMPATIVEL"),
-    ("viagem", "COMPATIVEL"),
-    # O TETO declarado: verbo que os tiers 1-2 não conhecem. Todos
-    # `out_of_scope 0.0`, então seguem sendo lidos como resposta.
-    ("poupei 100", "COMPATIVEL"),
-    ("mercado 50", "COMPATIVEL"),
-    ("uber 25", "COMPATIVEL"),
-    ("gasteii 50 no mercado", "COMPATIVEL"),
-    ("gasto fixo aluguel 1200", "COMPATIVEL"),
-    # ABANDONA-6, intocado pelo #281.
-    ("saldo", "ABANDONA"),
-    ("extrato", "ABANDONA"),
-    ("caixinhas", "ABANDONA"),
-]
-
-
-# As quatro vias colapsam nos DOIS veredictos que a porta 2 realmente devolve.
-# `EXPLICITO` e `ABANDONA` chegam ao mesmo `"abandona"` por caminhos
-# diferentes; `AMBIGUO` e `COMPATIVEL`, ao mesmo `"resolve"`.
-_VEREDICTO_DA_VIA = {
-    "EXPLICITO": "abandona", "ABANDONA": "abandona",
-    "AMBIGUO": "resolve", "COMPATIVEL": "resolve",
-}
-
-
-def _via_281(texto: str) -> str:
-    """Chama a PORTA 2 DE VERDADE com uma `clarification` sintética.
-
-    Antes esta função REIMPLEMENTAVA o predicado (mesma classificação, mesmos
-    portões, mesma ordem) — duas fontes de verdade para a mesma regra (§0.7),
-    e a tabela ficava verde com o `_clarification_abandonada` arbitrariamente
-    torto. Medido: invertendo o `return "abandona"` final do router, a tabela
-    de ~47 casos não produzia UM vermelho.
-
-    O payload sintético é o de uma pergunta de VALOR (`falta="amount"`,
-    `entities={}`): não dispara o `_ja_tem_o_valor` e não dispara o veto de
-    catálogo (`_CHAVE_DO_NOME["pockets.withdraw"]` é `pocket_name`, não
-    `amount`), então nenhum acesso a banco acontece e o `user_id` é inerte.
-    """
-    from core.intent_router import _clarification_abandonada
-
-    clarif = {"payload": {"intent": "pockets.withdraw", "falta": "amount",
-                          "entities": {}}}
-    return _clarification_abandonada(clarif, texto, 0)
-
-
-@pytest.mark.parametrize("texto,via", _VIAS_281)
-def test_281_tabela_do_predicado(texto, via):
-    assert _via_281(texto) == _VEREDICTO_DA_VIA[via], via
-
-
-def test_281_escrita_e_abandona_sao_disjuntos():
-    """Ser disjunto NÃO é o que torna o veto de catálogo alcançável — essa era
-    a afirmação errada do primeiro texto deste teste, e ela custou o achado A
-    do Tester (caixinha chamada `fatura` perdendo R$ 200).
-
-    O que a disjunção prende é só isto: nenhum intent está nos dois conjuntos,
-    então cada mensagem entra por UMA via. Quem garante o veto é o `elif` do
-    `_clarification_abandonada`, e quem prende isso é o
-    `test_281_veto_de_catalogo_alcanca_a_via_de_escrita`."""
-    from core.intent_router import ABANDONA, ESCRITA
-
-    assert ABANDONA & ESCRITA == set()
-
 
 def test_281_guarda_de_entrega_prende_o_valor_que_o_reroteamento_mudaria():
     """CONTROLE da guarda, pela CONVERSA: sem ela, `paguei 132,50. foi isso`
@@ -3271,37 +3180,16 @@ def test_281_guarda_de_entrega_prende_o_valor_que_o_reroteamento_mudaria():
     assert len(lancs) == 1 and abs(float(lancs[0]["valor"])) == 132.5, lancs
 
 
-def test_281_so_o_valor_nao_usa_normalize_text():
-    """A armadilha medida: `normalize_text` apaga `$` e `,`, e aí `R$ 100` e
-    `R$ 1.200,00` deixariam de consumir a mensagem inteira — viravam AMBÍGUO
-    e o valor digitado se perderia num turno de desempate."""
-    from core.intent_router import _so_o_valor
-
-    assert _so_o_valor("R$ 100")
-    assert _so_o_valor("R$ 1.200,00")
-    assert _so_o_valor("132,50.")
-
-
-def test_281_so_o_valor_nao_estoura_com_texto_longo():
-    """A primeira forma do `_SO_O_VALOR_RE` (`{PT_VALUE}(?:\\s+e\\s+{MOEDA})*`)
-    tinha backtracking catastrófico: 40 grupos de `2 mil e ` não terminaram em
-    120s. A unidade obrigatória em cada iteração externa desfaz a ambiguidade.
-    O limite é generoso de propósito — o que se mede aqui é exponencial × não
-    exponencial, não milissegundos."""
-    import time
-
-    from core.intent_router import _so_o_valor
-
-    inicio = time.perf_counter()
-    _so_o_valor(" e ".join(["2 mil"] * 40) + " x")
-    assert time.perf_counter() - inicio < 1.0
-
-
-# ── Os três achados do Tester no #281, pela CONVERSA ────────────────────────
-# Os três nasceram do mesmo desenho: a via `ESCRITA` decidindo sozinha, com
-# `return` próprio, antes das duas proteções que já existiam (o veto de
-# catálogo do #185 e o `valor_perigoso`). Cada um cobra um `assert` sobre o
-# DINHEIRO, não sobre o texto da resposta.
+# ── Os achados do Tester no #281, pela CONVERSA ─────────────────────────────
+# Nasceram do mesmo desenho: a via de comando decidindo sozinha, com `return`
+# próprio, antes das duas proteções que já existiam (o veto de catálogo do #185
+# e o `valor_perigoso`). Cada um cobra um `assert` sobre o DINHEIRO, não sobre o
+# texto da resposta.
+#
+# O quarto (`gastei tudo` virando "Quanto foi no *tudo*?") mudou de dono: quem o
+# prende agora é a célula D1/D2/D3 da tabela, em
+# `tests/test_perguntas_guardam_contexto.py` — o verbo sem quantidade nenhuma
+# não abandona nada.
 
 def _pergunta_de_valor_do_saque(uid, pocket="viagem", saldo=300, conta=400):
     """Deixa viva a pergunta "Qual o valor?" de um saque de caixinha."""
@@ -3323,11 +3211,11 @@ def _saldo(uid, pocket):
 
 @pytest.mark.parametrize("nome", ["fatura", "cartão", "limite"])
 def test_281_veto_de_catalogo_alcanca_a_via_de_escrita(nome):
-    """ACHADO A. O veto do #185 ficara INALCANÇÁVEL para os 9 intents de
-    escrita: a via `ESCRITA` dava `return "abandona"` antes dele.
+    """ACHADO A. O veto do #185 ficara INALCANÇÁVEL para os intents de escrita:
+    a via de comando dava `return "abandona"` antes dele.
 
     Vítimas são nomes triviais de caixinha — `fatura` classifica
-    `credit.handle` 1.0, que entrou no `ESCRITA` por decisão do dono. Medido
+    `credit.handle` 1.0, que é comando SEM quantidade. Medido
     sem o `elif`, caixinha `fatura` com R$ 300 e "saquei 200" pendente:
     "📭 Você ainda não tem cartões cadastrados", caixinha INTACTA, pendência
     CONSUMIDA, R$ 200 perdidos — e repetir `fatura` re-abandonava para sempre.
@@ -3346,18 +3234,19 @@ def test_281_veto_de_catalogo_alcanca_a_via_de_escrita(nome):
 
 
 @pytest.mark.parametrize("resposta", [
-    # A pontuação de prosa impede o `_so_o_valor` de casar, e sem o filtro a
-    # via EXPLÍCITO entregava a mensagem ao roteamento normal, por fora dele.
+    # A cauda depois do valor manda a mensagem para o desempate, e sem o filtro
+    # o "2" de lá entregaria a mensagem ao roteamento normal, por fora dele.
     "paguei, 132 50", "paguei: 132 50", "paguei 132 50 ok", "paguei 132 50?",
     "paguei os 132 50", "paguei 132 50​",
-    # ALVO NOMEADO: aqui não há pontuação nenhuma — o `_SO_O_VALOR_RE` nunca
-    # protegeu o que nomeia alvo, então a lista de formas não fecharia isto.
+    # ALVO NOMEADO: aqui não há pontuação nenhuma, e nenhuma lista de formas de
+    # mensagem fecharia isto — o filtro é sobre o VALOR, não sobre a forma.
     "gastei 132 50 no mercado", "paguei 132 50 de luz",
     "gastei -10 no mercado", "paguei 1.23.456 de luz",
     "gastei " + "1" * 400 + " no mercado",
-    # CONTROLE POSITIVO: já era verde antes da guarda (cai em AMBÍGUO pelo
-    # `_STARTS_WITH_VALUE_RE`, que vem antes) e continua verde depois — a
-    # guarda não mudou o caminho de quem começa com o valor.
+    # O sinal separado do dígito: "-50" NÃO casa o `_STARTS_WITH_VALUE_RE`
+    # (`^\s*(?:r\$\s*)?\d`, parsers.py:176), então quem o segura é o filtro —
+    # medido, desligando o filtro esta linha fica vermelha junto com as outras.
+    # A redação anterior dizia o contrário e estava errada.
     "-50 no mercado",
 ])
 def test_281_valor_perigoso_vem_antes_do_abandono(resposta):
@@ -3383,69 +3272,17 @@ def test_281_valor_perigoso_vem_antes_do_abandono(resposta):
     assert [l for l in (db.list_launches(uid, limit=20) or [])
             if (l.get("tipo") or "") == "despesa"] == [], saida
     assert _saldo(uid, "viagem") == 300.00, saida
-
-
-@pytest.mark.parametrize("resposta,fecha_o_saque", [
-    # Verbo de lançamento + UMA palavra: nem valor nem alvo, então não é
-    # comando novo. `tudo` preenche o mesmo slot que um valor preencheria.
-    ("gastei tudo", True), ("paguei tudo", True),
-    # A palavra que não é resposta nenhuma: o veredito é "re-pergunta", nunca
-    # "vira alvo de uma pendência nova".
-    ("gastei metade", False),
-])
-def test_281_verbo_com_uma_palavra_nao_abandona(resposta, fecha_o_saque):
-    """ACHADO D. Sem a guarda, `gastei tudo` respondia "🐷 Quanto foi no
-    *tudo*?": o saque se perdia E a palavra do usuário virava ALVO de uma
-    pendência nova — a classe do
-    `test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta`.
-
-    Abandonar só faz sentido quando o outro comando PODE RODAR; sem valor e
-    sem alvo, o `launches.add` só refaz a pergunta em cima do lixo."""
-    import uuid
-
-    uid = int(uuid.uuid4().int % 1_000_000_000) + 1
-    _pergunta_de_valor_do_saque(uid)
-    _diga(uid, "tirar da caixinha viagem")
-    assert "Qual o valor" in _diga(uid, "viagem")
-
-    saida = _diga(uid, resposta)
-
-    assert "*tudo*" not in saida and "*metade*" not in saida, saida
-    assert _saldo(uid, "viagem") == (0.00 if fecha_o_saque else 300.00), saida
-
-
-def test_281_verbo_com_uma_palavra_nao_come_o_comando_explicito():
-    """CONTROLE POSITIVO da guarda do ACHADO D: ela restringe UMA palavra, e o
-    que nomeia alvo continua abandonando. Sem este caso, a guarda passaria
-    recusando tudo — pior que o bug."""
-    from core.intent_router import _verbo_e_uma_palavra
-
-    assert _verbo_e_uma_palavra("gastei tudo")
-    assert not _verbo_e_uma_palavra("gastei 50 no mercado")
-    assert not _verbo_e_uma_palavra("paguei 120 de luz")
-    # Só os 12 `_VERBOS_LANCAMENTO` são prefixo sem conteúdo.
-    assert not _verbo_e_uma_palavra("retirei tudo")
-    assert not _verbo_e_uma_palavra("esvaziar caixinha viagem")
-    assert not _verbo_e_uma_palavra("fatura")
-
-
-def test_281_sem_conteudo_alt_e_deterministico():
-    """`_SEM_CONTEUDO` é `frozenset`: `key=len` sozinho desempatava pela ordem
-    de iteração, que muda com o `PYTHONHASHSEED`. O RESULTADO era estável (md5
-    idêntico em 7 seeds), mas o TEMPO não — `_so_o_valor("um "*1365 + "x")`
-    mediu de 463 ms a 6,1 s conforme a seed, e é alcançável por mensagem de
-    usuário. A segunda chave (alfabética) torna o custo reprodutível."""
-    from core.intent_router import _SEM_CONTEUDO_ALT
-
-    alt = _SEM_CONTEUDO_ALT.split("|")
-    # A alternância mais longa primeiro — é o que evita "um" casar dentro de
-    # "umas". Esta parte já valia com `key=len`.
-    assert all(len(a) >= len(b) for a, b in zip(alt, alt[1:])), alt
-    # E, dentro de cada comprimento, ordem ESTRITA. É o que tira o `frozenset`
-    # da jogada: sem a segunda chave, o desempate é a iteração do set.
+    # A TERCEIRA afirmação, e é a que faltava no grupo inteiro: "nada se moveu"
+    # também é verdade quando a pergunta MORRE e o dinheiro simplesmente se
+    # perde. Foi a ausência dela que deixou `gastei` escapar por três rodadas.
     #
-    # TETO desta forma: ela afirma a propriedade, não a expressão (senão seria
-    # tautológica), e com `key=len` sozinho a ordem dentro de um grupo PODERIA
-    # sair alfabética por sorte de uma seed. Com 39 palavras isso é remoto, mas
-    # não é zero — o teto é do teste, não do conserto.
-    assert all(a < b for a, b in zip(alt, alt[1:]) if len(a) == len(b)), alt
+    # E ela cobra o TIPO, não só a existência: sem o filtro, estas mensagens
+    # caem no DESEMPATE (a cauda depois do valor torto), que também deixa uma
+    # linha viva e também repete "Qual o valor" na opção 1 — medido, o teste
+    # ficava verde com o filtro desligado. O que o filtro garante é que o
+    # usuário nem chegue a ver a opção "registrar", porque um "2" ali entrega
+    # `132 50` ao roteamento normal e vira R$ 13.250,00.
+    pend = db.get_pending_action(uid)
+    assert pend and pend["action_type"] == "clarification", \
+        f"a pergunta morreu ou virou desempate com o valor recusado: {pend}"
+    assert "Qual o valor" in saida, saida

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -2413,13 +2413,7 @@ def test_porta_4_ponto_final_sem_virgula_paga_como_na_main(monkeypatch, resposta
     assert (depois["status"], float(depois["paid_amount"] or 0)) == ("paid", esperado)
 
 
-# "paguei 132." saiu daqui no #281, pelo MESMO motivo que já o tirava da porta
-# 1 (o comentário abaixo do próximo teste): ele tem verbo próprio, então a via
-# EXPLÍCITO abandona a pergunta antes da limpeza — a limpeza não participa.
-# O que ele faz agora está em `test_281_verbo_com_valor_e_nada_mais_custa_um_turno`.
-@pytest.mark.parametrize("resposta,esperado",
-                         [c for c in PONTO_FINAL_SEM_VIRGULA
-                          if not c[0].startswith("paguei")])
+@pytest.mark.parametrize("resposta,esperado", PONTO_FINAL_SEM_VIRGULA)
 def test_porta_2_ponto_final_sem_virgula_registra(resposta, esperado):
     """Porta 2, a única que já limpava antes — aqui só para as quatro
     concordarem no MESMO texto, que é o ponto do PR."""
@@ -2434,36 +2428,6 @@ def test_porta_2_ponto_final_sem_virgula_registra(resposta, esperado):
 
     lancs = db.list_launches(uid, limit=3)
     assert len(lancs) == 1 and abs(float(lancs[0]["valor"])) == esperado, lancs
-
-
-def test_281_verbo_com_valor_e_nada_mais_custa_um_turno():
-    """TETO do #281, medido e NÃO resolvido aqui: verbo + valor e MAIS NADA.
-
-    `paguei 132`, `gastei 50`, `recebi 1000`, `saquei 200` e `tirei 100` têm
-    verbo próprio e nenhum alvo — a via EXPLÍCITO os trata como comando novo,
-    então respondê-los a "Quanto foi no *luz*?" abandona a pergunta e o
-    roteamento normal pergunta de novo, agora pela DESCRIÇÃO.
-
-    NADA se perde e nada anda para o lado errado: o valor sobrevive na
-    `clarification` nova, e nenhum lançamento é gravado com alvo adivinhado.
-    O custo é UM turno e o `luz` da pergunta velha, que o usuário redigita.
-
-    Se o dono quiser esse caso de volta como resposta, a mudança é UMA linha
-    (`_VERBOS_LANCAMENTO` como prefixo aceito no `_SO_O_VALOR_RE`, ao lado do
-    `_ENCHIMENTO`) — mas ela decide que "verbo sem alvo não é comando", e essa
-    decisão não estava no plano do PR A.
-    """
-    import uuid
-    import db
-
-    uid = int(uuid.uuid4().int % 1_000_000_000)
-    db.ensure_user(uid)
-    assert "Quanto foi" in _diga(uid, "paguei a luz")
-
-    resp = _diga(uid, "paguei 132.  ")
-
-    assert "Em que você gastou R$ 132,00" in resp, resp
-    assert db.list_launches(uid, limit=3) == [], "nada podia ser gravado ainda"
 
 
 # "paguei 132." fica de fora: ele NÃO casa o `_VALOR_RE` (o verbo não está no
@@ -3169,8 +3133,10 @@ def test_cas_perdido_na_porta_3_ja_nao_tocava_a_pergunta_nova(monkeypatch):
 #   i = classify(texto, allow_ai=False).intent
 #   i in ABANDONA                     -> ABANDONA-6 (+ veto de catálogo, #280)
 #   i in ESCRITA and not _so_o_valor:
-#           não começa por valor      -> EXPLÍCITO
 #           começa por valor          -> AMBÍGUO (no PR A cai em COMPATÍVEL)
+#           reroteamento leria OUTRO
+#             número                  -> COMPATÍVEL (guarda de entrega)
+#           senão                     -> EXPLÍCITO
 #   senão                             -> COMPATÍVEL
 # ---------------------------------------------------------------------------
 
@@ -3184,6 +3150,7 @@ _VIAS_281 = [
     ("aportei 200 no CDB", "EXPLICITO"),
     ("resgatei 200 do CDB", "EXPLICITO"),
     ("saquei 200", "EXPLICITO"),
+    ("investi 80", "EXPLICITO"),
     ("criar caixinha viagem", "EXPLICITO"),
     ("apagar caixinha viagem", "EXPLICITO"),
     ("fatura", "EXPLICITO"),
@@ -3199,6 +3166,20 @@ _VIAS_281 = [
     ("10 mil", "COMPATIVEL"),
     ("2,5 mil", "COMPATIVEL"),
     ("30 reais e 50 centavos", "COMPATIVEL"),
+    # COMPATÍVEL pelo VERBO: os 12 do `_VERBOS_LANCAMENTO` são prefixo SEM
+    # conteúdo (`_SEM_CONTEUDO`) — a mesma operação que a pergunta já fazia, e
+    # nenhum alvo nomeado. Sem isto eles pulam o `valor_perigoso`, e os quatro
+    # de baixo viravam R$ 13.250,00 / R$ 10,00 positivos / "erro interno".
+    ("paguei 132", "COMPATIVEL"),
+    ("gastei 132", "COMPATIVEL"),
+    ("recebi 1000", "COMPATIVEL"),
+    ("paguei 132 50", "COMPATIVEL"),
+    ("paguei -10", "COMPATIVEL"),
+    ("paguei ,50", "COMPATIVEL"),
+    ("paguei " + "1" * 400, "COMPATIVEL"),
+    # COMPATÍVEL pela GUARDA DE ENTREGA: o roteamento normal leria 13250.0
+    # onde a porta lê 132.5, porque só as portas limpam a pontuação de prosa.
+    ("paguei 132,50. foi isso", "COMPATIVEL"),
     # COMPATÍVEL por INTENT — `out_of_scope`, nem chega ao portão de forma.
     ("100", "COMPATIVEL"),
     ("R$ 100", "COMPATIVEL"),
@@ -3225,11 +3206,17 @@ def _via_281(texto: str) -> str:
     """Reconstrói a via a partir das MESMAS peças que a porta 2 usa."""
     from parsers import _STARTS_WITH_VALUE_RE
     from core.intent_classifier import classify
-    from core.intent_router import ABANDONA, ESCRITA, _so_o_valor
+    from core.intent_router import (ABANDONA, ESCRITA,
+                                    _o_reroteamento_le_o_mesmo_valor,
+                                    _so_o_valor)
 
     i = classify(texto, allow_ai=False).intent
     if i in ESCRITA and not _so_o_valor(texto):
-        return "AMBIGUO" if _STARTS_WITH_VALUE_RE.match(texto) else "EXPLICITO"
+        if _STARTS_WITH_VALUE_RE.match(texto):
+            return "AMBIGUO"
+        if not _o_reroteamento_le_o_mesmo_valor(texto):
+            return "COMPATIVEL"
+        return "EXPLICITO"
     return "ABANDONA" if i in ABANDONA else "COMPATIVEL"
 
 
@@ -3246,6 +3233,26 @@ def test_281_escrita_e_abandona_sao_disjuntos():
     from core.intent_router import ABANDONA, ESCRITA
 
     assert ABANDONA & ESCRITA == set()
+
+
+def test_281_guarda_de_entrega_prende_o_valor_que_o_reroteamento_mudaria():
+    """CONTROLE da guarda, pela CONVERSA: sem ela, `paguei 132,50. foi isso`
+    respondendo "Quanto foi no *luz*?" registra R$ 13.250,00.
+
+    O furo é do `parse_money` sobre a pontuação de prosa e tem issue própria
+    (ver `_cola_separador_decimal`); enquanto ele existir, a via EXPLÍCITO não
+    pode entregar a mensagem ao roteamento normal."""
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    _diga(uid, "paguei 132,50. foi isso")
+
+    lancs = db.list_launches(uid, limit=3)
+    assert len(lancs) == 1 and abs(float(lancs[0]["valor"])) == 132.5, lancs
 
 
 def test_281_so_o_valor_nao_usa_normalize_text():

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -1494,10 +1494,16 @@ def test_claim_perdido_nao_anuncia_comando_que_paga_o_lancamento_errado(ia_espia
     `clarification` antes, e o 132,50 vira o valor do lançamento VELHO — a
     conta fica sem pagar e o dinheiro entra na descrição errada.
 
-    A correção (o texto não sugere mais isso) continua valendo, e a enumeração
-    do #133 continua inteira: a escotilha de abandono desta rodada só larga a
-    pergunta quando a resposta não fala de valor nenhum, e "paguei luz 132,50"
-    TEM valor. As 8 pendências seguem engolindo a forma completa.
+    O #281 INVERTEU a segunda metade, e este teste passou a medir o contrário:
+    "paguei luz 132,50" é `launches.add` 0.95, não é só-o-valor e não começa
+    por valor — via EXPLÍCITO. A `clarification` é abandonada e a conta É paga.
+    Medido: `✅ Conta paga: *Luz* — R$ 132,50`, um único lançamento
+    (`conta:Luz`, 132,50) e a pendência limpa.
+
+    A primeira metade continua valendo como está: o texto degradado não voltou
+    a sugerir a forma completa. Reverter o texto é decisão de produto separada
+    (o sequestro que motivou a degradação acabou de morrer), e NÃO é o PR A —
+    ele não muda nenhuma mensagem.
     """
     import uuid
     import db
@@ -1519,16 +1525,14 @@ def test_claim_perdido_nao_anuncia_comando_que_paga_o_lancamento_errado(ia_espia
     assert "132,50" not in texto, texto
     assert "Qual foi o valor?" in texto, texto
 
-    # E o motivo do texto degradado continua verdadeiro: a `clarification`
-    # engole a forma completa, a conta NÃO é paga e o 132,50 vira o lançamento
-    # velho. É por isso que este texto não pode anunciar "paguei luz 132,50".
+    # O motivo do texto degradado MORREU no #281: a forma completa não é mais
+    # engolida pela `clarification` — ela abandona a pergunta e paga a conta.
     _diga(uid, "paguei luz 132,50")
 
-    assert B.list_bills(uid, include_paid=True)[0]["status"] == "pending"
-    mercado = [l for l in db.list_launches(uid, limit=10)
-               if "mercado" in (l.get("alvo") or l.get("nota") or "").lower()]
-    assert mercado, "o 132,50 tinha que ter virado o lançamento do mercado"
-    assert abs(float(mercado[0]["valor"])) == 132.5, mercado[0]
+    assert B.list_bills(uid, include_paid=True)[0]["status"] == "paid"
+    lancamentos = db.list_launches(uid, limit=10)
+    assert [(l.get("alvo"), abs(float(l["valor"]))) for l in lancamentos] == \
+        [("conta:Luz", 132.5)], lancamentos
 
 
 def test_valor_invalido_continua_sugerindo_a_forma_completa(ia_espia):
@@ -1770,12 +1774,12 @@ def test_clarification_com_payload_torto_nao_estoura():
     """
     from core.intent_router import _clarification_abandonada
 
-    assert _clarification_abandonada({"payload": "x"}, "saldo", 1) is False
-    assert _clarification_abandonada({}, "saldo", 1) is False
+    assert _clarification_abandonada({"payload": "x"}, "saldo", 1) == "resolve"
+    assert _clarification_abandonada({}, "saldo", 1) == "resolve"
     # `falta` casa com a chave de nome, e o `intent` é o dado torto: sem o
     # `isinstance(intent, str)` esta linha estoura antes de chegar ao return.
     torto = {"payload": {"falta": "pocket_name", "intent": ["pockets.withdraw"]}}
-    assert _clarification_abandonada(torto, "saldo", 1) is True
+    assert _clarification_abandonada(torto, "saldo", 1) == "abandona"
 
 
 # ---------------------------------------------------------------------------
@@ -1953,7 +1957,7 @@ def test_escotilha_da_clarification_nao_apaga_pergunta_de_outra_tarefa(monkeypat
 
     def com_corrida(clarif, texto, uid_):
         decidiu = real(clarif, texto, uid_)
-        if decidiu:
+        if decidiu == "abandona":
             # outra tarefa chegou primeiro e já perguntou outra coisa. É um
             # `bill_pay_amount` de propósito: o `route()` não o consome (quem
             # consome é o runtime do WhatsApp), então o que sobrar no fim é
@@ -2409,7 +2413,13 @@ def test_porta_4_ponto_final_sem_virgula_paga_como_na_main(monkeypatch, resposta
     assert (depois["status"], float(depois["paid_amount"] or 0)) == ("paid", esperado)
 
 
-@pytest.mark.parametrize("resposta,esperado", PONTO_FINAL_SEM_VIRGULA)
+# "paguei 132." saiu daqui no #281, pelo MESMO motivo que já o tirava da porta
+# 1 (o comentário abaixo do próximo teste): ele tem verbo próprio, então a via
+# EXPLÍCITO abandona a pergunta antes da limpeza — a limpeza não participa.
+# O que ele faz agora está em `test_281_verbo_com_valor_e_nada_mais_custa_um_turno`.
+@pytest.mark.parametrize("resposta,esperado",
+                         [c for c in PONTO_FINAL_SEM_VIRGULA
+                          if not c[0].startswith("paguei")])
 def test_porta_2_ponto_final_sem_virgula_registra(resposta, esperado):
     """Porta 2, a única que já limpava antes — aqui só para as quatro
     concordarem no MESMO texto, que é o ponto do PR."""
@@ -2424,6 +2434,36 @@ def test_porta_2_ponto_final_sem_virgula_registra(resposta, esperado):
 
     lancs = db.list_launches(uid, limit=3)
     assert len(lancs) == 1 and abs(float(lancs[0]["valor"])) == esperado, lancs
+
+
+def test_281_verbo_com_valor_e_nada_mais_custa_um_turno():
+    """TETO do #281, medido e NÃO resolvido aqui: verbo + valor e MAIS NADA.
+
+    `paguei 132`, `gastei 50`, `recebi 1000`, `saquei 200` e `tirei 100` têm
+    verbo próprio e nenhum alvo — a via EXPLÍCITO os trata como comando novo,
+    então respondê-los a "Quanto foi no *luz*?" abandona a pergunta e o
+    roteamento normal pergunta de novo, agora pela DESCRIÇÃO.
+
+    NADA se perde e nada anda para o lado errado: o valor sobrevive na
+    `clarification` nova, e nenhum lançamento é gravado com alvo adivinhado.
+    O custo é UM turno e o `luz` da pergunta velha, que o usuário redigita.
+
+    Se o dono quiser esse caso de volta como resposta, a mudança é UMA linha
+    (`_VERBOS_LANCAMENTO` como prefixo aceito no `_SO_O_VALOR_RE`, ao lado do
+    `_ENCHIMENTO`) — mas ela decide que "verbo sem alvo não é comando", e essa
+    decisão não estava no plano do PR A.
+    """
+    import uuid
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    assert "Quanto foi" in _diga(uid, "paguei a luz")
+
+    resp = _diga(uid, "paguei 132.  ")
+
+    assert "Em que você gastou R$ 132,00" in resp, resp
+    assert db.list_launches(uid, limit=3) == [], "nada podia ser gravado ainda"
 
 
 # "paguei 132." fica de fora: ele NÃO casa o `_VALOR_RE` (o verbo não está no
@@ -3119,3 +3159,116 @@ def test_cas_perdido_na_porta_3_ja_nao_tocava_a_pergunta_nova(monkeypatch):
 
     _fila_intacta(uid)
     assert "Conta Corrente" in resp, resp
+
+
+# ---------------------------------------------------------------------------
+# #281 — a tabela do predicado da porta 2, input -> via. Unidade, sem banco:
+# o que a conversa prova está em `tests/test_perguntas_guardam_contexto.py`,
+# que é onde moram os controles negativos e a classe cega.
+#
+#   i = classify(texto, allow_ai=False).intent
+#   i in ABANDONA                     -> ABANDONA-6 (+ veto de catálogo, #280)
+#   i in ESCRITA and not _so_o_valor:
+#           não começa por valor      -> EXPLÍCITO
+#           começa por valor          -> AMBÍGUO (no PR A cai em COMPATÍVEL)
+#   senão                             -> COMPATÍVEL
+# ---------------------------------------------------------------------------
+
+_VIAS_281 = [
+    # EXPLÍCITO — verbo próprio, e a mensagem inteira não é o valor pedido.
+    ("gastei 50 no mercado", "EXPLICITO"),
+    ("paguei 120 de luz", "EXPLICITO"),
+    ("gastei 25,90 na farmácia ontem", "EXPLICITO"),
+    ("guardei 100 na caixinha viagem", "EXPLICITO"),
+    ("transferi 80 pro joão", "EXPLICITO"),
+    ("aportei 200 no CDB", "EXPLICITO"),
+    ("resgatei 200 do CDB", "EXPLICITO"),
+    ("saquei 200", "EXPLICITO"),
+    ("criar caixinha viagem", "EXPLICITO"),
+    ("apagar caixinha viagem", "EXPLICITO"),
+    ("fatura", "EXPLICITO"),
+    # AMBÍGUO — atalho sem verbo. No PR A tem o MESMO destino do COMPATÍVEL.
+    ("50 no mercado", "AMBIGUO"),
+    ("120 de luz", "AMBIGUO"),
+    ("100 na caixinha viagem", "AMBIGUO"),
+    ("132 no cartao", "AMBIGUO"),
+    ("100 reais mesmo", "AMBIGUO"),
+    # COMPATÍVEL por FORMA — `launches.add` 0.95, mas consome a mensagem toda.
+    ("100 reais", "COMPATIVEL"),
+    ("2 mil", "COMPATIVEL"),
+    ("10 mil", "COMPATIVEL"),
+    ("2,5 mil", "COMPATIVEL"),
+    ("30 reais e 50 centavos", "COMPATIVEL"),
+    # COMPATÍVEL por INTENT — `out_of_scope`, nem chega ao portão de forma.
+    ("100", "COMPATIVEL"),
+    ("R$ 100", "COMPATIVEL"),
+    ("132,50", "COMPATIVEL"),
+    ("cem", "COMPATIVEL"),
+    ("cento e vinte", "COMPATIVEL"),
+    ("tudo", "COMPATIVEL"),
+    ("viagem", "COMPATIVEL"),
+    # O TETO declarado: verbo que os tiers 1-2 não conhecem. Todos
+    # `out_of_scope 0.0`, então seguem sendo lidos como resposta.
+    ("poupei 100", "COMPATIVEL"),
+    ("mercado 50", "COMPATIVEL"),
+    ("uber 25", "COMPATIVEL"),
+    ("gasteii 50 no mercado", "COMPATIVEL"),
+    ("gasto fixo aluguel 1200", "COMPATIVEL"),
+    # ABANDONA-6, intocado pelo #281.
+    ("saldo", "ABANDONA"),
+    ("extrato", "ABANDONA"),
+    ("caixinhas", "ABANDONA"),
+]
+
+
+def _via_281(texto: str) -> str:
+    """Reconstrói a via a partir das MESMAS peças que a porta 2 usa."""
+    from parsers import _STARTS_WITH_VALUE_RE
+    from core.intent_classifier import classify
+    from core.intent_router import ABANDONA, ESCRITA, _so_o_valor
+
+    i = classify(texto, allow_ai=False).intent
+    if i in ESCRITA and not _so_o_valor(texto):
+        return "AMBIGUO" if _STARTS_WITH_VALUE_RE.match(texto) else "EXPLICITO"
+    return "ABANDONA" if i in ABANDONA else "COMPATIVEL"
+
+
+@pytest.mark.parametrize("texto,via", _VIAS_281)
+def test_281_tabela_do_predicado(texto, via):
+    assert _via_281(texto) == via
+
+
+def test_281_escrita_e_abandona_sao_disjuntos():
+    """A ordem dos dois ramos em `_clarification_abandonada` não pode mudar
+    resultado. Se um intent novo entrar nos dois conjuntos, ela passa a mudar —
+    e o veto de catálogo (que roda só depois do `ABANDONA`) deixaria de ser
+    alcançável para ele."""
+    from core.intent_router import ABANDONA, ESCRITA
+
+    assert ABANDONA & ESCRITA == set()
+
+
+def test_281_so_o_valor_nao_usa_normalize_text():
+    """A armadilha medida: `normalize_text` apaga `$` e `,`, e aí `R$ 100` e
+    `R$ 1.200,00` deixariam de consumir a mensagem inteira — viravam AMBÍGUO
+    e o valor digitado se perderia num turno de desempate."""
+    from core.intent_router import _so_o_valor
+
+    assert _so_o_valor("R$ 100")
+    assert _so_o_valor("R$ 1.200,00")
+    assert _so_o_valor("132,50.")
+
+
+def test_281_so_o_valor_nao_estoura_com_texto_longo():
+    """A primeira forma do `_SO_O_VALOR_RE` (`{PT_VALUE}(?:\\s+e\\s+{MOEDA})*`)
+    tinha backtracking catastrófico: 40 grupos de `2 mil e ` não terminaram em
+    120s. A unidade obrigatória em cada iteração externa desfaz a ambiguidade.
+    O limite é generoso de propósito — o que se mede aqui é exponencial × não
+    exponencial, não milissegundos."""
+    import time
+
+    from core.intent_router import _so_o_valor
+
+    inicio = time.perf_counter()
+    _so_o_valor(" e ".join(["2 mil"] * 40) + " x")
+    assert time.perf_counter() - inicio < 1.0

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -3202,34 +3202,50 @@ _VIAS_281 = [
 ]
 
 
-def _via_281(texto: str) -> str:
-    """Reconstrói a via a partir das MESMAS peças que a porta 2 usa."""
-    from parsers import _STARTS_WITH_VALUE_RE
-    from core.intent_classifier import classify
-    from core.intent_router import (ABANDONA, ESCRITA,
-                                    _o_reroteamento_le_o_mesmo_valor,
-                                    _so_o_valor)
+# As quatro vias colapsam nos DOIS veredictos que a porta 2 realmente devolve.
+# `EXPLICITO` e `ABANDONA` chegam ao mesmo `"abandona"` por caminhos
+# diferentes; `AMBIGUO` e `COMPATIVEL`, ao mesmo `"resolve"`.
+_VEREDICTO_DA_VIA = {
+    "EXPLICITO": "abandona", "ABANDONA": "abandona",
+    "AMBIGUO": "resolve", "COMPATIVEL": "resolve",
+}
 
-    i = classify(texto, allow_ai=False).intent
-    if i in ESCRITA and not _so_o_valor(texto):
-        if _STARTS_WITH_VALUE_RE.match(texto):
-            return "AMBIGUO"
-        if not _o_reroteamento_le_o_mesmo_valor(texto):
-            return "COMPATIVEL"
-        return "EXPLICITO"
-    return "ABANDONA" if i in ABANDONA else "COMPATIVEL"
+
+def _via_281(texto: str) -> str:
+    """Chama a PORTA 2 DE VERDADE com uma `clarification` sintética.
+
+    Antes esta função REIMPLEMENTAVA o predicado (mesma classificação, mesmos
+    portões, mesma ordem) — duas fontes de verdade para a mesma regra (§0.7),
+    e a tabela ficava verde com o `_clarification_abandonada` arbitrariamente
+    torto. Medido: invertendo o `return "abandona"` final do router, a tabela
+    de ~47 casos não produzia UM vermelho.
+
+    O payload sintético é o de uma pergunta de VALOR (`falta="amount"`,
+    `entities={}`): não dispara o `_ja_tem_o_valor` e não dispara o veto de
+    catálogo (`_CHAVE_DO_NOME["pockets.withdraw"]` é `pocket_name`, não
+    `amount`), então nenhum acesso a banco acontece e o `user_id` é inerte.
+    """
+    from core.intent_router import _clarification_abandonada
+
+    clarif = {"payload": {"intent": "pockets.withdraw", "falta": "amount",
+                          "entities": {}}}
+    return _clarification_abandonada(clarif, texto, 0)
 
 
 @pytest.mark.parametrize("texto,via", _VIAS_281)
 def test_281_tabela_do_predicado(texto, via):
-    assert _via_281(texto) == via
+    assert _via_281(texto) == _VEREDICTO_DA_VIA[via], via
 
 
 def test_281_escrita_e_abandona_sao_disjuntos():
-    """A ordem dos dois ramos em `_clarification_abandonada` não pode mudar
-    resultado. Se um intent novo entrar nos dois conjuntos, ela passa a mudar —
-    e o veto de catálogo (que roda só depois do `ABANDONA`) deixaria de ser
-    alcançável para ele."""
+    """Ser disjunto NÃO é o que torna o veto de catálogo alcançável — essa era
+    a afirmação errada do primeiro texto deste teste, e ela custou o achado A
+    do Tester (caixinha chamada `fatura` perdendo R$ 200).
+
+    O que a disjunção prende é só isto: nenhum intent está nos dois conjuntos,
+    então cada mensagem entra por UMA via. Quem garante o veto é o `elif` do
+    `_clarification_abandonada`, e quem prende isso é o
+    `test_281_veto_de_catalogo_alcanca_a_via_de_escrita`."""
     from core.intent_router import ABANDONA, ESCRITA
 
     assert ABANDONA & ESCRITA == set()
@@ -3279,3 +3295,157 @@ def test_281_so_o_valor_nao_estoura_com_texto_longo():
     inicio = time.perf_counter()
     _so_o_valor(" e ".join(["2 mil"] * 40) + " x")
     assert time.perf_counter() - inicio < 1.0
+
+
+# ── Os três achados do Tester no #281, pela CONVERSA ────────────────────────
+# Os três nasceram do mesmo desenho: a via `ESCRITA` decidindo sozinha, com
+# `return` próprio, antes das duas proteções que já existiam (o veto de
+# catálogo do #185 e o `valor_perigoso`). Cada um cobra um `assert` sobre o
+# DINHEIRO, não sobre o texto da resposta.
+
+def _pergunta_de_valor_do_saque(uid, pocket="viagem", saldo=300, conta=400):
+    """Deixa viva a pergunta "Qual o valor?" de um saque de caixinha."""
+    import db
+
+    db.ensure_user(uid)
+    db.add_launch_and_update_balance(uid, "receita", conta, alvo="salario",
+                                     nota="setup", categoria="salario",
+                                     is_internal_movement=False)
+    db.create_pocket(uid, pocket)
+    db.pocket_deposit_from_account(uid, pocket, saldo)
+
+
+def _saldo(uid, pocket):
+    import db
+
+    return {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}[pocket]
+
+
+@pytest.mark.parametrize("nome", ["fatura", "cartão", "limite"])
+def test_281_veto_de_catalogo_alcanca_a_via_de_escrita(nome):
+    """ACHADO A. O veto do #185 ficara INALCANÇÁVEL para os 9 intents de
+    escrita: a via `ESCRITA` dava `return "abandona"` antes dele.
+
+    Vítimas são nomes triviais de caixinha — `fatura` classifica
+    `credit.handle` 1.0, que entrou no `ESCRITA` por decisão do dono. Medido
+    sem o `elif`, caixinha `fatura` com R$ 300 e "saquei 200" pendente:
+    "📭 Você ainda não tem cartões cadastrados", caixinha INTACTA, pendência
+    CONSUMIDA, R$ 200 perdidos — e repetir `fatura` re-abandonava para sempre.
+
+    Os quatro testes do #185 não viam porque `saldo` está no `ABANDONA`, que
+    sempre passou pelo veto."""
+    import uuid
+
+    uid = int(uuid.uuid4().int % 1_000_000_000) + 1
+    _pergunta_de_valor_do_saque(uid, pocket=nome, saldo=300, conta=700)
+
+    assert "caixinha" in _diga(uid, "saquei 200").lower()
+    _diga(uid, nome)
+
+    assert _saldo(uid, nome) == 100.00
+
+
+@pytest.mark.parametrize("resposta", [
+    # A pontuação de prosa impede o `_so_o_valor` de casar, e sem o filtro a
+    # via EXPLÍCITO entregava a mensagem ao roteamento normal, por fora dele.
+    "paguei, 132 50", "paguei: 132 50", "paguei 132 50 ok", "paguei 132 50?",
+    "paguei os 132 50", "paguei 132 50​",
+    # ALVO NOMEADO: aqui não há pontuação nenhuma — o `_SO_O_VALOR_RE` nunca
+    # protegeu o que nomeia alvo, então a lista de formas não fecharia isto.
+    "gastei 132 50 no mercado", "paguei 132 50 de luz",
+    "gastei -10 no mercado", "paguei 1.23.456 de luz",
+    "gastei " + "1" * 400 + " no mercado",
+    # CONTROLE POSITIVO: já era verde antes da guarda (cai em AMBÍGUO pelo
+    # `_STARTS_WITH_VALUE_RE`, que vem antes) e continua verde depois — a
+    # guarda não mudou o caminho de quem começa com o valor.
+    "-50 no mercado",
+])
+def test_281_valor_perigoso_vem_antes_do_abandono(resposta):
+    """ACHADOS B e C. `valor_perigoso` mora no `_resolve_clarification`, e
+    abandonar passa por FORA dele. Medido sem a guarda, respondendo à pergunta
+    de valor de um saque: R$ 13.250,00 registrados, R$ 10,00 POSITIVOS para
+    `-10`, R$ 123.456,00 para `1.23.456` e "erro interno" para os 400 dígitos.
+
+    O consertado é a CLASSE, não as strings: o filtro roda antes da decisão,
+    então qualquer forma nova de resíduo cai nele igual."""
+    import uuid
+
+    import db
+
+    uid = int(uuid.uuid4().int % 1_000_000_000) + 1
+    _pergunta_de_valor_do_saque(uid)
+    _diga(uid, "tirar da caixinha viagem")
+    assert "Qual o valor" in _diga(uid, "viagem")
+
+    saida = _diga(uid, resposta)
+
+    assert "erro interno" not in saida.lower(), saida
+    assert [l for l in (db.list_launches(uid, limit=20) or [])
+            if (l.get("tipo") or "") == "despesa"] == [], saida
+    assert _saldo(uid, "viagem") == 300.00, saida
+
+
+@pytest.mark.parametrize("resposta,fecha_o_saque", [
+    # Verbo de lançamento + UMA palavra: nem valor nem alvo, então não é
+    # comando novo. `tudo` preenche o mesmo slot que um valor preencheria.
+    ("gastei tudo", True), ("paguei tudo", True),
+    # A palavra que não é resposta nenhuma: o veredito é "re-pergunta", nunca
+    # "vira alvo de uma pendência nova".
+    ("gastei metade", False),
+])
+def test_281_verbo_com_uma_palavra_nao_abandona(resposta, fecha_o_saque):
+    """ACHADO D. Sem a guarda, `gastei tudo` respondia "🐷 Quanto foi no
+    *tudo*?": o saque se perdia E a palavra do usuário virava ALVO de uma
+    pendência nova — a classe do
+    `test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta`.
+
+    Abandonar só faz sentido quando o outro comando PODE RODAR; sem valor e
+    sem alvo, o `launches.add` só refaz a pergunta em cima do lixo."""
+    import uuid
+
+    uid = int(uuid.uuid4().int % 1_000_000_000) + 1
+    _pergunta_de_valor_do_saque(uid)
+    _diga(uid, "tirar da caixinha viagem")
+    assert "Qual o valor" in _diga(uid, "viagem")
+
+    saida = _diga(uid, resposta)
+
+    assert "*tudo*" not in saida and "*metade*" not in saida, saida
+    assert _saldo(uid, "viagem") == (0.00 if fecha_o_saque else 300.00), saida
+
+
+def test_281_verbo_com_uma_palavra_nao_come_o_comando_explicito():
+    """CONTROLE POSITIVO da guarda do ACHADO D: ela restringe UMA palavra, e o
+    que nomeia alvo continua abandonando. Sem este caso, a guarda passaria
+    recusando tudo — pior que o bug."""
+    from core.intent_router import _verbo_e_uma_palavra
+
+    assert _verbo_e_uma_palavra("gastei tudo")
+    assert not _verbo_e_uma_palavra("gastei 50 no mercado")
+    assert not _verbo_e_uma_palavra("paguei 120 de luz")
+    # Só os 12 `_VERBOS_LANCAMENTO` são prefixo sem conteúdo.
+    assert not _verbo_e_uma_palavra("retirei tudo")
+    assert not _verbo_e_uma_palavra("esvaziar caixinha viagem")
+    assert not _verbo_e_uma_palavra("fatura")
+
+
+def test_281_sem_conteudo_alt_e_deterministico():
+    """`_SEM_CONTEUDO` é `frozenset`: `key=len` sozinho desempatava pela ordem
+    de iteração, que muda com o `PYTHONHASHSEED`. O RESULTADO era estável (md5
+    idêntico em 7 seeds), mas o TEMPO não — `_so_o_valor("um "*1365 + "x")`
+    mediu de 463 ms a 6,1 s conforme a seed, e é alcançável por mensagem de
+    usuário. A segunda chave (alfabética) torna o custo reprodutível."""
+    from core.intent_router import _SEM_CONTEUDO_ALT
+
+    alt = _SEM_CONTEUDO_ALT.split("|")
+    # A alternância mais longa primeiro — é o que evita "um" casar dentro de
+    # "umas". Esta parte já valia com `key=len`.
+    assert all(len(a) >= len(b) for a, b in zip(alt, alt[1:])), alt
+    # E, dentro de cada comprimento, ordem ESTRITA. É o que tira o `frozenset`
+    # da jogada: sem a segunda chave, o desempate é a iteração do set.
+    #
+    # TETO desta forma: ela afirma a propriedade, não a expressão (senão seria
+    # tautológica), e com `key=len` sozinho a ordem dentro de um grupo PODERIA
+    # sair alfabética por sorte de uma seed. Com 39 palavras isso é remoto, mas
+    # não é zero — o teto é do teste, não do conserto.
+    assert all(a < b for a, b in zip(alt, alt[1:]) if len(a) == len(b)), alt

--- a/tests/test_bill_amount_pending.py
+++ b/tests/test_bill_amount_pending.py
@@ -498,8 +498,13 @@ def test_ordem_de_prioridade_da_linha_de_pendencias():
     # 3. ocupada por PERGUNTA → cede, e a pergunta antiga fica intacta
     # `confirm_recurring_offer` está aqui, e não entre as ofertas: ela pergunta
     # "sim ou não" em texto e o runtime NÃO a consome no turno em que nasce.
+    # `value_or_command_choice` (o desempate do #281) está aqui porque é o caso
+    # mais caro da coluna: a pergunta original mora DENTRO do payload dele, então
+    # marcá-lo como oferta perderia DUAS perguntas de uma vez. Sem esta linha,
+    # `oferta=True` no registro não deixava um teste vermelho (medido).
     for pergunta in ("clarification", "multi_launch_values", "credit_card_setup",
-                     "delete_launch", "confirm_recurring_offer"):
+                     "delete_launch", "confirm_recurring_offer",
+                     "value_or_command_choice"):
         uid = int(uuid.uuid4().int % 1_000_000_000)
         db.ensure_user(uid)
         db.set_pending_action(uid, pergunta, {"valor": 77.9})
@@ -3243,10 +3248,10 @@ def test_281_veto_de_catalogo_alcanca_a_via_de_escrita(nome):
     "gastei 132 50 no mercado", "paguei 132 50 de luz",
     "gastei -10 no mercado", "paguei 1.23.456 de luz",
     "gastei " + "1" * 400 + " no mercado",
-    # O sinal separado do dígito: "-50" NÃO casa o `_STARTS_WITH_VALUE_RE`
-    # (`^\s*(?:r\$\s*)?\d`, parsers.py:176), então quem o segura é o filtro —
-    # medido, desligando o filtro esta linha fica vermelha junto com as outras.
-    # A redação anterior dizia o contrário e estava errada.
+    # Sinal separado do dígito. Quem o segura é o filtro — medido, desligando
+    # o filtro esta linha fica vermelha junto com as outras. (A redação
+    # anterior atribuía isso ao `_STARTS_WITH_VALUE_RE`, que saiu da via no
+    # #288 por levar a regra 3 do dono no atropelo.)
     "-50 no mercado",
 ])
 def test_281_valor_perigoso_vem_antes_do_abandono(resposta):

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -543,20 +543,29 @@ def test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta(pro_uid, ia_de_esclareci
     Medido no WhatsApp: "gastei no mercado" → "Quanto foi no *mercado*?" →
     "fatura" → "Quanto foi no *mercado - fatura*?". O `orig_text` crescia a
     cada turno e a palavra do usuário ficava gravada como alvo do lançamento.
+
+    O #281 fecha isto MAIS CEDO e por outra via, por DECISÃO DO DONO:
+    `credit.handle` entrou no `ESCRITA`, então "fatura" (sv=0, não é
+    só-o-valor) é comando novo — a porta 2 abandona a pergunta e responde o
+    cartão. Medido: "📭 Você ainda não tem cartões cadastrados", pendência
+    limpa, nada registrado. A IA não é mais consultada neste turno, e é por
+    isso que o `assert chamadas` saiu: o abandono acontece no `route()`, antes
+    do `_resolve_clarification`.
+
+    O que o teste protege continua o mesmo e é o que importa: a palavra do
+    usuário não vira alvo de lançamento nenhum.
     """
     import db
 
     uid = pro_uid
     _pergunta_de_valor(uid, "gastei no mercado")
-    chamadas = ia_de_esclarecimento(valor=44.0)
+    ia_de_esclarecimento(valor=44.0)
 
     resp = _send(uid, "fatura")
 
-    assert chamadas, "a IA não foi consultada — o teste não mede nada"
     assert "mercado - fatura" not in resp, f"o alvo engordou: {resp}"
-    pend = _pendencia(uid)
-    assert pend is not None, resp
-    assert pend["payload"]["orig_text"] == "gastei no mercado", pend["payload"]
+    assert "cart" in resp.lower(), f"a pergunta engoliu o comando de cartão: {resp}"
+    assert _pendencia(uid) is None, _pendencia(uid)
     assert not db.list_launches(uid, limit=5), "gravou com a resposta como alvo"
 
 
@@ -978,6 +987,17 @@ def test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando(
         pro_uid, spy_ai):
     """Porta 2, com `investi 80` (`investments.deposit` 0.95).
 
+    INVERTIDO PELO #281, de propósito: `investi 80` é um comando de ESCRITA de
+    OUTRA operação (aportar), não uma forma de dizer "80". A regra do dono é
+    que o comando explícito vence, então a pergunta É largada e o aporte roda.
+    Medido: "Qual valor você quer aportar? Você ainda não tem investimentos
+    cadastrados", nada registrado, e uma pendência NOVA (a do aporte) no lugar.
+
+    Isto NÃO vale para `paguei 132` / `gastei 132`: aqueles são os 12 verbos do
+    `_VERBOS_LANCAMENTO`, que o `_SO_O_VALOR_RE` trata como prefixo sem
+    conteúdo — a mesma operação que a pergunta já estava fazendo. Quem prende
+    esse recorte é `test_clarification_aceita_tudo_que_a_main_aceita`.
+
     `132 no cartao` fica FORA desta metade por medição, não por esquecimento:
     nas duas árvores (`main` cf54ffb e este branch) o combinado
     "gastei 132 no cartao a luz" é lido como compra no cartão e responde
@@ -992,11 +1012,13 @@ def test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando(
     import db
     _pergunta_de_valor(uid)
 
-    _send(uid, "investi 80")
+    resp = _send(uid, "investi 80")
 
-    lancs = db.list_launches(uid, limit=5)
-    assert lancs, "'investi 80' perdeu a pergunta e não registrou nada"
-    assert abs(float(lancs[0]["valor"])) == 80.0, lancs[0]
+    assert "aportar" in resp.lower(), f"a pergunta engoliu o aporte: {resp}"
+    assert not db.list_launches(uid, limit=5), \
+        "não havia investimento para aportar; nada podia ser gravado"
+    pend = _pendencia(uid)
+    assert pend and pend["payload"].get("intent") != "launches.add", pend
 
 
 def test_controle_negativo_credit_handle_no_conjunto_apaga_a_fila(free_uid, spy_ai, monkeypatch):

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -545,9 +545,9 @@ def test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta(pro_uid, ia_de_esclareci
     cada turno e a palavra do usuário ficava gravada como alvo do lançamento.
 
     O #281 fecha isto MAIS CEDO e por outra via, por DECISÃO DO DONO:
-    `credit.handle` entrou no `ESCRITA`, então "fatura" (sv=0, não é
-    só-o-valor) é comando novo — a porta 2 abandona a pergunta e responde o
-    cartão. Medido: "📭 Você ainda não tem cartões cadastrados", pendência
+    `credit.handle` entrou no `COMANDO_SEM_QUANTIDADE`, então "fatura" (sem
+    quantidade nenhuma) é comando novo — a porta 2 abandona a pergunta e
+    responde o cartão. Medido: "📭 Você ainda não tem cartões cadastrados", pendência
     limpa, nada registrado. A IA não é mais consultada neste turno, e é por
     isso que o `assert chamadas` saiu: o abandono acontece no `route()`, antes
     do `_resolve_clarification`.
@@ -723,6 +723,16 @@ def test_multi_launch_texto_sem_valor_ainda_abandona(free_uid, spy_ai):
 # filtro de dano roda DEPOIS, sobre o texto.
 # ---------------------------------------------------------------------------
 
+# As formas em que a CAUDA vem depois do número (células D7/D8 do #281): a
+# mensagem pode ser a resposta ou um lançamento novo, então a porta pergunta
+# antes de escrever. Não é uma lista de exceções do código — é a lista das
+# linhas DESTE teste que pagam o turno a mais, e ela está aqui para o custo
+# aparecer no arquivo em vez de sumir num `if`.
+_COM_CAUDA = {"deu 132 no total", "foi uns 132 no total",
+              "paguei 132 - da luz", "gastei 50 - mercado",
+              "paguei 132. foi isso"}
+
+
 @pytest.mark.parametrize("resposta,esperado", [
     ("132 mil", 132000.0),
     ("2,5 mil", 2500.0),
@@ -750,6 +760,11 @@ def test_clarification_aceita_tudo_que_a_main_aceita(pro_uid, spy_ai, resposta, 
     Assere DESCRIÇÃO e CATEGORIA junto com o valor: os dois modos de dano da
     rodada 2 se distinguem por aí. No laço, nada é registrado; na perda da
     pergunta, o valor até entra, mas com descrição errada e categoria "outros".
+
+    Duas das 17 passam pelo DESEMPATE do #281 antes de fechar (`_COM_CAUDA`):
+    o número não é a última coisa da mensagem, e nenhum outro sinal as
+    distingue de "gastei 50 no mercado". O valor aceito é o mesmo — muda o
+    turno a mais, e o teste o paga explicitamente para não esconder o custo.
     """
     from parsers import _extract_valor
     uid = pro_uid
@@ -758,6 +773,9 @@ def test_clarification_aceita_tudo_que_a_main_aceita(pro_uid, spy_ai, resposta, 
     _pergunta_de_valor(uid)
 
     resp = _send(uid, resposta)
+    if resposta in _COM_CAUDA:
+        assert "1️⃣" in resp, f"{resposta!r} devia ir ao desempate: {resp}"
+        resp = _send(uid, "1")
 
     lancs = db.list_launches(uid, limit=5)
     assert lancs, f"{resposta!r} não registrou nada (laço): {resp}"
@@ -987,16 +1005,15 @@ def test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando(
         pro_uid, spy_ai):
     """Porta 2, com `investi 80` (`investments.deposit` 0.95).
 
-    INVERTIDO PELO #281, de propósito: `investi 80` é um comando de ESCRITA de
-    OUTRA operação (aportar), não uma forma de dizer "80". A regra do dono é
-    que o comando explícito vence, então a pergunta É largada e o aporte roda.
-    Medido: "Qual valor você quer aportar? Você ainda não tem investimentos
-    cadastrados", nada registrado, e uma pendência NOVA (a do aporte) no lugar.
+    A rodada da TABELA do #281 UNIFORMIZOU a assimetria que este teste media:
+    `investi 80` e `paguei 132` têm a mesma forma — a quantidade fecha a
+    mensagem (célula D6) —, então os dois são RESPOSTA. Antes um abandonava e o
+    outro não, e o critério era o verbo estar ou não numa lista de 12.
 
-    Isto NÃO vale para `paguei 132` / `gastei 132`: aqueles são os 12 verbos do
-    `_VERBOS_LANCAMENTO`, que o `_SO_O_VALOR_RE` trata como prefixo sem
-    conteúdo — a mesma operação que a pergunta já estava fazendo. Quem prende
-    esse recorte é `test_clarification_aceita_tudo_que_a_main_aceita`.
+    O que se ganha: o saque/aporte de R$ 80 não se perde quando o alvo não
+    existe (era o teto 3 declarado na rodada anterior). O que se perde: quem
+    QUERIA aportar com uma pergunta de valor viva paga um turno — responde a
+    pergunta e repete o comando.
 
     `132 no cartao` fica FORA desta metade por medição, não por esquecimento:
     nas duas árvores (`main` cf54ffb e este branch) o combinado
@@ -1014,11 +1031,14 @@ def test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando(
 
     resp = _send(uid, "investi 80")
 
-    assert "aportar" in resp.lower(), f"a pergunta engoliu o aporte: {resp}"
-    assert not db.list_launches(uid, limit=5), \
-        "não havia investimento para aportar; nada podia ser gravado"
-    pend = _pendencia(uid)
-    assert pend and pend["payload"].get("intent") != "launches.add", pend
+    lancs = db.list_launches(uid, limit=5)
+    assert len(lancs) == 1 and abs(float(lancs[0]["valor"])) == 80.0, \
+        f"os R$ 80 tinham de fechar a pergunta viva: {resp} / {lancs}"
+    texto = f"{lancs[0].get('alvo') or ''} {lancs[0].get('nota') or ''}".lower()
+    assert "luz" in texto, f"o valor entrou sem a descrição da pergunta: {lancs[0]}"
+    # A `clarification` foi consumida; o que fica na linha é a oferta de
+    # recategorização do lançamento novo, do fluxo normal.
+    assert (_pendencia(uid) or {}).get("action_type") != "clarification", _pendencia(uid)
 
 
 def test_controle_negativo_credit_handle_no_conjunto_apaga_a_fila(free_uid, spy_ai, monkeypatch):
@@ -1196,12 +1216,19 @@ _PROSA = [("paguei 132 - da luz", 132.0), ("132 — luz", 132.0),
 
 @pytest.mark.parametrize("resposta,esperado", _PROSA)
 def test_clarification_prosa_registra_o_valor_certo(pro_uid, spy_ai, resposta, esperado):
-    """Porta 2. `gastei 50 - mercado` é o " - " que ESTE PR pôs no combinado."""
+    """Porta 2. `gastei 50 - mercado` é o " - " que ESTE PR pôs no combinado.
+
+    Três das oito passam pelo desempate do #281 antes de fechar (`_COM_CAUDA`)
+    — a pontuação de prosa deixa cauda depois do número. O valor registrado é o
+    mesmo."""
     uid = pro_uid
     import db
     _pergunta_de_valor(uid)
 
-    _send(uid, resposta)
+    resp = _send(uid, resposta)
+    if resposta in _COM_CAUDA:
+        assert "1️⃣" in resp, f"{resposta!r} devia ir ao desempate: {resp}"
+        _send(uid, "1")
 
     lancs = db.list_launches(uid, limit=1)
     assert lancs, f"{resposta!r} não registrou nada"

--- a/tests/test_full_handler_smoke.py
+++ b/tests/test_full_handler_smoke.py
@@ -548,9 +548,14 @@ def test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta(pro_uid, ia_de_esclareci
     `credit.handle` entrou no `COMANDO_SEM_QUANTIDADE`, então "fatura" (sem
     quantidade nenhuma) é comando novo — a porta 2 abandona a pergunta e
     responde o cartão. Medido: "📭 Você ainda não tem cartões cadastrados", pendência
-    limpa, nada registrado. A IA não é mais consultada neste turno, e é por
-    isso que o `assert chamadas` saiu: o abandono acontece no `route()`, antes
-    do `_resolve_clarification`.
+    limpa, nada registrado. A IA não é mais consultada neste turno — o abandono
+    acontece no `route()`, antes do `_resolve_clarification`.
+
+    A GUARDA ANTITAUTOLÓGICA virou do avesso, e continua sendo uma: o
+    `ia_de_esclarecimento(valor=44.0)` está armado e o teste afirma que ele
+    NÃO foi chamado. Se o turno voltar a passar pelo `_resolve_clarification`
+    (a regressão que este teste existe para pegar), `chamadas` enche e o teste
+    fica vermelho — o setup não é morto.
 
     O que o teste protege continua o mesmo e é o que importa: a palavra do
     usuário não vira alvo de lançamento nenhum.
@@ -559,10 +564,14 @@ def test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta(pro_uid, ia_de_esclareci
 
     uid = pro_uid
     _pergunta_de_valor(uid, "gastei no mercado")
-    ia_de_esclarecimento(valor=44.0)
+    chamadas = ia_de_esclarecimento(valor=44.0)
 
     resp = _send(uid, "fatura")
 
+    assert not chamadas, \
+        f"o turno passou pelo `_resolve_clarification`: {chamadas!r}"
+    assert "Cancelei a pergunta anterior" in resp, \
+        f"a pergunta morreu em silêncio: {resp}"
     assert "mercado - fatura" not in resp, f"o alvo engordou: {resp}"
     assert "cart" in resp.lower(), f"a pergunta engoliu o comando de cartão: {resp}"
     assert _pendencia(uid) is None, _pendencia(uid)
@@ -728,9 +737,14 @@ def test_multi_launch_texto_sem_valor_ainda_abandona(free_uid, spy_ai):
 # antes de escrever. Não é uma lista de exceções do código — é a lista das
 # linhas DESTE teste que pagam o turno a mais, e ela está aqui para o custo
 # aparecer no arquivo em vez de sumir num `if`.
+#
+# As TRÊS últimas entraram com a queda do `_STARTS_WITH_VALUE_RE` (#288): elas
+# começam pelo número e têm alvo depois, que é a forma exata de `50 no mercado`
+# na regra do dono. Antes um curto-circuito as resolvia; agora pagam o turno.
 _COM_CAUDA = {"deu 132 no total", "foi uns 132 no total",
               "paguei 132 - da luz", "gastei 50 - mercado",
-              "paguei 132. foi isso"}
+              "paguei 132. foi isso",
+              "132 no boleto", "132 — luz", "132. da luz"}
 
 
 @pytest.mark.parametrize("resposta,esperado", [
@@ -761,7 +775,7 @@ def test_clarification_aceita_tudo_que_a_main_aceita(pro_uid, spy_ai, resposta, 
     rodada 2 se distinguem por aí. No laço, nada é registrado; na perda da
     pergunta, o valor até entra, mas com descrição errada e categoria "outros".
 
-    Duas das 17 passam pelo DESEMPATE do #281 antes de fechar (`_COM_CAUDA`):
+    Três das 17 passam pelo DESEMPATE do #281 antes de fechar (`_COM_CAUDA`):
     o número não é a última coisa da mensagem, e nenhum outro sinal as
     distingue de "gastei 50 no mercado". O valor aceito é o mesmo — muda o
     turno a mais, e o teste o paga explicitamente para não esconder o custo.
@@ -1218,7 +1232,7 @@ _PROSA = [("paguei 132 - da luz", 132.0), ("132 — luz", 132.0),
 def test_clarification_prosa_registra_o_valor_certo(pro_uid, spy_ai, resposta, esperado):
     """Porta 2. `gastei 50 - mercado` é o " - " que ESTE PR pôs no combinado.
 
-    Três das oito passam pelo desempate do #281 antes de fechar (`_COM_CAUDA`)
+    Cinco das oito passam pelo desempate do #281 antes de fechar (`_COM_CAUDA`)
     — a pontuação de prosa deixa cauda depois do número. O valor registrado é o
     mesmo."""
     uid = pro_uid

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -1051,18 +1051,27 @@ def test_281_comando_explicito_vence_a_pergunta_de_nome(uid):
 
 
 def test_281_verbo_de_deposito_nao_vira_saque(uid):
-    """O exemplo do comentário da issue: GUARDEI nas duas mensagens, e a
-    segunda virava SAQUE. É a mesma causa por um `falta` diferente."""
-    _caixinhas_com_saldo(uid, "viagem")
+    """GUARDEI virando SAQUE — o sentido do dinheiro invertido.
 
-    respostas = _conversa(uid, "guardei na caixinha viagem",
-                          "guardei 100 na caixinha viagem")
+    O caminho medido na `main` (1fff16f) É a pergunta de VALOR, não a de nome:
+    `guardei na caixinha viagem` + `guardei 100 na caixinha viagem` já
+    DEPOSITA na `main` (medido — a primeira redação deste teste era
+    tautológica e o controle negativo a pegou). O que ainda invertia é a
+    resposta à pergunta de VALOR de um saque:
 
-    assert "Qual caixinha" in respostas[0], respostas[0]
+        tirar da caixinha viagem / viagem  -> "Qual o valor?"
+        guardei 100 na caixinha viagem     -> 📤 -R$ 100,00   (main)
+                                           -> ✅ +R$ 100,00   (aqui)
+    """
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "guardei 100 na caixinha viagem")
+
     assert _saldos(uid)["viagem"] == 400.00, \
-        f"o usuário disse GUARDEI e a caixinha não subiu: {respostas[-1]!r}"
+        f"o usuário disse GUARDEI e a caixinha caiu: {respostas[-1]!r}"
     assert round(float(db.get_balance(uid)), 2) == 0.00, \
         "conta = 100 do setup - 100 depositados"
+    assert _despesas(uid) == [], respostas[-1]
 
 
 @pytest.mark.parametrize("resposta,saque", [

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -149,7 +149,6 @@ def test_deposito_legitimo_ainda_funciona(uid):
     "viagem",                            # nome pelado
     "caixinha viagem",                   # repete o substantivo da pergunta
     "da caixinha viagem",                # com preposição
-    "coloquei 200 na caixinha viagem",   # o comando COMPLETO que a pergunta sugere
 ])
 def test_resposta_natural_ao_nome_da_caixinha(uid, resposta):
     """A pergunta sugere "Tente: *coloquei 200 na caixinha viagem*" — recusar esse
@@ -181,10 +180,39 @@ def test_saque_com_comando_completo_como_resposta(uid):
         categoria="salário", is_internal_movement=False,
     )
     _conversa(uid, "criar caixinha viagem", "coloquei 300 na caixinha viagem")
-    _conversa(uid, "tirar da caixinha viagem", "retirei 100 da caixinha viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "tirar da caixinha viagem", "retirei 100 da caixinha viagem", "1")
 
     pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
     assert pockets.get("viagem") == 200.00, "o saque de 100 sobre 300 não fechou"
+
+
+def test_comando_completo_sugerido_passa_pelo_desempate(uid):
+    """O comando COMPLETO que a própria pergunta sugere ("Tente: *coloquei 200
+    na caixinha viagem*") é valor + alvo — célula D8 do #281 —, então ele PASSA
+    pelo desempate antes de fechar.
+
+    CUSTO DECLARADO: o bot pede um turno a mais para o texto que ele mesmo
+    recomendou. Vale a pena porque a alternativa é a classe do #189 (o mesmo
+    texto respondendo a uma pergunta de SAQUE movia dinheiro no sentido
+    errado), e porque perguntar nunca escreve. Com o "1", o depósito fecha
+    exatamente como antes."""
+    db.add_launch_and_update_balance(
+        uid, "receita", 500.0, alvo="salário", nota="setup",
+        categoria="salário", is_internal_movement=False,
+    )
+    respostas = _conversa(uid, "criar caixinha viagem",
+                          "guardei na caixinha viagem",
+                          "coloquei 200 na caixinha viagem")
+
+    assert "1️⃣" in respostas[-1], respostas[-1]
+    respostas += _conversa(uid, "1")
+
+    pockets = {p["name"]: float(p["balance"]) for p in (db.list_pockets(uid) or [])}
+    assert pockets.get("viagem") == 200.00, respostas[-2:]
+    assert _despesas(uid) == []
 
 
 def test_nome_do_alvo_preserva_nome_legitimo():
@@ -575,7 +603,11 @@ def test_186_alvo_da_resposta_vence_o_guardado(uid, sem_teto_de_caixinha):
     OUTRA caixinha e o bot debitava a guardada."""
     _duas_caixinhas(uid)
 
-    _conversa(uid, "tirar da caixinha carro", "carro", "retirei 100 da caixinha viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "tirar da caixinha carro", "carro",
+              "retirei 100 da caixinha viagem", "1")
 
     p = _saldos(uid)
     assert p["viagem"] == 200.00, "não saiu da caixinha que o usuário nomeou"
@@ -586,19 +618,18 @@ def test_alvo_fora_do_catalogo_nao_sobrescreve(uid, sem_teto_de_caixinha):
     """CONTROLE do portão: "explícito" não é o mesmo que "existente".
 
     O #281 mudou o CAMINHO e manteve o que este teste protege — o dinheiro do
-    `carro`. `retirei 100 do salario` tem verbo próprio (`pockets.withdraw`
-    0.95), então a via EXPLÍCITO abandona a pergunta e o comando roda sozinho;
-    como `salario` não existe, ele erra e nada se move. Medido:
-    "Não encontrei *salario* nem em caixinhas nem em investimentos".
+    `carro`. `retirei 100 do salario` é valor + alvo (célula D8), então a porta
+    PERGUNTA; com o "2" o comando roda sozinho e, como `salario` não existe,
+    ele erra e nada se move. Medido: "Não encontrei *salario* nem em caixinhas
+    nem em investimentos".
 
-    Antes o resolver caía no alvo guardado e sacava R$ 100 do `carro`. É uma
-    troca deliberada e do lado seguro (não move dinheiro de caixinha que a
-    mensagem não nomeou, que é a direção da #186), mas custa um turno e é
-    TETO declarado do PR A."""
+    Antes o resolver caía no alvo guardado e sacava R$ 100 do `carro` sem que
+    ninguém tivesse escolhido isso. Agora quem escolhe é o usuário: o turno a
+    mais deixou de ser teto e virou a pergunta de desempate."""
     _duas_caixinhas(uid)
 
     respostas = _conversa(uid, "tirar da caixinha carro", "carro",
-                          "retirei 100 do salario")
+                          "retirei 100 do salario", "2")
 
     assert "Não encontrei" in respostas[-1], respostas[-1]
     assert _saldos(uid) == {"carro": 300.00, "viagem": 300.00}, \
@@ -611,7 +642,11 @@ def test_nota_do_lancamento_nao_cita_o_alvo_velho(uid, sem_teto_de_caixinha):
     envenena os três."""
     _duas_caixinhas(uid)
 
-    _conversa(uid, "tirar da caixinha carro", "carro", "retirei 100 da caixinha viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "tirar da caixinha carro", "carro",
+              "retirei 100 da caixinha viagem", "1")
 
     saque = next(l for l in db.list_launches(uid, limit=20)
                  if l.get("tipo") == "saque_caixinha")
@@ -642,7 +677,10 @@ def test_tudo_guardado_mais_quantia_nova_nao_esvazia(uid):
         categoria="salário", is_internal_movement=False)
     _conversa(uid, "criar caixinha viagem", "coloquei 300 na caixinha viagem")
 
-    _conversa(uid, "esvaziar caixinha", "tira 100 da viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "esvaziar caixinha", "tira 100 da viagem", "1")
 
     assert _saldos(uid)["viagem"] == 200.00, "esvaziou apesar de o usuário ter dito 100"
 
@@ -685,7 +723,10 @@ def test_p1a_quantia_da_resposta_nao_e_religada_pelo_orig_text(uid):
     _caixinhas_com_saldo(uid, "viagem")
 
     _pergunta_injetada(uid, "funds.withdraw", {}, "esvaziar")
-    _conversa(uid, "tira 100 da viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "tira 100 da viagem", "1")
 
     assert _saldos(uid)["viagem"] == 200.00, "esvaziou apesar do R$ 100 da resposta"
 
@@ -708,7 +749,10 @@ def test_p1b_nome_com_marcador_nao_esvazia_pela_conversa(uid):
     o marcador estava dentro do NOME, não na quantidade."""
     _caixinhas_com_saldo(uid, "zerar divida")
 
-    _conversa(uid, "tirar da caixinha", "tira 100 da zerar divida")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "tirar da caixinha", "tira 100 da zerar divida", "1")
 
     assert _saldos(uid)["zerar divida"] == 200.00, "o nome da caixinha virou 'esvaziar'"
 
@@ -737,7 +781,10 @@ def test_p1c_caixinha_aninhada_pela_conversa(uid, sem_teto_de_caixinha):
     saía da caixinha errada."""
     _caixinhas_com_saldo(uid, "viagem", "minha viagem")
 
-    _conversa(uid, "tirar da caixinha viagem", "tira 100 da minha viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "tirar da caixinha viagem", "tira 100 da minha viagem", "1")
 
     p = _saldos(uid)
     assert p["minha viagem"] == 200.00, "não saiu da caixinha que o usuário nomeou"
@@ -826,7 +873,10 @@ def test_p3_nota_nao_mente_quando_nao_havia_alvo_guardado(uid):
     "esvaziar caixinha"."""
     _caixinhas_com_saldo(uid, "viagem")
 
-    _conversa(uid, "esvaziar caixinha", "tira 100 da viagem")
+    # O "1" é o desempate do #281: valor + alvo na mesma mensagem é AMBÍGUO
+    # (célula D8), e "era a resposta" devolve o turno ao resolver — que é o que
+    # este teste mede.
+    _conversa(uid, "esvaziar caixinha", "tira 100 da viagem", "1")
 
     saque = next(l for l in db.list_launches(uid, limit=20)
                  if l.get("tipo") == "saque_caixinha")
@@ -949,7 +999,7 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
         "sacou sem que o valor fosse dito"
 
 
-# ── #281: o verbo da resposta entra na decisão (PR A de 2) ──────────────────
+# ── #281: a TABELA das 16 células, pela conversa ────────────────────────────
 #
 # P0 de dinheiro confirmado em produção (#189, fechada com os dados). Com uma
 # pergunta de handler viva, o resolver lia número e alvo da resposta e NUNCA o
@@ -957,68 +1007,74 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 # errado, despesa não registrada) e `guardei 100 na caixinha viagem` virava
 # saque (o usuário disse GUARDEI).
 #
-# A REGRA DO DONO, e o que este PR A faz de cada linha dela:
-#   comando explícito vence     -> via EXPLÍCITO (`ESCRITA` + não-só-o-valor
-#                                  + não começa por valor). FEITO aqui.
-#   resposta compatível vence   -> portão `_so_o_valor`. FEITO aqui.
-#   atalho ambíguo não escreve  -> `50 no mercado` cai em COMPATÍVEL, que é o
-#                                  comportamento de HOJE. É o PR B, com a
-#                                  pergunta de desempate.
-# O predicado inteiro mora em `_clarification_abandonada`; a tabela de unidade
-# input -> via está em `tests/test_bill_amount_pending.py` (§0.7 — não repetir).
+# A REGRA DO DONO, e o QUINTO SINAL que a fecha (`core/intent_router.py`,
+# `_quantidade_fecha`): **a quantidade é a última coisa da mensagem?**
+#   fecha  -> a mensagem é RESPOSTA         -> resolve a pergunta
+#   sobrou -> a mensagem é AMBÍGUA          -> PERGUNTA, e ninguém escreve
+# O que o classificador ainda decide são duas células: o intent de LEITURA
+# (`ABANDONA`) e o comando SEM quantidade (`COMANDO_SEM_QUANTIDADE`).
 #
-# CONTROLES NEGATIVOS — quatro, MEDIDOS um a um (contagem sobre
-# `test_perguntas_guardam_contexto.py` + `test_bill_amount_pending.py` +
-# `test_full_handler_smoke.py`, os três arquivos da porta 2):
+# A TABELA — R resolve · A abandona · ? pergunta (não escreve). Uma célula, um
+# teste, e esta é a única cópia dela no repositório (§0.7):
 #
-#   1. remover o ramo `if intent_da_resposta in ESCRITA and not _so_o_valor`
-#      -> 6 vermelhos, entre eles
-#         test_281_comando_explicito_vence_a_pergunta_de_valor
-#         test_281_comando_explicito_vence_a_pergunta_de_nome
-#         test_281_verbo_de_deposito_nao_vira_saque
-#   2. tirar o portão (`if intent_da_resposta in ESCRITA` sozinho)
-#      -> 12 vermelhos, TODOS da família `paguei …`
-#         (test_clarification_dano_nao_some_com_palavra_na_frente ×9,
-#          test_clarification_aceita_tudo_que_a_main_aceita ×2,
-#          test_porta_2_ponto_final_sem_virgula_registra ×1).
-#      MEDIDO, e não é o que se esperava: `100 reais` NÃO fica vermelho aqui —
-#      quem o segura é o `_STARTS_WITH_VALUE_RE`, não o `_so_o_valor`. O que o
-#      `_so_o_valor` segura sozinho é o VERBO sem alvo.
-#   3. trocar o `_SEM_CONTEUDO` pelo `_ENCHIMENTO_PALAVRAS` (tirar os 12 verbos
-#      do prefixo sem conteúdo) -> 19 vermelhos, incluindo o filtro de dano
-#      inteiro.
-#   4. tirar o `_STARTS_WITH_VALUE_RE`
-#      -> 1 vermelho: test_281_ambiguo_ainda_responde_a_pergunta.
-#      O plano previa que ele NÃO discriminasse no PR A; discrimina — sem ele
-#      `50 no mercado` (launches.add 0.95, não é só-o-valor) abandona.
+#   A0  LEITURA               saldo, extrato                       A
+#   B0  NEUTRO                132, cem, tudo, ok, retirei tudo     R
+#   C1  comando sem quantia   fatura, meus cartoes, criar caixinha A
+#   C2/C3 idem COM quantia    fatura 132, fatura tudo              R
+#   D1  verbo puro            gastei, paguei, recebi               R
+#   D2  cauda sem número      gastei o resto, gastei metade        R
+#   D3  cauda alvo sem número gastei no mercado                    R
+#   D4a TUDO no fim           gastei tudo, gastei quase tudo       R
+#   D4b TUDO com cauda        gastei tudo mesmo                    ?
+#   D5  TUDO + alvo           esvaziar caixinha                    ?
+#   D6  número no fim         paguei 132, saquei 100, investi 100  R
+#   D7  número + cauda        paguei 132 ok / hoje / no debito     ?
+#   D8  número + alvo         gastei 50 no mercado                 ?
+#   D9  valor perigoso        paguei, 132 50 / gastei -10          R
+#   D10 pontuação de prosa    paguei 132,50. foi isso              R
+#   D11 começa pelo valor     50 no mercado, 132 ok, 100 reais     R
 #
-# E a guarda de entrega tem o dela em `test_bill_amount_pending.py`: removê-la
-# deixa 2 vermelhos, os dois medindo R$ 13.250,00 no lugar de R$ 132,50.
+# D9 e D10 são medidos em `tests/test_bill_amount_pending.py`, onde moram as
+# duas guardas que os produzem (o filtro de dano e a guarda de entrega).
+#
+# CADA TESTE AFIRMA TRÊS COISAS, e a terceira é a que faltava por três rodadas:
+# o saldo da caixinha e da conta; que não nasceu despesa avulsa; e o que
+# aconteceu com a PENDÊNCIA. Um teste que só olha saldo passa igual quando a
+# pergunta MORRE levando o dinheiro junto — foi assim que `gastei` escapou.
+#
+# CONTROLES NEGATIVOS do grupo, MEDIDOS um a um nesta árvore (os números estão
+# no relato do PR #288; remedir antes de reusar):
+#   1. esvaziar o `COMANDO_SEM_QUANTIDADE`
+#      -> test_281_c1_comando_sem_quantidade_abandona vermelho (3 casos).
+#   2. trocar o `return "pergunta"` por `"resolve"` (desligar o desempate)
+#      -> test_281_quantidade_com_cauda_nao_escreve vermelho em D5/D7/D8, e os
+#         três testes do desempate junto.
+#   3. desligar o quinto sinal (toda quantidade vira `"pergunta"`)
+#      -> test_281_quantidade_que_fecha_e_resposta vermelho em D4a e D6.
+# CONTROLE POSITIVO: test_281_resposta_compativel_nunca_vira_lancamento —
+# `100 reais`, `cem`, `132,50`, `R$ 100`, `30 reais e 50 centavos` e `tudo`
+# continuam fechando o saque. Sem ele o grupo passaria num código que recusa
+# tudo, que é pior que o bug.
 #
 # CLASSE CEGA (a mesma do #185): o LLM está fora dos testes, então o
 # `classify_with_context` nunca roda e os payloads de caixinha/investimento que
 # carregam `amount` só são alcançáveis por ele. A rota determinística provada
 # aqui é a `funds.withdraw`.
 #
-# TRÊS TETOS, medidos, e todos escritos também no código:
+# TETOS, medidos, e todos escritos também no código:
 #
 #   1. o verbo que os tiers 1-2 não conhecem continua sequestrado — `poupei
 #      100`, `mercado 50`, `uber 25`, `gasteii 50 no mercado` e `gasto fixo
-#      aluguel 1200` são todos `out_of_scope 0.0`, então não entram no
-#      `ESCRITA`. A porta 2 roda `allow_ai=False` de propósito (ver
+#      aluguel 1200` são todos `out_of_scope 0.0`. Como B0, eles resolvem a
+#      pergunta. A porta 2 roda `allow_ai=False` de propósito (ver
 #      `abandona_pergunta_de_valor`).
-#   2. os 12 verbos de lançamento com valor e MAIS NADA (`paguei 132`,
-#      `gastei 132`) NÃO abandonam: eles são prefixo sem conteúdo. Não é
-#      esquecimento — medido, tratá-los como comando novo pula o
-#      `valor_perigoso` e faz `paguei 132 50` registrar R$ 13.250,00. A
-#      justificativa mora no `_SO_O_VALOR_RE`, com os quatro números.
-#   3. verbo de OUTRA operação com valor e nada mais (`investi 80`,
-#      `saquei 200`, `retirei 100 do salario`) ABANDONA, e quando o alvo não
-#      existe o usuário paga um turno — o comando erra e nada se move. É a
-#      regra do dono aplicada; prendem este teto
-#      `test_alvo_fora_do_catalogo_nao_sobrescreve` (aqui) e
-#      `test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando`
-#      (em `tests/test_full_handler_smoke.py`).
+#   2. a UNIDADE conta como cauda: `paguei 100 reais` PERGUNTA (custa um turno,
+#      nunca dinheiro), enquanto `paguei 2 mil` resolve — "mil" é valor para o
+#      `_extract_valor` e "reais" não. É o preço de não ter lista de cauda.
+#   3. `gastei tudo mesmo` PERGUNTA em vez de esvaziar. Decisão do dono, e é a
+#      única linha que saiu da tabela anterior: esvaziar zera a caixinha
+#      inteira, e o lado seguro de uma operação irreversível é o que não
+#      escreve.
 
 
 def _pergunta_de_valor(uid):
@@ -1031,14 +1087,158 @@ def _pergunta_de_valor(uid):
     assert "Qual o valor" in respostas[-1], respostas[-1]
 
 
-def test_281_comando_explicito_vence_a_pergunta_de_valor(uid):
-    """O caso do título da issue, com os números medidos em produção.
+def _nada_se_moveu(uid, resposta):
+    """As duas primeiras afirmações: caixinha, conta e nenhuma despesa avulsa."""
+    assert _saldos(uid)["viagem"] == 300.00, resposta
+    assert round(float(db.get_balance(uid)), 2) == 100.00, resposta
+    assert _despesas(uid) == [], f"virou lançamento: {resposta!r}"
+
+
+@pytest.mark.parametrize("celula,resposta,saque", [
+    ("B0", "132", 132.00),
+    ("B0", "cem", 100.00),
+    ("B0", "tudo", 300.00),
+    ("B0", "retirei tudo", 300.00),
+    ("C2", "fatura 132", 132.00),
+    ("C3", "fatura tudo", 300.00),
+    ("D4a", "gastei tudo", 300.00),
+    ("D4a", "gastei quase tudo", 300.00),
+    ("D6", "paguei 132", 132.00),
+    ("D6", "saquei 100", 100.00),
+    ("D6", "investi 100", 100.00),
+])
+def test_281_quantidade_que_fecha_e_resposta(uid, celula, resposta, saque):
+    """B0, C2/C3, D4a e D6: a quantidade fecha a mensagem, então ela É a
+    resposta — mesmo com verbo na frente (`paguei 132`), com comando na frente
+    (`fatura 132`) ou com o marcador de tudo no lugar do número.
+
+    `investi 100` e `saquei 100` uniformizam a assimetria que sobrava: eram
+    comando (abandonavam, e o saque de R$ 100 se perdia quando o alvo não
+    existia); agora são resposta, como `paguei 132` sempre foi."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, resposta)
+
+    assert _saldos(uid)["viagem"] == round(300.00 - saque, 2), \
+        f"{celula}: a resposta não fechou o saque: {respostas[-1]!r}"
+    assert round(float(db.get_balance(uid)), 2) == round(100.00 + saque, 2)
+    assert _despesas(uid) == [], f"{celula}: virou lançamento: {respostas[-1]!r}"
+    assert db.get_pending_action(uid) is None, "a pergunta tinha de ser consumida"
+
+
+@pytest.mark.parametrize("celula,resposta", [
+    ("D1", "gastei"), ("D1", "paguei"), ("D1", "recebi"),
+    ("D2", "gastei o resto"), ("D2", "gastei metade"),
+    ("D3", "gastei no mercado"), ("D3", "guardei na caixinha viagem"),
+])
+def test_281_sem_quantidade_a_pergunta_continua_viva(uid, celula, resposta):
+    """D1, D2 e D3: sem quantidade nenhuma o comando não teria como rodar — só
+    faria a própria pergunta, com a palavra do usuário no lugar do alvo
+    ("🐷 Quanto foi no *metade*?"), que é a classe do
+    `test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta`.
+
+    A TERCEIRA afirmação é a que discrimina: sem ela este teste passa igual
+    quando a pergunta morre e o saque de R$ 300 evapora."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, resposta)
+
+    _nada_se_moveu(uid, respostas[-1])
+    assert db.get_pending_action(uid) is not None, \
+        f"{celula}: a pergunta morreu levando o saque: {respostas[-1]!r}"
+    assert "Qual o valor" in respostas[-1], respostas[-1]
+    assert "*metade*" not in respostas[-1] and "*resto*" not in respostas[-1], \
+        f"{celula}: a palavra do usuário virou alvo: {respostas[-1]!r}"
+
+
+@pytest.mark.parametrize("resposta,marca", [
+    ("fatura", "cart"),
+    ("meus cartoes", "cart"),
+    # `carro`, não `viagem`: a caixinha da pergunta já existe, e "já existe"
+    # não distingue "o comando rodou" de "o comando foi engolido". A fixture é
+    # o teto do plano Grátis (uma caixinha), não parte do que se mede aqui.
+    ("criar caixinha carro", "carro"),
+])
+def test_281_c1_comando_sem_quantidade_abandona(uid, sem_teto_de_caixinha,
+                                                resposta, marca):
+    """C1, o ÚNICO abandono novo. `fatura` sem quantidade nenhuma não pode ser
+    resposta de "Qual o valor?" — e, ao contrário do verbo de lançamento, o
+    comando RODA sozinho (mostra a fatura, cria a caixinha).
+
+    Era um laço indefinido medido: a pergunta voltava ("Quanto foi no *luz*?")
+    e a pendência era RE-ARMADA a cada turno, então nunca expirava."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, resposta)
+
+    _nada_se_moveu(uid, respostas[-1])
+    assert db.get_pending_action(uid) is None, \
+        f"a pergunta sobreviveu ao comando: {respostas[-1]!r}"
+    assert marca in respostas[-1].lower(), \
+        f"o comando não rodou: {respostas[-1]!r}"
+
+
+@pytest.mark.parametrize("celula,resposta", [
+    ("D4b", "gastei tudo mesmo"),
+    ("D5", "esvaziar caixinha"),
+    ("D5", "guardei tudo na caixinha viagem"),
+    ("D7", "paguei 132 ok"),
+    ("D7", "paguei 132 hoje"),
+    ("D7", "paguei 132 no debito"),
+    ("D8", "gastei 50 no mercado"),
+    ("D8", "guardei 100 na caixinha viagem"),
+])
+def test_281_quantidade_com_cauda_nao_escreve(uid, celula, resposta):
+    """D4b, D5, D7 e D8: sobrou cauda depois da quantidade, então a mensagem
+    pode ser as duas coisas — e AMBÍGUO NÃO ESCREVE, nem o valor na pergunta
+    viva nem o comando novo. O turno acaba com as duas opções na tela.
+
+    É aqui que mora a decisão do dono sobre `gastei tudo mesmo`: perguntar
+    custa um turno, esvaziar por engano custa a caixinha inteira."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, resposta)
+
+    _nada_se_moveu(uid, respostas[-1])
+    pend = db.get_pending_action(uid)
+    assert pend and pend["action_type"] == "value_or_command_choice", \
+        f"{celula}: o desempate não foi armado: {pend}"
+    # A pergunta original não se perdeu: ela viaja DENTRO do payload e aparece
+    # na opção 1 (`pending_actions` é uma linha por usuário).
+    assert pend["payload"]["clarif"].get("question"), pend
+    assert "Qual o valor" in respostas[-1], respostas[-1]
+    assert resposta in respostas[-1], respostas[-1]
+
+
+# ── O desempate: três saídas, e a quarta que desembrulha ─────────────────────
+# Zero transições novas — `1` volta ao payload original e resolve com o texto
+# guardado, `2` roteia o texto como comando novo, e qualquer outra coisa
+# devolve a pergunta para a linha e reentra na tabela com a mensagem NOVA.
+
+@pytest.mark.parametrize("escolha", ["1", "responder"])
+def test_281_desempate_1_era_o_valor(uid, escolha):
+    """`gastei 50 no mercado` + "era o valor" = o saque de R$ 50 que a pergunta
+    pedia. O texto guardado volta a ser lido como resposta."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "gastei 50 no mercado", escolha)
+
+    assert _saldos(uid)["viagem"] == 250.00, respostas[-1]
+    assert round(float(db.get_balance(uid)), 2) == 150.00, respostas[-1]
+    assert _despesas(uid) == [], respostas[-1]
+    assert db.get_pending_action(uid) is None, "a linha ficou presa"
+
+
+@pytest.mark.parametrize("escolha", ["2", "registrar"])
+def test_281_desempate_2_o_comando_explicito_vence(uid, escolha):
+    """O caso do TÍTULO da issue, com os números medidos em produção — um turno
+    depois, e só quando o usuário confirma.
 
     Antes: `📤 Caixinha *viagem*: -R$ 50,00`, conta SOBE 50 e a despesa não
     existe. Depois: despesa de 50, conta CAI 50, caixinha intacta."""
     _pergunta_de_valor(uid)
 
-    respostas = _conversa(uid, "gastei 50 no mercado")
+    respostas = _conversa(uid, "gastei 50 no mercado", escolha)
 
     assert _saldos(uid)["viagem"] == 300.00, \
         f"o gasto saiu da caixinha em vez da conta: {respostas[-1]!r}"
@@ -1046,45 +1246,85 @@ def test_281_comando_explicito_vence_a_pergunta_de_valor(uid):
         "a conta tinha de CAIR 50 (100 -> 50), não subir para 150"
     assert [round(float(d["valor"]), 2) for d in _despesas(uid)] == [50.00], \
         f"o gasto sumiu do extrato: {respostas[-1]!r}"
+    # O desempate saiu da linha. O que fica lá é a oferta de recategorização do
+    # lançamento novo, que é do fluxo normal de `launches.add`.
+    pend = db.get_pending_action(uid)
+    assert (pend or {}).get("action_type") != "value_or_command_choice", pend
 
 
-def test_281_comando_explicito_vence_a_pergunta_de_nome(uid):
-    """A pergunta de NOME fecha de graça: o portão roda no `route()`, ANTES de
-    `payload["falta"]` ser lido, então não há ramo próprio para ela."""
-    _caixinhas_com_saldo(uid, "viagem")
-
-    respostas = _conversa(uid, "tirar da caixinha viagem", "gastei 50 no mercado")
-
-    assert "Qual caixinha" in respostas[0], respostas[0]
-    assert _saldos(uid)["viagem"] == 300.00, respostas[-1]
-    assert round(float(db.get_balance(uid)), 2) == 50.00, \
-        "conta = 100 do setup - 50 da despesa"
-    assert [round(float(d["valor"]), 2) for d in _despesas(uid)] == [50.00], \
-        f"a despesa não foi registrada: {respostas[-1]!r}"
-
-
-def test_281_verbo_de_deposito_nao_vira_saque(uid):
-    """GUARDEI virando SAQUE — o sentido do dinheiro invertido.
-
-    O caminho medido na `main` (1fff16f) É a pergunta de VALOR, não a de nome:
-    `guardei na caixinha viagem` + `guardei 100 na caixinha viagem` já
-    DEPOSITA na `main` (medido — a primeira redação deste teste era
-    tautológica e o controle negativo a pegou). O que ainda invertia é a
-    resposta à pergunta de VALOR de um saque:
-
-        tirar da caixinha viagem / viagem  -> "Qual o valor?"
-        guardei 100 na caixinha viagem     -> 📤 -R$ 100,00   (main)
-                                           -> ✅ +R$ 100,00   (aqui)
-    """
+def test_281_desempate_2_verbo_de_deposito_nao_vira_saque(uid):
+    """GUARDEI virando SAQUE — o sentido do dinheiro invertido, que é o outro
+    lado do P0. Na `main` (1fff16f) `guardei 100 na caixinha viagem`
+    respondendo "Qual o valor?" DEBITAVA a caixinha; aqui ele deposita, depois
+    de o usuário dizer que era comando."""
     _pergunta_de_valor(uid)
 
-    respostas = _conversa(uid, "guardei 100 na caixinha viagem")
+    respostas = _conversa(uid, "guardei 100 na caixinha viagem", "2")
 
     assert _saldos(uid)["viagem"] == 400.00, \
         f"o usuário disse GUARDEI e a caixinha caiu: {respostas[-1]!r}"
     assert round(float(db.get_balance(uid)), 2) == 0.00, \
         "conta = 100 do setup - 100 depositados"
     assert _despesas(uid) == [], respostas[-1]
+
+
+def test_281_desempate_cancela_mata_as_duas(uid):
+    """O cancelamento mata o texto pendurado E a pergunta que ele desalojou.
+
+    A palavra oferecida é *cancela*, não *cancelar*, e é medição: com QUALQUER
+    pendência determinística de pé, "cancelar" nunca chega ao `route()` — o
+    `handle_billing_command` (core/services/billing_commands.py:296) responde
+    "🐷 Você tá no plano Free, não tem o que cancelar" porque a guarda dele olha
+    o `ai_pending_actions` e não o `pending_actions`. Hole PRÉ-EXISTENTE (vale
+    igual para a confirmação de delete que o comentário de lá diz proteger) e
+    não consertado neste PR."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "gastei 50 no mercado", "cancela")
+
+    _nada_se_moveu(uid, respostas[-1])
+    assert "ancelado" in respostas[-1], respostas[-1]
+    assert db.get_pending_action(uid) is None, \
+        f"o cancelamento deixou uma linha viva: {db.get_pending_action(uid)}"
+
+
+def test_281_desempate_a_palavra_cancelar_nao_perde_nada(uid):
+    """O outro lado do hole: quem digitar *cancelar* recebe a resposta do
+    billing, e o desempate continua de pé — nada se move e nenhuma opção se
+    perde. É o que torna o hole barato o bastante para ficar para outro PR."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "gastei 50 no mercado", "cancelar")
+
+    _nada_se_moveu(uid, respostas[-1])
+    pend = db.get_pending_action(uid)
+    assert pend and pend["action_type"] == "value_or_command_choice", pend
+
+
+def test_281_desempate_terceira_coisa_reentra_na_tabela(uid):
+    """Uma TERCEIRA mensagem desembrulha o desempate e reentra na tabela com a
+    mensagem nova: `132` fecha a quantidade, então é a resposta da pergunta
+    original, que voltou para a linha. O texto guardado é descartado."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "gastei 50 no mercado", "132")
+
+    assert _saldos(uid)["viagem"] == 168.00, respostas[-1]
+    assert round(float(db.get_balance(uid)), 2) == 232.00, respostas[-1]
+    assert _despesas(uid) == [], respostas[-1]
+
+
+def test_281_desempate_terceira_coisa_pode_abandonar(uid):
+    """A mesma porta, do outro lado: `saldo` é LEITURA (A0), então a pergunta
+    que acabou de voltar para a linha é abandonada como sempre foi — o
+    desempate não criou estado do qual não se sai."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "gastei 50 no mercado", "saldo")
+
+    _nada_se_moveu(uid, respostas[-1])
+    assert "Conta Corrente" in respostas[-1], respostas[-1]
+    assert db.get_pending_action(uid) is None, db.get_pending_action(uid)
 
 
 @pytest.mark.parametrize("resposta,saque", [
@@ -1102,11 +1342,10 @@ def test_281_resposta_compativel_nunca_vira_lancamento(uid, resposta, saque):
     0.95 — os mesmos 0.95 de `gastei 50 no mercado`; `cem`, `132,50` e `tudo`
     caem em `out_of_scope 0.0`. Nenhum deles pode virar lançamento.
 
-    MEDIDO, e corrige o que se supunha: destes seis, os que dependem de um
-    portão dependem do `_STARTS_WITH_VALUE_RE` (começam por dígito), não do
-    `_so_o_valor` — desligar o `_so_o_valor` não deixa nenhuma linha daqui
-    vermelha. Quem o `_so_o_valor` segura sozinho é o verbo sem alvo
-    (`paguei 132`), e isso se mede em `test_full_handler_smoke.py`."""
+    MEDIDO: `100 reais`, `132,50`, `R$ 100` e `30 reais e 50 centavos` são
+    seguros pelo `_STARTS_WITH_VALUE_RE` (célula D11 — começam por dígito);
+    `cem` e `tudo` pelo quinto sinal, que os lê como quantidade que fecha a
+    mensagem."""
     _pergunta_de_valor(uid)
 
     respostas = _conversa(uid, resposta)
@@ -1131,17 +1370,33 @@ def test_281_resposta_compativel_grande_demais_nao_vira_lancamento(uid):
 
 
 def test_281_ambiguo_ainda_responde_a_pergunta(uid):
-    """O ATALHO sem verbo é o PR B, e este teste é o marcador dele.
+    """D11 — e a decisão medida de NÃO mandar esta célula ao desempate.
 
     `50 no mercado` classifica `launches.add` 0.95 igual a `gastei 50 no
-    mercado`, mas COMEÇA pelo valor (`_STARTS_WITH_VALUE_RE`) — pode ser o
-    gasto, pode ser "50, do mercado" respondendo a pergunta. No PR A ele cai
-    em COMPATÍVEL, que é o comportamento de HOJE: saque de 50, sem despesa.
-    Quando a pergunta de desempate do PR B chegar, é esta linha que fica
-    vermelha, de propósito."""
+    mercado` e tem cauda depois do número, então pelo quinto sinal sozinho ele
+    perguntaria. Começar pelo VALOR vem antes de propósito: é a forma de
+    `100 reais` e de `30 reais e 50 centavos`, que são resposta legítima —
+    mandá-las ao desempate cobraria um turno da resposta mais comum de todas.
+    Saque de 50, sem despesa, como hoje."""
     _pergunta_de_valor(uid)
 
     respostas = _conversa(uid, "50 no mercado")
 
     assert _saldos(uid)["viagem"] == 250.00, respostas[-1]
+    assert _despesas(uid) == [], respostas[-1]
+
+
+def test_281_c2_quantidade_grande_no_comando_nao_cria_a_caixinha(uid):
+    """C2 pelo outro lado: `criar caixinha 2028` respondendo "Qual o valor?" é
+    lido como VALOR (2028 fecha a mensagem), e 2028 > 300 — então o saque é
+    recusado pelo saldo e a caixinha `2028` NÃO nasce. É o teto declarado do
+    `_resolve_clarification`: caixinha chamada "2028" respondida a uma pergunta
+    de valor é lida como valor."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "criar caixinha 2028")
+
+    assert "insuficiente" in respostas[-1].lower(), respostas[-1]
+    assert sorted(_saldos(uid)) == ["viagem"], \
+        f"o comando rodou em vez de responder: {_saldos(uid)}"
     assert _despesas(uid) == [], respostas[-1]

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -583,14 +583,26 @@ def test_186_alvo_da_resposta_vence_o_guardado(uid, sem_teto_de_caixinha):
 
 
 def test_alvo_fora_do_catalogo_nao_sobrescreve(uid, sem_teto_de_caixinha):
-    """CONTROLE do portão: "explícito" não é o mesmo que "existente". Sem o
-    catálogo, `salario` sobrescreveria a caixinha certa e o usuário receberia
-    "não encontrada" no lugar de um saque perfeitamente executável."""
+    """CONTROLE do portão: "explícito" não é o mesmo que "existente".
+
+    O #281 mudou o CAMINHO e manteve o que este teste protege — o dinheiro do
+    `carro`. `retirei 100 do salario` tem verbo próprio (`pockets.withdraw`
+    0.95), então a via EXPLÍCITO abandona a pergunta e o comando roda sozinho;
+    como `salario` não existe, ele erra e nada se move. Medido:
+    "Não encontrei *salario* nem em caixinhas nem em investimentos".
+
+    Antes o resolver caía no alvo guardado e sacava R$ 100 do `carro`. É uma
+    troca deliberada e do lado seguro (não move dinheiro de caixinha que a
+    mensagem não nomeou, que é a direção da #186), mas custa um turno e é
+    TETO declarado do PR A."""
     _duas_caixinhas(uid)
 
-    _conversa(uid, "tirar da caixinha carro", "carro", "retirei 100 do salario")
+    respostas = _conversa(uid, "tirar da caixinha carro", "carro",
+                          "retirei 100 do salario")
 
-    assert _saldos(uid)["carro"] == 200.00, "o alvo inexistente atropelou o guardado"
+    assert "Não encontrei" in respostas[-1], respostas[-1]
+    assert _saldos(uid) == {"carro": 300.00, "viagem": 300.00}, \
+        "o alvo inexistente atropelou o guardado"
 
 
 def test_nota_do_lancamento_nao_cita_o_alvo_velho(uid, sem_teto_de_caixinha):
@@ -935,3 +947,159 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
     assert "Conta Corrente" in respostas[-1], respostas[-1]
     assert _saldos(uid) == {"viagem": 300.00, "saldo": 300.00}, \
         "sacou sem que o valor fosse dito"
+
+
+# ── #281: o verbo da resposta entra na decisão (PR A de 2) ──────────────────
+#
+# P0 de dinheiro confirmado em produção (#189, fechada com os dados). Com uma
+# pergunta de handler viva, o resolver lia número e alvo da resposta e NUNCA o
+# verbo: `gastei 50 no mercado` virava saque de caixinha (dinheiro no sentido
+# errado, despesa não registrada) e `guardei 100 na caixinha viagem` virava
+# saque (o usuário disse GUARDEI).
+#
+# A REGRA DO DONO, e o que este PR A faz de cada linha dela:
+#   comando explícito vence     -> via EXPLÍCITO (`ESCRITA` + não-só-o-valor
+#                                  + não começa por valor). FEITO aqui.
+#   resposta compatível vence   -> portão `_so_o_valor`. FEITO aqui.
+#   atalho ambíguo não escreve  -> `50 no mercado` cai em COMPATÍVEL, que é o
+#                                  comportamento de HOJE. É o PR B, com a
+#                                  pergunta de desempate.
+# O predicado inteiro mora em `_clarification_abandonada`; a tabela de unidade
+# input -> via está em `tests/test_bill_amount_pending.py` (§0.7 — não repetir).
+#
+# CONTROLES NEGATIVOS (cada um injetado num caso que estava VERDE):
+#   remover o ramo `if intent_da_resposta in ESCRITA and not _so_o_valor(text)`
+#     -> test_281_comando_explicito_vence_a_pergunta_de_valor
+#        test_281_comando_explicito_vence_a_pergunta_de_nome
+#        test_281_verbo_de_deposito_nao_vira_saque   (P1 e P4)
+#   trocar o portão por `if intent_da_resposta in ESCRITA` (todo ESCRITA
+#   abandona) -> test_281_resposta_compativel_nunca_vira_lancamento fica
+#        VERMELHO em `100 reais`, `2 mil` e `30 reais e 50 centavos` (as três
+#        que o classificador lê como `launches.add` 0.95).
+#   tirar o `_STARTS_WITH_VALUE_RE`: NÃO DISCRIMINA no PR A, e é declarado, não
+#        fingido — o AMBÍGUO e o COMPATÍVEL têm hoje o MESMO destino
+#        ("resolve"), então remover o teste do meio não muda saída nenhuma. O
+#        caso está preparado em `test_281_ambiguo_ainda_responde_a_pergunta`,
+#        que é a linha que fica vermelha quando o PR B chegar.
+#
+# CLASSE CEGA (a mesma do #185): o LLM está fora dos testes, então o
+# `classify_with_context` nunca roda e os payloads de caixinha/investimento que
+# carregam `amount` só são alcançáveis por ele. A rota determinística provada
+# aqui é a `funds.withdraw`.
+#
+# TETO, medido e escrito também no código: continua sequestrado o verbo que os
+# tiers 1-2 não conhecem — `poupei 100`, `mercado 50`, `uber 25`,
+# `gasteii 50 no mercado` e `gasto fixo aluguel 1200` são todos `out_of_scope
+# 0.0`, então não entram no `ESCRITA` e seguem sendo lidos como resposta. A
+# porta 2 roda `allow_ai=False` de propósito (ver `abandona_pergunta_de_valor`).
+
+
+def _pergunta_de_valor(uid):
+    """Deixa viva a pergunta "Qual o valor?" de um saque, com R$ 300 na
+    caixinha `viagem` e R$ 100 na conta (`_caixinhas_com_saldo` credita 400 e
+    deposita 300). Duas mensagens, não uma: `tirar da
+    caixinha viagem` pergunta o NOME primeiro (medido)."""
+    _caixinhas_com_saldo(uid, "viagem")
+    respostas = _conversa(uid, "tirar da caixinha viagem", "viagem")
+    assert "Qual o valor" in respostas[-1], respostas[-1]
+
+
+def test_281_comando_explicito_vence_a_pergunta_de_valor(uid):
+    """O caso do título da issue, com os números medidos em produção.
+
+    Antes: `📤 Caixinha *viagem*: -R$ 50,00`, conta SOBE 50 e a despesa não
+    existe. Depois: despesa de 50, conta CAI 50, caixinha intacta."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "gastei 50 no mercado")
+
+    assert _saldos(uid)["viagem"] == 300.00, \
+        f"o gasto saiu da caixinha em vez da conta: {respostas[-1]!r}"
+    assert round(float(db.get_balance(uid)), 2) == 50.00, \
+        "a conta tinha de CAIR 50 (100 -> 50), não subir para 150"
+    assert [round(float(d["valor"]), 2) for d in _despesas(uid)] == [50.00], \
+        f"o gasto sumiu do extrato: {respostas[-1]!r}"
+
+
+def test_281_comando_explicito_vence_a_pergunta_de_nome(uid):
+    """A pergunta de NOME fecha de graça: o portão roda no `route()`, ANTES de
+    `payload["falta"]` ser lido, então não há ramo próprio para ela."""
+    _caixinhas_com_saldo(uid, "viagem")
+
+    respostas = _conversa(uid, "tirar da caixinha viagem", "gastei 50 no mercado")
+
+    assert "Qual caixinha" in respostas[0], respostas[0]
+    assert _saldos(uid)["viagem"] == 300.00, respostas[-1]
+    assert round(float(db.get_balance(uid)), 2) == 50.00, \
+        "conta = 100 do setup - 50 da despesa"
+    assert [round(float(d["valor"]), 2) for d in _despesas(uid)] == [50.00], \
+        f"a despesa não foi registrada: {respostas[-1]!r}"
+
+
+def test_281_verbo_de_deposito_nao_vira_saque(uid):
+    """O exemplo do comentário da issue: GUARDEI nas duas mensagens, e a
+    segunda virava SAQUE. É a mesma causa por um `falta` diferente."""
+    _caixinhas_com_saldo(uid, "viagem")
+
+    respostas = _conversa(uid, "guardei na caixinha viagem",
+                          "guardei 100 na caixinha viagem")
+
+    assert "Qual caixinha" in respostas[0], respostas[0]
+    assert _saldos(uid)["viagem"] == 400.00, \
+        f"o usuário disse GUARDEI e a caixinha não subiu: {respostas[-1]!r}"
+    assert round(float(db.get_balance(uid)), 2) == 0.00, \
+        "conta = 100 do setup - 100 depositados"
+
+
+@pytest.mark.parametrize("resposta,saque", [
+    ("100 reais", 100.00),
+    ("cem", 100.00),
+    ("132,50", 132.50),
+    ("R$ 100", 100.00),
+    ("30 reais e 50 centavos", 30.50),
+    ("tudo", 300.00),
+])
+def test_281_resposta_compativel_nunca_vira_lancamento(uid, resposta, saque):
+    """CONTROLE POSITIVO, e é o que separa este conserto de um que recusa tudo.
+
+    `100 reais`, `2 mil` e `30 reais e 50 centavos` classificam `launches.add`
+    0.95 — os mesmos 0.95 de `gastei 50 no mercado`. Quem os separa é o
+    `_so_o_valor`, não o classificador."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, resposta)
+
+    assert _saldos(uid)["viagem"] == round(300.00 - saque, 2), \
+        f"a resposta não fechou o saque: {respostas[-1]!r}"
+    assert round(float(db.get_balance(uid)), 2) == round(100.00 + saque, 2)
+    assert _despesas(uid) == [], \
+        f"a resposta à pergunta virou lançamento: {respostas[-1]!r}"
+
+
+def test_281_resposta_compativel_grande_demais_nao_vira_lancamento(uid):
+    """`2 mil` numa caixinha de 300: a resposta é COMPATÍVEL, então o saque é
+    recusado pelo saldo — e continua sem virar despesa avulsa."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "2 mil")
+
+    assert "insuficiente" in respostas[-1].lower(), respostas[-1]
+    assert _saldos(uid)["viagem"] == 300.00
+    assert _despesas(uid) == [], f"virou lançamento: {respostas[-1]!r}"
+
+
+def test_281_ambiguo_ainda_responde_a_pergunta(uid):
+    """O ATALHO sem verbo é o PR B, e este teste é o marcador dele.
+
+    `50 no mercado` classifica `launches.add` 0.95 igual a `gastei 50 no
+    mercado`, mas COMEÇA pelo valor (`_STARTS_WITH_VALUE_RE`) — pode ser o
+    gasto, pode ser "50, do mercado" respondendo a pergunta. No PR A ele cai
+    em COMPATÍVEL, que é o comportamento de HOJE: saque de 50, sem despesa.
+    Quando a pergunta de desempate do PR B chegar, é esta linha que fica
+    vermelha, de propósito."""
+    _pergunta_de_valor(uid)
+
+    respostas = _conversa(uid, "50 no mercado")
+
+    assert _saldos(uid)["viagem"] == 250.00, respostas[-1]
+    assert _despesas(uid) == [], respostas[-1]

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -1041,8 +1041,20 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 # era "começa pelo valor" e resolvia por um curto-circuito
 # (`_STARTS_WITH_VALUE_RE`) posto ANTES do quinto sinal — que também levava
 # `50 no mercado`, `120 de luz` e `100 na caixinha viagem` junto, e essas TRÊS
-# são a regra 3 do dono. Medido em duas colunas nas 6 células (NOME × VALOR ×
-# 3 textos): `main` e o HEAD anterior escreviam 1 linha em `launches` nas seis.
+# são a regra 3 do dono. O dano NÃO era o mesmo nas 6 células (NOME × VALOR ×
+# 3 textos): 4 escreviam 1 linha em `launches`, e as outras DUAS — NOME ×
+# `50 no mercado` e NOME × `120 de luz` — escreviam ZERO e matavam a pendência,
+# com o texto engolido como nome de caixinha ("Caixinha *50 no mercado* não
+# encontrada"). Remedido em 2026-09-04 nas duas árvores — `main` em `ee0524a`
+# e o HEAD anterior a este conserto, `56ed7f1` —, copiando ESTE arquivo para
+# dentro delas:
+#   git worktree add /tmp/m288 ee0524a   # ou 56ed7f1
+#   cp tests/test_perguntas_guardam_contexto.py /tmp/m288/tests/
+#   cd /tmp/m288 && pytest tests/test_perguntas_guardam_contexto.py \
+#       -k test_288_regra3 -q --tb=line
+# Saída idêntica nas duas: `6 failed` — 4 em "escreveu em `launches`"
+# (`assert 4 == 3`) e 2 em "o desempate não foi armado: None". Remeça antes de
+# reusar qualquer um desses números.
 # O que separa as duas regras é a UNIDADE, não a posição: depois de `100` vem
 # `reais`, que é o próprio valor; depois de `50` vem um ALVO
 # (`core/intent_router.py::_UNIDADE_DE_VALOR_RE`).
@@ -1426,10 +1438,13 @@ def test_288_regra3_quantidade_com_alvo_nunca_escreve(uid, pergunta, texto):
     """A REGRA 3 DO DONO, verbatim, nas DUAS perguntas — e o defeito do #288.
 
     As três strings são as que ele escreveu; as duas perguntas são as duas que
-    a porta 2 protege (NOME e VALOR). Medido em duas colunas antes do conserto:
-    `main` e HEAD `371a49c` escreviam 1 linha em `launches` nas SEIS células,
-    porque o `_STARTS_WITH_VALUE_RE` (D11) devolvia "resolve" antes de o quinto
-    sinal ser consultado — a regra não existia no código.
+    a porta 2 protege (NOME e VALOR). Antes do conserto o
+    `_STARTS_WITH_VALUE_RE` (D11) devolvia "resolve" antes de o quinto sinal ser
+    consultado — a regra não existia no código —, mas o dano era de DOIS tipos:
+    4 células escreviam 1 linha em `launches` e 2 (NOME × `50 no mercado` e
+    NOME × `120 de luz`) escreviam ZERO e MATAVAM a pendência, engolindo o texto
+    como nome de caixinha. Este teste falha nos dois tipos; o comando que remede
+    as duas árvores está no comentário da tabela, acima.
 
     A afirmação de dinheiro é a CONTAGEM de `launches` antes/depois: zero linha
     nova. As outras duas são a pendência (a pergunta original tem de sobreviver,
@@ -1455,6 +1470,30 @@ def test_288_regra3_quantidade_com_alvo_nunca_escreve(uid, pergunta, texto):
         f"a pergunta original se perdeu: {pend}"
     assert "1️⃣" in resposta, \
         f"nenhum desempate na tela: {resposta!r}"
+
+
+def test_288_desempate_nao_embrulha_texto_com_marcacao(uid):
+    """A classe que o #270 fechou, reaberta pelo `_PERGUNTA_DE_DESEMPATE`.
+
+    O molde interpolava o texto CRU do usuário dentro de `*...*`. Medido em
+    2026-09-04 com o molde antigo (mutação `"Não sei se *{texto}*"`), pela
+    conversa real: `*gastei 50 no *mercado*` na tela e 11 asteriscos na
+    mensagem; com `wrap_wa_markup` são 9, e o texto sai inteiro, sem embrulho —
+    que é o que este teste afirma.
+
+    TETO DECLARADO, e é a issue #276: 9 é ÍMPAR. `wrap_wa_markup` decide POR
+    ARGUMENTO e o WhatsApp pareia POR MENSAGEM, então o `*` solto do usuário
+    ainda casa com a marcação PRÓPRIA do molde (`*responder*`, `*registrar*`,
+    `*cancela*` e os do `{pergunta}`). Fechar isso é o desenho da #276 e não
+    cabe aqui; o que cabe é não ser o bot a ABRIR o par."""
+    _caixinhas_com_saldo(uid, "viagem")
+    _conversa(uid, "tirar da caixinha viagem", "viagem")
+
+    resposta = _conversa(uid, "gastei 50 no *mercado")[-1]
+
+    assert "gastei 50 no *mercado" in resposta, resposta
+    assert "*gastei 50 no *mercado*" not in resposta, \
+        f"o bot embrulhou texto que já tem marcação: {resposta!r}"
 
 
 def test_281_c2_quantidade_grande_no_comando_nao_cria_a_caixinha(uid):

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -967,20 +967,33 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 # O predicado inteiro mora em `_clarification_abandonada`; a tabela de unidade
 # input -> via está em `tests/test_bill_amount_pending.py` (§0.7 — não repetir).
 #
-# CONTROLES NEGATIVOS (cada um injetado num caso que estava VERDE):
-#   remover o ramo `if intent_da_resposta in ESCRITA and not _so_o_valor(text)`
-#     -> test_281_comando_explicito_vence_a_pergunta_de_valor
-#        test_281_comando_explicito_vence_a_pergunta_de_nome
-#        test_281_verbo_de_deposito_nao_vira_saque   (P1 e P4)
-#   trocar o portão por `if intent_da_resposta in ESCRITA` (todo ESCRITA
-#   abandona) -> test_281_resposta_compativel_nunca_vira_lancamento fica
-#        VERMELHO em `100 reais`, `2 mil` e `30 reais e 50 centavos` (as três
-#        que o classificador lê como `launches.add` 0.95).
-#   tirar o `_STARTS_WITH_VALUE_RE`: NÃO DISCRIMINA no PR A, e é declarado, não
-#        fingido — o AMBÍGUO e o COMPATÍVEL têm hoje o MESMO destino
-#        ("resolve"), então remover o teste do meio não muda saída nenhuma. O
-#        caso está preparado em `test_281_ambiguo_ainda_responde_a_pergunta`,
-#        que é a linha que fica vermelha quando o PR B chegar.
+# CONTROLES NEGATIVOS — quatro, MEDIDOS um a um (contagem sobre
+# `test_perguntas_guardam_contexto.py` + `test_bill_amount_pending.py` +
+# `test_full_handler_smoke.py`, os três arquivos da porta 2):
+#
+#   1. remover o ramo `if intent_da_resposta in ESCRITA and not _so_o_valor`
+#      -> 6 vermelhos, entre eles
+#         test_281_comando_explicito_vence_a_pergunta_de_valor
+#         test_281_comando_explicito_vence_a_pergunta_de_nome
+#         test_281_verbo_de_deposito_nao_vira_saque
+#   2. tirar o portão (`if intent_da_resposta in ESCRITA` sozinho)
+#      -> 12 vermelhos, TODOS da família `paguei …`
+#         (test_clarification_dano_nao_some_com_palavra_na_frente ×9,
+#          test_clarification_aceita_tudo_que_a_main_aceita ×2,
+#          test_porta_2_ponto_final_sem_virgula_registra ×1).
+#      MEDIDO, e não é o que se esperava: `100 reais` NÃO fica vermelho aqui —
+#      quem o segura é o `_STARTS_WITH_VALUE_RE`, não o `_so_o_valor`. O que o
+#      `_so_o_valor` segura sozinho é o VERBO sem alvo.
+#   3. trocar o `_SEM_CONTEUDO` pelo `_ENCHIMENTO_PALAVRAS` (tirar os 12 verbos
+#      do prefixo sem conteúdo) -> 19 vermelhos, incluindo o filtro de dano
+#      inteiro.
+#   4. tirar o `_STARTS_WITH_VALUE_RE`
+#      -> 1 vermelho: test_281_ambiguo_ainda_responde_a_pergunta.
+#      O plano previa que ele NÃO discriminasse no PR A; discrimina — sem ele
+#      `50 no mercado` (launches.add 0.95, não é só-o-valor) abandona.
+#
+# E a guarda de entrega tem o dela em `test_bill_amount_pending.py`: removê-la
+# deixa 2 vermelhos, os dois medindo R$ 13.250,00 no lugar de R$ 132,50.
 #
 # CLASSE CEGA (a mesma do #185): o LLM está fora dos testes, então o
 # `classify_with_context` nunca roda e os payloads de caixinha/investimento que
@@ -1086,8 +1099,14 @@ def test_281_resposta_compativel_nunca_vira_lancamento(uid, resposta, saque):
     """CONTROLE POSITIVO, e é o que separa este conserto de um que recusa tudo.
 
     `100 reais`, `2 mil` e `30 reais e 50 centavos` classificam `launches.add`
-    0.95 — os mesmos 0.95 de `gastei 50 no mercado`. Quem os separa é o
-    `_so_o_valor`, não o classificador."""
+    0.95 — os mesmos 0.95 de `gastei 50 no mercado`; `cem`, `132,50` e `tudo`
+    caem em `out_of_scope 0.0`. Nenhum deles pode virar lançamento.
+
+    MEDIDO, e corrige o que se supunha: destes seis, os que dependem de um
+    portão dependem do `_STARTS_WITH_VALUE_RE` (começam por dígito), não do
+    `_so_o_valor` — desligar o `_so_o_valor` não deixa nenhuma linha daqui
+    vermelha. Quem o `_so_o_valor` segura sozinho é o verbo sem alvo
+    (`paguei 132`), e isso se mede em `test_full_handler_smoke.py`."""
     _pergunta_de_valor(uid)
 
     respostas = _conversa(uid, resposta)

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -987,11 +987,25 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 # carregam `amount` só são alcançáveis por ele. A rota determinística provada
 # aqui é a `funds.withdraw`.
 #
-# TETO, medido e escrito também no código: continua sequestrado o verbo que os
-# tiers 1-2 não conhecem — `poupei 100`, `mercado 50`, `uber 25`,
-# `gasteii 50 no mercado` e `gasto fixo aluguel 1200` são todos `out_of_scope
-# 0.0`, então não entram no `ESCRITA` e seguem sendo lidos como resposta. A
-# porta 2 roda `allow_ai=False` de propósito (ver `abandona_pergunta_de_valor`).
+# TRÊS TETOS, medidos, e todos escritos também no código:
+#
+#   1. o verbo que os tiers 1-2 não conhecem continua sequestrado — `poupei
+#      100`, `mercado 50`, `uber 25`, `gasteii 50 no mercado` e `gasto fixo
+#      aluguel 1200` são todos `out_of_scope 0.0`, então não entram no
+#      `ESCRITA`. A porta 2 roda `allow_ai=False` de propósito (ver
+#      `abandona_pergunta_de_valor`).
+#   2. os 12 verbos de lançamento com valor e MAIS NADA (`paguei 132`,
+#      `gastei 132`) NÃO abandonam: eles são prefixo sem conteúdo. Não é
+#      esquecimento — medido, tratá-los como comando novo pula o
+#      `valor_perigoso` e faz `paguei 132 50` registrar R$ 13.250,00. A
+#      justificativa mora no `_SO_O_VALOR_RE`, com os quatro números.
+#   3. verbo de OUTRA operação com valor e nada mais (`investi 80`,
+#      `saquei 200`, `retirei 100 do salario`) ABANDONA, e quando o alvo não
+#      existe o usuário paga um turno — o comando erra e nada se move. É a
+#      regra do dono aplicada; prendem este teto
+#      `test_alvo_fora_do_catalogo_nao_sobrescreve` (aqui) e
+#      `test_clarification_nao_perde_a_pergunta_com_resposta_que_parece_comando`
+#      (em `tests/test_full_handler_smoke.py`).
 
 
 def _pergunta_de_valor(uid):

--- a/tests/test_perguntas_guardam_contexto.py
+++ b/tests/test_perguntas_guardam_contexto.py
@@ -1032,10 +1032,20 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 #   D8  número + alvo         gastei 50 no mercado                 ?
 #   D9  valor perigoso        paguei, 132 50 / gastei -10          R
 #   D10 pontuação de prosa    paguei 132,50. foi isso              R
-#   D11 começa pelo valor     50 no mercado, 132 ok, 100 reais     R
+#   D11 quantidade + UNIDADE  100 reais, 30 reais e 50 centavos    R
 #
 # D9 e D10 são medidos em `tests/test_bill_amount_pending.py`, onde moram as
 # duas guardas que os produzem (o filtro de dano e a guarda de entrega).
+#
+# D11 mudou no #288, e é a diferença entre a tabela e a REGRA DO DONO. A célula
+# era "começa pelo valor" e resolvia por um curto-circuito
+# (`_STARTS_WITH_VALUE_RE`) posto ANTES do quinto sinal — que também levava
+# `50 no mercado`, `120 de luz` e `100 na caixinha viagem` junto, e essas TRÊS
+# são a regra 3 do dono. Medido em duas colunas nas 6 células (NOME × VALOR ×
+# 3 textos): `main` e o HEAD anterior escreviam 1 linha em `launches` nas seis.
+# O que separa as duas regras é a UNIDADE, não a posição: depois de `100` vem
+# `reais`, que é o próprio valor; depois de `50` vem um ALVO
+# (`core/intent_router.py::_UNIDADE_DE_VALOR_RE`).
 #
 # CADA TESTE AFIRMA TRÊS COISAS, e a terceira é a que faltava por três rodadas:
 # o saldo da caixinha e da conta; que não nasceu despesa avulsa; e o que
@@ -1051,6 +1061,8 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 #         três testes do desempate junto.
 #   3. desligar o quinto sinal (toda quantidade vira `"pergunta"`)
 #      -> test_281_quantidade_que_fecha_e_resposta vermelho em D4a e D6.
+#   4. repor o `_STARTS_WITH_VALUE_RE` no topo da via (o defeito do #288)
+#      -> test_288_regra3_quantidade_com_alvo_nunca_escreve vermelho nas 6.
 # CONTROLE POSITIVO: test_281_resposta_compativel_nunca_vira_lancamento —
 # `100 reais`, `cem`, `132,50`, `R$ 100`, `30 reais e 50 centavos` e `tudo`
 # continuam fechando o saque. Sem ele o grupo passaria num código que recusa
@@ -1068,9 +1080,11 @@ def test_185_pergunta_de_valor_continua_abandonando(uid, sem_teto_de_caixinha):
 #      aluguel 1200` são todos `out_of_scope 0.0`. Como B0, eles resolvem a
 #      pergunta. A porta 2 roda `allow_ai=False` de propósito (ver
 #      `abandona_pergunta_de_valor`).
-#   2. a UNIDADE conta como cauda: `paguei 100 reais` PERGUNTA (custa um turno,
-#      nunca dinheiro), enquanto `paguei 2 mil` resolve — "mil" é valor para o
-#      `_extract_valor` e "reais" não. É o preço de não ter lista de cauda.
+#   2. FECHADO no #288: a unidade deixou de contar como cauda (`paguei 100
+#      reais` resolve, como `paguei 2 mil` já resolvia). O vocabulário é o
+#      `h_bills._UNIDADE`, mais `centavos` e `k`, que na porta 1 mudariam o
+#      valor pago. Sobra o TETO NOVO: unidade que a lista não tem ("paguei 100
+#      pratas") continua perguntando — custa um turno, nunca dinheiro.
 #   3. `gastei tudo mesmo` PERGUNTA em vez de esvaziar. Decisão do dono, e é a
 #      única linha que saiu da tabela anterior: esvaziar zera a caixinha
 #      inteira, e o lado seguro de uma operação irreversível é o que não
@@ -1166,7 +1180,12 @@ def test_281_c1_comando_sem_quantidade_abandona(uid, sem_teto_de_caixinha,
     comando RODA sozinho (mostra a fatura, cria a caixinha).
 
     Era um laço indefinido medido: a pergunta voltava ("Quanto foi no *luz*?")
-    e a pendência era RE-ARMADA a cada turno, então nunca expirava."""
+    e a pendência era RE-ARMADA a cada turno, então nunca expirava.
+
+    E ela morre AVISANDO (#288): na `main` a pergunta sobrevivia ao `fatura`,
+    então descartá-la em silêncio deixaria o usuário esperando a resposta de uma
+    pergunta que já não existe. O A0 (`saldo`) segue calado — lá o abandono é o
+    comportamento de sempre."""
     _pergunta_de_valor(uid)
 
     respostas = _conversa(uid, resposta)
@@ -1176,6 +1195,8 @@ def test_281_c1_comando_sem_quantidade_abandona(uid, sem_teto_de_caixinha,
         f"a pergunta sobreviveu ao comando: {respostas[-1]!r}"
     assert marca in respostas[-1].lower(), \
         f"o comando não rodou: {respostas[-1]!r}"
+    assert "Cancelei a pergunta anterior" in respostas[-1], \
+        f"a pergunta morreu em silêncio: {respostas[-1]!r}"
 
 
 @pytest.mark.parametrize("celula,resposta", [
@@ -1342,10 +1363,11 @@ def test_281_resposta_compativel_nunca_vira_lancamento(uid, resposta, saque):
     0.95 — os mesmos 0.95 de `gastei 50 no mercado`; `cem`, `132,50` e `tudo`
     caem em `out_of_scope 0.0`. Nenhum deles pode virar lançamento.
 
-    MEDIDO: `100 reais`, `132,50`, `R$ 100` e `30 reais e 50 centavos` são
-    seguros pelo `_STARTS_WITH_VALUE_RE` (célula D11 — começam por dígito);
-    `cem` e `tudo` pelo quinto sinal, que os lê como quantidade que fecha a
-    mensagem."""
+    MEDIDO, e desde o #288 é o MESMO sinal para os seis: a quantidade é a
+    última coisa da mensagem. `132,50`, `R$ 100`, `cem` e `tudo` fecham no
+    próprio número/marcador; `100 reais` e `30 reais e 50 centavos` fecham
+    porque a UNIDADE não é cauda (`_UNIDADE_DE_VALOR_RE`). É este teste que
+    impede o conserto da regra 3 de virar um código que recusa tudo."""
     _pergunta_de_valor(uid)
 
     respostas = _conversa(uid, resposta)
@@ -1355,6 +1377,34 @@ def test_281_resposta_compativel_nunca_vira_lancamento(uid, resposta, saque):
     assert round(float(db.get_balance(uid)), 2) == round(100.00 + saque, 2)
     assert _despesas(uid) == [], \
         f"a resposta à pergunta virou lançamento: {respostas[-1]!r}"
+
+
+def test_288_cas_do_desempate_falha_e_ninguem_escreve(uid, monkeypatch):
+    """O fallback do CAS não pode escrever o que o desenho chamou de ambíguo.
+
+    Quando a linha já é de OUTRA tarefa, o desempate não pode ser armado. A
+    saída anterior caía no roteamento normal — medido com o CAS forçado a
+    False: `💸 *Despesa registrada*: R$ 50,00 ... ID: #3`, conta em 4950 e a
+    pergunta original perdida. O abandono pode cair no roteamento normal (lá o
+    texto é um comando que o usuário deu de propósito); isto aqui, não."""
+    import core.intent_router as IR
+
+    _pergunta_de_valor(uid)
+    real = IR.db.advance_pending_action
+
+    def perde_a_corrida(*args, **kwargs):
+        if kwargs.get("new_action_type") == "value_or_command_choice":
+            return False
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(IR.db, "advance_pending_action", perde_a_corrida)
+    antes = len(db.list_launches(uid, limit=50) or [])
+
+    resposta = _conversa(uid, "gastei 50 no mercado")[-1]
+
+    assert len(db.list_launches(uid, limit=50) or []) == antes, \
+        f"o ambíguo virou lançamento no caminho de exceção: {resposta!r}"
+    _nada_se_moveu(uid, resposta)
 
 
 def test_281_resposta_compativel_grande_demais_nao_vira_lancamento(uid):
@@ -1369,21 +1419,42 @@ def test_281_resposta_compativel_grande_demais_nao_vira_lancamento(uid):
     assert _despesas(uid) == [], f"virou lançamento: {respostas[-1]!r}"
 
 
-def test_281_ambiguo_ainda_responde_a_pergunta(uid):
-    """D11 — e a decisão medida de NÃO mandar esta célula ao desempate.
+@pytest.mark.parametrize("texto", ["50 no mercado", "120 de luz",
+                                   "100 na caixinha viagem"])
+@pytest.mark.parametrize("pergunta", ["nome", "valor"])
+def test_288_regra3_quantidade_com_alvo_nunca_escreve(uid, pergunta, texto):
+    """A REGRA 3 DO DONO, verbatim, nas DUAS perguntas — e o defeito do #288.
 
-    `50 no mercado` classifica `launches.add` 0.95 igual a `gastei 50 no
-    mercado` e tem cauda depois do número, então pelo quinto sinal sozinho ele
-    perguntaria. Começar pelo VALOR vem antes de propósito: é a forma de
-    `100 reais` e de `30 reais e 50 centavos`, que são resposta legítima —
-    mandá-las ao desempate cobraria um turno da resposta mais comum de todas.
-    Saque de 50, sem despesa, como hoje."""
-    _pergunta_de_valor(uid)
+    As três strings são as que ele escreveu; as duas perguntas são as duas que
+    a porta 2 protege (NOME e VALOR). Medido em duas colunas antes do conserto:
+    `main` e HEAD `371a49c` escreviam 1 linha em `launches` nas SEIS células,
+    porque o `_STARTS_WITH_VALUE_RE` (D11) devolvia "resolve" antes de o quinto
+    sinal ser consultado — a regra não existia no código.
 
-    respostas = _conversa(uid, "50 no mercado")
+    A afirmação de dinheiro é a CONTAGEM de `launches` antes/depois: zero linha
+    nova. As outras duas são a pendência (a pergunta original tem de sobreviver,
+    dentro do payload do desempate) e o desempate oferecido na tela."""
+    _caixinhas_com_saldo(uid, "viagem")
+    original = _conversa(uid, "tirar da caixinha viagem")[-1]
+    if pergunta == "valor":
+        original = _conversa(uid, "viagem")[-1]
+        assert "Qual o valor" in original, original
+    else:
+        assert "Qual caixinha" in original, original
+    antes = len(db.list_launches(uid, limit=50) or [])
 
-    assert _saldos(uid)["viagem"] == 250.00, respostas[-1]
-    assert _despesas(uid) == [], respostas[-1]
+    resposta = _conversa(uid, texto)[-1]
+
+    assert len(db.list_launches(uid, limit=50) or []) == antes, \
+        f"escreveu em `launches`: {resposta!r}"
+    _nada_se_moveu(uid, resposta)
+    pend = db.get_pending_action(uid)
+    assert pend and pend["action_type"] == "value_or_command_choice", \
+        f"o desempate não foi armado: {pend}"
+    assert pend["payload"]["clarif"].get("question"), \
+        f"a pergunta original se perdeu: {pend}"
+    assert "1️⃣" in resposta, \
+        f"nenhum desempate na tela: {resposta!r}"
 
 
 def test_281_c2_quantidade_grande_no_comando_nao_cria_a_caixinha(uid):

--- a/tests/test_whatsapp_markup_escape.py
+++ b/tests/test_whatsapp_markup_escape.py
@@ -59,6 +59,12 @@ interpola o nome DUAS vezes, então o `*` do usuário pareia consigo mesmo (2
 asteriscos). Fechar isso é mudança de desenho e fica fora deste PR — os dois
 casos estão aqui como `xfail(strict=True)` afirmando o estado DESEJADO.
 
+SÍTIO FORA DESTE ARQUIVO, e de propósito: o `_PERGUNTA_DE_DESEMPATE`
+(core/intent_router.py) só existe DEPOIS de uma pendência viva, então o teste
+dele mora onde a conversa real já está montada —
+`tests/test_perguntas_guardam_contexto.py::test_288_desempate_nao_embrulha_texto_com_marcacao`.
+Ele é da mesma classe: o embrulho sai, e o total ímpar que sobra é a #276.
+
 ESCOPO: os 7 sítios de `adapters/whatsapp/wa_runtime.py`, o
 `pergunta_de_valor_sem_contexto` (core/handlers/bills.py:63, chamado de
 wa_runtime.py:800), o `core/handlers/pending.py:90` e — porque é a MESMA


### PR DESCRIPTION
Fecha #281.

A porta 2 (`_clarification_abandonada`, `core/intent_router.py`) decidia pelo
INTENT, e o intent não separa `gastei 50 no mercado` de `100 reais` — os dois são
`launches.add` 0.95. Três rodadas tentaram fechar isso com listas (o que é
prefixo sem conteúdo, o que pode vir depois do número) e cada palavra esquecida
virava dinheiro no lugar errado.

Agora quem decide é a posição: **a quantidade é a última coisa da mensagem?**

- **fecha** → é RESPOSTA (a pessoa está respondendo "Qual o valor?");
- **tem cauda** → é AMBÍGUO → **pergunta**, e ninguém escreve.

O classificador ainda decide duas células: leitura (`ABANDONA`) e comando sem
quantidade (`COMANDO_SEM_QUANTIDADE` = `credit.handle`, `pockets.create`,
`pockets.delete`).

## A tabela — 16 células, uma por teste

`R` = resolve · `A` = abandona · `?` = pergunta (não escreve)

| célula | exemplo | veredito |
|---|---|---|
| A0 LEITURA | `saldo`, `extrato` | **A** (+ veto #185, inalterado) |
| B0 NEUTRO | `132`, `cem`, `tudo`, `ok`, `retirei tudo` | **R** |
| C1 comando sem quantidade | `fatura`, `meus cartoes`, `criar caixinha viagem` | **A** — o único abandono novo |
| C2/C3 idem COM quantidade | `fatura 132`, `criar caixinha 2028`, `fatura tudo` | **R** |
| D1 verbo puro | `gastei`, `paguei`, `recebi` | **R** |
| D2 cauda sem número | `gastei o resto`, `gastei metade` | **R** |
| D3 cauda alvo sem número | `gastei no mercado`, `guardei na caixinha viagem` | **R** |
| D4a TUDO no fim | `gastei tudo`, `gastei quase tudo` | **R** (esvazia) |
| D4b TUDO com cauda | `gastei tudo mesmo` | **?** |
| D5 TUDO + alvo | `esvaziar caixinha`, `guardei tudo na caixinha viagem` | **?** |
| D6 número no fim | `paguei 132`, `saquei 100`, `investi 100` | **R** |
| D7 número + cauda | `paguei 132 ok / hoje / no debito` | **?** |
| D8 número + alvo | `gastei 50 no mercado`, `guardei 100 na caixinha viagem` | **?** |
| D9 valor perigoso | `paguei, 132 50`, `gastei -10 no mercado` | **R** |
| D10 pontuação de prosa | `paguei 132,50. foi isso` | **R** |
| D11 começa pelo valor | `50 no mercado`, `132 ok`, `100 reais` | **R** |

D9 e D10 são as duas guardas que já existiam (`valor_perigoso` e
`_o_reroteamento_le_o_mesmo_valor`) e continuam rodando ANTES da decisão: sem
elas, `paguei, 132 50` e `paguei 132,50. foi isso` registram R$ 13.250,00.

## O desempate

Invólucro fino, zero transições novas. `pending_actions` é **uma linha por
usuário**, então armar o desempate desaloja a pergunta — o payload dela viaja
DENTRO do payload do desempate (`clarif` + `texto`), senão "era o valor" não
teria para onde voltar. Tipo novo `value_or_command_choice` declarado no
`_REGISTRO` (`db/pending.py`) com as três colunas da `clarification`: não é
oferta, suprime a IA, sobrevive a áudio.

- `1`/`responder` → devolve a pergunta à linha e resolve com o texto guardado;
- `2`/`registrar` → roteia o texto guardado como comando novo;
- `cancela` → mata as duas;
- **qualquer outra coisa** → desembrulha e reentra na tabela com a mensagem nova.

## Consequências medidas — todas do lado que não escreve

- `gastei tudo mesmo` **pergunta** em vez de esvaziar (decisão do dono: esvaziar
  zera a caixinha inteira, e ambíguo não escreve);
- `paguei 100 reais` **pergunta**: a unidade conta como cauda. `paguei 2 mil`
  resolve, porque "mil" é valor para o `_extract_valor`. Custa um turno, nunca
  dinheiro; fechar exigiria a lista que este desenho existe para não ter;
- `paguei luz 132,50` com pergunta viva volta ao comportamento da **`main`**:
  resolve a pergunta, e a conta segue pendente (o quinto sinal olha o que vem
  DEPOIS do número; o alvo aqui vem antes);
- 5 formas de `test_clarification_*` (`deu 132 no total`, `paguei 132 - da luz`…)
  pagam um turno a mais e registram o MESMO valor — o custo está escrito no
  arquivo, num conjunto nomeado, em vez de escondido num `if`.

## Apagado

`_so_o_valor`/`_SO_O_VALOR_RE`, `_verbo_e_uma_palavra`, `_dobrado`,
`_SEM_CONTEUDO_ALT`, o conjunto `ESCRITA` e o `import unicodedata` — sem
chamador depois desta rodada. Com eles, os testes que mediam só essas peças.
Dois comentários falsos corrigidos: `retirei/saquei/tirei tudo` e `esvaziar
caixinha viagem` **não** abandonavam na `main` — os quatro resolvem lá.

## Medição

Suíte inteira: **5914 passed, 4 xfailed, 0 failed** (baseline `b543228`: 5931 /
0 failed). A diferença é só coleta, comparada por NOME: 58 casos apagados, 40
novos, nenhum teste alheio sumiu.

Controles negativos, medidos um a um nesta árvore (3 arquivos da porta 2):

| mutação | vermelhos |
|---|---|
| `COMANDO_SEM_QUANTIDADE = set()` | 4 — as 3 células C1 + `test_ia_com_valor_nao_engorda_o_alvo_com_a_resposta` |
| `return "resolve"` no lugar de `"pergunta"` | 22 — D4b/D5/D7/D8, os 7 do desempate e as 5 formas de prosa |
| quinto sinal desligado (tudo vira `"pergunta"`) | 27 — D4a, D6, B0, C2/C3 e os controles positivos |
| guarda de entrega removida | 2 — os dois que medem R$ 132,50 × R$ 13.250,00 |
| `valor_perigoso` removido do portão | 8 — a família `132 50` / `-10` / 400 dígitos |

Controle positivo: `100 reais`, `cem`, `132,50`, `R$ 100`, `30 reais e 50
centavos` e `tudo` continuam fechando o saque sem virar lançamento.

**Não verificado aqui:** o WhatsApp real. Os testes mockam o LLM e o envio
(`CLAUDE.md §3`), então o texto do desempate na tela do aparelho e o
`classify_with_context` da conta Pro (que não roda no turno que abandona) só se
observam em produção.

**Hole pré-existente encontrado e NÃO consertado:** com qualquer pendência
determinística de pé, a palavra `cancelar` nunca chega ao `route()` — o
`handle_billing_command` (`core/services/billing_commands.py:296`) responde
antes, porque a guarda dele consulta `ai_pending_actions` e não `pending_actions`
(vale igual para a confirmação de delete que o comentário de lá diz proteger).
Por isso o desempate oferece `cancela`. Consertar aquilo move o `cancelar` de
todas as pendências do produto — outro PR.
