### PR TITLE
O tipo legado dobrava o saldo no dedupe do Open Finance, e mentia sobre ter apagado

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -207,7 +207,6 @@ from .cards import (
     list_bills_with_debt,
     list_credit_card_due_reminders,
     list_installment_groups,
-    monthly_summary_credit_debit,
     import_credit_ofx_bulk,
     consolidate_duplicate_bills,
     rebuild_bill_totals,
@@ -519,7 +518,7 @@ __all__ = [
     "get_open_bill_summary", "pay_bill_amount", "close_bill", "get_next_bill_summary",
     "list_open_bills", "list_bills_with_debt",
     "list_credit_card_due_reminders", "list_installment_groups",
-    "monthly_summary_credit_debit", "import_credit_ofx_bulk", "consolidate_duplicate_bills",
+    "import_credit_ofx_bulk", "consolidate_duplicate_bills",
     "get_installment_group_summaries", "rebuild_bill_totals",
     # open finance
     "create_mock_open_finance_connection", "get_open_finance_snapshot",

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -181,6 +181,13 @@ def list_launches_by_tipo(user_id: int, tipo: str, limit: int = 200):
     Os DOIS chamadores vêm de `describe_valueless_launch` (parsers.py:273), que
     só devolve 'despesa'/'receita' — nenhum passa a forma legada.
 
+    INVERSÃO, para quem for chamar isto de outro lugar: o colapso é da COLUNA,
+    então a forma legada COMO ARGUMENTO passa a devolver VAZIO — antes ela é que
+    trazia as linhas legadas. Medido, com uma linha 'saida' e uma 'despesa' na
+    base: `tipo='despesa'` → as DUAS; `tipo='saida'` → []; idem
+    'receita'/'entrada'. Inalcançável pelos chamadores de hoje (rastreados
+    acima), e é o preço de ter uma forma canônica só.
+
     Sem isto, `infer_recurring_value` (core/handlers/launches.py:1315) não via as
     ocorrências legadas e o bot voltava a PERGUNTAR o valor de um "aluguel" que
     ele já sabia. Medido: 4 linhas legadas 'aluguel' 1200 davam None; as mesmas
@@ -1971,17 +1978,30 @@ def delete_launch_and_rollback(user_id: int, launch_id: int, *,
 # ter apagado. Não é subcontagem, é relatório falso num caminho destrutivo.
 #
 # DUAS consequências visíveis que isto cria, de propósito:
-#   - a confirmação ("vou apagar N lançamentos", que sai de `count_launches`)
-#     passa a incluir a linha legada — o N muda ANTES do usuário confirmar;
+#   - o PORTÃO de "não tem nada pra apagar" muda ANTES do usuário confirmar.
+#     `count_launches` tem um consumidor só (`_delete_all_launches_validate`,
+#     core/services/ai_chat/tools/launches.py:511) e ele é `n <= 0`, não um "N"
+#     na frase: `_delete_all_launches_summary` (:503) nem recebe `user_id`.
+#     Medido com um histórico 100% legado ('saida' 50 + 'entrada' 300):
+#       antes  count=0 → "🐷 Você não tem nenhum lançamento pra apagar — seu
+#                         histórico já está limpo." (afirmação FALSA, com as
+#                         duas linhas na tabela)
+#       agora  count=2 → `validate` devolve None e o fluxo segue para a
+#                        confirmação, que é o que existe linha para apagar;
 #   - uma linha legada que carregue `efeitos` de caixinha/investimento agora
-#     entra no conjunto e é RECUSADA pelo pré-voo do #214
-#     (`_EFEITOS_FORA_DO_APAGAR_TUDO` → `kept_unsafe`, motivo `fora_do_escopo`),
-#     de forma PERMANENTE. É o teto conhecido do #214: recusar para sempre não
-#     perde dinheiro, e o usuário lê a frase de `kept_unsafe` em vez de a linha
-#     sumir calada. Antes disto ela nem era olhada.
+#     entra no conjunto e é RECUSADA pelo pré-voo do #214, indo para
+#     `kept_unsafe` de forma PERMANENTE. É o teto conhecido do #214: recusar
+#     para sempre não perde dinheiro, e o usuário lê a frase de `kept_unsafe`
+#     em vez de a linha sumir calada. Antes disto ela nem era olhada.
+#     O `motivo` que vai para o LOG é `fora_do_escopo` em 6 das 8 chaves de
+#     `_EFEITOS_FORA_DO_APAGAR_TUDO`; `delta_pocket` e `delta_invest` sem chave
+#     de lote saem `lote_ausente`, porque `_DELTA_EXIGE_LOTE` dispara ANTES da
+#     guarda de escopo (medido, uma chave por vez). O balde é o mesmo nas 8.
 #
 # Usado por count_launches e delete_all_launches_and_rollback pra ficarem
-# consistentes (o que se conta é o que se apaga).
+# consistentes (o que se conta é o que se apaga). Esses dois são TODO o alcance
+# desta constante: o "Recomeçar do zero" (`reset_user_data`, db/privacy.py:519)
+# apaga `launches` do usuário SEM filtro de tipo e não passa por aqui.
 _CONTA_CORRENTE_LAUNCH_FILTER = f"({TIPO_DESPESA_SQL} or {TIPO_RECEITA_SQL})"
 
 

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -172,15 +172,27 @@ def get_last_inserted_launch(user_id: int):
 def list_launches_by_tipo(user_id: int, tipo: str, limit: int = 200):
     """Lançamentos recentes de um tipo (despesa/receita) com só os campos que
     a detecção de valor recorrente precisa (valor + descrição). Ordenado do mais
-    recente pro mais antigo."""
+    recente pro mais antigo.
+
+    `TIPO_CANON_SQL` e não `TIPO_DESPESA_SQL`: aqui o tipo é PARÂMETRO, não
+    literal — colapsar a forma legada na moderna no lado da coluna faz um
+    `tipo='despesa'` casar também com 'saida' sem inventar regra por chamador, e
+    deixa qualquer outro valor (aporte_investimento…) casando exato como antes.
+    Os DOIS chamadores vêm de `describe_valueless_launch` (parsers.py:273), que
+    só devolve 'despesa'/'receita' — nenhum passa a forma legada.
+
+    Sem isto, `infer_recurring_value` (core/handlers/launches.py:1315) não via as
+    ocorrências legadas e o bot voltava a PERGUNTAR o valor de um "aluguel" que
+    ele já sabia. Medido: 4 linhas legadas 'aluguel' 1200 davam None; as mesmas
+    4 na forma moderna davam 1200.0."""
     ensure_user(user_id)
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 select valor, alvo, nota
                 from launches
-                where user_id=%s and tipo=%s
+                where user_id=%s and {TIPO_CANON_SQL}=%s
                 order by criado_em desc, id desc
                 limit %s
                 """,
@@ -1951,9 +1963,26 @@ def delete_launch_and_rollback(user_id: int, launch_id: int, *,
 # tipo evita essa armadilha. Validado no staging: 0 launches despesa/receita
 # carregam efeitos de caixinha/investimento.
 #
+# A forma LEGADA ('saida'/'entrada') é conta corrente do mesmo jeito, então
+# entra pelas duas constantes de `db/connection.py` (§0.7) em vez do literal.
+# Sem ela, medido num banco descartável com uma despesa moderna + uma 'saida' +
+# uma 'entrada': `count_launches` dizia 1 e o retorno vinha `remaining: 0` com as
+# DUAS linhas legadas ainda na tabela — o sistema afirmando que apagou tudo sem
+# ter apagado. Não é subcontagem, é relatório falso num caminho destrutivo.
+#
+# DUAS consequências visíveis que isto cria, de propósito:
+#   - a confirmação ("vou apagar N lançamentos", que sai de `count_launches`)
+#     passa a incluir a linha legada — o N muda ANTES do usuário confirmar;
+#   - uma linha legada que carregue `efeitos` de caixinha/investimento agora
+#     entra no conjunto e é RECUSADA pelo pré-voo do #214
+#     (`_EFEITOS_FORA_DO_APAGAR_TUDO` → `kept_unsafe`, motivo `fora_do_escopo`),
+#     de forma PERMANENTE. É o teto conhecido do #214: recusar para sempre não
+#     perde dinheiro, e o usuário lê a frase de `kept_unsafe` em vez de a linha
+#     sumir calada. Antes disto ela nem era olhada.
+#
 # Usado por count_launches e delete_all_launches_and_rollback pra ficarem
 # consistentes (o que se conta é o que se apaga).
-_CONTA_CORRENTE_LAUNCH_FILTER = "tipo in ('despesa', 'receita')"
+_CONTA_CORRENTE_LAUNCH_FILTER = f"({TIPO_DESPESA_SQL} or {TIPO_RECEITA_SQL})"
 
 
 def count_launches(user_id: int) -> int:

--- a/db/accounts.py
+++ b/db/accounts.py
@@ -455,11 +455,11 @@ def get_internal_movement_total(user_id: int, start_date: date, end_date: date) 
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 select coalesce(sum(valor), 0) as total
                 from launches
                 where user_id = %s
-                  and tipo = 'despesa'
+                  and {TIPO_DESPESA_SQL}
                   and is_internal_movement = true
                   and criado_em >= %s and criado_em < %s
                 """,

--- a/db/cards.py
+++ b/db/cards.py
@@ -2277,32 +2277,3 @@ def get_installment_group_summaries(user_id: int, group_ids: list) -> dict:
         }
         for r in rows
     }
-
-
-def monthly_summary_credit_debit(user_id: int, start: date, end: date):
-    with get_conn() as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                "select coalesce(sum(valor),0) as total_debito from launches "
-                "where user_id=%s and tipo='despesa' and criado_em::date between %s and %s",
-                (user_id, start, end),
-            )
-            deb = cur.fetchone()["total_debito"]
-
-            cur.execute(
-                "select coalesce(sum(valor),0) as total_credito from credit_transactions "
-                "where user_id=%s and purchased_at between %s and %s",
-                (user_id, start, end),
-            )
-            cred = cur.fetchone()["total_credito"]
-
-            cur.execute(
-                "select c.name, coalesce(sum(t.valor),0) as total "
-                "from credit_transactions t join credit_cards c on c.id=t.card_id "
-                "where t.user_id=%s and t.purchased_at between %s and %s "
-                "group by c.name order by total desc",
-                (user_id, start, end),
-            )
-            by_card = cur.fetchall()
-
-    return {"debito": deb, "credito": cred, "por_cartao": by_card}

--- a/db/categories.py
+++ b/db/categories.py
@@ -13,7 +13,7 @@ Duas tabelas distintas:
 import logging
 import unicodedata
 
-from .connection import get_conn
+from .connection import get_conn, TIPO_DESPESA_SQL
 from .users import ensure_user
 from utils_text import normalize_text
 
@@ -237,11 +237,11 @@ def get_uncategorized_launches(user_id: int, limit: int = 20) -> list[dict]:
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                f"""
                 select id, tipo, valor, alvo, nota, categoria, criado_em
                 from launches
                 where user_id = %s
-                  and tipo = 'despesa'
+                  and {TIPO_DESPESA_SQL}
                   and is_internal_movement = false
                   and (categoria is null or lower(categoria) = 'outros')
                 order by criado_em desc

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -16,7 +16,7 @@ from .cards import (
     get_or_create_open_finance_card,
     remove_single_credit_transaction,
 )
-from .connection import get_conn
+from .connection import TIPO_CANON_SQL, get_conn
 from .users import ensure_user, ensure_user_tx
 
 
@@ -1358,13 +1358,26 @@ def pick_reconciliation_match(valor, tx_date, description, candidates) -> dict:
 
 
 def _find_manual_candidates(cur, user_id: int, tipo: str, valor, tx_date) -> list[dict]:
-    """Lançamentos manuais/OFX (não-OF) elegíveis a casar, ainda não vinculados a nenhuma OF tx."""
+    """Lançamentos manuais/OFX (não-OF) elegíveis a casar, ainda não vinculados a nenhuma OF tx.
+
+    `TIPO_CANON_SQL` e não `tipo = %s` cru, pela mesma razão de
+    `list_launches_by_tipo` (db/accounts.py:172): o tipo aqui é PARÂMETRO — vem
+    de `classify_open_finance_launch`, que só produz 'despesa'/'receita' (:1277)
+    — então colapsar a forma legada no lado da COLUNA faz a linha antiga
+    ('saida'/'entrada') ser candidata sem inventar regra por chamador, e deixa
+    qualquer outro valor casando exato como antes.
+
+    Sem isto o gêmeo legado do lançamento não era candidato, o dedupe falhava e
+    o gasto contava DUAS vezes. Medido (mesma transação OF de -50, mesmo dia,
+    mesmo estabelecimento): manual 'saida' → `inserted=1, auto_merged=0` e
+    `monthly_expense=100.0`; o mesmo manual na forma moderna 'despesa' →
+    `inserted=0, auto_merged=1` e `monthly_expense=50.0`."""
     cur.execute(
-        """
+        f"""
         select id, valor, coalesce(posted_at, criado_em::date) as ref_date, alvo, nota
         from launches
         where user_id = %s
-          and tipo = %s
+          and {TIPO_CANON_SQL} = %s
           and coalesce(source, 'manual') <> 'open_finance'
           and is_internal_movement = false
           and abs(valor - %s) <= %s

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -1365,7 +1365,11 @@ def _find_manual_candidates(cur, user_id: int, tipo: str, valor, tx_date) -> lis
     de `classify_open_finance_launch`, que só produz 'despesa'/'receita' (:1277)
     — então colapsar a forma legada no lado da COLUNA faz a linha antiga
     ('saida'/'entrada') ser candidata sem inventar regra por chamador, e deixa
-    qualquer outro valor casando exato como antes.
+    qualquer outro valor casando exato como antes. Com a MESMA inversão de
+    `list_launches_by_tipo`: 'saida'/'entrada' passadas como ARGUMENTO passam a
+    não casar nada (antes casavam as linhas legadas). Inalcançável daqui — o
+    único produtor do argumento é `classify_open_finance_launch` — mas quem
+    ligar outro chamador precisa saber.
 
     Sem isto o gêmeo legado do lançamento não era candidato, o dedupe falhava e
     o gasto contava DUAS vezes. Medido (mesma transação OF de -50, mesmo dia,

--- a/db/recurring.py
+++ b/db/recurring.py
@@ -15,7 +15,7 @@ from decimal import Decimal
 from typing import Any
 
 from .categories import ensure_user_category, resolve_category_for_write
-from .connection import get_conn
+from .connection import get_conn, TIPO_DESPESA_SQL
 from .users import ensure_user
 
 
@@ -487,11 +487,11 @@ def find_recurring_candidate(
                     return 0
             # 3) despesas passadas com o MESMO valor exato (casa descrição depois)
             cur.execute(
-                """
+                f"""
                 select criado_em,
                        coalesce(nullif(alvo,''), nullif(nota,'')) as descr
                 from launches
-                where user_id=%s and tipo='despesa'
+                where user_id=%s and {TIPO_DESPESA_SQL}
                   and is_internal_movement=false
                   and valor=%s
                   and (%s::bigint is null or id <> %s)

--- a/scripts/medir_guarda_efeitos_214.py
+++ b/scripts/medir_guarda_efeitos_214.py
@@ -181,10 +181,31 @@ def _guarda_b4d0085(efeitos, *, escopo_conta_corrente):
 # Classificação
 # ---------------------------------------------------------------------------
 # `escopo_conta_corrente=True` é usado SÓ por `delete_all_launches_and_rollback`,
-# que lê `where tipo in ('despesa','receita')` (`_CONTA_CORRENTE_LAUNCH_FILTER`).
+# e o conjunto que ela apaga é `_CONTA_CORRENTE_LAUNCH_FILTER` (db/accounts.py).
 # Fora desse filtro o `fora_do_escopo` seria ruído — por isso a tabela do
 # "apagar tudo" só conta essas linhas.
-_TIPOS_APAGAR_TUDO = ("despesa", "receita")
+#
+# DERIVADO, não congelado (§0.7). O literal `("despesa", "receita")` que morava
+# aqui ficou falso no dia em que o filtro passou a incluir a forma legada: com
+# ele, `tipo='saida'` caía no bloco 'singular' e o script imprimia "apaga"
+# exatamente onde o código real devolve `kept_unsafe`/`fora_do_escopo` — a
+# medição sairia errada na direção "a guarda não pega nada", que é o oposto do
+# que ela faz. É outra coisa que a guarda `b4d0085` acima: lá o congelamento é
+# de propósito (a versão VELHA, para comparar duas colunas); aqui é o recorte de
+# HOJE, e ele tem de acompanhar o código.
+#
+# ponytail: extração por regex do literal SQL — vale enquanto o filtro for
+# disjunção de `tipo IN (...)`. Termo que não seja de `tipo` (um
+# `and is_internal_movement = false`, por exemplo) não aparece no conjunto;
+# quem pega o eixo `tipo` é
+# `tests/test_medir_guarda_efeitos.py::test_recorte_do_apagar_tudo_bate_com_o_sql`,
+# que roda o filtro DE VERDADE contra o banco e compara com este conjunto.
+@lru_cache(maxsize=1)
+def _tipos_apagar_tudo():
+    from db.accounts import _CONTA_CORRENTE_LAUNCH_FILTER
+
+    return frozenset(re.findall(r"'([^']*)'", _CONTA_CORRENTE_LAUNCH_FILTER))
+
 
 # Só a FORMA do caminho ('bill_id', 'delete_pocket.nome'), e só de um conjunto
 # FECHADO deles. Regex de identificador não servia: a mensagem de
@@ -245,7 +266,7 @@ def classificar(efeitos, tipo):
     ef = _normalizar(efeitos)
     if ef is None:
         return ("sem_efeitos", "", ""), ("sem_efeitos", "", "")
-    escopo = tipo in _TIPOS_APAGAR_TUDO
+    escopo = tipo in _tipos_apagar_tudo()
 
     def rodar(fn):
         try:
@@ -266,10 +287,11 @@ def medir(cur):
     O registro individual é DESCARTADO logo depois de contado: nada acumula em
     lista, nem para amostra."""
     cruz, detalhe, total = Counter(), Counter(), 0
+    tipos = _tipos_apagar_tudo()
     for tipo, efeitos in cur:
         total += 1
         velho, novo = classificar(efeitos, tipo)
-        alvo = "tudo" if tipo in _TIPOS_APAGAR_TUDO else "singular"
+        alvo = "tudo" if tipo in tipos else "singular"
         cruz[(alvo, velho[0], novo[0])] += 1
         if novo[0] == "recusa":   # `sem_efeitos` ja tem linha propria
             detalhe[(alvo, velho[0], novo[0], novo[1], novo[2])] += 1
@@ -329,8 +351,9 @@ def relatar(cruz, detalhe, total, info_servidor):
           "(HEAD do checkout, #214) ==")
     print(f"servidor: {info_servidor}")
     print(f"linhas de 'launches' examinadas: {total}")
-    _bloco("apagar tudo (escopo_conta_corrente=True) — tipo in "
-           "('despesa','receita')", "tudo", cruz, detalhe)
+    recorte = ",".join(f"'{t}'" for t in sorted(_tipos_apagar_tudo()))
+    _bloco(f"apagar tudo (escopo_conta_corrente=True) — tipo in ({recorte})",
+           "tudo", cruz, detalhe)
     _bloco("demais portas (escopo_conta_corrente=False) — os outros tipos",
            "singular", cruz, detalhe)
 
@@ -384,6 +407,14 @@ def _autoteste():
          "despesa", "recusa", "recusa"),
         ({"delta_conta": 0, "create_pocket": {"nome": "x"}},
          "despesa", "recusa", "recusa"),   # fora_do_escopo, nas duas
+        # a forma LEGADA é conta corrente do mesmo jeito. Com o literal
+        # `("despesa","receita")` de volta em `_tipos_apagar_tudo`, estes dois
+        # viram ("apaga","apaga") e o bloco impresso vira 'singular' — o script
+        # mediria "a guarda não pega nada" onde ela recusa.
+        ({"delta_conta": 0, "create_pocket": {"nome": "x"}},
+         "saida", "recusa", "recusa"),
+        ({"delta_conta": 0, "create_pocket": {"nome": "x"}},
+         "entrada", "recusa", "recusa"),
         # 'efeitos' que nao e dict
         (None, "despesa", "sem_efeitos", "sem_efeitos"),
         ([1, 2], "despesa", "sem_efeitos", "sem_efeitos"),
@@ -463,6 +494,7 @@ def main():
     # falha dele nascia com um `efeitos` no `__context__`.
     from db.accounts import LaunchUnsafeRollback, _validar_efeitos  # noqa: F401
     _caminhos_do_esquema()
+    _tipos_apagar_tudo()
 
     conn = psycopg.connect(dsn, options=_OPTIONS, connect_timeout=10,
                            autocommit=False)

--- a/tests/test_delete_all_launches.py
+++ b/tests/test_delete_all_launches.py
@@ -1730,3 +1730,79 @@ def test_bill_id_de_outro_usuario_recusa_em_vez_de_creditar(user_id: int):
     assert _bill_status(bill_meu) == "paid", "a fatura do dono não é tocada na recusa"
     assert any(int(r["id"]) == pgto for r in db.list_launches(user_id, limit=10))
 
+
+# ── a forma LEGADA no "apagar tudo" ─────────────────────────────────────────
+#
+# `_CONTA_CORRENTE_LAUNCH_FILTER` era `tipo in ('despesa','receita')` e deixava
+# 'saida'/'entrada' de fora dos DOIS lados do par ("o que se conta é o que se
+# apaga"). O sintoma não era subcontagem: medido num banco descartável com uma
+# despesa moderna + uma 'saida' + uma 'entrada', `count_launches` dizia 1 e o
+# retorno vinha `remaining: 0` com as duas legadas ainda na tabela — o sistema
+# afirmando ter apagado tudo. Com a constante ampliada, isto é o que muda:
+#   • a confirmação ("vou apagar N") passa a incluir a linha legada;
+#   • uma linha legada com `efeitos` de caixinha/investimento passa a ser
+#     RECUSADA (`kept_unsafe`, motivo `fora_do_escopo`) em vez de nem ser olhada
+#     — recusa PERMANENTE, o teto conhecido do #214.
+
+def test_apagar_tudo_conta_e_apaga_a_linha_legada(user_id: int):
+    """Controle NEGATIVO deste par: voltando o filtro para
+    `tipo in ('despesa','receita')`, `count_launches` dá 1, `deleted` dá 1 e o
+    `remaining: 0` sai com DUAS linhas ainda na tabela — que é o defeito.
+
+    A legada entra por `_set_tipo` sobre um lançamento REAL: assim ela carrega o
+    `efeitos` que o escritor de verdade grava, e o saldo tem o que reverter."""
+    add_launch_and_update_balance(user_id, "receita", 1000, None, "seed")
+    lid_saida, _s, _ = add_launch_and_update_balance(
+        user_id, "despesa", 100, "mercado", "gastei 100 mercado")
+    lid_entrada, _s2, _ = add_launch_and_update_balance(
+        user_id, "receita", 300, None, "freela")
+    _set_tipo(user_id, lid_saida, "saida")
+    _set_tipo(user_id, lid_entrada, "entrada")
+    assert _bal(user_id) == 1200.0
+
+    assert db.count_launches(user_id) == 3, "a confirmação tem de citar as 3"
+
+    result = db.delete_all_launches_and_rollback(user_id)
+
+    assert result == {"deleted": 3, "kept_no_effects": [], "kept_unsafe": [],
+                      "errors": [], "remaining": 0}, result
+    # o ponto: `remaining` é uma AFIRMAÇÃO sobre a tabela — confere contra ela,
+    # não contra `count_launches` (que usa o mesmo filtro e mentiria junto).
+    assert _linhas_cruas(user_id) == [], "sobrou linha com `remaining: 0` no retorno"
+    assert _bal(user_id) == 0.0, "o saldo da legada também tem de voltar"
+
+
+def test_linha_legada_de_caixinha_vai_para_kept_unsafe(user_id: int):
+    """Controle POSITIVO do teto: ampliar o filtro NÃO pode fazer o "apagar
+    tudo" destruir caixinha/investimento por uma linha legada.
+
+    Irmão de `test_apagar_tudo_nao_toca_caixinha_com_tipo_reescrito`, com
+    'saida' no lugar de 'despesa': é a porta que este PR ABRE. O pré-voo do #214
+    (`_EFEITOS_FORA_DO_APAGAR_TUDO`) recusa antes de qualquer escrita, a linha
+    cai em `kept_unsafe` (frase de produto), e `remaining` bate com a tabela.
+
+    Controle negativo medido: sem a guarda de escopo a caixinha some
+    (`_pocket_balance` volta None) — é o mesmo que o irmão mede."""
+    from db.pockets import create_pocket
+
+    lid, _pid, _nome = create_pocket(user_id, "viagem")
+    _set_tipo(user_id, lid, "saida")   # LEGADA: é o que a faz entrar no conjunto
+    assert db.count_launches(user_id) == 1, "sem o filtro ampliado ela nem seria contada"
+
+    result = db.delete_all_launches_and_rollback(user_id)
+
+    assert result["kept_unsafe"] == [_user_seq(user_id, lid)], result
+    assert result["deleted"] == 0, result
+    assert result["errors"] == [], "recusa de domínio não é erro técnico"
+    assert _pocket_balance(user_id, "viagem") is not None, "a caixinha foi apagada"
+    assert result["remaining"] == len(_linhas_cruas(user_id)) == 1, result
+
+
+def _linhas_cruas(user_id: int) -> list:
+    """As linhas do usuário SEM filtro de tipo — a realidade contra a qual
+    `remaining` é conferido."""
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select id, tipo from launches where user_id=%s order by id",
+                        (user_id,))
+            return [dict(r) for r in cur.fetchall()]

--- a/tests/test_delete_all_launches.py
+++ b/tests/test_delete_all_launches.py
@@ -1739,10 +1739,15 @@ def test_bill_id_de_outro_usuario_recusa_em_vez_de_creditar(user_id: int):
 # despesa moderna + uma 'saida' + uma 'entrada', `count_launches` dizia 1 e o
 # retorno vinha `remaining: 0` com as duas legadas ainda na tabela — o sistema
 # afirmando ter apagado tudo. Com a constante ampliada, isto é o que muda:
-#   • a confirmação ("vou apagar N") passa a incluir a linha legada;
+#   • o PORTÃO do `/ai/chat` (`delete_all_launches.validate`, o único consumidor
+#     de `count_launches`) deixa de afirmar "seu histórico já está limpo" com
+#     linha na tabela. Não é um "N" na frase: `_delete_all_launches_summary` nem
+#     recebe `user_id` — o que muda é `n <= 0`;
 #   • uma linha legada com `efeitos` de caixinha/investimento passa a ser
-#     RECUSADA (`kept_unsafe`, motivo `fora_do_escopo`) em vez de nem ser olhada
-#     — recusa PERMANENTE, o teto conhecido do #214.
+#     RECUSADA (`kept_unsafe`) em vez de nem ser olhada — recusa PERMANENTE, o
+#     teto conhecido do #214. O `motivo` do log é `fora_do_escopo` em 6 das 8
+#     chaves; `delta_pocket`/`delta_invest` sem lote saem `lote_ausente`
+#     (`_DELTA_EXIGE_LOTE` dispara antes da guarda de escopo).
 
 def test_apagar_tudo_conta_e_apaga_a_linha_legada(user_id: int):
     """Controle NEGATIVO deste par: voltando o filtro para
@@ -1760,7 +1765,7 @@ def test_apagar_tudo_conta_e_apaga_a_linha_legada(user_id: int):
     _set_tipo(user_id, lid_entrada, "entrada")
     assert _bal(user_id) == 1200.0
 
-    assert db.count_launches(user_id) == 3, "a confirmação tem de citar as 3"
+    assert db.count_launches(user_id) == 3, "as 3 têm de entrar no conjunto"
 
     result = db.delete_all_launches_and_rollback(user_id)
 
@@ -1770,6 +1775,32 @@ def test_apagar_tudo_conta_e_apaga_a_linha_legada(user_id: int):
     # não contra `count_launches` (que usa o mesmo filtro e mentiria junto).
     assert _linhas_cruas(user_id) == [], "sobrou linha com `remaining: 0` no retorno"
     assert _bal(user_id) == 0.0, "o saldo da legada também tem de voltar"
+
+
+def test_portao_do_chat_nao_diz_historico_limpo_com_linha_legada(user_id: int):
+    """O consumo REAL de `count_launches` é o portão `n <= 0` do `validate` da
+    tool `delete_all_launches` — não um "N" na frase de confirmação
+    (`_delete_all_launches_summary` nem recebe `user_id`).
+
+    Base 100% LEGADA de propósito: com uma linha moderna junto, `count` já era
+    >= 1 dos dois lados e o assert não mediria nada. Medido, com o filtro antigo:
+    `count=0` e o bot respondia "🐷 ... seu histórico já está limpo" com as duas
+    linhas na tabela — afirmação falsa num caminho destrutivo, ANTES de qualquer
+    confirmação. Com o filtro ampliado: `count=2` e `validate` devolve None.
+
+    Controle NEGATIVO: volte `_CONTA_CORRENTE_LAUNCH_FILTER` para
+    `tipo in ('despesa','receita')` e este caso fica vermelho na 1ª asserção."""
+    lid_s, _a, _ = add_launch_and_update_balance(
+        user_id, "despesa", 50, "mercado", "gastei 50 mercado")
+    lid_e, _b, _ = add_launch_and_update_balance(
+        user_id, "receita", 300, None, "freela")
+    _set_tipo(user_id, lid_s, "saida")
+    _set_tipo(user_id, lid_e, "entrada")
+
+    assert db.count_launches(user_id) == 2, "o portão do chat lê este número"
+    assert get_tool("delete_all_launches").validate(user_id, {}) is None, (
+        "o bot afirmou 'histórico já está limpo' com 2 linhas na tabela"
+    )
 
 
 def test_linha_legada_de_caixinha_vai_para_kept_unsafe(user_id: int):

--- a/tests/test_medir_guarda_efeitos.py
+++ b/tests/test_medir_guarda_efeitos.py
@@ -149,3 +149,49 @@ def test_escape_alem_do_tratador_nao_imprime_nada(tmp_path):
     assert "12345678900" not in fim.stdout + fim.stderr
     assert fim.stdout == "" and fim.stderr == ""
     assert fim.returncode == 5, "o codigo de saida e o unico aviso que sobra"
+
+
+# ── o recorte do "apagar tudo": duas fontes, um teste (§0.7) ────────────────
+#
+# O script decide o bloco ('tudo' × 'singular') e o `escopo_conta_corrente` da
+# guarda a partir de `_tipos_apagar_tudo()`; quem apaga de verdade é
+# `_CONTA_CORRENTE_LAUNCH_FILTER`, em SQL. Enquanto forem duas expressões, uma
+# tem de ser conferida contra a outra — senão o script volta a divergir calado,
+# que foi o que aconteceu: com o literal `("despesa","receita")` congelado, a
+# linha legada saía no bloco 'singular' com veredito "apaga" onde o código real
+# devolve `kept_unsafe`/`fora_do_escopo`.
+#
+# TETO: isto mede o eixo `tipo`. Um termo que não seja de `tipo` no filtro (um
+# `and is_internal_movement = false`) passaria por aqui — todas as linhas
+# semeadas nascem com o default da coluna.
+_TIPOS_SEMEADOS = (
+    "despesa", "receita", "saida", "entrada",
+    "aporte_investimento", "deposito_caixinha", "saque_caixinha",
+    "resgate_investimento", "criar_caixinha",
+)
+
+
+def test_recorte_do_apagar_tudo_bate_com_o_sql(user_id):
+    """Controle negativo: recongele `_tipos_apagar_tudo` em
+    `("despesa","receita")` e o SQL devolve 'saida'/'entrada' a mais — vermelho.
+    Controle positivo embutido: os tipos de caixinha/investimento continuam
+    FORA dos dois lados, então o teste não passa num filtro que pega tudo."""
+    import db
+    from db.accounts import _CONTA_CORRENTE_LAUNCH_FILTER
+
+    with db.get_conn() as conn, conn.cursor() as cur:
+        for tipo in _TIPOS_SEMEADOS:
+            cur.execute(
+                "insert into launches (user_id, tipo, valor, categoria, nota) "
+                "values (%s, %s, 1, 'outros', 'recorte')",
+                (user_id, tipo),
+            )
+        cur.execute(
+            f"select tipo from launches where user_id=%s "
+            f"and {_CONTA_CORRENTE_LAUNCH_FILTER}",
+            (user_id,),
+        )
+        do_sql = {r["tipo"] for r in cur.fetchall()}
+
+    assert do_sql == set(_carregar()._tipos_apagar_tudo()), do_sql
+    assert do_sql < set(_TIPOS_SEMEADOS), "o filtro passou a pegar TODO tipo"

--- a/tests/test_tipo_legado_no_dashboard.py
+++ b/tests/test_tipo_legado_no_dashboard.py
@@ -46,13 +46,17 @@ def _hoje_as(hora: int):
 
 
 def _grava_tipo_legado(user_id, tipo, valor, categoria, *,
-                       nota=None, criado_em=None, interno=False):
+                       nota=None, alvo=None, criado_em=None, interno=False):
     """`add_launch_and_update_balance` não grava a forma legada (nem deve): a
     linha antiga entra por SQL, que é como ela existe numa base de verdade.
 
-    `nota`/`criado_em`/`interno` são os eixos que os OUTROS leitores da forma
-    legada precisam variar (descrição para casar merchant, mês anterior, saída
-    interna) — ver `tests/test_tipo_legado_sem_numero.py`.
+    `nota`/`alvo`/`criado_em`/`interno` são os eixos que os OUTROS leitores da
+    forma legada precisam variar (descrição para casar merchant, mês anterior,
+    saída interna) — ver `tests/test_tipo_legado_sem_numero.py`.
+
+    `alvo` importa no dedupe do Open Finance: `alvo` NULO cai em
+    `_is_generic_merchant` (db/open_finance.py:1322) e casa com QUALQUER
+    estabelecimento — ver `tests/test_tipo_legado_no_dedupe_do_of.py`.
 
     `interno=True` marca `is_internal_movement` — a transferência antiga, que é
     linha legada E movimento interno ao mesmo tempo — e, sem `nota` explícita,
@@ -60,10 +64,10 @@ def _grava_tipo_legado(user_id, tipo, valor, categoria, *,
     `tests/test_tipo_legado_na_cauda.py` a reconhece na lista do dia)."""
     with db.get_conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "insert into launches (user_id, tipo, valor, categoria, nota, "
-            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,%s)",
+            "insert into launches (user_id, tipo, valor, categoria, nota, alvo, "
+            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,%s,%s)",
             (user_id, tipo, valor, categoria,
-             nota or ("legado-interno" if interno else "legado"),
+             nota or ("legado-interno" if interno else "legado"), alvo,
              criado_em or _hoje_as(9), interno),
         )
         conn.commit()

--- a/tests/test_tipo_legado_no_dashboard.py
+++ b/tests/test_tipo_legado_no_dashboard.py
@@ -45,14 +45,20 @@ def _hoje_as(hora: int):
     return datetime.combine(today_tz(), time(hora, 0))
 
 
-def _grava_tipo_legado(user_id, tipo, valor, categoria):
+def _grava_tipo_legado(user_id, tipo, valor, categoria, *,
+                       nota="legado", criado_em=None, interno=False):
     """`add_launch_and_update_balance` não grava a forma legada (nem deve): a
-    linha antiga entra por SQL, que é como ela existe numa base de verdade."""
+    linha antiga entra por SQL, que é como ela existe numa base de verdade.
+
+    `nota`/`criado_em`/`interno` são os eixos que os OUTROS leitores da forma
+    legada precisam variar (descrição para casar merchant, mês anterior, saída
+    interna) — ver `tests/test_tipo_legado_sem_numero.py`."""
     with db.get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "insert into launches (user_id, tipo, valor, categoria, nota, "
-            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,false)",
-            (user_id, tipo, valor, categoria, "legado", _hoje_as(9)),
+            "criado_em, is_internal_movement) values (%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, tipo, valor, categoria, nota,
+             criado_em or _hoje_as(9), interno),
         )
         conn.commit()
 

--- a/tests/test_tipo_legado_no_dedupe_do_of.py
+++ b/tests/test_tipo_legado_no_dedupe_do_of.py
@@ -1,0 +1,171 @@
+"""A forma legada de `tipo` no dedupe do Open Finance — a única da cauda que
+dobra DINHEIRO.
+
+Os irmãos (`test_tipo_legado_sem_numero.py`, `..._na_cauda.py`) tratam sugestão
+que some e lista que encolhe. Aqui o sintoma é outro: `_find_manual_candidates`
+(db/open_finance.py:1360) filtrava `tipo = %s` com o tipo vindo de
+`classify_open_finance_launch` (:1277), que só produz 'despesa'/'receita'. O
+gêmeo manual LEGADO ('saida') nunca era candidato, `pick_reconciliation_match`
+não tinha o que casar, e o importador criava um segundo lançamento para a MESMA
+transação real.
+
+Medido no caminho de produção (espelho Pluggy → `import_open_finance_launches`
+→ `get_financial_data`), manual de 50 + transação OF de -50, mesmo dia, mesmo
+estabelecimento:
+
+    manual 'saida'   (legado)  → inserted=1, auto_merged=0, monthly_expense=100.0
+    manual 'despesa' (moderno) → inserted=0, auto_merged=1, monthly_expense= 50.0
+
+50 reais gastos aparecendo como 100. Não há outra rede: o OF launch entra com
+`delta_conta=0` (não mexe em `accounts.balance`), mas conta inteiro no "Gastos
+do mês" e no "sobrou".
+
+Conserto: `TIPO_CANON_SQL` no lado da COLUNA, igual `list_launches_by_tipo`
+(db/accounts.py:172) — o tipo aqui também é parâmetro, não literal.
+
+O risco espelhado é o FALSO casamento — ampliar o que casa esconde lançamento
+legítimo — então o grupo tem as DUAS mutações medidas, uma para cada lado:
+
+  `{TIPO_CANON_SQL} = %s` → `tipo = %s`            (NEGATIVO, desliga o conserto)
+      FAILED test_gasto_legado_gemeo_nao_conta_duas_vezes      (100.0 != 50.0)
+      FAILED test_gasto_legado_de_outro_estabelecimento_nao_e_engolido
+      3 passed
+
+  `{TIPO_CANON_SQL} = %s` → `coalesce(%s, tipo) is not null`   (alargou de MAIS)
+      FAILED test_receita_legada_nao_casa_com_gasto_do_of
+      FAILED test_aporte_legado_nao_casa_com_gasto_do_of
+      3 passed
+
+`test_o_casamento_moderno_continua_igual` é o positivo do meio: verde nas duas
+mutações de propósito — ele prova que o caminho que já funcionava não mudou.
+
+`alvo` é obrigatório nos casos: `alvo` NULO cai em `_is_generic_merchant`
+(db/open_finance.py:1322) e casa com QUALQUER estabelecimento, o que apagaria a
+diferença entre casar por nome e casar por genérico.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, time
+from decimal import Decimal
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+from utils_date import _tz, today_tz
+
+from tests.test_tipo_legado_no_dashboard import _grava_tipo_legado
+
+
+def _importa_of(user_id: int, dia, *, valor="50.00", descricao="MERCADO PAGUE MENOS",
+                categoria="mercado") -> dict:
+    """A transação OF pelo caminho de PRODUÇÃO: espelho Pluggy → importador.
+
+    Local, e não o `_of_do_dia` de `test_category_launches_query.py`, porque
+    aquele crava `assert rep["inserted"] == 1` — que é exatamente o número que
+    este conserto muda."""
+    conexao = db.save_pluggy_open_finance_item(
+        user_id,
+        {"id": f"item-of-{user_id}", "connector": {"id": 612, "name": "Nubank"},
+         "status": "UPDATED"},
+    )
+    db.save_open_finance_sync(conexao["id"], [{
+        "provider_account_id": f"acc-of-{user_id}",
+        "name": "Nubank Conta", "type": "BANK", "subtype": "CHECKING_ACCOUNT",
+        "currency": "BRL", "balance": Decimal("1000.00"), "raw": {},
+        "transactions": [{
+            "provider_transaction_id": f"of-tx-{user_id}",
+            "description": descricao,
+            "amount": Decimal("-" + valor),
+            "transaction_date": dia,
+            "transacted_at": None,
+            "category": categoria,
+            "raw": {},
+        }],
+    }])
+    return db.import_open_finance_launches(user_id, conexao["id"])
+
+
+def _gasto_do_mes(user_id: int) -> float:
+    h = today_tz()
+    d = asyncio.run(dashboard.get_financial_data(user_id, year=h.year, month=h.month))
+    return d["monthly_expense"]
+
+
+# ── o defeito: gasto contado duas vezes ─────────────────────────────────────
+
+def test_gasto_legado_gemeo_nao_conta_duas_vezes(pro_user_id):
+    """Um gasto de 50 lançado à mão na forma legada + a mesma compra chegando
+    pelo Open Finance. Uma transação real = uma linha = 50 no mês."""
+    hoje = today_tz()
+    _grava_tipo_legado(pro_user_id, "saida", 50.00, "mercado",
+                       nota="Mercado Pague Menos", alvo="Mercado Pague Menos",
+                       criado_em=datetime.combine(hoje, time(9, 0)))
+
+    rep = _importa_of(pro_user_id, hoje)
+
+    assert rep["auto_merged"] == 1, rep
+    assert rep["inserted"] == 0, rep
+    assert _gasto_do_mes(pro_user_id) == 50.0, _gasto_do_mes(pro_user_id)
+
+
+# ── positivo 1: não alargou de menos ────────────────────────────────────────
+
+def test_o_casamento_moderno_continua_igual(pro_user_id):
+    hoje = today_tz()
+    db.add_launch_and_update_balance(
+        pro_user_id, "despesa", 50.00, "Mercado Pague Menos", "Mercado Pague Menos",
+        "mercado", criado_em=datetime.combine(hoje, time(9, 0), tzinfo=_tz()),
+    )
+
+    rep = _importa_of(pro_user_id, hoje)
+
+    assert (rep["auto_merged"], rep["inserted"]) == (1, 0), rep
+    assert _gasto_do_mes(pro_user_id) == 50.0, _gasto_do_mes(pro_user_id)
+
+
+# ── positivos 2 e 3: não alargou de MAIS (falso casamento) ──────────────────
+
+def test_receita_legada_nao_casa_com_gasto_do_of(pro_user_id):
+    """'entrada' é receita. Uma despesa do OF não pode engoli-la só porque o
+    valor, o dia e o estabelecimento coincidem — seria esconder uma entrada
+    legítima do usuário."""
+    hoje = today_tz()
+    _grava_tipo_legado(pro_user_id, "entrada", 50.00, "salario",
+                       nota="Mercado Pague Menos", alvo="Mercado Pague Menos",
+                       criado_em=datetime.combine(hoje, time(9, 0)))
+
+    rep = _importa_of(pro_user_id, hoje)
+
+    assert (rep["auto_merged"], rep["pending"], rep["inserted"]) == (0, 0, 1), rep
+    assert _gasto_do_mes(pro_user_id) == 50.0, _gasto_do_mes(pro_user_id)
+
+
+def test_aporte_legado_nao_casa_com_gasto_do_of(pro_user_id):
+    """`aporte_investimento` não é forma legada de nada: `TIPO_CANON_SQL` o
+    deixa casando EXATO, como antes. Uma despesa do OF não o alcança."""
+    hoje = today_tz()
+    _grava_tipo_legado(pro_user_id, "aporte_investimento", 50.00, "mercado",
+                       nota="Mercado Pague Menos", alvo="Mercado Pague Menos",
+                       criado_em=datetime.combine(hoje, time(9, 0)))
+
+    rep = _importa_of(pro_user_id, hoje)
+
+    assert (rep["auto_merged"], rep["pending"], rep["inserted"]) == (0, 0, 1), rep
+
+
+def test_gasto_legado_de_outro_estabelecimento_nao_e_engolido(pro_user_id):
+    """O que passa a ser candidato continua passando pelos MESMOS portões que a
+    forma moderna: nome diverge → 'ask' (sugestão pendente), nunca fusão
+    automática. A linha manual do usuário continua existindo."""
+    hoje = today_tz()
+    _grava_tipo_legado(pro_user_id, "saida", 50.00, "farmacia",
+                       nota="Drogaria Sao Paulo", alvo="Drogaria Sao Paulo",
+                       criado_em=datetime.combine(hoje, time(9, 0)))
+
+    rep = _importa_of(pro_user_id, hoje)
+
+    assert (rep["auto_merged"], rep["pending"], rep["inserted"]) == (0, 1, 1), rep
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select count(*) as n from launches where user_id=%s and tipo='saida'",
+                    (pro_user_id,))
+        assert cur.fetchone()["n"] == 1, "a linha manual do usuário sumiu"

--- a/tests/test_tipo_legado_no_dedupe_do_of.py
+++ b/tests/test_tipo_legado_no_dedupe_do_of.py
@@ -29,25 +29,38 @@ legítimo — então o grupo tem as DUAS mutações medidas, uma para cada lado:
   `{TIPO_CANON_SQL} = %s` → `tipo = %s`            (NEGATIVO, desliga o conserto)
       FAILED test_gasto_legado_gemeo_nao_conta_duas_vezes      (100.0 != 50.0)
       FAILED test_gasto_legado_de_outro_estabelecimento_nao_e_engolido
-      3 passed
+      FAILED test_alvo_nulo_casa_igual_no_legado_e_no_moderno[saida]  ((0,0,1))
+      4 passed  — entre eles o [despesa] do mesmo caso, verde de propósito
 
   `{TIPO_CANON_SQL} = %s` → `coalesce(%s, tipo) is not null`   (alargou de MAIS)
       FAILED test_receita_legada_nao_casa_com_gasto_do_of
       FAILED test_aporte_legado_nao_casa_com_gasto_do_of
-      3 passed
+      5 passed
 
 `test_o_casamento_moderno_continua_igual` é o positivo do meio: verde nas duas
 mutações de propósito — ele prova que o caminho que já funcionava não mudou.
 
-`alvo` é obrigatório nos casos: `alvo` NULO cai em `_is_generic_merchant`
+`alvo` é obrigatório nos casos ACIMA: `alvo` NULO cai em `_is_generic_merchant`
 (db/open_finance.py:1322) e casa com QUALQUER estabelecimento, o que apagaria a
 diferença entre casar por nome e casar por genérico.
+
+O eixo do `alvo` NULO é a fatia MAIS LARGA do conserto, e tem caso próprio
+(`test_alvo_nulo_casa_igual_no_legado_e_no_moderno`): ali o "gêmeo" pode ser uma
+compra genuinamente diferente, e o R$ 50 dela some sem pendência e sem volta
+(`reject_reconciliation` só age em `status='pending'`). Isso está prendido como
+ESCOLHA, não como acidente: o espelho MODERNO ('despesa' com `alvo` NULO) dá o
+mesmo resultado, então é o desenho pré-existente de `_is_generic_merchant`
+passando a valer para a linha legada também — e dobrar dinheiro (o defeito que
+este PR conserta) é pior que fundir por genérico. Mudar isso é mexer no
+`_is_generic_merchant`, que é outro escopo.
 """
 from __future__ import annotations
 
 import asyncio
 from datetime import datetime, time
 from decimal import Decimal
+
+import pytest
 
 import db
 import frontend.finance_bot_websocket_custom as dashboard
@@ -169,3 +182,37 @@ def test_gasto_legado_de_outro_estabelecimento_nao_e_engolido(pro_user_id):
         cur.execute("select count(*) as n from launches where user_id=%s and tipo='saida'",
                     (pro_user_id,))
         assert cur.fetchone()["n"] == 1, "a linha manual do usuário sumiu"
+
+
+# ── a fatia mais larga: `alvo` NULO casa com qualquer estabelecimento ───────
+
+@pytest.mark.parametrize("tipo", ["saida", "despesa"])
+def test_alvo_nulo_casa_igual_no_legado_e_no_moderno(pro_user_id, tipo):
+    """Legado e moderno, o MESMO insert, só o `tipo` muda — e o resultado tem de
+    ser o mesmo. É o que faz do comportamento uma escolha e não um acidente.
+
+    `alvo` NULO → `_is_generic_merchant` → casa com QUALQUER nome, então a
+    compra do OF ("POSTO IPIRANGA") funde com um gasto manual que pode ser
+    genuinamente OUTRO. Medido nos dois tipos: `auto_merged=1, inserted=0,
+    pending=0`, `monthly_expense=50.0`, 1 linha na tabela. Com o conserto
+    desligado (`{TIPO_CANON_SQL} = %s` → `tipo = %s`) o LEGADO vira
+    `auto_merged=0, inserted=1`, `monthly_expense=100.0` e 2 linhas — o moderno
+    fica igual, que é o ponto: o conserto só ALINHA os dois.
+
+    Custo conhecido e aceito: R$ 50 de gasto real somem sem pendência (o
+    `reject_reconciliation` só age em `status='pending'`). É o desenho
+    pré-existente de `_is_generic_merchant`, não algo que este PR inventou —
+    contar o mesmo gasto DUAS vezes, que é o defeito consertado aqui, é pior."""
+    hoje = today_tz()
+    _grava_tipo_legado(pro_user_id, tipo, 50.00, "mercado", nota="gasto",
+                       criado_em=datetime.combine(hoje, time(9, 0)))
+
+    rep = _importa_of(pro_user_id, hoje, descricao="POSTO IPIRANGA",
+                      categoria="transporte")
+
+    assert (rep["auto_merged"], rep["pending"], rep["inserted"]) == (1, 0, 0), rep
+    assert _gasto_do_mes(pro_user_id) == 50.0, _gasto_do_mes(pro_user_id)
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select count(*) as n from launches where user_id=%s",
+                    (pro_user_id,))
+        assert cur.fetchone()["n"] == 1, "a fusão tem de deixar UMA linha"

--- a/tests/test_tipo_legado_sem_numero.py
+++ b/tests/test_tipo_legado_sem_numero.py
@@ -1,0 +1,130 @@
+"""A forma legada de `tipo` nos três leitores que não mostram NÚMERO na tela.
+
+Irmão de `test_tipo_legado_no_dashboard.py`, separado de propósito: lá o sintoma
+é um total errado na cara do usuário; aqui é uma SUGESTÃO que não aparece, e o
+controle negativo precisa ser montado com mais cuidado justamente porque não há
+número para comparar.
+
+| leitor                        | o que a linha legada tira do usuário          |
+|-------------------------------|-----------------------------------------------|
+| `find_recurring_candidate`    | subconta meses → não pergunta "virar fixo?"   |
+| `get_uncategorized_launches`  | a linha nunca vira candidata a regra          |
+| `get_internal_movement_total` | aporte legado fora da projeção de saldo       |
+
+O terceiro é sintético: `is_internal_movement` nasceu depois da forma legada, e
+a produção deu ZERO linhas legadas em 27/08/2026 (ver o docstring do irmão).
+Ele entra por ser o mesmo filtro cru, não por ter sintoma alcançável hoje.
+
+Controles NEGATIVOS (um por site) — reverta o filtro para `tipo = 'despesa'` em:
+  • db/recurring.py  (find_recurring_candidate)  → `test_repeticao_legada...` vermelho
+  • db/categories.py (get_uncategorized_launches) → `test_linha_legada_e_candidata...` vermelho
+  • db/accounts.py   (get_internal_movement_total) → `test_aporte_legado_entra...` vermelho
+Controle POSITIVO: `test_base_sem_linha_legada_responde_o_mesmo` — base normal
+(100% da produção hoje) devolve exatamente os mesmos números, sem contar duas vezes.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import db
+from db.accounts import add_launch_and_update_balance, get_internal_movement_total
+from db.categories import get_uncategorized_launches
+from db.recurring import find_recurring_candidate
+from utils_date import _tz, today_tz
+
+from tests.test_tipo_legado_no_dashboard import _grava_tipo_legado, _hoje_as
+
+
+def _add_moderno(user_id, valor, alvo, categoria, ano, mes, dia=10):
+    return add_launch_and_update_balance(
+        user_id, "despesa", valor, alvo, alvo, categoria,
+        criado_em=datetime(ano, mes, dia, 12, 0, tzinfo=_tz()),
+    )
+
+
+# ── 1) sugestão de gasto fixo ───────────────────────────────────────────────
+
+def test_repeticao_legada_conta_como_mes_de_evidencia(user_id):
+    """Duas ocorrências legadas em meses distintos são a MESMA evidência que
+    duas modernas: `>= 1` é o que faz o bot perguntar "quer virar gasto fixo?"."""
+    _grava_tipo_legado(user_id, "saida", 39.90, "assinaturas",
+                       nota="Netflix", criado_em=datetime(2026, 6, 10, 12, 0))
+    _grava_tipo_legado(user_id, "saida", 39.90, "assinaturas",
+                       nota="Netflix", criado_em=datetime(2026, 7, 10, 12, 0))
+
+    n = find_recurring_candidate(
+        user_id, "netflix", 39.90, current_year=2026, current_month=8,
+    )
+    assert n == 2, n
+
+
+def test_mes_legado_soma_com_mes_moderno(user_id):
+    """O caso que mais dói: a base tem UMA linha de cada forma. Filtrando só a
+    moderna sobra 1 mês — abaixo do limiar — e a sugestão nunca dispara."""
+    _grava_tipo_legado(user_id, "saida", 55.00, "assinaturas",
+                       nota="Spotify", criado_em=datetime(2026, 6, 10, 12, 0))
+    _add_moderno(user_id, 55.00, "Spotify", "assinaturas", 2026, 7)
+
+    n = find_recurring_candidate(
+        user_id, "spotify", 55.00, current_year=2026, current_month=8,
+    )
+    assert n == 2, n
+
+
+# ── 2) candidata a regra de categorização ───────────────────────────────────
+
+def test_linha_legada_e_candidata_a_regra(user_id):
+    _grava_tipo_legado(user_id, "saida", 31.00, "outros", nota="Padaria legada")
+    _add_moderno(user_id, 12.00, "Padaria nova", "outros", *_ano_mes_hoje())
+
+    notas = {l["nota"] for l in get_uncategorized_launches(user_id)}
+    assert "Padaria legada" in notas, notas
+    assert "Padaria nova" in notas, notas
+
+
+# ── 3) aporte interno na projeção de saldo ──────────────────────────────────
+
+def test_aporte_legado_entra_no_total_interno(user_id):
+    hoje = today_tz()
+    _grava_tipo_legado(user_id, "saida", 70.00, "caixinha", interno=True)
+    assert get_internal_movement_total(user_id, hoje, hoje) == 70.0
+
+
+# ── controle POSITIVO: base sem linha legada não muda ───────────────────────
+
+def test_base_sem_linha_legada_responde_o_mesmo(user_id):
+    """Sem esta prova o grupo passaria num código que conta a mesma linha duas
+    vezes — os três leitores têm que devolver o valor de sempre numa base
+    100% moderna, que é a produção de hoje."""
+    _add_moderno(user_id, 39.90, "Netflix", "assinaturas", 2026, 6)
+    _add_moderno(user_id, 39.90, "Netflix", "assinaturas", 2026, 7)
+    assert find_recurring_candidate(
+        user_id, "netflix", 39.90, current_year=2026, current_month=8,
+    ) == 2
+
+    _add_moderno(user_id, 12.00, "Padaria nova", "outros", *_ano_mes_hoje())
+    notas = [l["nota"] for l in get_uncategorized_launches(user_id)]
+    assert notas.count("Padaria nova") == 1, notas
+
+    hoje = today_tz()
+    _grava_interno_moderno(user_id, 70.00)
+    assert get_internal_movement_total(user_id, hoje, hoje) == 70.0
+
+
+# ── auxiliares ──────────────────────────────────────────────────────────────
+
+def _ano_mes_hoje():
+    h = today_tz()
+    return (h.year, h.month, h.day)
+
+
+def _grava_interno_moderno(user_id, valor):
+    """Aporte interno na forma MODERNA. `add_launch_and_update_balance` não
+    expõe `is_internal_movement`, então o espelho do legado também entra por SQL."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "insert into launches (user_id, tipo, valor, categoria, nota, "
+            "criado_em, is_internal_movement) values (%s,'despesa',%s,%s,%s,%s,true)",
+            (user_id, valor, "caixinha", "aporte", _hoje_as(9)),
+        )
+        conn.commit()

--- a/tests/test_tipo_legado_sem_numero.py
+++ b/tests/test_tipo_legado_sem_numero.py
@@ -146,6 +146,13 @@ def test_migracao_marca_a_linha_legada_como_interna(user_id):
                        nota="aporte legado")
     assert _flag_interna(user_id, "aporte legado") is False, "pré-condição"
 
+    # ponytail: `init_db()` roda o `update launches set is_internal_movement=true
+    # where categoria in (...)` SEM `user_id` — escrita GLOBAL, sobre a base
+    # inteira. Benigna na suíte de hoje (sequencial, um banco por execução,
+    # `_cleanup_user` por teste); morde no dia em que duas suítes dividirem o
+    # mesmo banco, ligando a flag em linhas de outro usuário. A saída seria
+    # repetir o `update` aqui com `user_id` — a segunda cópia da regra que este
+    # teste existe para pegar (§0.7). A troca é deliberada.
     init_db()
 
     assert _flag_interna(user_id, "aporte legado") is True, (

--- a/tests/test_tipo_legado_sem_numero.py
+++ b/tests/test_tipo_legado_sem_numero.py
@@ -1,4 +1,4 @@
-"""A forma legada de `tipo` nos três leitores que não mostram NÚMERO na tela.
+"""A forma legada de `tipo` nos quatro leitores que não mostram NÚMERO na tela.
 
 Irmão de `test_tipo_legado_no_dashboard.py`, separado de propósito: lá o sintoma
 é um total errado na cara do usuário; aqui é uma SUGESTÃO que não aparece, e o
@@ -10,23 +10,62 @@ número para comparar.
 | `find_recurring_candidate`    | subconta meses → não pergunta "virar fixo?"   |
 | `get_uncategorized_launches`  | a linha nunca vira candidata a regra          |
 | `get_internal_movement_total` | aporte legado fora da projeção de saldo       |
+| `list_launches_by_tipo`       | bot pergunta o valor recorrente que já sabe   |
 
-O terceiro é sintético: `is_internal_movement` nasceu depois da forma legada, e
-a produção deu ZERO linhas legadas em 27/08/2026 (ver o docstring do irmão).
-Ele entra por ser o mesmo filtro cru, não por ter sintoma alcançável hoje.
+O terceiro NÃO é sintético — a versão anterior deste docstring dizia o oposto do
+que o código faz. A migração retroativa de `db/schema.py:245-256` marca
+`is_internal_movement` por CATEGORIA, sem olhar o `tipo`, e roda a cada
+`init_db()`; então uma linha legada com categoria 'investimentos' (ou
+'criptomoedas', 'bitcoin'…) sai de lá marcada como movimento interno. Medido num
+banco descartável, uma única linha `tipo='saida'`/`categoria='investimentos'`:
+
+    antes da migracao : is_internal_movement=False
+    DEPOIS da migracao: is_internal_movement=True
+    get_internal_movement_total: 500.0
+
+O que continua valendo é que a produção deu ZERO linhas legadas em 27/08/2026
+(ver o docstring do irmão) — o caminho é alcançável, a base de hoje é que está
+vazia. `test_migracao_marca_a_linha_legada_como_interna` prende o mecanismo.
+
+O quarto (`list_launches_by_tipo`, db/accounts.py:172) é o único em que o `tipo`
+é PARÂMETRO e não literal: o conserto é `TIPO_CANON_SQL` no lado da coluna.
 
 Controles NEGATIVOS (um por site) — reverta o filtro para `tipo = 'despesa'` em:
   • db/recurring.py  (find_recurring_candidate)  → `test_repeticao_legada...` vermelho
   • db/categories.py (get_uncategorized_launches) → `test_linha_legada_e_candidata...` vermelho
   • db/accounts.py   (get_internal_movement_total) → `test_aporte_legado_entra...` vermelho
-Controle POSITIVO: `test_base_sem_linha_legada_responde_o_mesmo` — base normal
-(100% da produção hoje) devolve exatamente os mesmos números, sem contar duas vezes.
+  • db/accounts.py   (list_launches_by_tipo, `{TIPO_CANON_SQL}=%s` → `tipo=%s`)
+    → `test_valor_recorrente_legado_e_sugerido` vermelho (None != 1200.0)
+Controles POSITIVOS — são DOIS, porque um só não separa as duas maneiras de errar:
+  • `test_base_sem_linha_legada_responde_o_mesmo` (não alargou de menos): base
+    normal, 100% moderna, devolve os mesmos números;
+  • `test_receita_nao_conta_como_despesa` (não alargou de MAIS): trocar os quatro
+    filtros por `tipo is not null` deixaria receita/entrada/aporte entrarem como
+    despesa, e sem este caso o grupo ficava verde nessa mutação (medido: 5 passed).
+
+TETO MEDIDO do positivo "não alargou de menos" — ele pega 2 dos 4 sites, e os
+outros 2 são cegos por construção da FUNÇÃO, não do teste. Medido injetando
+`from launches, (values (1),(2)) as _dup(n)` (cada linha exatamente duas vezes)
+em UM site por vez, e rodando só `test_base_sem_linha_legada_responde_o_mesmo`:
+
+  db/categories.py  get_uncategorized_launches   → FAILED  (2 notas, esperava 1)
+  db/accounts.py    get_internal_movement_total  → FAILED  (140.0 != 70.0)
+  db/accounts.py    list_launches_by_tipo        → passed  (cego)
+  db/recurring.py   find_recurring_candidate     → cego, não medido
+
+Os dois cegos não têm conserto no teste: `find_recurring_candidate` devolve
+`len(months)` sobre um `set`, e `infer_recurring_value` é um argmax sobre um
+`Counter` — duplicação uniforme não muda nem conjunto nem qual valor é o mais
+frequente. Para esses dois, o que a duplicação alcançaria é a janela `limit=200`
+(200 linhas duplicadas = 100 reais), e isso precisa de outro método, não de mais
+um caso aqui.
 """
 from __future__ import annotations
 
 from datetime import datetime
 
 import db
+from core.handlers.launches import infer_recurring_value
 from db.accounts import add_launch_and_update_balance, get_internal_movement_total
 from db.categories import get_uncategorized_launches
 from db.recurring import find_recurring_candidate
@@ -90,12 +129,94 @@ def test_aporte_legado_entra_no_total_interno(user_id):
     assert get_internal_movement_total(user_id, hoje, hoje) == 70.0
 
 
+def test_migracao_marca_a_linha_legada_como_interna(user_id):
+    """O mecanismo que torna o caso acima ALCANÇÁVEL, e não sintético.
+
+    A migração de `db/schema.py:245-256` roda a cada `init_db()` e marca
+    `is_internal_movement` por CATEGORIA — o `tipo` não aparece no `where`, então
+    a forma legada é marcada igual à moderna. Ninguém precisou gravar a flag à
+    mão: o teste NÃO passa `interno=True`, quem liga é a migração.
+
+    `init_db()` de verdade em vez de repetir o `update` aqui: repetir criaria a
+    segunda cópia da regra (§0.7), e é justamente a divergência entre as duas que
+    este teste existe para pegar."""
+    from db import init_db
+
+    _grava_tipo_legado(user_id, "saida", 500.00, "investimentos",
+                       nota="aporte legado")
+    assert _flag_interna(user_id, "aporte legado") is False, "pré-condição"
+
+    init_db()
+
+    assert _flag_interna(user_id, "aporte legado") is True, (
+        "a migração deixou de marcar a linha legada — o caso acima virou sintético"
+    )
+    hoje = today_tz()
+    assert get_internal_movement_total(user_id, hoje, hoje) == 500.0
+
+
+# ── 4) valor recorrente auto-preenchido ─────────────────────────────────────
+
+def test_valor_recorrente_legado_e_sugerido(user_id):
+    """`infer_recurring_value` lê por `list_launches_by_tipo`, o único site em
+    que o `tipo` é PARÂMETRO. Com só a forma moderna casando, o bot volta a
+    PERGUNTAR "quanto foi o aluguel?" para quem já lançou o mesmo valor 4 vezes.
+
+    4 linhas e não 2: `_RECURRING_MIN_COUNT` é 2, e sobrar folga deixa claro que
+    o `None` do controle negativo é ausência de linha, não empate."""
+    for mes in (5, 6, 7, 8):
+        _grava_tipo_legado(user_id, "saida", 1200.00, "moradia", nota="aluguel",
+                           criado_em=datetime(2026, mes, 5, 12, 0))
+
+    assert infer_recurring_value(user_id, "despesa", "aluguel") == 1200.0
+
+
+# ── controle POSITIVO (não alargou de MAIS) ─────────────────────────────────
+
+def test_receita_nao_conta_como_despesa(user_id):
+    """Alargar de menos e alargar demais são erros DIFERENTES, e o grupo só
+    media o primeiro: trocar os filtros por `tipo is not null` deixava receita,
+    entrada e aporte entrarem como despesa e dava `5 passed` mesmo assim.
+
+    A base aqui é 100% NÃO-despesa. Todo leitor de despesa tem que devolver
+    vazio/zero — e `list_launches_by_tipo('despesa')` não pode ver a receita."""
+    _grava_tipo_legado(user_id, "entrada", 900.00, "salario", nota="Salario legado",
+                       criado_em=datetime(2026, 6, 10, 12, 0))
+    _grava_tipo_legado(user_id, "entrada", 900.00, "salario", nota="Salario legado",
+                       criado_em=datetime(2026, 7, 10, 12, 0))
+    add_launch_and_update_balance(
+        user_id, "receita", 900.00, "Salario legado", "Salario legado", "outros",
+        criado_em=datetime(2026, 8, 10, 12, 0, tzinfo=_tz()),
+    )
+    # aporte interno na forma que o produto grava (tipo próprio, nem despesa
+    # nem receita): não é despesa em leitor nenhum.
+    _grava_aporte_de_caixinha(user_id, 70.00)
+
+    assert find_recurring_candidate(
+        user_id, "salario legado", 900.00, current_year=2026, current_month=9,
+    ) == 0
+    assert get_uncategorized_launches(user_id) == []
+    hoje = today_tz()
+    assert get_internal_movement_total(user_id, hoje, hoje) == 0.0
+    assert infer_recurring_value(user_id, "despesa", "Salario legado") is None
+    # e o espelho: como RECEITA a mesma descrição é encontrada — senão o caso
+    # acima passaria num código que simplesmente não acha nada.
+    assert infer_recurring_value(user_id, "receita", "Salario legado") == 900.0
+
+
 # ── controle POSITIVO: base sem linha legada não muda ───────────────────────
 
 def test_base_sem_linha_legada_responde_o_mesmo(user_id):
     """Sem esta prova o grupo passaria num código que conta a mesma linha duas
-    vezes — os três leitores têm que devolver o valor de sempre numa base
-    100% moderna, que é a produção de hoje."""
+    vezes — os quatro leitores têm que devolver o valor de sempre numa base
+    100% moderna, que é a produção de hoje.
+
+    TETO MEDIDO: ele pega 2 dos 4 sites (`get_uncategorized_launches` e
+    `get_internal_movement_total`). Em `find_recurring_candidate` (`set` de
+    meses) e em `list_launches_by_tipo` (argmax de um `Counter`) a contagem
+    dupla é invisível por construção da FUNÇÃO — a tabela da medição está no
+    docstring do módulo. Ali este caso prova só "o valor certo continua
+    saindo"; não tente consertar isso com mais um caso."""
     _add_moderno(user_id, 39.90, "Netflix", "assinaturas", 2026, 6)
     _add_moderno(user_id, 39.90, "Netflix", "assinaturas", 2026, 7)
     assert find_recurring_candidate(
@@ -110,12 +231,38 @@ def test_base_sem_linha_legada_responde_o_mesmo(user_id):
     _grava_interno_moderno(user_id, 70.00)
     assert get_internal_movement_total(user_id, hoje, hoje) == 70.0
 
+    # `list_launches_by_tipo`: prova só que o valor certo continua saindo (ver o
+    # TETO acima — duplicação uniforme não move um argmax).
+    assert infer_recurring_value(user_id, "despesa", "Netflix") == 39.90
+
 
 # ── auxiliares ──────────────────────────────────────────────────────────────
 
 def _ano_mes_hoje():
     h = today_tz()
     return (h.year, h.month, h.day)
+
+
+def _flag_interna(user_id, nota):
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "select is_internal_movement from launches where user_id=%s and nota=%s",
+            (user_id, nota),
+        )
+        return cur.fetchone()["is_internal_movement"]
+
+
+def _grava_aporte_de_caixinha(user_id, valor):
+    """Aporte com o TIPO PRÓPRIO que db/pockets.py grava — nem despesa nem
+    receita. É o que a mutação "alarga demais" arrastaria para dentro."""
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "insert into launches (user_id, tipo, valor, categoria, nota, "
+            "criado_em, is_internal_movement) values "
+            "(%s,'deposito_caixinha',%s,'caixinha','aporte',%s,true)",
+            (user_id, valor, _hoje_as(9)),
+        )
+        conn.commit()
 
 
 def _grava_interno_moderno(user_id, valor):


### PR DESCRIPTION
Continuação do #284 (mergeado), e **o escopo cresceu três vezes durante a revisão** — cada expansão autorizada pelo dono depois de medição. Comece por aqui, porque o título não conta a história inteira.

## O que este PR toca, em ordem de risco

| categoria | site | sintoma **provado rodando** |
|---|---|---|
| **dinheiro dobrado** | `db/open_finance.py` `_find_manual_candidates` | R$50 gastos aparecendo como **R$100** |
| **caminho destrutivo** | `_CONTA_CORRENTE_LAUNCH_FILTER` | `remaining: 0` com duas linhas ainda na tabela |
| sugestão que some | `db/recurring.py`, `db/categories.py`, `db/accounts.py` `get_internal_movement_total`, `list_launches_by_tipo` | candidato a gasto fixo, candidata a regra e auto-preenchimento de recorrente não aparecem |
| código morto | `db/cards.py` `monthly_summary_credit_debit` | apagado — zero chamadores, varrido no repo inteiro |

## O problema

`launches.tipo` tem **duas formas para a mesma coisa**: moderna (`'despesa'`, `'receita'`) e legada (`'saida'`, `'entrada'`). Nenhum escritor de hoje grava a legada; leitores que filtram só a moderna **descartam** a linha.

## 1. O dedupe do Open Finance dobrava o saldo

`_find_manual_candidates` procura o lançamento **manual** gêmeo de uma transação importada, para não duplicar. Filtrava `and tipo = %s` cru — então nunca encontrava o gêmeo legado. Medido pelo caminho de produção (espelho Pluggy → `import_open_finance_launches` → `get_financial_data`), manual de 50 e transação OF de −50, mesmo dia e estabelecimento:

| manual | relatório do importador | `monthly_expense` | linhas em `launches` |
|---|---|---|---|
| `'saida'` (legado) | `inserted=1, auto_merged=0` | **100.0** | 2 |
| `'despesa'` (moderno) | `inserted=0, auto_merged=1` | **50.0** | 1 |

Não havia outra rede: o lançamento do OF entra com `delta_conta=0`, então não move o saldo da conta, mas **conta inteiro** no "Gastos do mês" e no "sobrou".

**O trade-off, medido e declarado:** com o conserto, uma linha legada de `alvo` **nulo** passa a casar com estabelecimento genuinamente diferente, e R$50 de gasto real **somem** sem pendência e sem volta. Isso não é regressão: o espelho moderno (`'despesa'` com `alvo` nulo) faz **exatamente o mesmo** — é o desenho pré-existente do `_is_generic_merchant`, agora aplicado consistentemente à forma legada. Dobrar dinheiro é pior. Há teste parametrizado prendendo os dois lados como escolha, não como acidente.

## 2. O `_CONTA_CORRENTE_LAUNCH_FILTER` mentia sobre ter apagado

```
count_launches: 1
delete_all -> {'deleted': 1, 'remaining': 0}
SOBROU no banco: [{'tipo':'saida','valor':100}, {'tipo':'entrada','valor':300}]
```

Não é subcontagem: é o sistema **afirmando** ter apagado tudo com linhas do usuário ainda na tabela.

**Alcance real, e uma correção de enquadramento:** este filtro **não** alimenta o "Recomeçar do zero" — `db/privacy.py::reset_user_data` apaga `launches` sem filtro de tipo. O consumidor afetado é a tool `delete_all_launches` do `/ai/chat`. E a melhoria é maior do que "o número muda": antes, com base 100% legada, o portão `n <= 0` respondia *"🐷 Você não tem nenhum lançamento pra apagar — seu histórico já está limpo"*.

**Enumeração das 8 formas**, com `remaining` conferido contra a tabela **crua** (nunca contra `count_launches`, que usa o mesmo filtro e mentiria junto):

| forma legada | del | no_eff | unsafe | rem | linhas cruas |
|---|---|---|---|---|---|
| pura com `efeitos` | 1 | 0 | 0 | 0 | 0 |
| `entrada` com `efeitos` | 1 | 0 | 0 | 0 | 0 |
| sem `efeitos` | 0 | 1 | 0 | 1 | 1 |
| `efeitos={}` | 0 | 0 | 1 | 1 | 1 |
| `efeitos` lista/escalar | 0 | 1 | 0 | 1 | 1 |
| com lote | 0 | 0 | 1 | 1 | 1 |
| com `bill_id`+`paid_amount_added` | 1 | 0 | 0 | 0 | 0 |
| chave desconhecida | 0 | 0 | 1 | 1 | 1 |

**A guarda do #214 segue fechada**, reconfirmada por medição: **8/8** das chaves de `_EFEITOS_FORA_DO_APAGAR_TUDO` caem em `kept_unsafe`, com `WARNING` (não `ERROR`) e a frase de recusa, não a de erro técnico. Ressalva: 6 saem com `motivo=fora_do_escopo` e 2 (`delta_pocket`, `delta_invest`) com `lote_ausente` — o `_DELTA_EXIGE_LOTE` dispara antes. Balde final igual; o `motivo=` do log é outro, e está escrito no comentário.

**Teto herdado:** `kept_unsafe` é **permanente** e o usuário não tem saída. Não piorou — antes a linha não era nem olhada; agora ele lê a frase.

Isolamento (§0) e concorrência medidos: o "apagar tudo" de A não toca B; dois `delete_all` simultâneos revertem cada linha **uma** vez.

## 3. Este PR quebrou o instrumento de medição do #214, e conserta

`scripts/medir_guarda_efeitos_214.py` tinha `_TIPOS_APAGAR_TUDO = ("despesa","receita")` congelado. Ao ampliar o filtro, o script passou a classificar as linhas legadas no bloco errado e a dizer **"apaga"** onde o código devolve `kept_unsafe/fora_do_escopo` — justamente o script que existe para dimensionar a guarda contra produção. Agora **deriva** de `_CONTA_CORRENTE_LAUNCH_FILTER`, com teste comparando as duas fontes. A guarda congelada do `b4d0085` (artefato de comparação de duas colunas) **não** foi tocada.

## 4. Uma afirmação minha que a medição derrubou

O docstring original dizia que o caso de `get_internal_movement_total` era **sintético**, porque `is_internal_movement` nasceu depois da forma legada. **O oposto é o caso**: a migração retroativa de `db/schema.py` marca `is_internal_movement` **por CATEGORIA, sem olhar o tipo**, e roda a cada `init_db()`:

```
antes da migracao : [{'tipo':'saida', 'is_internal_movement': False}]
DEPOIS da migracao: [{'tipo':'saida', 'is_internal_movement': True}]
get_internal_movement_total: 500.0
```

É alcançável, e o texto foi corrigido.

## Controles

**Negativos, um por site**, cada um injetado em caso que estava verde — os cinco derrubam teste nomeado. **"Alargou demais"** (`tipo is not null` nos sites, e `coalesce(%s, tipo) is not null` nos dois com parâmetro): era `5 passed`, hoje derruba 10 e 3. **Positivo**: base 100% moderna — que é 100% da produção hoje — responde exatamente o mesmo.

**Teto do positivo, declarado:** ele é cego a contagem dupla em 2 dos 4 sites, por construção das funções (`find_recurring_candidate` devolve `len()` sobre um `set`; `infer_recurring_value` é argmax sobre `Counter`, e duplicação uniforme não move argmax). Está escrito no docstring em vez de coberto por caso inventado.

Os caminhos de conversa entram por `handle_incoming` e pelo importador real, não por função com `db` mockado.

## Incidência — isto fecha classe, não apaga incêndio

Produção deu **zero** linhas legadas em **27/08/2026 21:50 UTC**. **A medição tem mais de uma semana e precisa ser refeita** (§2) — é ela que separa "convenção" de "usuário vendo saldo dobrado agora":

```sql
select count(*) filter (where tipo = 'saida')   as saida,
       count(*) filter (where tipo = 'entrada') as entrada,
       count(*)                                 as total_launches
  from launches;
```

## O que fica fora — **#287**

`frontend/home.html` tem **três** sites, não um: `:1147` (uma linha `'entrada'` renderiza como **despesa vermelha com sinal de menos** — sinal invertido), `:944` (imprime `saida` cru como rótulo) e `:1094` (o onboarding nunca marca "primeiro lançamento" para quem só tem linha legada). Separados por **verificabilidade**: são frontend, e o app carrega o site ao vivo — só se provam depois do deploy.

`db/open_finance.py:1608/1922/1984` filtram `source='open_finance'` antes do tipo, e o único escritor desse `source` grava a forma moderna — **inalcançáveis**, diff sem efeito. A prova está na issue.

## Onde foi provado

`pigbank_ci_test` e bancos descartáveis, com `handle_incoming` e o importador de OF reais. **Nada verificado no WhatsApp real nem pós-deploy** — os testes de WhatsApp mockam LLM e envio, então o verde cobre a lógica intermediária, não o comando ponta a ponta.

Suíte: **5870 passed, 4 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
