### PR TITLE
O portão de tamanho pula na máquina do dev e reprova no CI

### DIFF
--- a/tests/frontend/eslint_max_lines_gate.test.mjs
+++ b/tests/frontend/eslint_max_lines_gate.test.mjs
@@ -18,13 +18,38 @@
 //
 // Rodar:  npm run test:frontend
 //         (ou só este: node --test tests/frontend/eslint_max_lines_gate.test.mjs)
-import { test } from "node:test";
+import { test as nodeTest } from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
-import { ESLint } from "eslint";
+
+// Import dinâmico, e não estático, por causa do que a ausência do pacote fazia:
+// o `import { ESLint } from "eslint"` derruba o ARQUIVO inteiro com
+// `ERR_MODULE_NOT_FOUND` antes de qualquer teste existir, e três PRs seguidos
+// (#221, #257, #268) pararam para concluir "é ambiente" antes de comparar a
+// baseline — a quarta vez é alguém olhando só o número (issue #279).
+//
+// O alívio é do DEV, nunca do CI. Lá o `npm ci` roda (.github/workflows/tests.yml,
+// step "Install dependencies"), então eslint ausente é o gate quebrado de verdade,
+// e pular seria exatamente o silêncio que se quer evitar — é o mesmo motivo pelo
+// qual o `PYTEST_ALLOW_MISSING_OPTIONAL_DEPS` do conftest.py é opt-in: alívio
+// automático faz a dependência sumir do projeto sem uma linha vermelha.
+let ESLint;
+try {
+  ({ ESLint } = await import("eslint"));
+} catch (erro) {
+  if (process.env.CI) throw erro;
+}
+
+const skip = ESLint
+  ? false
+  : "eslint não está no node_modules: rode `npm ci` na raiz do repo para rodar este portão localmente (no CI a ausência REPROVA, não pula)";
+
+// Sem o pacote, `skip` desliga os testes antes de o corpo rodar — o wrapper
+// existe para que teste novo neste arquivo herde isso sem ninguém lembrar.
+const test = (nome, fn) => nodeTest(nome, { skip }, fn);
 
 const cwd = fileURLToPath(new URL("../..", import.meta.url));
-const eslint = new ESLint({ cwd });
+const eslint = ESLint ? new ESLint({ cwd }) : null;
 
 const LONGO = "x\n".repeat(500);
 // 351 linhas de conteúdo: uma acima do teto. É o que prende o 350.


### PR DESCRIPTION
Fecha #279.

## O problema

`tests/frontend/eslint_max_lines_gate.test.mjs` fazia `import { ESLint } from "eslint"` estático. Sem o pacote no `node_modules`, isso derruba o **arquivo inteiro** com `ERR_MODULE_NOT_FOUND` antes de qualquer teste existir — a suíte de frontend nasce vermelha na máquina do dev, e três PRs (#221, #257, #268) pararam para concluir "é ambiente" antes de comparar a baseline.

## O conserto

Import dinâmico dentro de `try` + a opção `skip` nativa do `node:test`. A ausência vira skip com a mensagem que **diz o que fazer** (`npm ci`) em vez do stack trace.

O alívio é **opt-out pela env `CI`**: no GitHub Actions o step `Install dependencies` roda `npm ci` (`.github/workflows/tests.yml:427`), então eslint ausente **lá** é o portão quebrado de verdade e continua vermelho. É a metade que a issue não pedia e que o repo já documenta no `conftest.py`: alívio automático faz a dependência sumir sem uma linha vermelha — foi por isso que o `PYTEST_ALLOW_MISSING_OPTIONAL_DEPS` ficou opt-in.

## Medições (worktree limpo de `origin/main`, node v23.9.0, deps do `package-lock.json`)

| cenário | resultado |
|---|---|
| eslint presente (baseline e depois) | **323 pass / 0 fail / 0 skipped**; o portão roda 7/7 |
| eslint ausente, sem `CI` | **316 pass / 0 fail / 7 skipped**, exit 0 — o critério da issue |
| eslint ausente, `CI=true` | **exit 1**, `ERR_MODULE_NOT_FOUND` |
| `npm run lint` (o mesmo do CI) | 0 errors, 208 warnings, exit 0 |

**Controle positivo (mutação, o que a issue nomeia como intransferível):** com o eslint presente e `max: 350` → `600` em `eslint.config.mjs:143`, o portão vai a **4 fail / 3 pass**. A sonda de 351 linhas continua reprovando — o conserto não afrouxou o teto nem tornou o teste tautológico.

**Controle negativo:** a ausência foi simulada com `mv node_modules/eslint node_modules/eslint.ausente` e desfeita com o `mv` inverso; conferido no fim que `node_modules/eslint` voltou e que não sobrou nada com `ausente` no nome. Nada foi apagado.

## As duas perguntas de antes de escrever

1. **Ausente ou desatualizado?** Genuinamente **ausente**. `ls node_modules` na raiz `/Users/lucaskuramoti/Desktop/bot/bot_wa/` devolve exatamente 2 entradas — `playwright` e `playwright-core`. Faltam `eslint`, `@eslint/js` e `globals`: o `npm ci` nunca rodou ali depois do #258. **Um `npm ci` na raiz resolve a máquina** — e continua valendo fazer, independente deste PR. A degradação é o conserto do *repositório*, para a próxima máquina que não tiver rodado.
2. **É o único da classe?** Enumerado, não amostrado: os únicos specifiers externos em `tests/frontend/*.mjs` (contando `_server.mjs` e import dinâmico) são `playwright` e `eslint`. O playwright está instalado. Nenhum irmão na mesma situação — a classe tem um membro só e ele foi tratado.

## Escopo e o que NÃO foi verificado

Só o arquivo de teste: nada de instalar eslint como parte do conserto, mexer nas regras do portão ou tocar no `package-lock.json`.

A suíte **pytest não foi rodada** — a mudança é Node, não toca em Python. O `npm run test:frontend` foi rodado por inteiro, três vezes (as três linhas da tabela).

🤖 Generated with [Claude Code](https://claude.com/claude-code)