### PR TITLE
Arquivo Python novo acima de 350 linhas passa a reprovar o CI

### DIFF
--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -147,8 +147,21 @@ seção nesse arquivo — e ele precisa de rota própria em `static_pages.py` (v
 Teto de **350 linhas** para arquivo novo, nos dois lados: JavaScript pela regra
 `quality/max-lines` (`eslint.config.mjs`, em `error`, step bloqueante do CI) e
 Python por `tests/test_max_lines_python.py`, que roda no `pytest` e cuja lista de
-legado mora em `tests/_max_lines_baseline.py`. Nos dois, **a isenção é por caminho
-exato e mais nada** — as isenções por *basename* (`index`, `constants`, `types`,
+legado mora em `tests/_max_lines_baseline.py`.
+
+**Os dois NÃO isentam do mesmo jeito, e a diferença importa.** No **Python** a
+isenção é **só por caminho exato**: `LEGADOS` é um `frozenset` de strings e a
+varredura compara por igualdade, então glob e sufixo não são sequer
+representáveis, e **arquivo de teste não tem tratamento especial** — os ~45 de
+`tests/` estão na lista nominalmente, e teste novo acima de 350 **reprova**. No
+**JavaScript** sobram duas frouxidões: o baseline casa **caminho inteiro ou
+sufixo** (`eslint-rules/utils.cjs:53-55`), e arquivo de teste continua sendo
+reconhecido **por regex** (`isTestFile`, `/\.(test|spec)\.[cm]?[jt]sx?$/`,
+`utils.cjs:49-51`), com `tests/frontend/**/*.mjs` em **`warn`** — que não reprova,
+porque o `eslint` só sai != 0 com erro. **O portão de Python é o mais estrito dos
+dois, de propósito.**
+
+O que os dois têm em comum é o que foi REMOVIDO: as isenções por *basename* (`index`, `constants`, `types`,
 `*.config.*`) e por *diretório* (`generated/`, `fixtures/`, `mocks/`) vieram de um
 template TypeScript e foram removidas em 2026-09-04, porque `frontend/index.js`
 chegou a 404 linhas passando limpo por causa delas.

--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -142,6 +142,59 @@ Três fatos que decidem qualquer mexida ali:
 Ao adicionar funcionalidade nova de dashboard, **prefira arquivo novo** a mais uma
 seção nesse arquivo — e ele precisa de rota própria em `static_pages.py` (ver abaixo).
 
+### Portões de tamanho: o que eles prendem, e o que NÃO prendem
+
+Teto de **350 linhas** para arquivo novo, nos dois lados: JavaScript pela regra
+`quality/max-lines` (`eslint.config.mjs`, em `error`, step bloqueante do CI) e
+Python por `tests/test_max_lines_python.py`, que roda no `pytest` e cuja lista de
+legado mora em `tests/_max_lines_baseline.py`. Nos dois, **a isenção é por caminho
+exato e mais nada** — as isenções por *basename* (`index`, `constants`, `types`,
+`*.config.*`) e por *diretório* (`generated/`, `fixtures/`, `mocks/`) vieram de um
+template TypeScript e foram removidas em 2026-09-04, porque `frontend/index.js`
+chegou a 404 linhas passando limpo por causa delas.
+
+**O que as sondas prendem: os predicados historicamente perigosos, nomeados um a
+um.** Basename e diretório, que são exatamente os do template. Devolver qualquer
+um deles deixa vermelho na hora.
+
+**O que elas NÃO prendem: predicado arbitrário.** Isto é medição, não hipótese —
+três pontos de inserção, com as 8 sondas do arquivo VERDES:
+
+| onde | predicado | resultado |
+|---|---|---|
+| `_lidos` | `rel.startswith("handlers/")` | 8 passed |
+| `_lidos` | `rel.startswith("adapters/discord/")` | 8 passed |
+| `_estoura` | `caminho.startswith("scripts/")` | 8 passed |
+
+Com a segunda, `adapters/discord/enorme_novo.py` com 400 linhas entra sem uma
+linha vermelha.
+
+**O padrão que decide, e é acionável:** isenção que atinge um diretório **que já
+tem legado dentro** morre pelo ratchet — `rel.startswith("adapters/whatsapp/")`
+dá vermelho, porque os legados daquele diretório somem do universo e caem no
+`sobrando`. A que atinge diretório **sem legado** sobrevive. Ou seja, a proteção
+que existe ali é **efeito colateral do ratchet, não controle desenhado** — e o
+mapa de quem está protegido é a lista de legado, que encolhe com o tempo.
+
+**Não gaste rodada tentando fechar isso: enumeração não cobre arbitrário.** O
+portão de JS que o de Python espelha tem o mesmo piso — a isenção dele é o `if`
+booleano de `eslint-rules/core-rules.cjs:67-72`, e um termo novo somado ali
+também não é pego pelas 7 sondas de `tests/frontend/eslint_max_lines_gate.test.mjs`.
+A defesa contra termo novo na condição é revisão de diff, não teste.
+
+**Post-mortem das duas rodadas que custaram isso**, porque o erro se repetiu com
+cara diferente: na primeira versão do portão de Python, as sondas exercitavam um
+`_estoura()` que o enforcement **não chamava** — uma isenção por basename no laço
+real passava com as sondas verdes. Consertado, o buraco **desceu uma função**: as
+sondas passaram a chamar `_varrer()`, mas quem monta o universo a partir do disco
+(`_lidos()`) continuou sem sonda, e a mesma isenção escondida lá repetia o
+sintoma. O conserto que valeu foi estrutural, não mais um caso enumerado: uma
+sonda ponta a ponta (`test_ponta_a_ponta_pelo_disco_e_pelo_git`) que monta um
+repositório de brinquedo com `git init` + `git add` num `tmp_path` e roda
+**git → `_rastreados` → `_lidos` → `_varrer`**. É a §2 do `CLAUDE.md` ao vivo:
+"achei um caso" não é "resolvi a categoria", e consertar a instância move a
+fronteira do não-coberto em vez de fechá-la.
+
 ### Assets: não há `StaticFiles` mount
 
 Cada CSS/JS servido tem **uma rota `@router.get` escrita à mão** em

--- a/tests/_max_lines_baseline.py
+++ b/tests/_max_lines_baseline.py
@@ -7,8 +7,11 @@ foram removidas em 2026-09-04 (`eslint-rules/utils.cjs`). `tests/test_max_lines_
 prende as duas do lado Python com sondas.
 
 A lista é um RATCHET, não uma anistia: arquivo daqui que cair para 350 ou menos
-deixa o CI vermelho até ser REMOVIDO desta lista. Ninguém acrescenta nome novo
-sem quebrar o arquivo primeiro.
+deixa o CI vermelho até ser REMOVIDO desta lista. O que o CI garante
+MECANICAMENTE é só isso: o ratchet dos nomes JÁ registrados. Nome novo não
+entra aqui por POLÍTICA, não por impedimento técnico — acrescentar um arquivo
+novo e grande a esta lista passa em tudo. Alteração de baseline depende de
+revisão de diff, e é lá que a política é aplicada.
 
 Sem o tamanho de cada um anotado: número que um comando responde envelhece em
 silêncio (CLAUDE.md §2 — o `eslint.config.mjs` recusou a mesma anotação pelo

--- a/tests/_max_lines_baseline.py
+++ b/tests/_max_lines_baseline.py
@@ -1,0 +1,163 @@
+"""Linha de base do portão de tamanho dos arquivos Python (`TETO = 350`).
+
+Isenção é por CAMINHO EXATO e só isso. Não há isenção por nome de arquivo nem
+por diretório: foi assim que o portão de JavaScript deixou passar
+`frontend/index.js` com 404 linhas, e as duas isenções do template TypeScript
+foram removidas em 2026-09-04 (`eslint-rules/utils.cjs`). `tests/test_max_lines_python.py`
+prende as duas do lado Python com sondas.
+
+A lista é um RATCHET, não uma anistia: arquivo daqui que cair para 350 ou menos
+deixa o CI vermelho até ser REMOVIDO desta lista. Ninguém acrescenta nome novo
+sem quebrar o arquivo primeiro.
+
+Sem o tamanho de cada um anotado: número que um comando responde envelhece em
+silêncio (CLAUDE.md §2 — o `eslint.config.mjs` recusou a mesma anotação pelo
+mesmo motivo). Para remedir a lista inteira, da raiz do repositório:
+
+    git ls-files -z '*.py' | xargs -0 -n1 awk 'END{if (NR > 350) print FILENAME}' | sort
+
+Sem prefixo `test_` de propósito, como `tests/_billing_grants_helpers.py`: o
+pytest não coleta este arquivo. Sendo `.py` e rastreado, ele é medido pelo
+próprio portão.
+"""
+
+LEGADOS: frozenset[str] = frozenset(
+    {
+        "adapters/whatsapp/wa_app.py",
+        "adapters/whatsapp/wa_client.py",
+        "adapters/whatsapp/wa_runtime.py",
+        "adapters/whatsapp/wa_tutorial.py",
+        "admin.py",
+        "core/admin_dashboard.py",
+        "core/ai_patterns.py",
+        "core/blog_guides.py",
+        "core/handle_incoming.py",
+        "core/handlers/credit.py",
+        "core/handlers/help_handler.py",
+        "core/handlers/investments.py",
+        "core/handlers/launches.py",
+        "core/handlers/pending.py",
+        "core/help_text.py",
+        "core/intent_classifier.py",
+        "core/intent_router.py",
+        "core/services/ai_chat/runner.py",
+        "core/services/ai_chat/tools/bills.py",
+        "core/services/ai_chat/tools/budgets.py",
+        "core/services/ai_chat/tools/cards.py",
+        "core/services/ai_chat/tools/investments.py",
+        "core/services/ai_chat/tools/launches.py",
+        "core/services/ai_chat/tools/pockets.py",
+        "core/services/ai_guard.py",
+        "core/services/category_service.py",
+        "core/services/email_service.py",
+        "core/services/piggy_agents.py",
+        "core/services/plan_service.py",
+        "core/services/pluggy_health.py",
+        "core/services/pluggy_sync.py",
+        "core/services/recurring_charger.py",
+        "db/__init__.py",
+        "db/accounts.py",
+        "db/affiliates.py",
+        "db/agents.py",
+        "db/analytics.py",
+        "db/budgets.py",
+        "db/cards.py",
+        "db/categories.py",
+        "db/insights.py",
+        "db/investments.py",
+        "db/mfa.py",
+        "db/open_finance.py",
+        "db/open_finance_state.py",
+        "db/pending.py",
+        "db/pockets.py",
+        "db/privacy.py",
+        "db/recurring.py",
+        "db/reports.py",
+        "db/schema.py",
+        "db/users.py",
+        "db_support.py",
+        "frontend/finance_bot_websocket_custom.py",
+        "frontend/routes/cards.py",
+        "frontend/routes/open_finance.py",
+        "frontend/routes/pockets.py",
+        "frontend/routes/settings.py",
+        "frontend/routes/shared.py",
+        "frontend/routes/static_pages.py",
+        "ofx_credit_import.py",
+        "parsers.py",
+        "scripts/coluna_dupla.py",
+        "scripts/medir_guarda_efeitos_214.py",
+        "scripts/migrate_pii_to_encrypted.py",
+        "scripts/post_deploy_deletion_check.py",
+        "scripts/whatsapp_qa_vault_harness.py",
+        "statement_import.py",
+        "tests/conftest.py",
+        "tests/test_account_reset.py",
+        "tests/test_admin_users_panel.py",
+        "tests/test_ai_chat_bloco_b.py",
+        "tests/test_ai_chat_concurrent_confirm.py",
+        "tests/test_ai_chat_tier2.py",
+        "tests/test_auth_cookie.py",
+        "tests/test_bill_amount_pending.py",
+        "tests/test_billing_checkout.py",
+        "tests/test_budget_category_accent.py",
+        "tests/test_categoria_custom_pela_conversa.py",
+        "tests/test_category_launches_query.py",
+        "tests/test_category_normalization.py",
+        "tests/test_coluna_dupla_gate.py",
+        "tests/test_credit_transactions_endpoints.py",
+        "tests/test_custom_category_infer.py",
+        "tests/test_db_core.py",
+        "tests/test_db_investments.py",
+        "tests/test_delete_all_launches.py",
+        "tests/test_error_pages.py",
+        "tests/test_full_handler_smoke.py",
+        "tests/test_funding_source.py",
+        "tests/test_fuso_do_app.py",
+        "tests/test_ga4_measurement_protocol.py",
+        "tests/test_log_falha_traceback.py",
+        "tests/test_log_falha_user_id.py",
+        "tests/test_market_rates_cache_first.py",
+        "tests/test_mfa.py",
+        "tests/test_multi_launch_concurrency.py",
+        "tests/test_nlp_and_pending_flow.py",
+        "tests/test_of_concurrency.py",
+        "tests/test_of_connection_state.py",
+        "tests/test_of_health.py",
+        "tests/test_of_refresh_schedule.py",
+        "tests/test_pending_consume_race.py",
+        "tests/test_pending_rollback.py",
+        "tests/test_perguntas_guardam_contexto.py",
+        "tests/test_piggy_agents.py",
+        "tests/test_plan_tiers.py",
+        "tests/test_prospect_referrals.py",
+        "tests/test_routes_categories.py",
+        "tests/test_statement_import.py",
+        "tests/test_static_pages_routes.py",
+        "tests/test_tipo_legado_na_cauda.py",
+        "tests/test_tipo_legado_na_tendencia.py",
+        "tests/test_virada_de_mes.py",
+        "tests/test_whatsapp_markup_escape.py",
+        "utils_date.py",
+        "utils_text.py",
+
+        # --- Bloco de 2026-09-07: os 4 arquivos que o PR #298 acrescentou ---
+        # Entram como legado por decisão do dono, e não porque o portão os
+        # aprovou: o #298 já estava mergeado na `main` quando este portão
+        # nasceu, então cobrá-los aqui seria reprovar código que entrou sob
+        # regra que ainda não existia — o portão passaria a medir a data do
+        # merge, não o tamanho do arquivo.
+        #
+        # Os DOIS de teste saem no PR seguinte, pelo corte já definido no
+        # registro do assunto: canais `R2-5` e `R2-5b`, os três `B1` cruzados
+        # com veredito/matriz (`9r` ×2, `9t-b`), `R3-1` e `R3-5`. Quando o
+        # corte entrar, os dois nomes saem DESTA lista — e o teste `sobrando`
+        # de `tests/test_max_lines_python.py` fica vermelho até que saiam.
+        # Os dois de produção não têm data: quebrar `billing_access.py` é
+        # trabalho de fatoração, fora deste ciclo.
+        "core/services/billing_access.py",
+        "db/plan_grants.py",
+        "tests/test_billing_grants_reducao.py",
+        "tests/test_billing_grants_tier.py",
+    }
+)

--- a/tests/test_max_lines_python.py
+++ b/tests/test_max_lines_python.py
@@ -1,0 +1,264 @@
+"""Portão de tamanho para arquivo Python — o par do `quality/max-lines` do JS.
+
+Teto de 350 linhas para arquivo NOVO. O de JavaScript já existia
+(`eslint.config.mjs`, em `error`); este roda no `pytest -q`, que já é bloqueante,
+então não há step novo no CI. A dívida herdada mora em `_max_lines_baseline.py`,
+e a lista é um ratchet: legado que encolher tem de SAIR de lá.
+
+**Uma política, um caminho.** `_varrer()` é o veredito e é a mesma função que as
+sondas do fim do arquivo executam; `_lidos()` só monta o universo a partir do
+disco, e a sonda ponta a ponta o cobre por um repositório de brinquedo. Duas
+implementações da mesma regra é o que o CLAUDE.md §0.7 proíbe, e aqui já custou
+duas rodadas de revisão — o registro está em `docs/armadilhas.md`, seção
+"Portões de tamanho: o que eles prendem, e o que NÃO prendem".
+
+O QUE ESTE ARQUIVO NÃO PRENDE — leia antes de confiar nele:
+  * **Predicado arbitrário.** As sondas nomeiam os predicados perigosos por
+    HISTÓRICO (basename e diretório, os do template TypeScript). Um
+    `rel.startswith("handlers/")` novo em `_lidos` ou em `_estoura` passa com as
+    8 sondas verdes — medido, com a tabela em `docs/armadilhas.md`. Enumeração
+    não cobre arbitrário, e o portão de JS que este espelha tem o mesmo piso
+    (`eslint-rules/core-rules.cjs:67-72`). A defesa aí é revisão de diff.
+  * **Tamanho não é coesão.** Arquivo de `LEGADOS` pode ir de 400 para 4000
+    linhas sem vermelho, e um de 349 linhas ilegível passa limpo.
+  * **O universo é o que o git RASTREIA.** Arquivo novo só é medido depois do
+    `git add`; no CI isso é vácuo, porque lá tudo está commitado.
+  * `_linhas` conta só `b"\n"`: fonte com terminador `\r` PURO escapa inteira
+    (CRLF, o caso real, é contado certo). Symlink `.py` para diretório dá
+    `IsADirectoryError` e `RAIZ` fora de repo git dá `CalledProcessError` —
+    nenhum alcançável aqui, e os dois são erro ruidoso, não veredito silencioso.
+
+Rodar:  .venv/bin/python -m pytest tests/test_max_lines_python.py -q
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from _max_lines_baseline import LEGADOS
+
+TETO = 350
+RAIZ = Path(__file__).resolve().parent.parent
+
+
+def _linhas(dados: bytes) -> int:
+    """Linhas VISÍVEIS. Idêntico ao `wc -l` para quem termina em `\\n`, e é o ponto:
+    a mensagem de falha cita o mesmo número do comando de remedição.
+
+    Sem `\\n` final o portão conta a linha visível e o `wc -l` diz um a menos — a
+    MESMA divergência do lado JS (`eslint-rules/core-rules.cjs`), de propósito:
+    uma definição de linha para os dois portões (CLAUDE.md §0.7). O `and dados`
+    faz arquivo vazio valer 0 em vez de 1.
+    """
+    return dados.count(b"\n") + (1 if dados and not dados.endswith(b"\n") else 0)
+
+
+def _grande(dados: bytes) -> bool:
+    """Acima do teto, ANTES de qualquer isenção. Única implementação do número."""
+    return _linhas(dados) > TETO
+
+
+def _estoura(caminho: str, dados: bytes) -> bool:
+    """O veredito por arquivo. Única implementação da ISENÇÃO, que é por CAMINHO
+    EXATO: sem `basename` e sem prefixo de diretório, porque foi por causa dessas
+    duas que `frontend/index.js` passou com 404 linhas. As sondas prendem as duas.
+    """
+    return _grande(dados) and caminho not in LEGADOS
+
+
+def _varrer(arquivos: dict[str, bytes]) -> tuple[list[str], list[str]]:
+    """`{caminho: conteúdo}` -> `(faltando, sobrando)`. O caminho de enforcement,
+    puro sobre bytes para as sondas rodarem ESTA função sem escrever no disco (é o
+    que o `lintText` de caminho virtual faz no portão de JS).
+
+    `sobrando` usa `_grande` e NÃO `_estoura`: `_estoura` é sempre falso para quem
+    está em `LEGADOS`, e a pergunta do ratchet é outra — "este legado ainda é
+    grande?". Caminho ausente do dicionário (apagado, renomeado, ou escrito como
+    glob) vira `b""`, não é grande, e por isso é reportado.
+    """
+    faltando = sorted(c for c, d in arquivos.items() if _estoura(c, d))
+    sobrando = sorted(c for c in LEGADOS if not _grande(arquivos.get(c, b"")))
+    return faltando, sobrando
+
+
+def _rastreados(raiz: Path = RAIZ) -> list[str]:
+    """Universo = o que o git rastreia, nunca `rglob` — num worktree
+    (`.claude/worktrees/<nome>/`) o `rglob` engole o repo inteiro mais `.venv`
+    (armadilha registrada em `tests/test_frontend_assets_e_rotas.py`).
+
+    `-z`: sem ele o git CITA e escapa em octal caminho com acento
+    (`"caf\\303\\251.py"`), que não existe em disco e sai do universo em silêncio.
+    `surrogateescape`: nome não-UTF-8 é impossível no APFS e possível no ext4 do
+    runner; sem ele o portão morre em `UnicodeDecodeError` em vez de veredito.
+    """
+    saida = subprocess.run(
+        ["git", "-C", str(raiz), "ls-files", "-z", "*.py"],
+        capture_output=True,
+        check=True,
+    ).stdout
+    return [c for c in saida.decode(errors="surrogateescape").split("\0") if c]
+
+
+def _lidos(raiz: Path = RAIZ) -> dict[str, bytes]:
+    """Universo do disco. O `raiz` existe para a sonda ponta a ponta rodar ESTA
+    função contra um repositório de brinquedo."""
+    arquivos = {}
+    for rel in _rastreados(raiz):
+        arq = raiz / rel
+        if not arq.exists():
+            # Rastreado e ausente do working tree = deleção não estagiada. Sem
+            # isto o portão morre em `FileNotFoundError` em vez de dar veredito.
+            continue
+        arquivos[rel] = arq.read_bytes()
+    return arquivos
+
+
+def test_nenhum_python_novo_passa_de_350_linhas():
+    """Portão, ratchet e proibição de glob no mesmo teste.
+
+    `faltando` é o portão: arquivo NOVO acima do teto.
+    `sobrando` é o ratchet e cobre três coisas de uma vez — legado que encolheu,
+    nome morto, e nome que virou glob/prefixo e por isso não casa mais nada.
+    """
+    faltando, sobrando = _varrer(_lidos())
+
+    assert not faltando, (
+        f"{len(faltando)} arquivo(s) Python acima de {TETO} linhas fora da linha "
+        f"de base: {faltando}.\n"
+        f"QUEBRE O ARQUIVO em módulos por assunto (CLAUDE.md §0.5). Acrescentar o "
+        f"nome em LEGADOS (tests/_max_lines_baseline.py) NÃO é a saída: a lista é "
+        f"a dívida herdada, não a porta de entrada."
+    )
+    assert not sobrando, (
+        f"{len(sobrando)} nome(s) em LEGADOS que não estão mais acima de {TETO} "
+        f"linhas: {sobrando}.\n"
+        f"APAGUE cada uma dessas linhas de tests/_max_lines_baseline.py. Um nome "
+        f"sobra por três motivos e os três pedem a mesma edição: o arquivo foi "
+        f"quebrado (parabéns, tranque o ganho), o arquivo foi apagado/renomeado, "
+        f"ou a entrada foi escrita como glob/prefixo e não casa caminho nenhum."
+    )
+
+
+# 351 linhas: uma acima do teto. É o que prende o 350 — com uma sonda de 500,
+# subir TETO para qualquer valor até 499 passaria despercebido.
+UMA_ACIMA = b"x\n" * 350 + b"x"
+NO_TETO = b"x\n" * 350
+
+# Os nomes que o template TypeScript isentava sozinho: por basename (`index`,
+# `constants`, `types`, `*.config.*`) e por diretório (`generated/`, `fixtures/`,
+# `migrations/`, `mocks/`). Nenhum deles pode voltar a ser isenção.
+SONDAS_SEM_ISENCAO = [
+    "__init__.py",
+    "constants.py",
+    "types.py",
+    "settings.py",
+    "core/conftest.py",
+    "core/generated/g.py",
+    "core/migrations/0001_x.py",
+    "tests/fixtures/f.py",
+]
+
+
+def test_sondas_nao_colidem_com_a_linha_de_base():
+    """Higiene: sonda que estivesse em LEGADOS mediria a isenção, não o teto.
+
+    Não é o teste que fecha esse buraco — a colisão já sai vermelha nas sondas
+    abaixo, porque a isenção inverte o que elas afirmam. O que este teste entrega
+    é a MENSAGEM: `constants.py` está na lista, em vez de "passou silencioso".
+    """
+    colisao = sorted(set(SONDAS_SEM_ISENCAO) & LEGADOS)
+    assert not colisao, (
+        f"caminho(s) de sonda dentro de LEGADOS: {colisao}. Troque o nome da "
+        f"sonda aqui, ou tire o nome de tests/_max_lines_baseline.py."
+    )
+
+
+def test_350_linhas_passam_e_351_reprovam():
+    assert _varrer({"core/qualquer_coisa.py": NO_TETO})[0] == []
+    assert _varrer({"core/qualquer_coisa.py": UMA_ACIMA})[0] == [
+        "core/qualquer_coisa.py"
+    ]
+
+
+def test_isencao_por_nome_e_por_diretorio_nao_voltam():
+    faltando, _ = _varrer({c: UMA_ACIMA for c in SONDAS_SEM_ISENCAO})
+    assert faltando == sorted(SONDAS_SEM_ISENCAO), (
+        f"passaram silenciosos: {sorted(set(SONDAS_SEM_ISENCAO) - set(faltando))}"
+    )
+
+
+def test_legado_de_5000_linhas_nao_e_reportado():
+    """Controle positivo: o portão não reprova tudo.
+
+    Sem este caso, o grupo inteiro passaria num `_varrer` que reportasse todo
+    arquivo — que é pior que não ter portão.
+    """
+    if not LEGADOS:
+        pytest.skip("dívida quitada: sem legado não há isenção para exercitar")
+    legado = sorted(LEGADOS)[0]
+    assert _varrer({legado: b"x\n" * 5000})[0] == []
+
+
+def test_ratchet_reporta_legado_que_encolheu_ou_sumiu():
+    """Os DOIS ramos do `sobrando`, porque eles pegam coisas diferentes.
+
+    Presente-e-pequeno é o legado que alguém quebrou. Ausente é o `arquivos.get(c,
+    b"")` do `_varrer`, e é o único que pega as outras três: arquivo apagado,
+    arquivo renomeado, e entrada escrita como GLOB (`tests/*`), que não casa
+    caminho nenhum e por isso nunca apareceria no universo.
+    """
+    if not LEGADOS:
+        pytest.skip("dívida quitada: sem legado não há ratchet para exercitar")
+    legado = sorted(LEGADOS)[0]
+    assert legado in _varrer({legado: NO_TETO})[1], "ramo presente-e-pequeno"
+    assert legado in _varrer({})[1], "ramo ausente (apagado/renomeado/glob)"
+
+
+def _repo_de_brinquedo(tmp_path: Path, arquivos: dict[str, bytes]) -> Path:
+    """`git add` sem commit — o `git ls-files` lê o índice. Sonda o caminho real
+    sem tocar no índice DESTE repositório."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    for nome, dados in arquivos.items():
+        alvo = tmp_path / nome
+        alvo.parent.mkdir(parents=True, exist_ok=True)
+        alvo.write_bytes(dados)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+    return tmp_path
+
+
+def test_ponta_a_ponta_pelo_disco_e_pelo_git(tmp_path):
+    """Cobre `_lidos` pelo caminho real: git -> `_rastreados` -> `_lidos` -> `_varrer`.
+
+    As outras sondas montam o dicionário à mão e por isso não veem `_lidos`; uma
+    isenção por basename ou por diretório escondida LÁ deixava as outras verdes.
+    Esta prende os dois predicados, e SÓ eles — predicado arbitrário
+    (`rel.startswith("handlers/")`) continua passando, medido e registrado em
+    `docs/armadilhas.md`.
+    """
+    raiz = _repo_de_brinquedo(
+        tmp_path,
+        {
+            "constants.py": UMA_ACIMA,      # isenção por BASENAME não volta
+            "generated/g.py": UMA_ACIMA,    # isenção por DIRETÓRIO não volta
+            "pequeno.py": NO_TETO,          # e o portão não reprova tudo
+        },
+    )
+    assert _varrer(_lidos(raiz))[0] == ["constants.py", "generated/g.py"]
+
+
+def test_nome_com_acento_sobrevive_a_leitura(tmp_path):
+    """O que o `-z` compra. Repo de brinquedo: nome DESTE repo não tem acento.
+
+    Dois tetos, medidos: (1) o vermelho dela depende do gitconfig GLOBAL — com
+    `core.quotepath = false` (comum em dotfiles) apagar o `-z` a deixa VERDE; no
+    CI, que usa o default, o controle vale. (2) o `-z` compra duas coisas e esta
+    prova uma; a outra é nome com `\\n` embutido, patológico demais para virar sonda.
+    """
+    raiz = _repo_de_brinquedo(tmp_path, {"café da manhã.py": UMA_ACIMA})
+
+    (nome,) = _rastreados(raiz)
+    assert '"' not in nome and "\\" not in nome, f"caminho citado/escapado: {nome!r}"
+    assert (raiz / nome).exists(), f"não existe em disco: {nome!r}"


### PR DESCRIPTION
Arquivo `.py` **novo** acima de 350 linhas passa a reprovar o CI.

O repo já tinha esse teto em JavaScript (`quality/max-lines` em `error`, step bloqueante),
mas o ESLint tem parser de JavaScript — **nenhum `.py` passava por ele**. Medido: 380
arquivos Python, **121 acima de 350**, e nenhuma verificação de tamanho olhando para eles.

## O instrumento: pytest, não `ruff`

A razão decisiva não é custo. **A isenção do ruff é glob:** um `per-file-ignores` com
`"tests/*"` isentaria 45 arquivos numa linha que some na revisão de diff — exatamente a
armadilha que este repo já removeu do lado JS. Com `frozenset` de caminhos exatos, glob
**não é representável**: um padrão nunca é igual a um caminho rastreado, e a varredura o
reprova sozinha.

Custo: **dois arquivos novos, nenhum existente tocado.** Sem dependência, sem
`pyproject.toml`, sem step no CI — entra no `pytest` que já é bloqueante.

## Mais estrito que o lado JS, de propósito

O gate de JavaScript isenta arquivo de teste. **Este não:** os ~45 de `tests/` entram na
lista nominalmente, e **teste novo acima de 350 reprova**.

## A lista é nominal e o ratchet é mecânico

Glob dentro dela reprova. Nome morto reprova. E legado que **encolher** deixa o CI vermelho
até o nome sair — quebrar o arquivo e baixá-lo da lista viram o mesmo commit, e não há
caminho para o verde que deixe a lista mentindo.

O comando de remediação no cabeçalho usa **`awk`, não `wc -l`**: seis arquivos do repo não
terminam em `\n`, e o `wc -l` divergiria do portão justo no comando que a pessoa roda para
consertar.

## Os quatro arquivos do #298 entram na lista

O portão mede o **futuro**; a linha de base é a foto do dia em que ele nasce, e qualquer
data isenta o código da véspera. Estão em bloco datado, com a condição de saída escrita.
O corte dos dois de teste vem em PR próprio, pelo canal já definido.

## O que ele NÃO prende — medido, e escrito no arquivo

**Predicado arbitrário escapa.** As sondas nomeiam basename e diretório porque são os do
template TypeScript que já deixou `frontend/index.js` chegar a **404 linhas**. Um
`startswith` novo em `_lidos` passa com as 8 sondas verdes, e o gate de JS tem o mesmo piso.

Duas rodadas de revisão foram gastas descobrindo que a proteção olhava para a **função que
o portão não executava** — primeiro em `_estoura`, depois em `_lidos`. Fechado com sonda
ponta a ponta por repositório de brinquedo, rodando git → `_rastreados` → `_lidos` →
`_varrer`. Post-mortem em `docs/armadilhas.md`.

Ele também não pega: arquivo isento que engorda, e arquivo de 349 linhas ilegível. **Mede
tamanho, não coesão.**

## Testes

**6065 passed, 4 xfailed, 0 failed**; `+8 / −0` por node ID contra o pai. Cada um dos 8
morre em pelo menos uma mutação — 23 rodadas de mutação entre Tester e Manager.

## Não verificado

Nada rodou no runner Ubuntu: `git ls-files -z` e o `surrogateescape` foram provados nesta
máquina (macOS) e por mecanismo. O que reduz o risco é `tests/test_coluna_dupla_gate.py` já
fazer `git init` no mesmo CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
