### PR TITLE
Regras de skill saem da memória local e entram no CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,31 @@ implementação, correção, refatoração, arquivo novo. Não são um checklist
 `CLAUDE.md` mais específico dentro da área que você vai mexer, ele também vale — e o
 mais específico ganha quando os dois falarem do mesmo assunto.
 
+**Toda alteração de código passa pela skill `time-dev`** (Arquiteto → Coder → Tester
+→ Manager). Não é "para trabalho não-trivial" nem "quando pedirem por nome": vale
+para correção de uma linha também. Invoque `Skill(skill="time-dev")` **antes** de
+abrir o arquivo, não depois de já ter editado. É o §4 ("ataque antes de empurrar")
+virado em rotina: o Arquiteto levanta as perguntas de escopo enquanto ainda dá para
+mudar de plano, e o Tester acha o defeito antes do revisor — quando isso não é feito,
+a descoberta é terceirizada para o Codex e cada rodada dele revela um irmão que a
+varredura anterior descartou com justificativa errada.
+
+**O Coder invoca a skill `pigbank-frontend` antes de escrever código de frontend.**
+Ela carrega a identidade visual (rosa `#FF2D8E` como principal e não em toda
+superfície, base branco/preto/neutros, verde só para sucesso e valor positivo, Piggy
+e os agentes, público de 18–24 anos) e a seção "Verificação" que exige abrir no
+navegador em desktop **e** mobile e relatar como conferiu. Subagente começa sem
+contexto e não herda esta regra: o prompt do Coder tem de mandar isso explicitamente.
+A skill mora em `.claude/skills/pigbank-frontend/SKILL.md`, versionada na `main`.
+Ela própria diz "não use para tarefas exclusivamente de backend" — nessas, registre
+no relato que ela não se aplicava, em vez de omitir (§7).
+
+**Quando faltar skill para a tarefa, use a `find-skills` antes de improvisar.** Ela
+busca e instala do ecossistema aberto (`npx skills find <termo>` / `npx skills add`).
+É para quando for útil, não em toda tarefa: se o assunto é frontend, teste ou o ciclo
+do time, as skills acima já cobrem. Ela mora em `~/.claude/skills/` e **não** viaja
+com o repositório — quem clonar precisa instalá-la.
+
 ### 0.1 Procure antes de criar
 
 Antes de escrever **qualquer** função, classe, helper, utilitário, componente,


### PR DESCRIPTION
## O problema

Três regras já valiam na prática, mas nenhuma estava no repositório:

- `/time-dev` obrigatório em toda alteração de código — vivia só em memória local da máquina (`memory/usar-time-dev-sempre.md`, desde 2026-08-27).
- Coder invoca a skill `pigbank-frontend` — idem (`memory/coder-usa-skill-pigbank-frontend.md`, desde 2026-08-26).
- `find-skills` quando falta skill para a tarefa — só hábito, nada escrito.

`grep -i "time-dev\|pigbank-frontend\|find-skills" CLAUDE.md docs/CLAUDE.md` dava **zero** ocorrências antes deste commit. A única skill citada era a `baseline-testes` (§3).

Consequência: quem clona o repo não vê as regras, e subagente — que começa sem contexto e não herda memória local — também não. Regra permanente que depende da máquina de uma pessoa não é regra do projeto.

## O que muda

Um bloco no §0 (as regras que valem antes de escrever qualquer linha), +25 linhas, nenhuma remoção. Segue o mesmo argumento do bloco de isolamento por usuário que já mora ali: instrução que depende de alguém abrir outro documento é instrução que não chega.

## Verificado

- Só documentação — nenhuma linha de código muda, então não rodei a suíte (não há o que ela cubra aqui).
- Caminho da skill conferido contra a `main`, não de memória: `git ls-tree -r origin/main` mostra `.claude/skills/pigbank-frontend/SKILL.md` versionada.
- **Não verificado:** que a `find-skills` esteja instalada em outra máquina — ela mora em `~/.claude/skills/` e não é versionada aqui. O próprio texto avisa isso.

## Ressalva honesta

Este PR foi editado direto, sem passar pelo `/time-dev` que ele mesmo institui — é mudança de documentação, não de código, e o ciclo Arquiteto → Coder → Tester não teria o que atacar. Registrado para não virar precedente silencioso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)