### PR TITLE
Cookie de afiliado passa a honrar a blindagem de produção do app

### DIFF
--- a/frontend/routes/affiliates.py
+++ b/frontend/routes/affiliates.py
@@ -29,7 +29,6 @@ from frontend.routes import shared
 router = APIRouter()
 
 REF_COOKIE_NAME = "ref_code"
-_COOKIE_SECURE = shared.DASHBOARD_URL.startswith("https://")
 
 
 @router.get("/r/{code}")
@@ -39,12 +38,17 @@ async def affiliate_link(code: str):
     response = RedirectResponse(url="/", status_code=302)
     affiliate = await asyncio.to_thread(get_affiliate_by_code, code)
     if affiliate and affiliate["status"] == "active":
+        # COOKIE_SECURE do app inclui a blindagem APP_ENV=prod (Secure mesmo
+        # com DASHBOARD_URL http por engano). Import tardio porque o monólito
+        # importa este router antes de definir a constante (precedente:
+        # open_finance.py importa `manager` do mesmo jeito).
+        from frontend.finance_bot_websocket_custom import COOKIE_SECURE
         response.set_cookie(
             REF_COOKIE_NAME,
             affiliate["code"],
             max_age=REF_COOKIE_MAX_AGE_DAYS * 24 * 3600,
             httponly=True,
-            secure=_COOKIE_SECURE,
+            secure=COOKIE_SECURE,
             samesite="lax",
         )
     return response

--- a/tests/test_affiliate_link.py
+++ b/tests/test_affiliate_link.py
@@ -1,0 +1,128 @@
+"""Testes do link público de afiliado (GET /r/{code}).
+
+O afiliado vem do banco real (`create_affiliate`, que já entrega
+status='active' por default do schema) porque o par lookup + `status ==
+"active"` decide se o cookie sai, e `test_afiliado_desativado_nao_seta_cookie`
+exercita o lado `disabled` — sem ele o banco real não pagaria por si: com
+todos os casos active, trocar o handler por `if affiliate:` mantinha o
+arquivo verde. A fixture `user_id` limpa o afiliado no teardown
+(`affiliates.user_id ... on delete cascade`).
+
+Os dois casos de `secure` andam em par de propósito: `shared.DASHBOARD_URL`
+depende do ambiente, então só um deles é o que fica vermelho sem o conserto
+— mas um dos dois fica, em qualquer ambiente.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from db.affiliates import (
+    REF_COOKIE_MAX_AGE_DAYS,
+    create_affiliate,
+    set_affiliate_status,
+)
+import frontend.finance_bot_websocket_custom as dashboard
+
+
+def _ref_cookie(resp):
+    """Único set-cookie `ref_code=` da resposta, ou None."""
+    return next(
+        (h for h in resp.headers.get_list("set-cookie") if h.startswith("ref_code=")),
+        None,
+    )
+
+
+def _attrs(cookie):
+    """Só os atributos do set-cookie. O valor é um code sorteado de um alfabeto
+    que contém S,E,C,U,R,E (`_CODE_ALPHABET`), então procurar "secure" no
+    header inteiro daria vermelho por sorteio."""
+    return cookie.partition(";")[2].lower()
+
+
+@pytest.fixture
+def affiliate_code(user_id):
+    return create_affiliate(user_id)["code"]
+
+
+def test_link_valido_seta_cookie(affiliate_code):
+    """Pede em MINÚSCULO de propósito: o cookie tem de trazer o `code` canônico
+    do banco (maiúsculo), não a entrada crua da URL."""
+    client = TestClient(dashboard.app)
+    resp = client.get(f"/r/{affiliate_code.lower()}", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"
+    cookie = _ref_cookie(resp)
+    assert cookie is not None
+    assert affiliate_code in cookie
+    assert "httponly" in cookie.lower()
+    assert "samesite=lax" in cookie.lower()
+    assert f"max-age={REF_COOKIE_MAX_AGE_DAYS * 24 * 3600}" in cookie.lower()
+
+
+def test_link_honra_cookie_secure_do_app(monkeypatch, affiliate_code):
+    """COOKIE_SECURE do app inclui a blindagem APP_ENV=prod."""
+    monkeypatch.setattr(dashboard, "COOKIE_SECURE", True)
+    client = TestClient(dashboard.app)
+    resp = client.get(f"/r/{affiliate_code}", follow_redirects=False)
+    cookie = _ref_cookie(resp)
+    assert cookie is not None
+    assert "secure" in _attrs(cookie)
+
+
+def test_link_ignora_secure_quando_app_nao_exige(monkeypatch, affiliate_code):
+    """Par do teste acima: o cookie SEGUE a constante do app nas duas direções."""
+    monkeypatch.setattr(dashboard, "COOKIE_SECURE", False)
+    client = TestClient(dashboard.app)
+    resp = client.get(f"/r/{affiliate_code}", follow_redirects=False)
+    cookie = _ref_cookie(resp)
+    assert cookie is not None
+    assert "secure" not in _attrs(cookie)
+
+
+def test_codigo_inexistente_nao_seta_cookie():
+    client = TestClient(dashboard.app)
+    resp = client.get("/r/naoexiste", follow_redirects=False)
+    assert resp.status_code == 302
+    assert _ref_cookie(resp) is None
+
+
+def test_afiliado_desativado_nao_seta_cookie(user_id):
+    """O código EXISTE e mesmo assim não atribui: é o caso que o `status ==
+    "active"` do handler decide sozinho (com `if affiliate:` fica vermelho)."""
+    aff = create_affiliate(user_id)
+    assert set_affiliate_status(aff["id"], "disabled")
+    client = TestClient(dashboard.app)
+    resp = client.get(f"/r/{aff['code']}", follow_redirects=False)
+    assert resp.status_code == 302
+    assert _ref_cookie(resp) is None
+
+
+def test_codigo_hostil_nao_seta_cookie(affiliate_code):
+    """Espelho de test_prospect_referrals.py::test_link_invalido_nao_seta_cookie.
+    Aqui a superfície é maior: o `/i/{code}` só passa por regex, e no `/r/{code}`
+    6 dos 7 payloads chegam ao handler e viram query (`get_affiliate_by_code`) —
+    o `..%2F..%2Fetc%2Fpasswd` toma 404 no roteamento (o cliente normaliza o
+    path) e prova só que a rota não casa.
+
+    Os dois primeiros são os que medem injeção, e é por eles que o teste pede
+    `affiliate_code`: com a query montada por f-string, a aspa solta vira 500 e
+    o `or '1'='1'` casa a tabela inteira, devolvendo um afiliado ATIVO que nada
+    tem a ver com o code pedido (302 com cookie alheio). SEM a fixture não há
+    linha garantida — a tautologia poderia varrer uma tabela vazia e sair verde
+    com o buraco aberto, ou depender de linha deixada por outro teste. O code
+    hostil não casa nenhum afiliado no código são, então o cookie continua None.
+    Um `'--` sozinho não serve: ele comenta o resto, o SQL fica válido e sem
+    linhas, indistinguível do comportamento correto."""
+    client = TestClient(dashboard.app)
+    hostis = (
+        "abc%27",                  # aspa solta -> quebra a query se concatenada
+        "x' or '1'='1'--",         # tautologia -> vazaria afiliado alheio
+        "abc%0Ainjected:%201",     # CRLF -> header splitting
+        "..%2F..%2Fetc%2Fpasswd",  # travessia de caminho
+        "ç" * 30,                  # não-ASCII
+        "a" * 5000,                # muito longo
+        "a b c",                   # espaços
+    )
+    for bad in hostis:
+        resp = client.get(f"/r/{bad}", follow_redirects=False)
+        assert resp.status_code < 500, f"5xx para {bad!r}: {resp.status_code}"
+        assert _ref_cookie(resp) is None, f"cookie setado para {bad!r}"


### PR DESCRIPTION
## O problema

`frontend/routes/affiliates.py:32` derivava o `Secure` do cookie `ref_code` de uma constante própria:

```python
_COOKIE_SECURE = shared.DASHBOARD_URL.startswith("https://")
```

Isso ignora o segundo braço do `COOKIE_SECURE` do app (`frontend/finance_bot_websocket_custom.py:180`):

```python
COOKIE_SECURE = DASHBOARD_URL.startswith("https://") or _APP_ENV in ("prod", "production")
```

O comentário das linhas 175-178 diz que esse braço existe exatamente para cobrir `DASHBOARD_URL` http/ausente em produção. Sem ele, o cookie de atribuição de afiliado sairia em claro nesse cenário.

Gap **pré-existente**. O router irmão de prospecção já tinha sido corrigido no #216 — este PR aplica a mesma correção ao de afiliados.

## A correção

Import tardio dentro do handler, idêntico ao de `frontend/routes/prospects.py:38-42`. Import no topo não funciona: o monólito importa os routers antes de definir a constante (precedente do padrão: `open_finance.py`). Isso não é fragilidade — é o que **protege** a correção: mover o import para o topo dá `ImportError: cannot import name 'COOKIE_SECURE' from partially initialized module` já na coleta, e o app nem sobe.

Diff de produção: 1 arquivo, 6 inserções, 2 deleções. `_COOKIE_SECURE` tinha zero leitores externos (conferido por grep) e agora tem zero ocorrências no repo.

## Os testes

`tests/test_affiliate_link.py` é novo — **não havia teste de rota nenhum para afiliados**, só da camada db em `tests/test_db_affiliates.py`.

Os dois casos de `secure` andam em par de propósito. Forçar só `COOKIE_SECURE=True` seria tautológico numa máquina com `DASHBOARD_URL=https://`: o assert passaria com e sem o conserto. Sem a correção o handler lê uma constante congelada no import, então ou o caso `True` fica vermelho (constante `False`) ou o caso `False` fica (constante `True`) — um dos dois quebra em qualquer ambiente. Aqui e no CI (que não define `DASHBOARD_URL`), quem discrimina é `test_link_honra_cookie_secure_do_app`.

Dois testes que pareciam medir e não mediam, achados atacando o próprio grupo antes do push:

1. **O banco real não pagava por si.** Com todos os afiliados `active`, mutar o handler para `if affiliate:` mantinha os 4 casos verdes. Fechado com `test_afiliado_desativado_nao_seta_cookie`.
2. **O payload "SQL-ish" era decorativo.** Com um buraco de injeção real aberto em `db/affiliates.py:96`, os 6 casos ficavam verdes: `injecao'--%22` comenta o resto da query, que fica válida e sem linhas — indistinguível do comportamento correto. Trocado por `abc%27` (500) e `x' or '1'='1'--`, este último com fixture de afiliado, sem a qual varreria uma tabela vazia e continuaria inerte.

## Medido

- `tests/test_affiliate_link.py`: **6 passed**
- Suíte inteira: **6076 passed, 4 xfailed** (baseline 6074 + os 2 casos novos, zero falhas)
- Prova negativa: revertendo `secure=COOKIE_SECURE`, `test_link_honra_cookie_secure_do_app` fica vermelho e os outros 5 seguem verdes
- `fastapi` 0.115.6 (venv local) × 0.141.1 (`requirements.txt`/CI): venv scratch comparou o `Set-Cookie` byte a byte sob starlette 0.41.3 e 1.6.0 — **idêntico**, nenhuma asserção frágil ao salto de major

## Não verificado

- **Comportamento real do `Secure` no navegador.** A suíte prova o header que o servidor emite, não que o cookie deixe de trafegar em http. Só pós-deploy.
- **O braço `APP_ENV=prod` não foi exercitado por nenhuma rodada deste ciclo** — aqui `APP_ENV='dev'` e o `DASHBOARD_URL` cai no fallback http; o CI não define nenhuma das duas. O ganho está provado por construção (o handler passa a ler a constante do app), não medido em prod.
- O 6076 é com fastapi 0.115.6; o CI é a confirmação.
- Skill `pigbank-frontend` não se aplicava: backend puro, nenhum HTML/CSS/JS tocado.

## Fora de escopo

A blindagem `APP_ENV=prod` da linha 180 não é medida por nenhum dos 6076 testes — apagá-la mantém a suíte verde. Afeta as 3 famílias de cookie (auth, prospect, ref), é pré-existente e tem alcance maior que este PR. Issue separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)