### PR TITLE
fix: 500 sem autenticação em 11 comparações de segredo com entrada não-ASCII

### DIFF
--- a/adapters/whatsapp/wa_app.py
+++ b/adapters/whatsapp/wa_app.py
@@ -22,6 +22,7 @@ from core.reports.reports_daily import (
     build_weekly_report_summary,
     build_monthly_report_summary,
 )
+from core.secure_compare import constant_time_eq
 from db import (
     claim_daily_report_send,
     claim_weekly_report_send,
@@ -223,7 +224,8 @@ async def wa_verify(request: Request):
         )
         return PlainTextResponse("forbidden", status_code=403)
 
-    if mode == "subscribe" and token == VERIFY_TOKEN and challenge:
+    # `token` vem da query (pode ser None): a guarda antes do compare fica.
+    if mode == "subscribe" and token and constant_time_eq(token, VERIFY_TOKEN) and challenge:
         log_system_event_sync(
             "info",
             "whatsapp_webhook_verified",

--- a/adapters/whatsapp/wa_runtime.py
+++ b/adapters/whatsapp/wa_runtime.py
@@ -38,6 +38,7 @@ from adapters.whatsapp.wa_commands_menu import (
 )
 from core.handle_incoming import handle_incoming
 from core.intent_router import abandona_pergunta_de_valor
+from core.secure_compare import constant_time_eq
 from core.handlers import report as h_report
 from core.observability import log_system_event_sync
 from core.response_formatter import wrap_wa_markup
@@ -99,7 +100,7 @@ def verify_webhook_signature(raw_body: bytes, signature_header: str, app_secret:
         return False
     expected_hash = hmac.new(app_secret.encode(), raw_body, hashlib.sha256).hexdigest()
     expected = f"sha256={expected_hash}"
-    return hmac.compare_digest(signature_header, expected)
+    return constant_time_eq(signature_header, expected)
 
 
 def _seen_recent(msg_id: str) -> bool:

--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import secrets
 import sys
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
@@ -29,6 +28,7 @@ from core.crypto import (
     encrypt_pii_optional,
     pii_audit_batch,
 )
+from core.secure_compare import constant_time_eq
 
 
 load_app_env()
@@ -248,8 +248,8 @@ def _check_admin_password(password: str) -> bool:
             return False
     if not ADMIN_DASHBOARD_PASSWORD:
         return False
-    # compare_digest pra evitar timing leak no fallback plaintext.
-    return secrets.compare_digest(password, ADMIN_DASHBOARD_PASSWORD)
+    # Tempo constante pra evitar timing leak no fallback plaintext.
+    return constant_time_eq(password, ADMIN_DASHBOARD_PASSWORD)
 
 
 def _make_admin_jwt(username: str, jwt_secret: str) -> str:

--- a/core/secure_compare.py
+++ b/core/secure_compare.py
@@ -29,40 +29,54 @@ def constant_time_eq(fornecido: str, esperado: str) -> bool:
       (`/health` com `SMOKE_HEALTH_TOKEN` assim dava 500). `surrogateescape`
       faz o round-trip exato dos bytes do env, sem a colisão que `replace`
       criaria: dois segredos distintos continuam distintos.
-    - `fornecido` → `replace`, porque é o lado que não pode levantar nunca,
-      venha o caractere que vier. NÃO é peso morto, é caminho quente: o corpo
-      JSON entrega surrogate SOLITÁRIO — `json.loads('{"p": "\\udcff"}')` dá
-      `'\\udcff'` — e o login do admin (`_check_admin_password`) lê a senha
+    - `fornecido` → `surrogatepass`, porque é o lado que não pode levantar
+      nunca, venha o caractere que vier. NÃO é peso morto, é caminho quente: o
+      corpo JSON entrega surrogate SOLITÁRIO — `json.loads('{"p": "\\udcff"}')`
+      dá `'\\udcff'` — e o login do admin (`_check_admin_password`) lê a senha
       dali. Trocar por `.encode("utf-8")` estrito devolve `UnicodeEncodeError`
       → 500 sem autenticação nenhuma, medido em `POST /admin/auth/login`
       (`tests/test_admin_security.py::
       test_admin_login_com_surrogate_no_corpo_json_nao_da_500`). Header e
       cookie (latin-1) e query (`replace`) é que não produzem surrogate; o
       corpo produz. `surrogateescape` não serve aqui — surrogate fora da faixa
-      `\\udc80-\\udcff` voltaria a levantar.
+      `\\udc80-\\udcff` voltaria a levantar. `surrogatepass` não levanta em
+      NENHUMA entrada (UTF-8 codifica todo code point; o único que o Python
+      recusa é o surrogate, e é exatamente o que este handler libera).
 
-    Efeito da assimetria, e é o desejado: segredo com byte não-UTF-8 nunca
-    casa (o HTTP não entrega esse byte cru de volta), então falha FECHADO em
-    vez de 500.
+    Era `replace` deste lado até o apontamento do Codex no PR #309: `replace`
+    colapsa todo surrogate em `b"?"`, então uma senha com `?` literal casava
+    também com o surrogate na mesma posição — colisão sem ganho pro atacante
+    (ele podia mandar `?` literal), mas colisão. `surrogatepass` preserva os
+    bytes do surrogate e é injetivo, então a colisão não existe mais. **Não
+    volte pra `replace`** — `test_fornecido_preserva_surrogate_sem_colidir`
+    fica vermelho se alguém tentar.
 
-    Duas propriedades surpreendentes pra uma função chamada `eq`, ambas
-    consequência do `replace` e sem ganho pro atacante (que pode mandar `?`
-    literal de qualquer jeito):
+    Efeito da assimetria, e é o desejado: segredo do env com byte não-UTF-8
+    falha FECHADO em vez de dar 500, porque o `surrogateescape` do lado
+    `esperado` devolve o byte cru e o lado `fornecido` não tem como produzi-lo
+    — `b"senha-\\xff-cru"` é inalcançável. A exceção medida é o segredo cujos
+    bytes crus formam a codificação de um surrogate (`\\xed\\xa0\\x80`..
+    `\\xed\\xbf\\xbf`, CESU-8): esse o `fornecido` alcança mandando o
+    surrogate correspondente. Não é bypass — quem manda tem de conhecer o
+    segredo inteiro, e o espaço de busca continua uma string de bytes por
+    tentativa. Sob `replace` ele falhava fechado; a troca cobre uma classe
+    comum (senha com `?`) e abre uma que nenhum env real tem.
 
-    - não é injetiva — `eq("\\udcff", "?")`, `eq("\\ud800", "?")` e
-      `eq("a\\udcffb", "a?b")` são todos True;
-    - não é reflexiva — `eq(x, x)` é False quando o surrogate de `x` está na
-      faixa `\\udc80-\\udcff` (a que o `surrogateescape` do `os.getenv`
-      produz); é a mesma falha-fechado do parágrafo acima, vista do outro
-      lado. FORA dessa faixa o lado `esperado` LEVANTA `UnicodeEncodeError`
-      (`eq("\\ud800", "\\ud800")`), porque `surrogateescape` só codifica a
-      faixa dele. Hoje nenhum chamador pode trazer surrogate fora da faixa no
-      `esperado` (ele vem de `os.getenv`, de cookie latin-1 ou de
-      hexdigest/base64 ASCII) — é armadilha pro próximo site, não bug aberto.
+    Uma propriedade surpreendente pra uma função chamada `eq`, e ela sobrevive
+    à troca: não é reflexiva — `eq(x, x)` é False quando o surrogate de `x`
+    está na faixa `\\udc80-\\udcff` (a que o `surrogateescape` do `os.getenv`
+    produz), porque o `fornecido` codifica os 3 bytes do surrogate e o
+    `esperado` devolve o byte cru. É a mesma falha-fechado do parágrafo acima,
+    vista do outro lado. FORA dessa faixa o lado `esperado` LEVANTA
+    `UnicodeEncodeError` (`eq("\\ud800", "\\ud800")`), porque `surrogateescape`
+    só codifica a faixa dele. Hoje nenhum chamador pode trazer surrogate fora
+    da faixa no `esperado` (ele vem de `os.getenv`, de cookie latin-1 ou de
+    hexdigest/base64 ASCII) — é armadilha pro próximo site, não bug aberto.
 
     Não valida vazio: `constant_time_eq("", "")` é True, igual ao
     `compare_digest`. Quem depende disso já tem o `if valor and ...` antes.
     """
     return hmac.compare_digest(
-        fornecido.encode("utf-8", "replace"), esperado.encode("utf-8", "surrogateescape")
+        fornecido.encode("utf-8", "surrogatepass"),
+        esperado.encode("utf-8", "surrogateescape"),
     )

--- a/core/secure_compare.py
+++ b/core/secure_compare.py
@@ -1,0 +1,68 @@
+"""Comparação em tempo constante que aguenta entrada não-ASCII.
+
+`hmac.compare_digest` (e o `secrets.compare_digest`, que é o mesmo objeto) só
+aceita `str` ASCII: com um caractere acentuado de qualquer lado ele levanta
+`TypeError`. Como o lado esquerdo vem de header/query/cookie de quem chama,
+isso vira 500 com stack trace ANTES de qualquer autenticação — o atacante
+escolhe o byte e ganha o 500. Comparar bytes não tem essa restrição.
+
+Um helper só, e não o par de `.encode()` copiado em cada site: o dia em que
+alguém esquecer o `errors=` de um lado, o 500 volta (CLAUDE.md §0.7).
+
+Quem chama: `grep -rn constant_time_eq --include='*.py'` (a contagem não mora
+aqui de propósito — CLAUDE.md §2).
+"""
+
+import hmac
+
+
+def constant_time_eq(fornecido: str, esperado: str) -> bool:
+    """`fornecido` é o lado controlado por quem chama; `esperado`, o segredo.
+
+    Os dois `errors=` são diferentes de propósito, cada um contra um 500 medido:
+
+    - `esperado` → `surrogateescape`, porque é DESTE lado que o surrogate
+      aparece de verdade: `os.getenv` decodifica o ambiente com
+      `surrogateescape`, então um segredo com byte não-UTF-8 chega como
+      `'segredo-\\udcff-cru'` e o `.encode("utf-8")` estrito levantaria
+      `UnicodeEncodeError` — o mesmo 500 que este helper existe pra fechar
+      (`/health` com `SMOKE_HEALTH_TOKEN` assim dava 500). `surrogateescape`
+      faz o round-trip exato dos bytes do env, sem a colisão que `replace`
+      criaria: dois segredos distintos continuam distintos.
+    - `fornecido` → `replace`, porque é o lado que não pode levantar nunca,
+      venha o caractere que vier. NÃO é peso morto, é caminho quente: o corpo
+      JSON entrega surrogate SOLITÁRIO — `json.loads('{"p": "\\udcff"}')` dá
+      `'\\udcff'` — e o login do admin (`_check_admin_password`) lê a senha
+      dali. Trocar por `.encode("utf-8")` estrito devolve `UnicodeEncodeError`
+      → 500 sem autenticação nenhuma, medido em `POST /admin/auth/login`
+      (`tests/test_admin_security.py::
+      test_admin_login_com_surrogate_no_corpo_json_nao_da_500`). Header e
+      cookie (latin-1) e query (`replace`) é que não produzem surrogate; o
+      corpo produz. `surrogateescape` não serve aqui — surrogate fora da faixa
+      `\\udc80-\\udcff` voltaria a levantar.
+
+    Efeito da assimetria, e é o desejado: segredo com byte não-UTF-8 nunca
+    casa (o HTTP não entrega esse byte cru de volta), então falha FECHADO em
+    vez de 500.
+
+    Duas propriedades surpreendentes pra uma função chamada `eq`, ambas
+    consequência do `replace` e sem ganho pro atacante (que pode mandar `?`
+    literal de qualquer jeito):
+
+    - não é injetiva — `eq("\\udcff", "?")`, `eq("\\ud800", "?")` e
+      `eq("a\\udcffb", "a?b")` são todos True;
+    - não é reflexiva — `eq(x, x)` é False quando o surrogate de `x` está na
+      faixa `\\udc80-\\udcff` (a que o `surrogateescape` do `os.getenv`
+      produz); é a mesma falha-fechado do parágrafo acima, vista do outro
+      lado. FORA dessa faixa o lado `esperado` LEVANTA `UnicodeEncodeError`
+      (`eq("\\ud800", "\\ud800")`), porque `surrogateescape` só codifica a
+      faixa dele. Hoje nenhum chamador pode trazer surrogate fora da faixa no
+      `esperado` (ele vem de `os.getenv`, de cookie latin-1 ou de
+      hexdigest/base64 ASCII) — é armadilha pro próximo site, não bug aberto.
+
+    Não valida vazio: `constant_time_eq("", "")` é True, igual ao
+    `compare_digest`. Quem depende disso já tem o `if valor and ...` antes.
+    """
+    return hmac.compare_digest(
+        fornecido.encode("utf-8", "replace"), esperado.encode("utf-8", "surrogateescape")
+    )

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -107,6 +107,7 @@ from db import (
     LaunchUnsafeRollback,
 )
 from core.observability import _log_falha, get_logger
+from core.secure_compare import constant_time_eq
 from frontend.routes.affiliates import router as affiliates_router
 from frontend.routes.agents import router as agents_router
 from frontend.routes.analytics import router as analytics_router
@@ -2125,7 +2126,7 @@ async def csrf_middleware(request: Request, call_next):
 
     if request.method.upper() not in CSRF_SAFE_METHODS and not _csrf_exempt(request.url.path):
         header_token = request.headers.get(CSRF_HEADER_NAME) or ""
-        if not token or not header_token or not secrets.compare_digest(token, header_token):
+        if not token or not header_token or not constant_time_eq(header_token, token):
             # HOJE nenhum caminho conhecido cai aqui por navegação: o CSRF só
             # olha método não-seguro, e o produto não tem submit de formulário —
             # os 13 `<form>` de frontend/*.html não têm um `method=`/`action=`
@@ -3849,7 +3850,7 @@ async def auth_google_callback(
     if error:
         return _google_redirect_to_landing(f"Login com Google cancelado: {error}")
 
-    if not code or not state or not cookie_state or not secrets.compare_digest(state, cookie_state):
+    if not code or not state or not cookie_state or not constant_time_eq(state, cookie_state):
         return _google_redirect_to_landing("Sessão de login expirou. Tente novamente.")
 
     try:
@@ -5650,7 +5651,7 @@ def _verify_unsub_token(user_id: int, email: str, token: str) -> bool:
     payload  = f"{user_id}:{email}".encode()
     sig      = _hmac.new(secret, payload, _hashlib.sha256).digest()
     expected = _base64.urlsafe_b64encode(sig).decode().rstrip("=")
-    return _hmac.compare_digest(expected, token)
+    return constant_time_eq(token, expected)
 
 
 async def _apply_unsubscribe(uid: int, token: str) -> bool:

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 
 from core.admin_dashboard import log_system_event
 from core.audit import AuditEvent, record_audit_event
+from core.secure_compare import constant_time_eq
 from core.services.pluggy import (
     PluggyApiError,
     PluggyConfigError,
@@ -1064,7 +1065,7 @@ def _verify_pluggy_webhook_signature(raw_body: bytes, signature_header: str, sec
         return False
 
     expected = hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(signature, expected)
+    return constant_time_eq(signature, expected)
 
 
 # Headers de secret compartilhado aceitos (caso configurados no painel da Pluggy).
@@ -1091,12 +1092,12 @@ def _authorize_pluggy_webhook(request: Request, raw_body: bytes, secret: str) ->
     """
     # 1. token na query string
     token = request.query_params.get("token") or ""
-    if token and hmac.compare_digest(token, secret):
+    if token and constant_time_eq(token, secret):
         return True
     # 2. header com o secret
     for header_name in _PLUGGY_WEBHOOK_SECRET_HEADERS:
         value = (request.headers.get(header_name) or "").strip()
-        if value and hmac.compare_digest(value, secret):
+        if value and constant_time_eq(value, secret):
             return True
     # 3. assinatura HMAC do corpo (compat)
     signature = request.headers.get("X-Pluggy-Signature") or ""

--- a/frontend/routes/prospects.py
+++ b/frontend/routes/prospects.py
@@ -2,7 +2,7 @@
 
 Público:  GET /i/{code}              → seta cookie prospect_code (30d) e manda pra landing.
 Serviço:  POST /api/prospect/status  → status dos códigos (sem PII), autenticado
-          por X-Prospect-Key = env PROSPECT_API_KEY (secrets.compare_digest).
+          por X-Prospect-Key = env PROSPECT_API_KEY (constant_time_eq).
 
 Espelho de frontend/routes/affiliates.py, sem lookup no banco no /i/{code}:
 o código não é pré-registrado (o lead engine o gera), então não há o que
@@ -10,12 +10,12 @@ consultar — e não consultar também não vaza a existência de código.
 """
 import asyncio
 import os
-import secrets
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
+from core.secure_compare import constant_time_eq
 from db.prospects import (
     PROSPECT_COOKIE_MAX_AGE_DAYS,
     is_valid_prospect_code,
@@ -68,11 +68,13 @@ async def prospect_status(request: Request, body: ProspectStatusBody):
     if not expected:
         raise HTTPException(status_code=503, detail="Serviço não configurado.")
     provided = request.headers.get("X-Prospect-Key") or ""
-    # compare em bytes: compare_digest com str levanta TypeError se o header
-    # vier não-ASCII (viraria 500 sem autenticação; tem de ser 401).
-    if not secrets.compare_digest(
-        provided.encode("utf-8", "replace"), expected.encode("utf-8")
-    ):
+    # Migrou pro helper por causa do lado DIREITO, não do esquerdo: o
+    # `expected.encode("utf-8")` que estava aqui era estrito, e `expected` vem
+    # de `os.getenv` — um PROSPECT_API_KEY com byte não-UTF-8 chega como
+    # `'...\udcff...'` e levantava UnicodeEncodeError → 500 latente. O lado
+    # esquerdo já estava certo. O `errors=` de cada lado mora no helper — ver
+    # core/secure_compare.py.
+    if not constant_time_eq(provided, expected):
         raise HTTPException(status_code=401, detail="Chave inválida.")
 
     codes = (body.codes or [])[:_STATUS_CODES_CAP]

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -5,7 +5,6 @@ finance_bot_websocket_custom.py sem mudança de comportamento.
 """
 
 import asyncio
-import hmac
 import html as _html
 import os
 from urllib.parse import quote
@@ -14,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel
 
+from core.secure_compare import constant_time_eq
 from frontend.routes.shared import (
     FRONTEND_DIR,
     gate_onboarding,
@@ -773,6 +773,6 @@ async def health(request: Request):
     # deploy ANTERIOR, e o gate abriria cedo: o verde falso que ele impede.
     corpo = {"status": "ok"}
     esperado = os.getenv("SMOKE_HEALTH_TOKEN", "")
-    if esperado and hmac.compare_digest(request.headers.get("x-smoke-token", ""), esperado):
+    if esperado and constant_time_eq(request.headers.get("x-smoke-token", ""), esperado):
         corpo["commit"] = os.getenv("RAILWAY_GIT_COMMIT_SHA", "unknown")
     return JSONResponse(corpo, headers={"Cache-Control": "no-store"})

--- a/tests/test_admin_security.py
+++ b/tests/test_admin_security.py
@@ -13,6 +13,16 @@ def configured_admin(monkeypatch):
     monkeypatch.setattr(admin_dashboard, "ADMIN_DASHBOARD_PASSWORD", "secret-admin")
     monkeypatch.setattr(admin_dashboard, "ADMIN_DASHBOARD_PASSWORD_HASH", "")
     monkeypatch.setattr(admin_dashboard, "log_system_event", _noop_log)
+    # /admin/auth/login tem rate limit de 10/min (slowapi, storage em memória
+    # compartilhado entre testes). Este arquivo faz 4 POSTs nessa rota; somados
+    # aos de outros arquivos da mesma sessão isso estoura o teto e derruba um
+    # teste com 429 (que se lê como regressão de segurança). Zera o storage por
+    # teste — não afrouxa o limite em produção. Mesmo padrão de
+    # `tests/test_admin_users_panel.py`.
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:
+        pass
 
 
 def _csrf_headers(client: TestClient) -> dict[str, str]:
@@ -63,3 +73,63 @@ def test_admin_logout_clears_http_only_cookie():
     assert "admin_auth_token=" in set_cookie
     assert "Max-Age=0" in set_cookie
     assert "Path=/admin" in set_cookie
+
+
+def test_admin_login_com_senha_nao_ascii_no_fallback_plaintext():
+    """A senha digitada chega ao `compare_digest` do fallback plaintext. Com
+    acento ele levanta TypeError → 500 no login do admin, em vez do 401.
+
+    O par deste é o test_admin_login_aceita_senha_acentuada_correta abaixo: sem
+    ele o grupo passaria num código que recusasse toda senha acentuada.
+    """
+    client = TestClient(dashboard.app, base_url="https://testserver")
+
+    errada = client.post(
+        "/admin/auth/login",
+        headers=_csrf_headers(client),
+        json={"username": "admin", "password": "senhá-errada"},
+    )
+    assert errada.status_code == 401
+
+
+def test_admin_login_aceita_senha_acentuada_correta(monkeypatch):
+    monkeypatch.setattr(admin_dashboard, "ADMIN_DASHBOARD_PASSWORD", "sênha-com-acento")
+    client = TestClient(dashboard.app, base_url="https://testserver")
+
+    login = client.post(
+        "/admin/auth/login",
+        headers=_csrf_headers(client),
+        json={"username": "admin", "password": "sênha-com-acento"},
+    )
+
+    assert login.status_code == 200
+    assert "admin_auth_token=" in login.headers["set-cookie"]
+
+
+def test_admin_login_com_surrogate_no_corpo_json_nao_da_500():
+    """O corpo JSON é o único transporte que entrega surrogate SOLITÁRIO ao
+    handler: query usa `errors='replace'`, header e cookie são latin-1, e
+    nenhum dos três produz surrogate — mas `json.loads('{"p": "\\udcff"}')`
+    produz, e `_check_admin_password` lê a senha justamente dali.
+
+    Controle negativo do lado `fornecido` do `constant_time_eq`: troque o
+    `fornecido.encode("utf-8", "replace")` por `.encode("utf-8")` estrito em
+    `core/secure_compare.py` e este teste fica vermelho com
+    `UnicodeEncodeError` — 500 sem autenticação nenhuma, que é a classe que o
+    helper existe pra fechar. O controle positivo do grupo é o
+    test_admin_login_sets_http_only_cookie_and_unlocks_dashboard, que continua
+    verde sob a mesma mutação.
+
+    Corpo montado à mão de propósito: o `json=` do httpx serializa com
+    `ensure_ascii=False` e levantaria no CLIENTE, sem chegar na rota.
+    """
+    client = TestClient(dashboard.app, base_url="https://testserver")
+
+    response = client.post(
+        "/admin/auth/login",
+        headers={**_csrf_headers(client), "content-type": "application/json"},
+        content=b'{"username": "admin", "password": "\\udcff"}',
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Credenciais inválidas."

--- a/tests/test_admin_security.py
+++ b/tests/test_admin_security.py
@@ -113,7 +113,7 @@ def test_admin_login_com_surrogate_no_corpo_json_nao_da_500():
     produz, e `_check_admin_password` lê a senha justamente dali.
 
     Controle negativo do lado `fornecido` do `constant_time_eq`: troque o
-    `fornecido.encode("utf-8", "replace")` por `.encode("utf-8")` estrito em
+    `fornecido.encode("utf-8", "surrogatepass")` por `.encode("utf-8")` estrito em
     `core/secure_compare.py` e este teste fica vermelho com
     `UnicodeEncodeError` — 500 sem autenticação nenhuma, que é a classe que o
     helper existe pra fechar. O controle positivo do grupo é o

--- a/tests/test_auth_cookie.py
+++ b/tests/test_auth_cookie.py
@@ -5,6 +5,7 @@ import uuid
 import zipfile
 from io import BytesIO
 from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
@@ -822,3 +823,70 @@ def test_401_de_autenticacao_manda_www_authenticate_e_o_de_aplicacao_nao(monkeyp
         "401 de aplicação marcado como renovável — o interceptor volta a gastar "
         "refresh + retry, que é o bug da #176"
     )
+
+
+def test_csrf_com_header_nao_ascii_da_403_e_nao_500():
+    """Cookie e header do CSRF são AMBOS escolhidos por quem chama, e o
+    middleware não passa por exception handler nenhum: `compare_digest` sobre
+    str não-ASCII levanta TypeError e vira 500 cru em qualquer POST do site."""
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, "test-csrf-token")
+
+    # Em bytes: o httpx recusa str não-ASCII em header antes de a requisição sair.
+    response = client.post(
+        "/auth/dashboard-token",
+        headers={dashboard.CSRF_HEADER_NAME: "café".encode("latin-1")},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Token CSRF inválido ou ausente."
+
+
+_ERRO_DE_STATE = "Sessão de login expirou. Tente novamente."
+
+
+def _google_error(response) -> str:
+    """A mensagem do redirect, decodificada. Asserir o PREFIXO `/?google_error=`
+    não distingue nada: todo caminho de erro do callback usa o mesmo prefixo."""
+    qs = urlparse(response.headers["location"]).query
+    return parse_qs(qs)["google_error"][0]
+
+
+def test_google_callback_com_state_nao_ascii_redireciona_e_nao_500():
+    """O `state` volta na query do redirect do Google — qualquer um chama a URL
+    com o valor que quiser. Recusa é o redirect pra landing, não 500."""
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.GOOGLE_OAUTH_STATE_COOKIE, "state-ascii-do-cookie")
+
+    response = client.get(
+        "/auth/google/callback?code=qualquer&state=café",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert _google_error(response) == _ERRO_DE_STATE
+
+
+def test_google_callback_com_state_ascii_que_bate_passa_do_portao():
+    """Controle positivo do par acima: sem ele o grupo passaria num portão que
+    RECUSA TODO state — que derrubaria 100% dos logins com Google.
+
+    `state` ASCII igual ao cookie tem de atravessar o portão e morrer só
+    depois, no token exchange. Nesta suíte as vars do Google estão ausentes de
+    `os.environ`, então quem mata o exchange é o `_required_env`
+    (`get_client_id()`, antes do bloco `httpx`) e o `httpx` nem é tocado; a
+    fixture autouse `_block_outbound_network` (`tests/conftest.py`), que
+    mockeia `httpx.AsyncClient.request`, é a segunda barreira, para o ambiente
+    onde as vars existirem. Medido nos dois mundos, verde nos dois.
+    O que se afirma é o negativo: a mensagem NÃO é a de state expirado.
+    """
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.GOOGLE_OAUTH_STATE_COOKIE, "state-ascii-do-cookie")
+
+    response = client.get(
+        "/auth/google/callback?code=qualquer&state=state-ascii-do-cookie",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert _google_error(response) != _ERRO_DE_STATE

--- a/tests/test_pluggy_webhook_security.py
+++ b/tests/test_pluggy_webhook_security.py
@@ -105,3 +105,36 @@ def test_pluggy_webhook_rejects_wrong_url_token(monkeypatch):
     )
 
     assert response.status_code == 401
+
+
+def test_pluggy_webhook_rejects_non_ascii_credentials(monkeypatch):
+    """Os três caminhos de autenticação leem valor escolhido por quem chama.
+
+    `compare_digest` sobre str não-ASCII levanta TypeError → 500 com stack
+    trace, sem autenticação nenhuma. Tem de continuar 401 nos três.
+    """
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", "test-webhook-secret")
+    client = TestClient(dashboard.app)
+
+    # 1. token na query string
+    por_query = client.post(
+        "/open-finance/pluggy/webhook?token=café",
+        json={"event": "item/updated"},
+    )
+    assert por_query.status_code == 401
+
+    # 2. header de secret compartilhado (em bytes: o httpx recusa str não-ASCII)
+    por_header = client.post(
+        "/open-finance/pluggy/webhook",
+        json={"event": "item/updated"},
+        headers={"X-Webhook-Token": "café".encode("latin-1")},
+    )
+    assert por_header.status_code == 401
+
+    # 3. assinatura HMAC
+    por_assinatura = client.post(
+        "/open-finance/pluggy/webhook",
+        json={"event": "item/updated"},
+        headers={"X-Pluggy-Signature": "sha256=café".encode("latin-1")},
+    )
+    assert por_assinatura.status_code == 401

--- a/tests/test_secure_compare.py
+++ b/tests/test_secure_compare.py
@@ -1,0 +1,89 @@
+"""Contrato do `constant_time_eq` — o que o docstring dele promete, asserido.
+
+Sem fixture, sem mock, sem TestClient: é função pura. Os testes de rota
+(`test_health_com_segredo_surrogate_no_env_nao_da_500`,
+`test_admin_login_com_surrogate_no_corpo_json_nao_da_500`) provam que o 500
+fecha em produção; estes aqui prendem a ASSIMETRIA dos dois `errors=`, que
+até agora só existia em prosa e sobreviveria intacta a uma "simplificação"
+(CLAUDE.md §0.7).
+"""
+
+import pytest
+
+from core.secure_compare import constant_time_eq as eq
+
+
+def test_caminho_legitimo():
+    """Controle positivo: sem ele o grupo passaria num helper que recusa tudo."""
+    assert eq("abc", "abc") is True
+    assert eq("abc", "abd") is False
+    assert eq("café", "café") is True
+
+
+def test_segredo_com_byte_nao_utf8_nao_casa_com_interrogacao_literal():
+    """O caso que fecha o B1 — vermelho sob QUALQUER mutação do lado `esperado`.
+
+    - `esperado` → `replace`: os dois lados viram `b"senha-?-cru"` e isto
+      passa a ser True. Um segredo com byte não-UTF-8 no env casaria com um
+      literal que qualquer um digita.
+    - `esperado` → `.encode("utf-8")` estrito: levanta `UnicodeEncodeError`,
+      que é o 500 pré-autenticação que o helper existe pra fechar.
+
+    Só o `surrogateescape` faz o round-trip exato dos bytes do env: falha
+    FECHADO (False), sem colisão e sem exceção.
+    """
+    segredo = b"senha-\xff-cru".decode("utf-8", "surrogateescape")
+
+    assert eq("senha-?-cru", segredo) is False
+
+
+def test_segredos_distintos_nao_colidem():
+    """`replace` no lado `esperado` colapsaria `\\udcff` e `\\udcfe` no mesmo
+    `b"senha-?-cru"` — dois segredos diferentes, um único literal que abre os
+    dois. `surrogateescape` mantém 0xff ≠ 0xfe."""
+    a = b"senha-\xff-cru".decode("utf-8", "surrogateescape")
+    b = b"senha-\xfe-cru".decode("utf-8", "surrogateescape")
+
+    assert a != b
+    assert eq(a, b) is False
+    assert eq("senha-?-cru", a) is False
+    assert eq("senha-?-cru", b) is False
+
+
+def test_nao_e_injetiva():
+    """Docstring, linhas 52-53: consequência do `replace` do lado `fornecido`,
+    sem ganho pro atacante (ele pode mandar `?` literal de qualquer jeito).
+
+    Vermelho se `fornecido` virar `.encode("utf-8")` estrito
+    (`UnicodeEncodeError`) ou `surrogateescape` (`\\ud800` fora da faixa)."""
+    assert eq("\udcff", "?") is True
+    assert eq("\ud800", "?") is True
+    assert eq("a\udcffb", "a?b") is True
+
+
+def test_nao_e_reflexiva_na_faixa_do_surrogateescape():
+    """Docstring, linhas 54-61: `eq(x, x)` é False quando o surrogate de `x`
+    está em `\\udc80-\\udcff` — o lado `fornecido` faz `?`, o `esperado`
+    devolve o byte cru. É a mesma falha-fechado vista do outro lado."""
+    assert eq("\udcff", "\udcff") is False
+    assert eq("\udc80", "\udc80") is False
+
+
+def test_esperado_fora_da_faixa_levanta():
+    """Docstring, linhas 58-61: `surrogateescape` só codifica `\\udc80-\\udcff`.
+    Fora dela o lado `esperado` LEVANTA — armadilha pro próximo call site, não
+    bug aberto (hoje `esperado` vem de `os.getenv`, cookie latin-1 ou
+    hexdigest/base64 ASCII). Se algum dia isto parar de levantar, foi porque
+    alguém mexeu no `errors=` do lado errado."""
+    with pytest.raises(UnicodeEncodeError):
+        eq("x", "\ud800")
+
+
+def test_vazio_com_vazio_e_true():
+    """Docstring, linha 63: o helper NÃO valida vazio, igual ao
+    `compare_digest`. É o invariante de que os `if <valor> and ...` dos call
+    sites dependem — sem eles, segredo não configurado casaria com header
+    ausente."""
+    assert eq("", "") is True
+    assert eq("", "x") is False
+    assert eq("x", "") is False

--- a/tests/test_secure_compare.py
+++ b/tests/test_secure_compare.py
@@ -50,27 +50,69 @@ def test_segredos_distintos_nao_colidem():
     assert eq("senha-?-cru", b) is False
 
 
-def test_nao_e_injetiva():
-    """Docstring, linhas 52-53: consequência do `replace` do lado `fornecido`,
-    sem ganho pro atacante (ele pode mandar `?` literal de qualquer jeito).
+def test_fornecido_preserva_surrogate_sem_colidir():
+    """O apontamento do Codex no PR #309, virado em portão.
 
-    Vermelho se `fornecido` virar `.encode("utf-8")` estrito
-    (`UnicodeEncodeError`) ou `surrogateescape` (`\\ud800` fora da faixa)."""
-    assert eq("\udcff", "?") is True
-    assert eq("\ud800", "?") is True
-    assert eq("a\udcffb", "a?b") is True
+    Com `replace` no lado `fornecido` todo surrogate virava `b"?"`, então uma
+    senha com `?` literal casava também com o surrogate na mesma posição.
+    `surrogatepass` preserva os 3 bytes do surrogate: a colisão morre e a
+    função passa a ser injetiva deste lado.
+
+    Injetividade é o argumento inteiro da troca, então cada handler que APAGA
+    ou ESCAPA o surrogate precisa aqui da pré-imagem ASCII que ele criaria. Só
+    com o `?` o grupo passava verde sob `ignore`, `backslashreplace` e
+    `xmlcharrefreplace` — e `ignore` é PIOR que o `replace` apontado, porque dá
+    pré-imagem infinita para qualquer segredo (`eq("abc\\ud800", "abc")`,
+    `eq("\\ud800abc", "abc")`, …).
+
+    Vermelho sob QUALQUER mutação do `errors=` do lado `fornecido`. As seis
+    medidas: `replace`, `ignore`, `backslashreplace` e `xmlcharrefreplace`
+    viram algum assert em True; `.encode("utf-8")` estrito e `surrogateescape`
+    levantam `UnicodeEncodeError` em `\\ud800` (fora da faixa dele).
+    """
+    assert eq("\udcff", "?") is False  # mata `replace`
+    assert eq("\ud800", "?") is False
+    assert eq("a\udcffb", "a?b") is False
+    assert eq("abc\ud800", "abc") is False  # mata `ignore`
+    assert eq("abc\ud800", "abc\\ud800") is False  # mata `backslashreplace`
+    assert eq("abc\ud800", "abc&#55296;") is False  # mata `xmlcharrefreplace`
+
+    # o `?` literal continua casando com a senha que tem `?` — o que morreu foi
+    # a segunda pré-imagem, não o caminho legítimo.
+    assert eq("a?b", "a?b") is True
+
+
+def test_segredo_cesu8_e_alcancavel_classe_conhecida_e_aceita():
+    """Docstring, parágrafo da assimetria — a ÚNICA classe que a troca abre.
+
+    Segredo cujos bytes crus formam a codificação CESU-8 de um surrogate
+    (`\\xed\\xa0\\x80`..`\\xed\\xbf\\xbf`) passa a ser alcançável: o
+    `surrogatepass` do lado `fornecido` produz exatamente esses 3 bytes quando
+    recebe o surrogate correspondente. São 2048 segredos, e o diferencial
+    exaustivo sobre 1–3 bytes não achou outro ganho de alcance.
+
+    É DECIDIDO, não bug — não "conserte": quem manda tem de conhecer o segredo
+    inteiro (não é bypass), e nenhum env real tem esses bytes. O assert existe
+    pra que a afirmação não more só na prosa do docstring (CLAUDE.md §0.7).
+    """
+    segredo = b"\xed\xa0\x80".decode("utf-8", "surrogateescape")
+
+    assert eq("\ud800", segredo) is True
 
 
 def test_nao_e_reflexiva_na_faixa_do_surrogateescape():
-    """Docstring, linhas 54-61: `eq(x, x)` é False quando o surrogate de `x`
-    está em `\\udc80-\\udcff` — o lado `fornecido` faz `?`, o `esperado`
-    devolve o byte cru. É a mesma falha-fechado vista do outro lado."""
+    """Docstring, bloco da não-reflexividade: `eq(x, x)` é False quando o
+    surrogate de `x` está em `\\udc80-\\udcff` — o `fornecido` codifica os 3
+    bytes do surrogate, o `esperado` devolve o byte cru. É a mesma
+    falha-fechado vista do outro lado, e ela sobreviveu à troca de `replace`
+    por `surrogatepass`."""
     assert eq("\udcff", "\udcff") is False
     assert eq("\udc80", "\udc80") is False
 
 
 def test_esperado_fora_da_faixa_levanta():
-    """Docstring, linhas 58-61: `surrogateescape` só codifica `\\udc80-\\udcff`.
+    """Docstring, bloco da não-reflexividade: `surrogateescape` só codifica
+    `\\udc80-\\udcff`.
     Fora dela o lado `esperado` LEVANTA — armadilha pro próximo call site, não
     bug aberto (hoje `esperado` vem de `os.getenv`, cookie latin-1 ou
     hexdigest/base64 ASCII). Se algum dia isto parar de levantar, foi porque
@@ -80,7 +122,7 @@ def test_esperado_fora_da_faixa_levanta():
 
 
 def test_vazio_com_vazio_e_true():
-    """Docstring, linha 63: o helper NÃO valida vazio, igual ao
+    """Docstring, último parágrafo: o helper NÃO valida vazio, igual ao
     `compare_digest`. É o invariante de que os `if <valor> and ...` dos call
     sites dependem — sem eles, segredo não configurado casaria com header
     ausente."""

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -189,6 +189,44 @@ def test_health_sem_token_configurado_nao_aceita_header_vazio(monkeypatch):
     assert client.get("/health").json() == {"status": "ok"}
 
 
+def test_health_com_token_nao_ascii_nao_derruba_a_rota(monkeypatch):
+    """`compare_digest` sobre str não-ASCII levanta TypeError: seria 500 com
+    stack trace num endpoint público, escolhido byte a byte por quem chama.
+
+    NÃO vira 401: o x-smoke-token aqui é portão de DIVULGAÇÃO, não
+    autenticação — o healthcheck do Railway não manda header nenhum e depende
+    do 200. O que o token errado tira é só o campo `commit`.
+    """
+    monkeypatch.setenv("SMOKE_HEALTH_TOKEN", "token-de-teste-32-bytes-ou-mais!!")
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc123def456")
+
+    # Em bytes: o httpx recusa str não-ASCII em header (UnicodeEncodeError)
+    # antes da requisição sair, e o teste nunca chegaria no servidor.
+    resp = client.get("/health", headers={"X-Smoke-Token": "café".encode("latin-1")})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_health_com_segredo_surrogate_no_env_nao_da_500(monkeypatch):
+    """O surrogate mora no SEGREDO, não no header: `os.getenv` decodifica o
+    ambiente com `surrogateescape`, então um SMOKE_HEALTH_TOKEN com byte
+    não-UTF-8 chega como `'...\\udcff...'` e o `.encode("utf-8")` estrito
+    levantava UnicodeEncodeError → 500 nesta rota pública.
+
+    Ver o `errors="surrogateescape"` do lado `esperado` em
+    core/secure_compare.py. Falha FECHADO: nenhum header casa com esse
+    segredo (o HTTP não devolve o byte cru), mas o /health segue 200.
+    """
+    monkeypatch.setenv("SMOKE_HEALTH_TOKEN", b"token-\xff-cru".decode("utf-8", "surrogateescape"))
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc123def456")
+
+    resp = client.get("/health", headers={"X-Smoke-Token": "token-cru"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
 def test_robots_txt():
     resp = client.get("/robots.txt")
     assert resp.status_code == 200

--- a/tests/test_unsubscribe_one_click.py
+++ b/tests/test_unsubscribe_one_click.py
@@ -104,6 +104,27 @@ def test_get_unsubscribe_continua_funcionando(user_id):
     assert _engagement_opt_out(user_id) is True
 
 
+def test_unsubscribe_token_nao_ascii_da_400(user_id):
+    """O `token` vem da query do link do e-mail — quem clica escolhe o valor.
+    `compare_digest` sobre str não-ASCII levanta TypeError → 500 nas DUAS
+    rotas (o GET do humano e o POST one-click do Gmail). Segue 400.
+
+    Pela pilha HTTP, não chamando o handler direto: os bytes `caf%C3%A9` na
+    query são o que o cliente de e-mail manda de verdade, e é o Starlette que
+    decide qual `str` chega na função. Chamada direta seria cega à classe "a
+    rota deixou de entregar `str` não-ASCII ao handler".
+    """
+    _make_auth_account(user_id)
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app_mod.app)
+    url = f"/unsubscribe?uid={user_id}&token=caf%C3%A9"  # "café" em UTF-8 percent-encoded
+
+    assert client.post(url).status_code == 400
+    assert client.get(url).status_code == 400
+    assert _engagement_opt_out(user_id) is False
+
+
 def test_post_unsubscribe_atravessa_o_middleware_csrf(user_id):
     """O POST do Gmail/Yahoo chega sem cookie/header CSRF — o path precisa
     estar em CSRF_EXEMPT_PATHS, senão o middleware devolve 403 antes do

--- a/tests/test_wa_webhook_signature.py
+++ b/tests/test_wa_webhook_signature.py
@@ -1,0 +1,89 @@
+"""verify_webhook_signature (adapters/whatsapp/wa_runtime.py).
+
+O X-Hub-Signature-256 é escolhido por quem posta no webhook — é o primeiro
+dado não confiável que o processo toca, antes de qualquer autenticação. O
+hub.verify_token do GET /webhook (wa_app.wa_verify) é a mesma categoria e
+mora aqui embaixo.
+"""
+
+import asyncio
+import hashlib
+import hmac
+
+from starlette.requests import Request
+
+import adapters.whatsapp.wa_app as wa_app
+from adapters.whatsapp.wa_runtime import verify_webhook_signature
+
+CORPO = b'{"entry":[]}'
+SEGREDO = "app-secret-de-teste"
+
+
+def test_assinatura_valida_aceita():
+    """Controle positivo do grupo: sem ele, um verify que recusasse TUDO
+    passaria nos outros dois."""
+    esperado = hmac.new(SEGREDO.encode(), CORPO, hashlib.sha256).hexdigest()
+
+    assert verify_webhook_signature(CORPO, f"sha256={esperado}", SEGREDO) is True
+
+
+def test_assinatura_errada_recusa():
+    assert verify_webhook_signature(CORPO, "sha256=" + "0" * 64, SEGREDO) is False
+
+
+def test_assinatura_nao_ascii_recusa_sem_typeerror():
+    """`compare_digest` sobre str não-ASCII levanta TypeError → 500 com stack
+    trace, de graça, pra quem mandar um header acentuado."""
+    assert verify_webhook_signature(CORPO, "sha256=café", SEGREDO) is False
+
+
+# ─── hub.verify_token (GET /webhook, adapters/whatsapp/wa_app.py) ─────────────
+
+def _wa_verify(query: str, monkeypatch):
+    monkeypatch.setattr(wa_app, "VERIFY_TOKEN", "verify-token-de-teste")
+    monkeypatch.setattr(wa_app, "log_system_event_sync", lambda *a, **k: None)
+    req = Request({"type": "http", "method": "GET", "headers": [],
+                   "query_string": query.encode()})
+    return asyncio.run(wa_app.wa_verify(req))
+
+
+def test_wa_verify_token_correto_devolve_challenge(monkeypatch):
+    """Controle positivo: sem ele o grupo passaria num wa_verify que recusa
+    TUDO — e aí a Meta nunca revalida o webhook."""
+    resp = _wa_verify(
+        "hub.mode=subscribe&hub.verify_token=verify-token-de-teste&hub.challenge=1234",
+        monkeypatch,
+    )
+
+    assert resp.status_code == 200
+    assert resp.body == b"1234"
+
+
+def test_wa_verify_token_errado_403(monkeypatch):
+    resp = _wa_verify(
+        "hub.mode=subscribe&hub.verify_token=errado&hub.challenge=1234", monkeypatch
+    )
+
+    assert resp.status_code == 403
+
+
+def test_wa_verify_sem_token_403_e_nao_500(monkeypatch):
+    """`hub.verify_token` ausente vira None — a guarda `token and` antes do
+    compare em tempo constante é o que mantém isso 403 em vez de
+    AttributeError."""
+    resp = _wa_verify("hub.mode=subscribe&hub.challenge=1234", monkeypatch)
+
+    assert resp.status_code == 403
+
+
+def test_wa_verify_token_nao_ascii_403_e_nao_500(monkeypatch):
+    """NÃO prova o conserto original: aqui era `token == VERIFY_TOKEN`, e `==`
+    nunca levantou. O que este caso guarda é a MIGRAÇÃO — trocar o `==` por um
+    `compare_digest` cru (em vez do helper) levantaria TypeError e viraria 500
+    numa query string que qualquer um escolhe. Provado mutando o helper para
+    `hmac.compare_digest`: este é o teste que fica vermelho."""
+    resp = _wa_verify(
+        "hub.mode=subscribe&hub.verify_token=caf%C3%A9&hub.challenge=1234", monkeypatch
+    )
+
+    assert resp.status_code == 403


### PR DESCRIPTION
## O problema

`hmac.compare_digest` (e o `secrets.compare_digest`, que é o mesmo objeto) só aceita `str` ASCII: com um caractere acentuado de qualquer lado ele levanta `TypeError`. Como o lado de fora vem de header/query/cookie/corpo de quem chama, isso vira **500 com stack trace ANTES de qualquer autenticação** — o atacante escolhe o byte e gera 500 à vontade.

O relato original apontava 2 sites. A varredura da categoria (§2) achou **11**, e o mais exposto não era nenhum dos dois: o **middleware CSRF**, onde quem chama escolhe cookie *e* header, e que não passa por exception handler.

**Havia um segundo 500, do lado do segredo.** `os.getenv` decodifica o ambiente com `surrogateescape`, então um segredo com byte não-UTF-8 chega como `'segredo-\udcff-cru'` e o `.encode("utf-8")` estrito levanta `UnicodeEncodeError`. `/health` com um `SMOKE_HEALTH_TOKEN` assim dava 500 de verdade. O padrão do #216, que este PR foi aberto para replicar, tinha esse buraco — inclusive no próprio `prospects.py`, que o plano tinha excluído *por já estar correto*.

## O que muda

Um helper — `core/secure_compare.py`, `constant_time_eq(fornecido, esperado)` — substitui o `compare_digest` cru em **11 call sites**. Um helper só, e não o par de `.encode()` copiado em cada site: o dia em que alguém esquecer o `errors=` de um lado, o 500 volta (§0.7).

| site | entrada de quem chama |
|---|---|
| `frontend/finance_bot_websocket_custom.py:2129` — middleware CSRF | cookie + header, ambos dele |
| `frontend/routes/open_finance.py:1068/1095/1100` — webhook Pluggy | assinatura, `?token=`, 3 headers |
| `adapters/whatsapp/wa_runtime.py:103` — assinatura do webhook | `X-Hub-Signature-256` |
| `adapters/whatsapp/wa_app.py:228` — `wa_verify` | `?token=` (era `==`, timing leak) |
| `frontend/routes/static_pages.py:776` — `/health` | `x-smoke-token` |
| `frontend/finance_bot_websocket_custom.py:3853` — callback Google | `?state=` |
| `frontend/finance_bot_websocket_custom.py:5654` — `/unsubscribe` | `?token=` |
| `core/admin_dashboard.py:252` — login admin | senha do corpo JSON |
| `frontend/routes/prospects.py:74` — prospecção | `X-Prospect-Key` |

**Zero mudança de status code em qualquer site**: cada entrada não-ASCII passou a seguir a recusa que o site já tinha (403 no CSRF, 401 nos webhooks, redirect no Google, 400 no unsubscribe). Nenhuma guarda `if <valor> and compare(...)` saiu — `compare_digest("","")` é `True` e cinco sites dependem disso.

**`/health` não virou 401.** Ali o `x-smoke-token` não autentica: é portão de divulgação num 200 público — token errado só omite o campo `commit`. 401 quebraria `test_health_endpoint_does_not_expose_infrastructure`, `test_health_entrega_o_commit_so_com_o_token` e o healthcheck do Railway, que não manda header.

**A assimetria do helper é deliberada e está documentada**: `replace` no lado de fora (o corpo JSON entrega surrogate solitário, e o login admin lê a senha dali — trocar por estrito devolve o 500), `surrogateescape` no segredo (round-trip exato dos bytes do env, sem a colisão que `replace` criaria). Efeito: segredo com byte não-UTF-8 falha **fechado** em vez de dar 500.

## O que foi medido

- **24 testes novos.** Suíte **6100 passed, 4 xfailed, 0 failed**, contra base pós-merge de 6076. Comparado por nome, não por contagem: **0 node ID sumiu**.
- **Prova negativa, 4 mutações independentes**, cada uma refeita por um segundo agente e não herdada do relato:
  - helper → `compare_digest` cru: **18 vermelhos**, um por site;
  - `fornecido` → estrito: vermelho no grupo do helper **e** em `test_admin_login_com_surrogate_no_corpo_json_nao_da_500`;
  - `esperado` → estrito: vermelho no grupo **e** em `test_health_com_segredo_surrogate_no_env_nao_da_500`;
  - `esperado` → `replace` (a simplificação que a assimetria convida): **4 vermelhos** — era o único caminho que passava batido, e é o que `tests/test_secure_compare.py` fecha.
- **Controle positivo honesto**: rodado contra um helper que recusa tudo, o grupo fica vermelho. O verde não é vácuo.

Dois defeitos foram achados pelo ciclo e não pelo revisor: um teste do callback Google que passava com o portão recusando tudo *e* aceitando tudo, e a metade `replace` do helper, que podia ser apagada sem uma linha vermelha.

## Fora de escopo

Provado pré-existente em `0557aea`, mecanismo diferente, merece issue própria:
- `POST /admin/auth/login` com corpo JSON de topo não-objeto (`[1,2,3]`, `42`, `null`) → **500 sem autenticação**, `AttributeError` em `core/admin_dashboard.py:1594`;
- `adapters/whatsapp/wa_app.py:257` (`json.loads` fora do `try`) e `frontend/routes/open_finance.py:1142` (`event.get` após `json.loads`) → 500 pós-autenticação.

## Não verificado aqui

Tudo passou por `TestClient`, com envio e LLM mockados (§3). **Nenhum** webhook foi exercitado contra tráfego real da Meta, da Pluggy ou do Google, e o `/health` não foi provado atrás do healthcheck do Railway.

**Vale conferir o env do Railway antes do deploy**: se algum segredo tiver byte não-UTF-8 hoje, o comportamento muda de 500 para recusa silenciosa — que é o correto, mas quem depende daquele segredo passa a ver 401 em vez de erro.

Backend puro — a skill `pigbank-frontend` não se aplicava, nenhum arquivo de frontend tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)