### PR TITLE
Aviso de saldo legível no onboarding, e item de Open Finance órfão deixa de travar a reconexão

### DIFF
--- a/core/services/pluggy.py
+++ b/core/services/pluggy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import time
 from collections.abc import Callable
 from typing import Any
@@ -106,18 +107,41 @@ def _pluggy_get(path: str, api_key: str, params: dict[str, Any] | None = None) -
     return resp.json()
 
 
+# O que a Pluggy emite como id de item é um UUID; o que CHEGA aqui pode não ser.
+# Desde a adoção de item órfão (`_adota_item_orfao`), o `itemId` do CORPO do
+# webhook — que vem de fora, e cujo único portão é um secret que trafega em query
+# param — vira URL na API da Pluggy com a NOSSA chave. Sem esta régua,
+# `itemId='../../accounts'` virava `GET https://api.pluggy.ai/accounts`, e
+# `x?include=all` / `abc#frag` passavam intactos: requisição forjada por corpo
+# alheio. Validado na FRONTEIRA de saída, uma vez, para os três montadores de
+# `/items/{id}` (get/update/delete) — guarda no chamador deixaria os irmãos
+# abertos (CLAUDE.md §0.1).
+#
+# Charset, não UUID estrito: o que precisa ser barrado é o que muda a ESTRUTURA
+# da URL (`/`, `?`, `#`, `.`, espaço, `%`). Exigir UUID recusaria id de sandbox e
+# de ambiente de teste sem fechar nada a mais.
+_ITEM_ID_OK = re.compile(r"[A-Za-z0-9_-]{1,64}\Z")
+
+
+def _item_path(item_id: str) -> str:
+    if not _ITEM_ID_OK.match(str(item_id or "")):
+        raise PluggyApiError("Id de item Pluggy inválido.", status_code=400)
+    return f"/items/{item_id}"
+
+
 def get_pluggy_item(item_id: str, api_key: str | None = None) -> dict:
-    key = api_key or create_pluggy_api_key()
-    return _pluggy_get(f"/items/{item_id}", key)
+    path = _item_path(item_id)   # antes da chave: id inválido não gasta um POST /auth
+    return _pluggy_get(path, api_key or create_pluggy_api_key())
 
 
 def update_pluggy_item(item_id: str, api_key: str | None = None) -> dict:
     """PATCH /items/{id}: força a Pluggy a re-buscar do banco. Ao concluir, ela manda
     webhook (item/updated, transactions/*), que dispara o sync. Usado no refresh periódico."""
+    path = _item_path(item_id)   # antes da chave: id inválido não gasta um POST /auth
     key = api_key or create_pluggy_api_key()
     with httpx.Client(timeout=_pluggy_timeout()) as client:
         resp = client.patch(
-            f"{_pluggy_base_url()}/items/{item_id}",
+            f"{_pluggy_base_url()}{path}",
             headers={"X-API-KEY": key},
             json={},
         )
@@ -134,10 +158,11 @@ def delete_pluggy_item(item_id: str, api_key: str | None = None) -> bool:
     """
     if not item_id:
         return False
+    path = _item_path(item_id)   # antes da chave: id inválido não gasta um POST /auth
     key = api_key or create_pluggy_api_key()
     with httpx.Client(timeout=_pluggy_timeout()) as client:
         resp = client.delete(
-            f"{_pluggy_base_url()}/items/{item_id}",
+            f"{_pluggy_base_url()}{path}",
             headers={"X-API-KEY": key},
         )
     if resp.status_code in (200, 202, 204, 404):

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -272,6 +272,7 @@ from .open_finance_state import (
     pluggy_item_lock,
     register_item,
     token_hash,
+    unregister_item,
 )
 
 # ── Renda variável (ações/FIIs via Open Finance) ──────────────────────────────
@@ -550,6 +551,7 @@ __all__ = [
     "list_connections_for_health_check", "mark_sync_attempt", "mark_sync_result",
     "item_registry_origins",
     "of_health_counters", "pluggy_item_lock", "register_item", "token_hash",
+    "unregister_item",
     "list_pluggy_connections_for_trial_sweep", "pause_open_finance_connection",
     # reports
     "set_daily_report_enabled", "set_daily_report_hour", "get_daily_report_prefs",

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -29,6 +29,7 @@ from .schema import init_db
 from .users import (
     ensure_user_tx,
     ensure_user,
+    user_exists,
     merge_users,
     choose_primary_user,
     user_score,
@@ -263,6 +264,7 @@ from .open_finance_state import (
     claim_items_for_refresh,
     claim_manual_refresh,
     get_connections_by_item_id,
+    item_registry_origins,
     list_connections_for_health_check,
     mark_sync_attempt,
     mark_sync_result,
@@ -458,7 +460,7 @@ __all__ = [
     # schema
     "init_db",
     # users
-    "ensure_user_tx", "ensure_user", "merge_users", "choose_primary_user", "user_score",
+    "ensure_user_tx", "ensure_user", "user_exists", "merge_users", "choose_primary_user", "user_score",
     "get_or_create_canonical_user", "create_link_code", "create_platform_onboarding_token",
     "consume_platform_onboarding_token", "consume_link_code", "bind_identity",
     "link_platform_identity",
@@ -546,6 +548,7 @@ __all__ = [
     "AmbiguousItemError", "claim_items_for_refresh", "claim_manual_refresh",
     "get_connections_by_item_id",
     "list_connections_for_health_check", "mark_sync_attempt", "mark_sync_result",
+    "item_registry_origins",
     "of_health_counters", "pluggy_item_lock", "register_item", "token_hash",
     "list_pluggy_connections_for_trial_sweep", "pause_open_finance_connection",
     # reports

--- a/db/open_finance.py
+++ b/db/open_finance.py
@@ -619,11 +619,23 @@ class _CursorComTeto:
 
 
 def save_pluggy_open_finance_item(user_id: int, item: dict, *,
-                                  budget_ms: int | None = None) -> dict:
+                                  budget_ms: int | None = None,
+                                  criar_usuario: bool = True) -> dict:
     """Grava (ou reconecta) o item da Pluggy.
 
     `budget_ms` é o teto de espera desta escrita, para quem tem cliente HTTP
     esperando — a rota de reconexão. Sem ele, comportamento de sempre.
+
+    `criar_usuario=False` desliga o `ensure_user_tx` e deixa a FK
+    `open_finance_connections.user_id -> users(id)` decidir: sem a linha de
+    `users`, o insert estoura `ForeignKeyViolation` na MESMA transação, em vez de
+    criar o usuário que falta. É o que a adoção pelo webhook usa
+    (`frontend/routes/open_finance._adota_item_orfao`): lá o `user_id` vem do
+    `clientUserId` REMOTO e é lido fora da transação da escrita, então uma
+    exclusão de conta (LGPD) que commite no meio deixava o `ensure_user_tx`
+    RESSUSCITAR a conta apagada e pendurar a conexão nela (Codex #313, P1).
+    Quem tem sessão autenticada continua com o default: a linha de `users` é
+    pré-requisito da sessão, e o `ensure_user_tx` ainda repõe a de `accounts`.
 
     O `ensure_user` saiu daqui e virou `ensure_user_tx` DENTRO da mesma
     transação do upsert: eram duas aquisições de conexão do pool (até 30s cada,
@@ -664,7 +676,8 @@ def save_pluggy_open_finance_item(user_id: int, item: dict, *,
         with conn.cursor() as cur:
             if budget_ms is not None:
                 cur = _CursorComTeto(cur, budget_ms, t0)
-            ensure_user_tx(cur, user_id)
+            if criar_usuario:
+                ensure_user_tx(cur, user_id)
             cur.execute(
                 """
                 insert into open_finance_connections (

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -317,7 +317,9 @@ ITEMS_SEM_CONEXAO = """
 """
 
 
-def item_registry_origins(provider_item_id: str, *, provider: str = "pluggy") -> set[str]:
+def item_registry_origins(provider_item_id: str, *, provider: str = "pluggy",
+                          exceto_registro_id: int | None = None,
+                          exceto_user_id: int | None = None) -> set[str]:
     """Por quais portas este item já foi visto COM DONO.
 
     Uma pergunta, uma fonte (CLAUDE.md §0.7). Vazio = o item nunca foi atribuído
@@ -333,19 +335,65 @@ def item_registry_origins(provider_item_id: str, *, provider: str = "pluggy") ->
         adotar (auditoria de reconexão);
       • `scripts/adotar_items_of_orfaos.py` — o alvo do one-shot.
 
+    `exceto_registro_id` IGNORA uma linha do rastro pelo `id` — a que o próprio
+    chamador acabou de gravar. É o que permite ao `_salva_item_sob_lock` refazer
+    a pergunta do 1º leitor DENTRO do `pluggy_item_lock` ("alguém MAIS já tem
+    este item?") sem que a adoção em curso responda a si mesma (Codex #313, P1).
+    Um parâmetro na fonte única em vez de uma 2ª query com o mesmo `user_id is
+    not null`: a regra "teve dono" continua escrita uma vez (CLAUDE.md §0.7).
+    Ele ANDA COM `exceto_user_id`, e o `ValueError` abaixo OBRIGA: a query filtra
+    por `provider + provider_item_id`, então um `id` de OUTRO item nunca mascara
+    nada, mas o mesmo item pode ter linha de outro USUÁRIO — e esconder a origem
+    dela seria vazar decisão entre usuários (CLAUDE.md §0, isolamento). O par só
+    ignora a linha que é do próprio dono em curso. Sem a guarda, meio par era
+    SILENCIOSAMENTE pior que nenhum: só `exceto_registro_id` faz o `user_id = %s`
+    virar `= null`, o `not (...)` inteiro vira NULL, e o `where` descarta TODA
+    linha — `set()` no lugar de `{'webhook_adopt'}`, ou seja "item nunca teve
+    dono" para um item que tem. O chamador de produção passa os dois; isto é
+    fronteira para o PRÓXIMO (CLAUDE.md §0.2, validação não se simplifica).
+
     Devolve ORIGENS, nunca `user_id`: o chamador decide sobre o item, e nenhum
     dado de outro usuário sai daqui.
     """
+    if (exceto_registro_id is None) != (exceto_user_id is None):
+        raise ValueError("exceto_registro_id e exceto_user_id andam juntos ou nenhum")
     with get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
                 select distinct origin from open_finance_item_registry
                  where provider = %s and provider_item_id = %s and user_id is not null
+                   and (%s::bigint is null or not (id = %s and user_id = %s))
                 """,
-                (provider, str(provider_item_id or "")),
+                (provider, str(provider_item_id or ""),
+                 exceto_registro_id, exceto_registro_id, exceto_user_id),
             )
             return {r["origin"] for r in (cur.fetchall() or []) if r["origin"]}
+
+
+def unregister_item(registro_id: int, user_id: int) -> int:
+    """Apaga UMA linha do rastro: a reivindicação que a própria adoção ABANDONOU.
+
+    O registry é log de append ("este item existiu, visto por esta porta") e
+    continua sendo — o único caso que apaga é a linha que ESTA adoção gravou
+    segundos atrás e não vai honrar, porque outra entrega ficou com o item. Sem
+    isso o aborto era TERMINAL: rastro com dono e zero conexão recusa toda
+    retentativa (1ª guarda de `_adota_item_orfao`) e some do
+    `scripts/adotar_items_of_orfaos.py` (o filtro dele exclui rastro com dono),
+    e o usuário fica com 0 bancos sem saída pelo produto.
+
+    `user_id` no `where` não é decoração: é o isolamento por usuário do
+    CLAUDE.md §0 aplicado a um DELETE que recebe um `id` cru.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "delete from open_finance_item_registry where id = %s and user_id = %s",
+                (registro_id, user_id),
+            )
+            n = cur.rowcount
+        conn.commit()
+    return n
 
 
 def register_item(

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -302,6 +302,52 @@ def list_connections_for_health_check(*, older_than_sec: int, limit: int) -> lis
             return [dict(r) for r in (cur.fetchall() or [])]
 
 
+# Item visto no registry (o único rastro: o `GET /items` da Pluggy devolve 401)
+# que não tem NENHUMA conexão local. Uma fonte só, porque dois leitores precisam
+# enxergar exatamente o mesmo universo: o contador do painel de saúde abaixo e o
+# `scripts/adotar_items_of_orfaos.py`, que adota justamente esses items.
+ITEMS_SEM_CONEXAO = """
+  from open_finance_item_registry r
+ where r.provider_item_id is not null
+   and not exists (
+       select 1 from open_finance_connections c
+        where c.provider = r.provider
+          and c.provider_item_id = r.provider_item_id
+   )
+"""
+
+
+def item_registry_origins(provider_item_id: str, *, provider: str = "pluggy") -> set[str]:
+    """Por quais portas este item já foi visto COM DONO.
+
+    Uma pergunta, uma fonte (CLAUDE.md §0.7). Vazio = o item nunca foi atribuído
+    a ninguém, e é isso que separa ADOTAR de RESSUSCITAR: nem o disconnect nem o
+    reset apagam o registry (`db/privacy.py` o preserva), então banco REMOVIDO
+    fica para sempre "sem conexão local" e só o rastro com dono
+    (`pluggy_item`/`webhook_adopt`) conta que ele existiu. Os três leitores:
+
+      • `_adota_item_orfao` — só adota item sem NENHUM dono no rastro (duplicata
+        de `item/created`, entrega at-least-once, ressuscitava o removido);
+      • `POST /pluggy-item` — `'pluggy_item' in ...` = o NAVEGADOR já registrou
+        este item, logo a conexão que existe não é a que o webhook acabou de
+        adotar (auditoria de reconexão);
+      • `scripts/adotar_items_of_orfaos.py` — o alvo do one-shot.
+
+    Devolve ORIGENS, nunca `user_id`: o chamador decide sobre o item, e nenhum
+    dado de outro usuário sai daqui.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select distinct origin from open_finance_item_registry
+                 where provider = %s and provider_item_id = %s and user_id is not null
+                """,
+                (provider, str(provider_item_id or "")),
+            )
+            return {r["origin"] for r in (cur.fetchall() or []) if r["origin"]}
+
+
 def register_item(
     user_id: int | None,
     *,
@@ -378,18 +424,7 @@ def of_health_counters() -> dict[str, Any]:
             row["stale_por_produto"] = {r["produto"]: int(r["n"]) for r in (cur.fetchall() or [])}
 
             # Items vistos (registry) que não têm conexão local nenhuma.
-            cur.execute(
-                """
-                select count(distinct r.provider_item_id) as n
-                  from open_finance_item_registry r
-                 where r.provider_item_id is not null
-                   and not exists (
-                       select 1 from open_finance_connections c
-                        where c.provider = r.provider
-                          and c.provider_item_id = r.provider_item_id
-                   )
-                """
-            )
+            cur.execute(f"select count(distinct r.provider_item_id) as n {ITEMS_SEM_CONEXAO}")
             row["items_sem_conexao"] = int((cur.fetchone() or {}).get("n") or 0)
 
             # Deadlocks/retries recentes (24h) — o log de sistema é a fonte.

--- a/db/open_finance_state.py
+++ b/db/open_finance_state.py
@@ -326,10 +326,12 @@ def item_registry_origins(provider_item_id: str, *, provider: str = "pluggy",
     a ninguém, e é isso que separa ADOTAR de RESSUSCITAR: nem o disconnect nem o
     reset apagam o registry (`db/privacy.py` o preserva), então banco REMOVIDO
     fica para sempre "sem conexão local" e só o rastro com dono
-    (`pluggy_item`/`webhook_adopt`) conta que ele existiu. Os três leitores:
+    (`pluggy_item`/`webhook_adopt`) conta que ele existiu. Os leitores:
 
       • `_adota_item_orfao` — só adota item sem NENHUM dono no rastro (duplicata
-        de `item/created`, entrega at-least-once, ressuscitava o removido);
+        de `item/created`, entrega at-least-once, ressuscitava o removido), e a
+        MESMA pergunta de novo dentro do lock, em `_salva_item_sob_lock`
+        (`exceto_registro_id`, abaixo);
       • `POST /pluggy-item` — `'pluggy_item' in ...` = o NAVEGADOR já registrou
         este item, logo a conexão que existe não é a que o webhook acabou de
         adotar (auditoria de reconexão);

--- a/db/users.py
+++ b/db/users.py
@@ -31,6 +31,27 @@ def ensure_user(user_id: int):
         conn.commit()
 
 
+def user_exists(user_id: int) -> bool:
+    """A conta existe? Pergunta para quem NÃO pode criá-la ao consultar.
+
+    Nasceu do webhook da Pluggy (`_adota_item_orfao`): lá o dono vem do
+    `clientUserId` remoto, e todo caminho de escrita passa por `ensure_user_tx`,
+    que INSERE a linha em vez de recusar. Conta apagada por LGPD
+    (`db/privacy.py`) cujo item sobreviveu ao delete best-effort voltava a
+    existir no banco por causa de um evento da Pluggy.
+
+    LIMITE CONHECIDO: responde True durante a janela da exclusão AGENDADA
+    (`auth_accounts.deletion_status in ('scheduled','processing')`) — a linha de
+    `users` só some no fim. Fechar isso é join com `auth_accounts`, outra tabela,
+    dentro do que hoje é um `select 1 from users`; não vale o custo aqui: nessa
+    janela a conta ainda EXISTE, e a exclusão, quando roda, leva a conexão junto.
+    """
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select 1 from users where id = %s", (user_id,))
+            return cur.fetchone() is not None
+
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Merge de usuários (vinculação Discord ↔ WhatsApp)
 # ──────────────────────────────────────────────────────────────────────────────

--- a/frontend/comecar.css
+++ b/frontend/comecar.css
@@ -13,7 +13,7 @@
    por especificidade (as duas são 0,1,0), mas porque folha de autor vence folha
    de user-agent. Como `.onb-done` declara `display:flex` e `.btn` declara
    `display:inline-flex`, os quatro elementos que o JS controla por `hidden`
-   ficavam SEMPRE visíveis: "já tem saldo lançado", "WhatsApp já conectado", o
+   ficavam SEMPRE visíveis: "Saldo lançado com sucesso", "WhatsApp conectado com sucesso", o
    botão do WhatsApp e o "+ Adicionar cartão".
 
    O `!important` é necessário: sem ele, `.btn{display:inline-flex}` (mesma
@@ -123,7 +123,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--neon-ink, var(--neon));
+  color: var(--neon);
   font-size: .88rem;
   font-weight: 600;
   padding: 12px 14px;

--- a/frontend/comecar.html
+++ b/frontend/comecar.html
@@ -63,7 +63,7 @@
           <button type="button" class="btn btn-outline btn-block" data-action="save-balance">Salvar saldo</button>
         </div>
         <p class="onb-done" data-role="balance-done" hidden>
-          <i class="ph ph-check-circle" aria-hidden="true"></i> Você já tem saldo lançado.
+          <i class="ph ph-check-circle" aria-hidden="true"></i> Saldo lançado com sucesso.
         </p>
       </div>
 
@@ -138,7 +138,7 @@
       </div>
 
       <p class="onb-done" data-role="wa-linked" hidden>
-        <i class="ph ph-check-circle" aria-hidden="true"></i> WhatsApp já conectado.
+        <i class="ph ph-check-circle" aria-hidden="true"></i> WhatsApp conectado com sucesso.
       </p>
 
       <div class="onb-acts">

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -821,7 +821,7 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         ele limpou — o delete remoto é best-effort e o item sobrevive lá. POR QUE
         o rastro com dono é o sinal certo (e por que banco removido fica "sem
         conexão local" para sempre): docstring de `db.item_registry_origins`,
-        fonte única dos três leitores (CLAUDE.md §0.7). A 1ª adoção grava rastro
+        fonte única dos leitores (CLAUDE.md §0.7). A 1ª adoção grava rastro
         com dono ANTES da conexão, então ela mesma fecha a duplicata — e a
         guarda é REFEITA dentro do `pluggy_item_lock`, imediatamente antes da
         escrita da conexão (`_salva_item_sob_lock`, `adocao_registro_id`),
@@ -867,12 +867,17 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
     escrita: consertar só o primeiro TROCAVA o perdedor (quem aborta limpa, quem
     perde o lock fica), e era regressão contra a `main`, onde a mesma
     intercalação dava 1 conexão. O que continua pagando o preço é a falha de
-    INFRA DENTRO da escrita (FK da conta apagada, erro no meio do upsert, commit
-    ambíguo), em que o desfecho é DESCONHECIDO e apagar a reivindicação poderia
-    soltar uma segunda adoção por cima de uma conexão que existe. Pool esgotado
-    NÃO está nesta lista: ele estoura no `get_conn`, ANTES de qualquer statement,
-    e `PoolTimeout`/`PoolClosed` saindo do `save_...` desfazem a reivindicação
-    como qualquer outra falha pré-escrita. Aí a saída é OPERACIONAL:
+    INFRA DENTRO da escrita (erro no meio do upsert, commit ambíguo), em que o
+    desfecho é DESCONHECIDO e apagar a reivindicação poderia soltar uma segunda
+    adoção por cima de uma conexão que existe. Pool esgotado NÃO está nesta
+    lista: ele estoura no `get_conn`, ANTES de qualquer statement, e
+    `PoolTimeout`/`PoolClosed` saindo do `save_...` desfazem a reivindicação como
+    qualquer outra falha pré-escrita. A FK da conta apagada também não está, e
+    não é escolha: `open_finance_item_registry.user_id` é `on delete cascade`
+    (`db/schema.py`), então o mesmo `delete from users` que faz a FK estourar já
+    levou o rastro `webhook_adopt` junto — não sobra reivindicação nenhuma
+    (`test_conta_apagada_no_meio_da_adocao_nao_ressuscita`). Aí a saída é
+    OPERACIONAL:
     `python -m scripts.adotar_items_of_orfaos --item ID --apply --delete` apaga o
     item na Pluggy, o `avoidDuplicates` libera, e o usuário reconecta pelo
     widget. Fechar isso sozinho exigiria o disconnect deixar rastro próprio
@@ -888,10 +893,11 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
     LIMITE CONHECIDO (medido). Duas entregas CONCORRENTES do mesmo `item/created`
     ainda leem o rastro vazio antes de qualquer uma escrever, e as duas gravam
     rastro (`register_item` fica FORA do lock, de propósito: é ele que a
-    retentativa do `_grava_reconexao` não pode repetir). O que a revalidação sob
-    o lock mais o desfazimento garantem é que NUNCA sobre reivindicação sem
-    conexão: no caso comum uma entrega grava e fica com o rastro, e as outras
-    abortam apagando o que gravaram; na intercalação em que a entrega que pega o
+    retentativa do `_grava_reconexao` não pode repetir). A revalidação sob o lock
+    mais o desfazimento fecham isso NAS CORRIDAS de entrega concorrente, e só
+    nelas: nenhuma intercalação delas deixa reivindicação sem conexão — no caso
+    comum uma entrega grava e fica com o rastro, e as outras abortam apagando o
+    que gravaram; na intercalação em que a entrega que pega o
     lock é justamente a que aborta, ninguém grava e ninguém reivindica — o item
     volta a ser órfão e a PRÓXIMA entrega (ou o script one-shot) adota. Sobra uma
     janela de LEITURA, não de estado: enquanto a perdedora não chega ao lock, o
@@ -904,9 +910,12 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
     RECUSAVA toda retentativa e sumia do script, deixando o usuário com 0 bancos
     e sem saída (o P0 do Tester, 30/30 rodadas), a 3ª consertou só o aborto sob o
     lock e criou esse MESMO estado terminal pela porta do 503. Também fica aberto:
-    `item/updated` chegando ANTES do `item/created` (entrega fora de ordem) é
-    adotado sem contas e sem sync agendado até o evento seguinte ou o
-    pull-to-refresh. Nenhum dos dois é regressão contra a `main`.
+    SÓ `item/created` adota (o gate é `event_name == "item/created"` no webhook, e
+    `test_so_item_created_adota` prende), então item cujo `item/created` se perdeu
+    ou nunca foi entregue não é adotado por evento NENHUM depois — nem pelo
+    `item/updated` —, e a única recuperação é o one-shot
+    (`scripts/adotar_items_of_orfaos.py`). Nenhum dos dois é regressão contra a
+    `main`.
 
     ponytail: custa uma chamada HTTP a mais dentro do webhook no ramo de item
     desconhecido — inclusive quando ele acaba recusado por já ter dono, que é o
@@ -994,7 +1003,7 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         # Registrado, não consertado: sem o `ensure_user_tx` a adoção também
         # deixa de REPOR a linha de `accounts`, e existe estado de produção com
         # `users` sem `accounts` (`merge_users` apaga a do `from_user_id` e nunca
-        # apaga o `users` dele, db/users.py:107). Medido: a adoção grava, o
+        # apaga o `users` dele, db/users.py:109). Medido: a adoção grava, o
         # snapshot responde e `get_consolidated_balance` devolve zeros sem
         # estourar; qualquer `ensure_user` posterior (o próximo login) repara.
         # `adocao_registro_id`: a 1ª guarda (rastro sem dono) é REFEITA dentro do
@@ -1748,7 +1757,7 @@ async def open_finance_pluggy_webhook(request: Request):
                 # ponytail: INSERT puro, sem teto — sob entrega at-least-once,
                 # cada retentativa de um item que já tem dono soma mais uma linha
                 # `origin='webhook'`/`user_id NULL` aqui. Igual à `main` (não é
-                # regressão) e inofensivo para os dois leitores, que perguntam
+                # regressão) e inofensivo para os leitores, que perguntam
                 # por rastro COM dono; se o volume incomodar, é um upsert por
                 # (provider, item, origin) com contador.
                 await log_system_event(

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -19,6 +19,7 @@ import random
 import time
 
 import psycopg
+from psycopg_pool import PoolClosed, PoolTimeout
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -270,7 +271,8 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
                          budget_ms: int | None = None,
                          tinha_conexao_propria: bool = False,
                          criar_usuario: bool = True,
-                         adocao_registro_id: int | None = None) -> tuple[dict, bool]:
+                         adocao_registro_id: int | None = None,
+                         *, escrita_tentada: list | None = None) -> tuple[dict, bool]:
     """Grava a reconexão DENTRO do `pluggy_item_lock` do item.
 
     A relectura da geração em `_sync_pluggy_item_confirmado` não é atômica com as
@@ -285,6 +287,16 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
     Pegar o mesmo lock aqui fecha a fresta na origem: enquanto um sync escreve, a
     reconexão espera; enquanto a reconexão grava, nenhum sync entra na fase de
     escrita — e o próximo a entrar relê a geração nova e aborta.
+
+    `escrita_tentada` é o canal de SAÍDA para "a execução chegou à escrita?" — uma
+    lista do chamador, marcada na linha anterior ao
+    `save_pluggy_open_finance_item` e DESMARCADA no `PoolTimeout`/`PoolClosed`
+    que prova que nem o pool foi adquirido. Existe porque `return` não sobrevive
+    a exceção e o TIPO dela não distingue: `psycopg.OperationalError` sai igual
+    do commit ambíguo e de tudo que roda antes (o `psycopg.connect` do
+    `pluggy_item_lock`, o `set_config`, o `pg_advisory_lock`, as leituras das
+    revalidações). Quem lê é o desfazimento da reivindicação de adoção no 503 de
+    `_grava_reconexao`.
 
     Sem o lock NÃO grava. A primeira versão disto gravava assim mesmo e só logava
     o aviso — e essa é exatamente a escrita que o lock existe para serializar
@@ -393,8 +405,48 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
         # propósito: o número muda com a versão do psycopg e envelhece errado.
         resto = None if budget_ms is None else max(
             1, budget_ms - int((time.monotonic() - t0) * 1000))
-        return save_pluggy_open_finance_item(
-            user_id, remote, budget_ms=resto, criar_usuario=criar_usuario), True
+        # A ÚNICA linha que responde "a escrita chegou a ser tentada?" (Codex
+        # #313, P1). Ela atravessa o `except` do chamador porque é a lista DELE
+        # que está sendo mutada — `return` não sobrevive a exceção, e o tipo do
+        # erro não sabe responder isso: `psycopg.OperationalError` sai tanto
+        # daqui de dentro (commit ambíguo) quanto de tudo que veio ANTES (o
+        # `psycopg.connect` dedicado do `pluggy_item_lock`, o `set_config`, o
+        # `pg_advisory_lock`, as leituras das duas revalidações). Marcado ANTES
+        # da chamada, e não no `except`, porque a pergunta é do CHAMADOR ("pode
+        # ter escrito?"): se o erro vier da saída do `with` depois de um commit
+        # que deu certo, ele ainda tem de contar como escrita tentada.
+        if escrita_tentada is not None:
+            escrita_tentada.append(True)
+        try:
+            return save_pluggy_open_finance_item(
+                user_id, remote, budget_ms=resto, criar_usuario=criar_usuario), True
+        except (PoolTimeout, PoolClosed):
+            # ... e DESMARCA no único erro que prova o contrário. Os dois só
+            # saem do `getconn`, e o `get_conn()` do `save_...` é a ÚNICA
+            # aquisição de pool da função e a primeira linha com I/O dela: aqui
+            # nenhum statement rodou. (Medido no psycopg_pool 3.3.1: `PoolTimeout`
+            # só nasce da espera do `getconn`; `PoolClosed`, do
+            # `_check_open_getconn`; a devolução no fim do `with` levanta
+            # `ValueError`, não estes. A invariante do "única aquisição" tem
+            # guarda em `tests/test_of_webhook_adopt_503.py`.)
+            #
+            # É o membro MAIS PROVÁVEL da classe, e não precisa de infra doente:
+            # o `resto` acima tem piso de 1 ms, então uma espera longa pelo lock
+            # — o cenário para o qual esta feature existe — manda
+            # `get_conn(timeout=0.001)`. Medido em 2026-09-08 no Postgres local
+            # SAUDÁVEL (`ConnectionPool(open=True)` + `connection(timeout=0.001)`
+            # imediato): pool frio → `PoolTimeout`; quente → ok. O tempo varia com
+            # a carga (1,4 ms e 4,2 ms em duas medições), remeça antes de reusar —
+            # o que não varia é o desfecho. Sem isto, o caminho
+            # mais provável de todos preservava a reivindicação sem uma única
+            # escrita e reconstruía o estado terminal que o P0 fechou.
+            #
+            # `pop()` e não `clear()`: a lista é do PRAZO INTEIRO e cada chamada
+            # marca no máximo uma vez, então cada uma só desfaz a SUA marca — uma
+            # tentativa anterior que chegou a escrever continua contando.
+            if escrita_tentada:
+                escrita_tentada.pop()
+            raise
 
 
 async def _grava_reconexao(
@@ -423,14 +475,27 @@ async def _grava_reconexao(
     """
     fim = time.monotonic() + _RECONNECT_DEADLINE_MS / 1000.0
     causa = None   # None = lock ocupado; senão, o erro de infra da última tentativa
-    # LATCHED (nunca volta a False), e é por isso que não é `causa is None`:
-    # `causa` é só a da ÚLTIMA tentativa, de propósito
+    # A pergunta do desfazimento lá embaixo é "alguma tentativa pode ter
+    # ESCRITO?", e ela tem duas metades.
+    #
+    # PRAZO INTEIRO: a lista é LATCHED (só cresce), e é por isso que não é
+    # `causa is None` — `causa` é só a da ÚLTIMA tentativa, de propósito
     # (`test_causa_e_a_da_ultima_tentativa`), então infra na 1ª + lock ocupado na
-    # 2ª chega ao fim com `causa is None` tendo passado por uma escrita de
-    # desfecho DESCONHECIDO. Quem decide o desfazimento lá embaixo precisa da
-    # pergunta do prazo INTEIRO ("alguma tentativa pode ter escrito?"), não da
-    # última.
-    escrita_incerta = False
+    # 2ª chega ao fim com `causa is None` tendo passado por escrita de desfecho
+    # DESCONHECIDO.
+    #
+    # PRECISÃO: quem marca é o `_salva_item_sob_lock`, na linha ANTES da escrita
+    # — não o tipo da exceção (Codex #313, P1). `OperationalError` também sai de
+    # tudo que roda antes dela (o `psycopg.connect` dedicado do
+    # `pluggy_item_lock`, o `set_config` inicial, o `pg_advisory_lock` — que só
+    # trata `LockNotAvailable`/`QueryCanceled` e deixa passar um `AdminShutdown`
+    # —, as leituras das revalidações) e do próprio `get_conn` da escrita,
+    # e nessas a escrita PROVADAMENTE não aconteceu. Preservar a reivindicação
+    # ali reconstruía o estado terminal que o P0 fechou: zero conexões + rastro
+    # com dono, a 1ª guarda de `_adota_item_orfao` recusando toda retentativa e
+    # o `scripts/adotar_items_of_orfaos.py` sem enxergar a linha — o usuário sem
+    # banco e sem saída pelo produto.
+    escrita_tentada: list = []
     for tentativa in range(1, _RECONNECT_LOCK_ATTEMPTS + 1):
         folga_ms = int((fim - time.monotonic()) * 1000)
         if folga_ms < 1:
@@ -453,7 +518,8 @@ async def _grava_reconexao(
         try:
             connection, sob_lock = await asyncio.to_thread(
                 _salva_item_sob_lock, user_id, remote, item_id, restante_ms,
-                tinha_conexao_propria, criar_usuario, adocao_registro_id)
+                tinha_conexao_propria, criar_usuario, adocao_registro_id,
+                escrita_tentada=escrita_tentada)
             causa = None
         except psycopg.OperationalError as exc:
             # UM `except` para a CATEGORIA inteira, cobrindo o lock E a escrita.
@@ -513,7 +579,6 @@ async def _grava_reconexao(
             # (é a própria `causa`), a decisão é de outro PR.
             connection, sob_lock = None, False
             causa = f"{type(exc).__name__}: {exc}"
-            escrita_incerta = True
         if sob_lock:
             return connection
         # O backoff também cabe no prazo: dormir "só mais um pouco" depois de
@@ -581,11 +646,17 @@ async def _grava_reconexao(
     # lista rastro com dono). Com o desfazimento, ninguém escreveu e ninguém
     # reivindicou: a próxima entrega do `item/created` adota.
     #
-    # "Provadamente": o ÚNICO `return None, False` de `_salva_item_sob_lock` é o
-    # `if not locked`, antes do `save_pluggy_open_finance_item` — e
-    # `escrita_incerta` cobre o resto do prazo, porque infra é desfecho
-    # desconhecido e aí a reivindicação FICA (apagá-la poderia soltar uma segunda
-    # adoção por cima de uma conexão que existe).
+    # "Provadamente" é medido, não deduzido do tipo do erro: `escrita_tentada` só
+    # tem item se a execução CHEGOU ao `save_pluggy_open_finance_item`, e a marca
+    # é feita lá, na linha anterior à chamada. Cobre o prazo inteiro e as duas
+    # portas de saída sem escrita — o `if not locked` (lock ocupado) e a infra
+    # PRÉ-escrita, que é `psycopg.OperationalError` igualzinho à do commit
+    # (`psycopg.connect` do lock, `set_config`, `pg_advisory_lock`, as leituras
+    # das revalidações, e o `get_conn` do próprio `save_...`) e
+    # antes desta linha ficava preservada à toa (Codex #313, P1). Vazia: ninguém
+    # escreveu, a reivindicação vai embora. Com item: desfecho DESCONHECIDO e a
+    # reivindicação FICA — apagá-la poderia soltar uma segunda adoção por cima de
+    # uma conexão que existe.
     #
     # AQUI e não no `if not locked`: apagar entre as tentativas deixaria a
     # tentativa que enfim pega o lock gravar a conexão sem rastro com dono — item
@@ -595,7 +666,7 @@ async def _grava_reconexao(
     # DEPOIS dos logs: o diagnóstico do 503 já está gravado se este delete
     # estourar (ele sobe para o `except Exception` de `_adota_item_orfao`, que
     # loga e responde 200 ao webhook).
-    if adocao_registro_id is not None and not escrita_incerta:
+    if adocao_registro_id is not None and not escrita_tentada:
         await asyncio.to_thread(unregister_item, adocao_registro_id, user_id)
     raise HTTPException(
         status_code=503,
@@ -755,10 +826,10 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         escrita da conexão (`_salva_item_sob_lock`, `adocao_registro_id`),
         porque entre as duas leituras cabe uma entrega concorrente inteira.
         Quem perde essa segunda leitura APAGA o próprio rastro antes de
-        abortar, ainda com o lock na mão — e quem DESISTE do lock (503 sem
-        infra) apaga também, no `_grava_reconexao`: reivindicação abandonada
-        que fica para trás é o que torna o aborto terminal (ver o LIMITE
-        CONHECIDO);
+        abortar, ainda com o lock na mão — e quem sai no 503 sem NUNCA ter
+        chegado à escrita apaga também, no `_grava_reconexao`: reivindicação
+        abandonada que fica para trás é o que torna o aborto terminal (ver o
+        LIMITE CONHECIDO);
       • o usuário TEM de existir, e são DUAS defesas para o mesmo estrago.
         `user_exists` recusa por IDENTIDADE (o log diz `usuario_inexistente`), e
         é ele que responde quando a conta já não existia — mas é leitura em
@@ -782,16 +853,25 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
     `item/created` não readota (a 1ª guarda acima). É por isso que os DOIS
     desfechos em que a escrita provadamente não aconteceu apagam o rastro que a
     adoção acabou de gravar, em vez de deixá-lo: o aborto sob o lock
-    (`_salva_item_sob_lock`) e a desistência do lock — o 503 com `causa` vazia,
-    em que nenhuma tentativa passou do `if not locked`. Sem os dois, duas
+    (`_salva_item_sob_lock`) e o 503 em que NENHUMA tentativa do prazo chegou ao
+    `save_pluggy_open_finance_item` — lock ocupado (`if not locked`) ou infra
+    PRÉ-escrita, que é `psycopg.OperationalError` idêntica à do commit e vem do
+    `psycopg.connect` dedicado do lock, do `set_config`, do `pg_advisory_lock`,
+    das leituras das revalidações ou do `get_conn` do próprio
+    `save_pluggy_open_finance_item` (Codex #313, P1). Quem responde isso é a
+    marca feita na linha anterior à escrita — desfeita quando o erro é
+    `PoolTimeout`/`PoolClosed`, que só sai do `getconn` —, não o tipo do erro.
+    Sem os dois desfazimentos, duas
     entregas concorrentes caíam neste estado sozinhas, sem falha nenhuma de
     escrita: consertar só o primeiro TROCAVA o perdedor (quem aborta limpa, quem
     perde o lock fica), e era regressão contra a `main`, onde a mesma
     intercalação dava 1 conexão. O que continua pagando o preço é a falha de
-    INFRA (`psycopg.OperationalError` em qualquer tentativa: FK da conta apagada,
-    commit ambíguo, pool esgotado), em que o desfecho da escrita é DESCONHECIDO e
-    apagar a reivindicação poderia soltar uma segunda adoção por cima de uma
-    conexão que existe. Aí a saída é OPERACIONAL:
+    INFRA DENTRO da escrita (FK da conta apagada, erro no meio do upsert, commit
+    ambíguo), em que o desfecho é DESCONHECIDO e apagar a reivindicação poderia
+    soltar uma segunda adoção por cima de uma conexão que existe. Pool esgotado
+    NÃO está nesta lista: ele estoura no `get_conn`, ANTES de qualquer statement,
+    e `PoolTimeout`/`PoolClosed` saindo do `save_...` desfazem a reivindicação
+    como qualquer outra falha pré-escrita. Aí a saída é OPERACIONAL:
     `python -m scripts.adotar_items_of_orfaos --item ID --apply --delete` apaga o
     item na Pluggy, o `avoidDuplicates` libera, e o usuário reconecta pelo
     widget. Fechar isso sozinho exigiria o disconnect deixar rastro próprio

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -17,6 +17,7 @@ import math
 import os
 import random
 import time
+from datetime import datetime, timedelta, timezone
 
 import psycopg
 from psycopg_pool import PoolClosed, PoolTimeout
@@ -1328,6 +1329,13 @@ async def open_finance_connect_token_route(request: Request, user_id: int):
     }
 
 
+# Por quanto tempo, depois da adoção pelo webhook, o `POST /pluggy-item` ainda é
+# o HANDOFF dela — e não uma reconexão nova. `item/created` chega com o widget
+# aberto e o `onSuccess` vem em seguida: o vão real é de segundos. Uma hora é
+# folga, não alvo, e fora dela o desfecho é AUDITAR — o lado barato do erro.
+JANELA_HANDOFF_WEBHOOK = timedelta(hours=1)
+
+
 @router.post("/open-finance/{user_id}/pluggy-item")
 async def open_finance_pluggy_item_route(request: Request, user_id: int, payload: OpenFinancePluggyItemPayload):
     """Registra o item que o widget da Pluggy acabou de criar.
@@ -1418,11 +1426,20 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
         # POST fica 500 PERMANENTE para aquele usuário. Nenhum escritor de hoje
         # grava assim (os dois passam dict, e `Jsonb(details or {})` normaliza o
         # `None`) — é fronteira de dado vindo do banco, custa uma linha.
+        # `created_at` (já vem no SELECT de `list_audit_events`) porque item+origem
+        # NÃO correlaciona a evidência com ESTE POST: item adotado cujo navegador
+        # nunca postou fica sem `pluggy_item` no registry PARA SEMPRE, e a
+        # reconexão de dias depois consumia a auditoria histórica como se fosse a
+        # duplicata da adoção de agora — a 1ª reconexão real sumia do log de
+        # segurança (Codex #313, P2, 2ª rodada). A janela é a duração do próprio
+        # handoff: sem coluna nova, sem marcador consumível, sem estado novo.
+        handoff_desde = datetime.now(timezone.utc) - JANELA_HANDOFF_WEBHOOK
         conexao_recem_adotada = any(
             e["event"] == AuditEvent.OPEN_FINANCE_CONNECTED
             and isinstance(e.get("details"), dict)
             and e["details"].get("item_id") == new_item_id
             and e["details"].get("origin") == "webhook_adopt"
+            and e["created_at"] >= handoff_desde
             for e in await asyncio.to_thread(list_audit_events, session_uid, 50)
         )
 
@@ -1450,11 +1467,13 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
     # fechados pela mesma coisa — marcar a adoção na PRÓPRIA conexão (coluna
     # nova + migração), que é o custo que nenhum dos dois paga hoje:
     #   1. item adotado pelo webhook cujo navegador NUNCA postou (aba fechada):
-    #      a 1ª reconexão cai como duplicata e não audita — mas só ENQUANTO a
-    #      auditoria do webhook estiver nos 50 últimos eventos do usuário
-    #      (`min(limit, 50)` do `list_audit_events`). Com mais de 50 eventos no
-    #      meio, a evidência sai da janela e a 1ª reconexão audita. Da 2ª em
-    #      diante audita sempre: aí o registry já tem `pluggy_item`.
+    #      uma reconexão que caia DENTRO da `JANELA_HANDOFF_WEBHOOK` contada da
+    #      adoção não audita. Fora da janela audita, e da 2ª em diante audita
+    #      sempre: aí o registry já tem `pluggy_item`. O teto é UM evento, e só
+    #      para quem reconecta o mesmo item na mesma hora em que ele foi adotado.
+    #      O limite de 50 eventos do `list_audit_events` só ENCOLHE a supressão
+    #      (evidência fora dos 50 = audita), então quem define este teto é o
+    #      tempo, não o histórico do usuário.
     #   2. a janela invertida, que é DUPLICATA e não buraco: `_adota_item_orfao`
     #      commita a conexão e só depois grava o `record_audit_event` do webhook.
     #      Um `POST /pluggy-item` que caia nesse vão vê a conexão de pé e a

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -24,7 +24,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from core.admin_dashboard import log_system_event
-from core.audit import AuditEvent, record_audit_event
+from core.audit import AuditEvent, list_audit_events, record_audit_event
 from core.secure_compare import constant_time_eq
 from core.pg_text import limpa_para_pg
 from core.services.pluggy import (
@@ -267,7 +267,8 @@ def _retryable(exc: BaseException) -> bool:
 
 def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
                          budget_ms: int | None = None,
-                         tinha_conexao_propria: bool = False) -> tuple[dict, bool]:
+                         tinha_conexao_propria: bool = False,
+                         criar_usuario: bool = True) -> tuple[dict, bool]:
     """Grava a reconexão DENTRO do `pluggy_item_lock` do item.
 
     A relectura da geração em `_sync_pluggy_item_confirmado` não é atômica com as
@@ -344,11 +345,13 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
         # propósito: o número muda com a versão do psycopg e envelhece errado.
         resto = None if budget_ms is None else max(
             1, budget_ms - int((time.monotonic() - t0) * 1000))
-        return save_pluggy_open_finance_item(user_id, remote, budget_ms=resto), True
+        return save_pluggy_open_finance_item(
+            user_id, remote, budget_ms=resto, criar_usuario=criar_usuario), True
 
 
 async def _grava_reconexao(
     user_id: int, remote: dict, item_id: str, tinha_conexao_propria: bool = False,
+    criar_usuario: bool = True,
 ) -> dict:
     """Grava a reconexão sob o lock, RETENTANDO antes de desistir.
 
@@ -394,7 +397,7 @@ async def _grava_reconexao(
         try:
             connection, sob_lock = await asyncio.to_thread(
                 _salva_item_sob_lock, user_id, remote, item_id, restante_ms,
-                tinha_conexao_propria)
+                tinha_conexao_propria, criar_usuario)
             causa = None
         except psycopg.OperationalError as exc:
             # UM `except` para a CATEGORIA inteira, cobrindo o lock E a escrita.
@@ -665,10 +668,16 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         conexão local" para sempre): docstring de `db.item_registry_origins`,
         fonte única dos três leitores (CLAUDE.md §0.7). A 1ª adoção grava rastro
         com dono ANTES da conexão, então ela mesma fecha a duplicata;
-      • o usuário TEM de existir. Não dá para delegar à FK: todo caminho de
-        escrita passa por `ensure_user_tx`, que CRIA a linha de `users`. Conta
-        apagada por LGPD (`db/privacy.py`) cujo item sobreviveu ao delete
-        best-effort ressuscitava por causa de um evento da Pluggy;
+      • o usuário TEM de existir, e são DUAS defesas para o mesmo estrago.
+        `user_exists` recusa por IDENTIDADE (o log diz `usuario_inexistente`), e
+        é ele que responde quando a conta já não existia — mas é leitura em
+        transação própria, então sozinho ele só cobre a foto do instante em que
+        leu. Quem cobre a JANELA (exclusão da conta commitando entre a leitura e
+        a escrita) é a FK, e só porque as duas escritas desta função passaram a
+        ser incapazes de criar usuário: `register_item` nunca criou, e a conexão
+        vai com `criar_usuario=False`. Antes, `ensure_user_tx` RESSUSCITAVA a
+        conta apagada por LGPD (`db/privacy.py`) cujo item sobreviveu ao delete
+        best-effort — pelo evento da Pluggy, e depois pela corrida (Codex #313);
       • o rastro (`register_item`) vai ANTES da conexão, e a ordem inversa é pior:
         ela deixava conexão commitada com registry VAZIO — item adotado sem
         nenhum rastro, e o rastro é a única enumeração que existe (`GET /items`
@@ -777,7 +786,22 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
             register_item, dono, provider_item_id=item_id, origin="webhook_adopt",
             status=str(remote.get("status") or "") or None, last_event=last_event,
         )
-        await _grava_reconexao(dono, remote, item_id, tinha_conexao_propria=False)
+        # `criar_usuario=False`: a FK da conexão é a ÚNICA coisa atômica com o
+        # insert. O `user_exists` acima é leitura em transação PRÓPRIA, e uma
+        # exclusão de conta (db/privacy.py) que commite entre ele e esta escrita
+        # deixava o `ensure_user_tx` recriar a linha de `users` que a LGPD acabou
+        # de apagar — o `register_item` acima já cai na FK dele quando a exclusão
+        # chega antes, e esta fecha o resto da janela (Codex #313, P1). Sem a
+        # linha de `users`, o insert estoura `ForeignKeyViolation`, o `except`
+        # abaixo registra e o webhook responde 200 sem adotar.
+        # Registrado, não consertado: sem o `ensure_user_tx` a adoção também
+        # deixa de REPOR a linha de `accounts`, e existe estado de produção com
+        # `users` sem `accounts` (`merge_users` apaga a do `from_user_id` e nunca
+        # apaga o `users` dele, db/users.py:107). Medido: a adoção grava, o
+        # snapshot responde e `get_consolidated_balance` devolve zeros sem
+        # estourar; qualquer `ensure_user` posterior (o próximo login) repara.
+        await _grava_reconexao(dono, remote, item_id, tinha_conexao_propria=False,
+                               criar_usuario=False)
     except Exception as exc:
         # `motivo` sozinho não basta AQUI: `HTTPException` é o nome de três
         # desfechos com ações de operador diferentes — 402 (teto de bancos do
@@ -1169,6 +1193,34 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
     # Lido ANTES do `register_item` abaixo, que grava justamente essa origem.
     conexao_recem_adotada = tinha_conexao_propria and "pluggy_item" not in (
         await asyncio.to_thread(item_registry_origins, new_item_id))
+    if conexao_recem_adotada:
+        # ...e o webhook TEM de ter auditado de verdade. `record_audit_event`
+        # ENGOLE falha de banco (core/audit.py:156) — o rastro prova a adoção, não
+        # a auditoria —, então o insert dele podia falhar lá e esta guarda suprimir
+        # aqui: NENHUM `OPEN_FINANCE_CONNECTED` para uma conexão que nasceu. Num
+        # log de segurança duplicata é ruído e buraco é perda (Codex #313, P2).
+        # Fecha junto o 2º caso do mesmo achado: conexão ANTERIOR ao registry não
+        # tem rastro nenhum, e a 1ª reconexão dela caía como duplicata de um
+        # webhook que nunca existiu.
+        # `list_audit_events` (já existente, e já filtrada por `user_id`) em vez de
+        # query nova: são os 50 últimos eventos do usuário, e a adoção que este POST
+        # duplica aconteceu segundos atrás. Fora dessa janela o desfecho é auditar DE
+        # NOVO, que é o lado barato do erro — e falha de banco cai do mesmo lado
+        # porque quem captura `Exception` e devolve `[]` é a PRÓPRIA
+        # `list_audit_events` (core/audit.py:95-97). Aqui não há `try`: o que
+        # escapar dela vira 500 para o usuário, não degradação.
+        # `isinstance(..., dict)` e não `or {}`: uma linha com `details` escalar
+        # (`'"texto"'::jsonb`) estoura `AttributeError` no `.get`, e sem guarda o
+        # POST fica 500 PERMANENTE para aquele usuário. Nenhum escritor de hoje
+        # grava assim (os dois passam dict, e `Jsonb(details or {})` normaliza o
+        # `None`) — é fronteira de dado vindo do banco, custa uma linha.
+        conexao_recem_adotada = any(
+            e["event"] == AuditEvent.OPEN_FINANCE_CONNECTED
+            and isinstance(e.get("details"), dict)
+            and e["details"].get("item_id") == new_item_id
+            and e["details"].get("origin") == "webhook_adopt"
+            for e in await asyncio.to_thread(list_audit_events, session_uid, 50)
+        )
 
     await _enforce_bank_limit(session_uid, new_item_id)
     try:
@@ -1190,9 +1242,21 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
     # O que se suprime é "o webhook JÁ auditou ESTA conexão", não "o usuário já
     # tinha este banco" — reconexão legítima (re-consentimento, conserto de
     # LOGIN_ERROR) é evento de segurança e continua aparecendo, uma vez cada.
-    # ponytail: a 1ª reconexão de um item adotado pelo webhook cujo navegador
-    # NUNCA postou (aba fechada) ainda cai como duplicata e não audita — a partir
-    # da 2ª, audita. Fechar isso exige marcar a adoção na própria conexão.
+    # ponytail: dois tetos conhecidos, ambos de UM evento de auditoria e ambos
+    # fechados pela mesma coisa — marcar a adoção na PRÓPRIA conexão (coluna
+    # nova + migração), que é o custo que nenhum dos dois paga hoje:
+    #   1. item adotado pelo webhook cujo navegador NUNCA postou (aba fechada):
+    #      a 1ª reconexão cai como duplicata e não audita — mas só ENQUANTO a
+    #      auditoria do webhook estiver nos 50 últimos eventos do usuário
+    #      (`min(limit, 50)` do `list_audit_events`). Com mais de 50 eventos no
+    #      meio, a evidência sai da janela e a 1ª reconexão audita. Da 2ª em
+    #      diante audita sempre: aí o registry já tem `pluggy_item`.
+    #   2. a janela invertida, que é DUPLICATA e não buraco: `_adota_item_orfao`
+    #      commita a conexão e só depois grava o `record_audit_event` do webhook.
+    #      Um `POST /pluggy-item` que caia nesse vão vê a conexão de pé e a
+    #      evidência ainda não → audita, e o webhook audita em seguida: 2
+    #      `OPEN_FINANCE_CONNECTED` para 1 conexão. Escolha deliberada, mesma
+    #      régua do bloco acima — duplicata é ruído, buraco é perda.
     if not conexao_recem_adotada:
         await asyncio.to_thread(
             record_audit_event,

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -58,6 +58,7 @@ from db import (
     register_item,
     save_pluggy_open_finance_item,
     token_hash,
+    unregister_item,
     update_pluggy_open_finance_item_status,
     user_exists,
 )
@@ -268,7 +269,8 @@ def _retryable(exc: BaseException) -> bool:
 def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
                          budget_ms: int | None = None,
                          tinha_conexao_propria: bool = False,
-                         criar_usuario: bool = True) -> tuple[dict, bool]:
+                         criar_usuario: bool = True,
+                         adocao_registro_id: int | None = None) -> tuple[dict, bool]:
     """Grava a reconexão DENTRO do `pluggy_item_lock` do item.
 
     A relectura da geração em `_sync_pluggy_item_confirmado` não é atômica com as
@@ -325,6 +327,52 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
                     detail="Sua conta foi reiniciada ou o banco foi desconectado enquanto "
                            "a conexão era concluída. Conecte o banco de novo.",
                 )
+        # A MESMA revalidação, pelo lado da ADOÇÃO (Codex #313, P1). O fato que a
+        # adoção leu fora do lock não é "a conexão existe" — é "NENHUMA linha do
+        # rastro deste item tem dono" (1ª guarda de `_adota_item_orfao`), e ele
+        # muda na espera: duas entregas concorrentes do MESMO `item/created` leem
+        # o rastro vazio, a 1ª adota, o usuário DESCONECTA, e a 2ª chegava aqui
+        # com `tinha_conexao_propria=False` — item órfão nunca teve conexão, o
+        # valor era honesto — pulando a revalidação acima e recriando a conexão
+        # COM sync agendado, na carteira que o usuário acabou de limpar.
+        # Uma releitura fecha os DOIS casos porque o disconnect preserva o
+        # registry (`db/privacy.py`): duplicata pura (a 1ª já gravou o rastro) e
+        # ressurreição pós-disconnect (o rastro sobreviveu à conexão). `exceto` é
+        # a linha que ESTA entrega gravou segundos atrás — sem ela a adoção
+        # legítima se recusaria a si mesma.
+        #
+        # E o aborto DESFAZ a própria reivindicação, dentro do lock, antes de
+        # subir. Sem isso a revalidação sozinha trocava um estrago por outro
+        # PIOR (medido pelo Tester, 30/30): duas entregas concorrentes gravam o
+        # rastro antes de qualquer uma pegar o lock, cada uma enxerga o rastro
+        # da OUTRA, as duas abortam, e sobra rastro com dono e ZERO conexão —
+        # estado terminal, do qual nem a retentativa (1ª guarda) nem o script
+        # one-shot (o filtro dele exclui rastro com dono) tiram o usuário.
+        # Apagando a linha AQUI, com o lock na mão, quem entrar depois não vê
+        # mais reivindicação nenhuma e adota: com N entregas simultâneas, o
+        # último a pegar o lock ganha e os outros saem sem deixar rastro. São
+        # DOIS os pontos que apagam (o outro é a desistência do lock, no 503 de
+        # `_grava_reconexao`), e nos dois a linha é a que a própria adoção acabou
+        # de escrever (`db.unregister_item`, que filtra por `user_id`).
+        #
+        # REGISTRADO, não consertado: quando quem "ganhou" foi o `POST
+        # /pluggy-item` do MESMO usuário (o navegador voltou enquanto o webhook
+        # esperava o lock), este delete tira a linha `webhook_adopt` e o log de
+        # append perde o registro de que o item também entrou por ali. O desfecho
+        # funcional está certo (1 conexão, 1 auditoria, a linha `pluggy_item`
+        # fica) e NENHUMA decisão lê `origin` para isso — só o diagnóstico "por
+        # onde ele entrou" fica mais pobre. Fechar exigiria distinguir origem
+        # rival no aborto, e a distinção não muda decisão nenhuma hoje.
+        if adocao_registro_id is not None:
+            outras = item_registry_origins(item_id, exceto_registro_id=adocao_registro_id,
+                                           exceto_user_id=user_id)
+            if outras:
+                unregister_item(adocao_registro_id, user_id)
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Item {item_id} já foi atribuído por outra porta "
+                           f"({sorted(outras)}): adoção abortada sob o lock.",
+                )
         # O que sobrou DEPOIS de pegar o lock vai para a escrita. Sem isto o
         # orçamento parava aqui: `save_pluggy_open_finance_item` esperava o pool
         # (até `DB_CONNECT_TIMEOUT`) fora do prazo, e podia COMMITAR depois de o
@@ -351,7 +399,7 @@ def _salva_item_sob_lock(user_id: int, remote: dict, item_id: str,
 
 async def _grava_reconexao(
     user_id: int, remote: dict, item_id: str, tinha_conexao_propria: bool = False,
-    criar_usuario: bool = True,
+    criar_usuario: bool = True, adocao_registro_id: int | None = None,
 ) -> dict:
     """Grava a reconexão sob o lock, RETENTANDO antes de desistir.
 
@@ -375,6 +423,14 @@ async def _grava_reconexao(
     """
     fim = time.monotonic() + _RECONNECT_DEADLINE_MS / 1000.0
     causa = None   # None = lock ocupado; senão, o erro de infra da última tentativa
+    # LATCHED (nunca volta a False), e é por isso que não é `causa is None`:
+    # `causa` é só a da ÚLTIMA tentativa, de propósito
+    # (`test_causa_e_a_da_ultima_tentativa`), então infra na 1ª + lock ocupado na
+    # 2ª chega ao fim com `causa is None` tendo passado por uma escrita de
+    # desfecho DESCONHECIDO. Quem decide o desfazimento lá embaixo precisa da
+    # pergunta do prazo INTEIRO ("alguma tentativa pode ter escrito?"), não da
+    # última.
+    escrita_incerta = False
     for tentativa in range(1, _RECONNECT_LOCK_ATTEMPTS + 1):
         folga_ms = int((fim - time.monotonic()) * 1000)
         if folga_ms < 1:
@@ -397,7 +453,7 @@ async def _grava_reconexao(
         try:
             connection, sob_lock = await asyncio.to_thread(
                 _salva_item_sob_lock, user_id, remote, item_id, restante_ms,
-                tinha_conexao_propria, criar_usuario)
+                tinha_conexao_propria, criar_usuario, adocao_registro_id)
             causa = None
         except psycopg.OperationalError as exc:
             # UM `except` para a CATEGORIA inteira, cobrindo o lock E a escrita.
@@ -457,6 +513,7 @@ async def _grava_reconexao(
             # (é a própria `causa`), a decisão é de outro PR.
             connection, sob_lock = None, False
             causa = f"{type(exc).__name__}: {exc}"
+            escrita_incerta = True
         if sob_lock:
             return connection
         # O backoff também cabe no prazo: dormir "só mais um pouco" depois de
@@ -514,6 +571,32 @@ async def _grava_reconexao(
         details={"item_id": item_id, "deadline_ms": _RECONNECT_DEADLINE_MS,
                  "erro": causa},
     )
+    # DESISTIR DO LOCK também desfaz a reivindicação da adoção — é o SEGUNDO
+    # desfecho em que a escrita provadamente não aconteceu, e sem ele o conserto
+    # do aborto sob o lock era REGRESSÃO contra a `main` (medido, duas colunas):
+    # duas entregas concorrentes, a que pega o lock aborta e apaga a linha dela,
+    # a que PERDE o lock deixava a dela para trás — 1 conexão saudável na `main`
+    # virava 0 conexões + reivindicação abandonada, que é o estado terminal (a 1ª
+    # guarda de `_adota_item_orfao` recusa a retentativa e o script one-shot não
+    # lista rastro com dono). Com o desfazimento, ninguém escreveu e ninguém
+    # reivindicou: a próxima entrega do `item/created` adota.
+    #
+    # "Provadamente": o ÚNICO `return None, False` de `_salva_item_sob_lock` é o
+    # `if not locked`, antes do `save_pluggy_open_finance_item` — e
+    # `escrita_incerta` cobre o resto do prazo, porque infra é desfecho
+    # desconhecido e aí a reivindicação FICA (apagá-la poderia soltar uma segunda
+    # adoção por cima de uma conexão que existe).
+    #
+    # AQUI e não no `if not locked`: apagar entre as tentativas deixaria a
+    # tentativa que enfim pega o lock gravar a conexão sem rastro com dono — item
+    # com banco conectado que o one-shot lista como órfão e a entrega seguinte
+    # readota. O desfazimento é do desfecho, não da tentativa.
+    #
+    # DEPOIS dos logs: o diagnóstico do 503 já está gravado se este delete
+    # estourar (ele sobe para o `except Exception` de `_adota_item_orfao`, que
+    # loga e responde 200 ao webhook).
+    if adocao_registro_id is not None and not escrita_incerta:
+        await asyncio.to_thread(unregister_item, adocao_registro_id, user_id)
     raise HTTPException(
         status_code=503,
         detail="Não foi possível concluir a conexão agora. Tente de novo em alguns segundos.",
@@ -667,7 +750,15 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         o rastro com dono é o sinal certo (e por que banco removido fica "sem
         conexão local" para sempre): docstring de `db.item_registry_origins`,
         fonte única dos três leitores (CLAUDE.md §0.7). A 1ª adoção grava rastro
-        com dono ANTES da conexão, então ela mesma fecha a duplicata;
+        com dono ANTES da conexão, então ela mesma fecha a duplicata — e a
+        guarda é REFEITA dentro do `pluggy_item_lock`, imediatamente antes da
+        escrita da conexão (`_salva_item_sob_lock`, `adocao_registro_id`),
+        porque entre as duas leituras cabe uma entrega concorrente inteira.
+        Quem perde essa segunda leitura APAGA o próprio rastro antes de
+        abortar, ainda com o lock na mão — e quem DESISTE do lock (503 sem
+        infra) apaga também, no `_grava_reconexao`: reivindicação abandonada
+        que fica para trás é o que torna o aborto terminal (ver o LIMITE
+        CONHECIDO);
       • o usuário TEM de existir, e são DUAS defesas para o mesmo estrago.
         `user_exists` recusa por IDENTIDADE (o log diz `usuario_inexistente`), e
         é ele que responde quando a conta já não existia — mas é leitura em
@@ -688,7 +779,19 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
     pelo usuário. Aí NÃO há recuperação automática: o script one-shot deixa de
     listar o item (o filtro dele exclui rastro com dono, de propósito — a mesma
     regra, `db/open_finance_state.item_registry_origins`) e a retentativa do
-    `item/created` não readota (a 1ª guarda acima). A saída é OPERACIONAL:
+    `item/created` não readota (a 1ª guarda acima). É por isso que os DOIS
+    desfechos em que a escrita provadamente não aconteceu apagam o rastro que a
+    adoção acabou de gravar, em vez de deixá-lo: o aborto sob o lock
+    (`_salva_item_sob_lock`) e a desistência do lock — o 503 com `causa` vazia,
+    em que nenhuma tentativa passou do `if not locked`. Sem os dois, duas
+    entregas concorrentes caíam neste estado sozinhas, sem falha nenhuma de
+    escrita: consertar só o primeiro TROCAVA o perdedor (quem aborta limpa, quem
+    perde o lock fica), e era regressão contra a `main`, onde a mesma
+    intercalação dava 1 conexão. O que continua pagando o preço é a falha de
+    INFRA (`psycopg.OperationalError` em qualquer tentativa: FK da conta apagada,
+    commit ambíguo, pool esgotado), em que o desfecho da escrita é DESCONHECIDO e
+    apagar a reivindicação poderia soltar uma segunda adoção por cima de uma
+    conexão que existe. Aí a saída é OPERACIONAL:
     `python -m scripts.adotar_items_of_orfaos --item ID --apply --delete` apaga o
     item na Pluggy, o `avoidDuplicates` libera, e o usuário reconecta pelo
     widget. Fechar isso sozinho exigiria o disconnect deixar rastro próprio
@@ -701,15 +804,28 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
     falha de escrita, devolve None e o chamador mantém o rastro sem dono que já
     existia.
 
-    LIMITE CONHECIDO (medido, decidido não consertar): duas entregas CONCORRENTES
-    do mesmo `item/created` podem ler o rastro vazio antes de qualquer uma
-    escrever, e gravam DUAS auditorias para UMA conexão (o `pluggy_item_lock`
-    protege a conexão, a auditoria fica fora dele). A janela é a distância entre
-    a leitura do rastro e o `register_item` — hoje duas idas ao banco; fechá-la
-    de vez é serializar a adoção pelo `pluggy_item_lock`, que muda o desenho do
-    lock. Também fica aberto: `item/updated` chegando ANTES do `item/created`
-    (entrega fora de ordem) é adotado sem contas e sem sync agendado até o evento
-    seguinte ou o pull-to-refresh. Nenhum dos dois é regressão contra a `main`.
+    LIMITE CONHECIDO (medido). Duas entregas CONCORRENTES do mesmo `item/created`
+    ainda leem o rastro vazio antes de qualquer uma escrever, e as duas gravam
+    rastro (`register_item` fica FORA do lock, de propósito: é ele que a
+    retentativa do `_grava_reconexao` não pode repetir). O que a revalidação sob
+    o lock mais o desfazimento garantem é que NUNCA sobre reivindicação sem
+    conexão: no caso comum uma entrega grava e fica com o rastro, e as outras
+    abortam apagando o que gravaram; na intercalação em que a entrega que pega o
+    lock é justamente a que aborta, ninguém grava e ninguém reivindica — o item
+    volta a ser órfão e a PRÓXIMA entrega (ou o script one-shot) adota. Sobra uma
+    janela de LEITURA, não de estado: enquanto a perdedora não chega ao lock, o
+    rastro dela existe e um leitor concorrente (o painel de saúde, o script
+    one-shot) vê uma linha a mais desse item. E sobra o desfecho DESCONHECIDO —
+    infra no meio da escrita mantém a reivindicação de propósito, e aí vale o
+    parágrafo de cima. Três rodadas erraram este parágrafo — a 1ª chamou a janela
+    de "só auditoria duplicada" (era ressurreição de banco desconectado, o P1 do
+    Codex #313), a 2ª deu o rastro extra como permanente e não viu que ele
+    RECUSAVA toda retentativa e sumia do script, deixando o usuário com 0 bancos
+    e sem saída (o P0 do Tester, 30/30 rodadas), a 3ª consertou só o aborto sob o
+    lock e criou esse MESMO estado terminal pela porta do 503. Também fica aberto:
+    `item/updated` chegando ANTES do `item/created` (entrega fora de ordem) é
+    adotado sem contas e sem sync agendado até o evento seguinte ou o
+    pull-to-refresh. Nenhum dos dois é regressão contra a `main`.
 
     ponytail: custa uma chamada HTTP a mais dentro do webhook no ramo de item
     desconhecido — inclusive quando ele acaba recusado por já ter dono, que é o
@@ -782,7 +898,7 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         # viram o item de verdade. Deduplicar apagaria justamente o que responde
         # "por onde ele entrou". O que NÃO pode duplicar é a conexão (uma só, o
         # upsert garante) e a auditoria (ver o `POST /pluggy-item`).
-        await asyncio.to_thread(
+        registro_id = await asyncio.to_thread(
             register_item, dono, provider_item_id=item_id, origin="webhook_adopt",
             status=str(remote.get("status") or "") or None, last_event=last_event,
         )
@@ -800,12 +916,20 @@ async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int 
         # apaga o `users` dele, db/users.py:107). Medido: a adoção grava, o
         # snapshot responde e `get_consolidated_balance` devolve zeros sem
         # estourar; qualquer `ensure_user` posterior (o próximo login) repara.
+        # `adocao_registro_id`: a 1ª guarda (rastro sem dono) é REFEITA dentro do
+        # `pluggy_item_lock`, ignorando a linha recém-gravada acima — e o aborto
+        # APAGA essa linha. Sem a releitura, a decisão de adotar valia por uma
+        # leitura de segundos atrás e a corrida com outra entrega ressuscitava
+        # banco removido (Codex #313, P1); sem o desfazimento, a mesma corrida
+        # deixava o item reivindicado e sem conexão para sempre (P0 do Tester).
         await _grava_reconexao(dono, remote, item_id, tinha_conexao_propria=False,
-                               criar_usuario=False)
+                               criar_usuario=False, adocao_registro_id=registro_id)
     except Exception as exc:
-        # `motivo` sozinho não basta AQUI: `HTTPException` é o nome de três
+        # `motivo` sozinho não basta AQUI: `HTTPException` é o nome de quatro
         # desfechos com ações de operador diferentes — 402 (teto de bancos do
-        # plano), 409 (o estado sumiu durante o lock) e 503 (lock ocupado). O
+        # plano), 409 do estado que sumiu na espera do lock, 409 do item que
+        # OUTRA entrega já atribuiu (a revalidação da adoção) e 503 (lock
+        # ocupado); os dois 409 se separam pelo texto do `detail`. O
         # `str()` do `HTTPException` já é `"{status_code}: {detail}"`
         # (starlette), então não precisa de formatação nossa.
         await log_system_event(

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -38,6 +38,7 @@ from core.services.pluggy import (
 )
 from core.services.plan_service import is_pro
 from core.services.pluggy_sync import (
+    ITEM_UPDATING,
     _env_int,
     refresh_and_sync_pluggy_user,
     sync_pluggy_item,
@@ -51,12 +52,14 @@ from db import (
     get_connections_by_item_id,
     get_open_finance_connection_by_item_id,
     get_open_finance_snapshot,
+    item_registry_origins,
     list_pluggy_item_ids,
     pluggy_item_lock,
     register_item,
     save_pluggy_open_finance_item,
     token_hash,
     update_pluggy_open_finance_item_status,
+    user_exists,
 )
 from frontend.routes import shared
 
@@ -630,6 +633,200 @@ def _schedule_pluggy_sync(item_id: str) -> None:
     task.add_done_callback(lambda _t: _on_sync_done(item_id))
 
 
+async def _adota_item_orfao(item_id: str, last_event: str | None = None) -> int | None:
+    """Adota um item da Pluggy que existe lá e não tem conexão local. Devolve o dono.
+
+    Por que existe: a linha em `open_finance_connections` só nascia no
+    `POST /pluggy-item`, que é chamado pelo NAVEGADOR. Quem fechava a aba no meio
+    do widget ficava com o item vivo na Pluggy e nenhuma linha aqui — a tela mostra
+    0 bancos, o `DELETE /open-finance/{uid}` enumera a partir das conexões e não
+    apaga nada lá, e o `avoidDuplicates` do connect token recusa item novo. O
+    usuário fica travado sem saída pelo produto.
+
+    SÓ o chamador decide QUANDO adotar, e ele adota só em `item/created` — o
+    porquê está no webhook.
+
+    O dono vem SEMPRE da resposta REMOTA (`clientUserId`, que nós mesmos setamos ao
+    emitir o connect token) — NUNCA do corpo do webhook, que vem de fora e não
+    decide posse. E ele é aceito com a MESMA régua do `POST /pluggy-item`, que
+    compara STRING (`str(dono_remoto or "") != str(session_uid)`): só passa o que
+    for a forma canônica de um inteiro. `int()` sozinho aceitava mais do que a
+    rota — `' 5 '`, `'+5'`, `'1_2'` (PEP 515) e `'١٢'` (dígitos árabe-índicos) —
+    e as duas portas divergiam no mesmo valor.
+
+    Três guardas de escrita, nesta ordem:
+      • o item não pode ter tido dono NUNCA. "Item/created dispara uma vez" é
+        premissa errada: webhook é entrega AT-LEAST-ONCE e este endpoint devolve
+        401/400/503 (e pode dar 500 antes daqui), o que faz a Pluggy retentar o
+        MESMO evento. Uma 2ª entrega depois de o usuário remover o banco
+        ressuscitava a conexão, com sync agendado, re-importando na carteira que
+        ele limpou — o delete remoto é best-effort e o item sobrevive lá. POR QUE
+        o rastro com dono é o sinal certo (e por que banco removido fica "sem
+        conexão local" para sempre): docstring de `db.item_registry_origins`,
+        fonte única dos três leitores (CLAUDE.md §0.7). A 1ª adoção grava rastro
+        com dono ANTES da conexão, então ela mesma fecha a duplicata;
+      • o usuário TEM de existir. Não dá para delegar à FK: todo caminho de
+        escrita passa por `ensure_user_tx`, que CRIA a linha de `users`. Conta
+        apagada por LGPD (`db/privacy.py`) cujo item sobreviveu ao delete
+        best-effort ressuscitava por causa de um evento da Pluggy;
+      • o rastro (`register_item`) vai ANTES da conexão, e a ordem inversa é pior:
+        ela deixava conexão commitada com registry VAZIO — item adotado sem
+        nenhum rastro, e o rastro é a única enumeração que existe (`GET /items`
+        da Pluggy devolve 401).
+
+    O PREÇO dessa ordem, medido: se a escrita da conexão falhar no meio, sobra
+    rastro COM dono e nenhuma conexão — estado indistinguível de banco removido
+    pelo usuário. Aí NÃO há recuperação automática: o script one-shot deixa de
+    listar o item (o filtro dele exclui rastro com dono, de propósito — a mesma
+    regra, `db/open_finance_state.item_registry_origins`) e a retentativa do
+    `item/created` não readota (a 1ª guarda acima). A saída é OPERACIONAL:
+    `python -m scripts.adotar_items_of_orfaos --item ID --apply --delete` apaga o
+    item na Pluggy, o `avoidDuplicates` libera, e o usuário reconecta pelo
+    widget. Fechar isso sozinho exigiria o disconnect deixar rastro próprio
+    (`origin='disconnect'`) para separar "removido" de "adoção que falhou" —
+    escrita em outro fluxo, outro PR.
+
+    Nada escapa daqui: o chamador (webhook) tem de responder 200 mesmo em falha,
+    senão a Pluggy retenta em laço. Sem dono resolvível, sem usuário, com o teto
+    de bancos do plano estourado (`_enforce_bank_limit`, 402) ou com qualquer
+    falha de escrita, devolve None e o chamador mantém o rastro sem dono que já
+    existia.
+
+    LIMITE CONHECIDO (medido, decidido não consertar): duas entregas CONCORRENTES
+    do mesmo `item/created` podem ler o rastro vazio antes de qualquer uma
+    escrever, e gravam DUAS auditorias para UMA conexão (o `pluggy_item_lock`
+    protege a conexão, a auditoria fica fora dele). A janela é a distância entre
+    a leitura do rastro e o `register_item` — hoje duas idas ao banco; fechá-la
+    de vez é serializar a adoção pelo `pluggy_item_lock`, que muda o desenho do
+    lock. Também fica aberto: `item/updated` chegando ANTES do `item/created`
+    (entrega fora de ordem) é adotado sem contas e sem sync agendado até o evento
+    seguinte ou o pull-to-refresh. Nenhum dos dois é regressão contra a `main`.
+
+    ponytail: custa uma chamada HTTP a mais dentro do webhook no ramo de item
+    desconhecido — inclusive quando ele acaba recusado por já ter dono, que é o
+    preço da ordem escolhida acima. Se virar latência, jogar num
+    `asyncio.create_task` como o `_schedule_pluggy_sync` já faz.
+    """
+    try:
+        remote = await asyncio.to_thread(get_pluggy_item, item_id)
+        bruto = str(remote.get("clientUserId") or "")
+        dono = int(bruto)
+        if str(dono) != bruto:   # ' 5 ', '+5', '007', '1_2', '١٢' → não é o que a rota aceita
+            raise ValueError(f"clientUserId fora da forma canônica: {bruto!r}")
+    except Exception as exc:
+        # Sem dono resolvível: o chamador registra o rastro como antes. O MOTIVO
+        # importa — `PluggyConfigError`, 404, timeout e item sem `clientUserId`
+        # viravam todos o mesmo `of_webhook_item_unknown` genérico.
+        await log_system_event(
+            "warning", "of_webhook_adopt_skipped",
+            "Item órfão sem dono resolvível",
+            source="open_finance",
+            details={"item_id": item_id, "motivo": type(exc).__name__,
+                     "error": str(exc)[:200]},
+        )
+        return None
+
+    # A leitura do rastro vem DEPOIS do HTTP de propósito, e custa um POST /auth
+    # + GET /items desperdiçado na duplicata. Antes dele, ela ficava separada da
+    # escrita (`register_item`) por um round-trip inteiro da Pluggy — e MEDIDO
+    # (duas entregas concorrentes de `item/created`, a 2ª começando com a 1ª
+    # ainda dentro do GET): 2 auditorias e 2 rastros para 1 conexão, contra 1 e 1
+    # com a leitura aqui. A posição NÃO é neutra: a troca é uma chamada HTTP num
+    # caminho raro (retentativa) por uma janela de corrida N vezes menor. O que
+    # SOBRA de janela é o "LIMITE CONHECIDO" da docstring acima, que é onde ele
+    # está descrito por extenso (CLAUDE.md §0.7).
+    # Falha de leitura NÃO adota (não dá para verificar).
+    try:
+        origens = await asyncio.to_thread(item_registry_origins, item_id)
+    except Exception as exc:  # noqa: BLE001 — nada escapa daqui (o webhook responde 200)
+        await log_system_event(
+            "warning", "of_webhook_adopt_skipped",
+            "Rastro do item ilegível: adoção não verificável",
+            source="open_finance",
+            details={"item_id": item_id, "motivo": type(exc).__name__,
+                     "error": str(exc)[:200]},
+        )
+        return None
+    if origens:
+        await log_system_event(
+            "warning", "of_webhook_adopt_skipped",
+            "Item já teve dono: adoção só vale para item nunca atribuído",
+            source="open_finance",
+            details={"item_id": item_id, "motivo": "rastro_com_dono",
+                     "origens": sorted(origens)},
+        )
+        return None
+
+    try:
+        if not await asyncio.to_thread(user_exists, dono):
+            await log_system_event(
+                "warning", "of_webhook_adopt_skipped",
+                "Item órfão de usuário que não existe mais",
+                source="open_finance",
+                details={"item_id": item_id, "user_id": dono, "motivo": "usuario_inexistente"},
+            )
+            return None
+        await _enforce_bank_limit(dono, item_id)
+        # O rastro DUPLICA de propósito quando o navegador volta depois (o POST
+        # grava outra linha, `origin='pluggy_item'`): o registry é um log de
+        # append, "este item existiu, visto por esta porta", e as duas portas
+        # viram o item de verdade. Deduplicar apagaria justamente o que responde
+        # "por onde ele entrou". O que NÃO pode duplicar é a conexão (uma só, o
+        # upsert garante) e a auditoria (ver o `POST /pluggy-item`).
+        await asyncio.to_thread(
+            register_item, dono, provider_item_id=item_id, origin="webhook_adopt",
+            status=str(remote.get("status") or "") or None, last_event=last_event,
+        )
+        await _grava_reconexao(dono, remote, item_id, tinha_conexao_propria=False)
+    except Exception as exc:
+        # `motivo` sozinho não basta AQUI: `HTTPException` é o nome de três
+        # desfechos com ações de operador diferentes — 402 (teto de bancos do
+        # plano), 409 (o estado sumiu durante o lock) e 503 (lock ocupado). O
+        # `str()` do `HTTPException` já é `"{status_code}: {detail}"`
+        # (starlette), então não precisa de formatação nossa.
+        await log_system_event(
+            "warning", "of_webhook_adopt_skipped",
+            "Item órfão não adotado",
+            source="open_finance",
+            details={"item_id": item_id, "user_id": dono, "motivo": type(exc).__name__,
+                     "error": str(exc)[:200]},
+        )
+        return None
+
+    # Daqui pra baixo a adoção JÁ aconteceu: nada pode desfazê-la nem virar 5xx
+    # para a Pluggy. Auditoria é o mesmo evento que o `POST /pluggy-item` grava —
+    # sem `request`, que aqui é o POST da Pluggy e não o do usuário.
+    try:
+        await asyncio.to_thread(
+            record_audit_event, dono, AuditEvent.OPEN_FINANCE_CONNECTED,
+            details={"provider": "pluggy", "item_id": item_id, "origin": "webhook_adopt"},
+        )
+        # Sync em tudo MENOS `UPDATING`/`CREATED` (`ITEM_UPDATING` é só esses
+        # dois): o que está barrado é o item que a Pluggy ainda está montando —
+        # em `item/created` esse é o status normal, e sincronizar ali é uma task
+        # esperando o item sair de UPDATING (`pluggy_sync`, que já faz essa
+        # espera) para achar zero conta. O `item/updated` seguinte sincroniza
+        # sozinho, e a essa altura a conexão JÁ existe, então ele entra pelo
+        # caminho comum (`len(conexoes) == 1`). É menos código rodando, não mais.
+        # Os outros status AGENDAM: `WAITING_USER_INPUT`, `WAITING_USER_ACTION`,
+        # `LOGIN_ERROR`, `OUTDATED` e `ERROR` viram um sync que provavelmente
+        # não traz nada — e isso NÃO vira estado errado na tela, porque
+        # `connection_ui_state` testa `_NEEDS_USER` antes de `no_accounts`.
+        # `_UPDATING` vem de `pluggy_health` — a fonte que o `pluggy_sync` também
+        # usa; não é uma segunda lista de status (CLAUDE.md §0.7).
+        if str(remote.get("status") or "").upper() not in ITEM_UPDATING:
+            _schedule_pluggy_sync(item_id)
+    except Exception as exc:
+        await log_system_event(
+            "warning", "of_webhook_adopt_incompleto",
+            "Item adotado, mas auditoria/sync falharam",
+            source="open_finance",
+            details={"item_id": item_id, "user_id": dono, "motivo": type(exc).__name__,
+                     "error": str(exc)[:200]},
+        )
+    return dono
+
+
 def _bank_limit_enabled() -> bool:
     # Gate dormante: só bloqueia quando ligado no ambiente (como os outros gates do projeto).
     return (os.getenv("OF_BANK_LIMIT_ENABLED") or "").strip().lower() in ("1", "true", "yes", "on")
@@ -962,6 +1159,17 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
         )
         raise HTTPException(status_code=409, detail="Este item já está vinculado a outra conta.")
 
+    # A conexão que JÁ existia nasceu do webhook (que auditou por ela) ou é um
+    # banco que o usuário está RECONECTANDO? `tinha_conexao_propria` sozinho não
+    # separa os dois: o widget reconecta banco existente e o `avoidDuplicates`
+    # devolve o MESMO itemId, então re-consentimento e conserto de LOGIN_ERROR
+    # também chegam aqui com a conexão de pé — e sumiam de "Atividade da conta".
+    # O fato que separa: `pluggy_item` no rastro = o NAVEGADOR já registrou este
+    # item alguma vez, logo a conexão não é a que o webhook acabou de adotar.
+    # Lido ANTES do `register_item` abaixo, que grava justamente essa origem.
+    conexao_recem_adotada = tinha_conexao_propria and "pluggy_item" not in (
+        await asyncio.to_thread(item_registry_origins, new_item_id))
+
     await _enforce_bank_limit(session_uid, new_item_id)
     try:
         connection = await _grava_reconexao(
@@ -975,13 +1183,24 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
         status=str(remote.get("status") or "") or None,
     )
 
-    await asyncio.to_thread(
-        record_audit_event,
-        user_id,
-        AuditEvent.OPEN_FINANCE_CONNECTED,
-        request=request,
-        details={"provider": "pluggy", "item_id": (connection or {}).get("provider_item_id")},
-    )
+    # Pula SÓ a duplicata do webhook. `item/created` chega antes do `onSuccess`
+    # do widget (que só dispara em status final), então em produção a ordem comum
+    # é webhook primeiro: a adoção grava a conexão E a auditoria, e este POST
+    # chegava depois gravando o SEGUNDO `OPEN_FINANCE_CONNECTED` da MESMA conexão.
+    # O que se suprime é "o webhook JÁ auditou ESTA conexão", não "o usuário já
+    # tinha este banco" — reconexão legítima (re-consentimento, conserto de
+    # LOGIN_ERROR) é evento de segurança e continua aparecendo, uma vez cada.
+    # ponytail: a 1ª reconexão de um item adotado pelo webhook cujo navegador
+    # NUNCA postou (aba fechada) ainda cai como duplicata e não audita — a partir
+    # da 2ª, audita. Fechar isso exige marcar a adoção na própria conexão.
+    if not conexao_recem_adotada:
+        await asyncio.to_thread(
+            record_audit_event,
+            user_id,
+            AuditEvent.OPEN_FINANCE_CONNECTED,
+            request=request,
+            details={"provider": "pluggy", "item_id": (connection or {}).get("provider_item_id")},
+        )
 
     # Sync inicial: puxa contas + transações do banco recém-conectado.
     _schedule_pluggy_sync(str((connection or {}).get("provider_item_id") or ""))
@@ -1220,17 +1439,50 @@ async def open_finance_pluggy_webhook(request: Request):
         if len(conexoes) == 1:
             _schedule_pluggy_sync(item_id)
         elif not conexoes:
-            # Item que não conhecemos: registra (o GET /items lista devolve 401,
-            # então este é o único jeito de saber que ele existe) e NÃO sincroniza.
-            await log_system_event(
-                "warning", "of_webhook_item_unknown",
-                "Webhook de item sem conexão local",
-                source="open_finance", details={"item_id": item_id, "event": event_name},
-            )
-            await asyncio.to_thread(
-                register_item, None, provider_item_id=item_id,
-                origin="webhook", last_event=event_name,
-            )
+            # Item que não conhecemos. Em `item/created` — e SÓ nele — pergunta à
+            # Pluggy de quem ele é e adota. QUEM ele destrava está na docstring de
+            # `_adota_item_orfao` ("Por que existe"), fonte única (CLAUDE.md §0.7);
+            # aqui fica só o QUANDO, que é decisão deste chamador:
+            #
+            # Por que só nesse evento: `item/created` dispara UMA vez, na criação,
+            # e é exatamente "item novo que o navegador não registrou". Evento
+            # POSTERIOR (`item/updated`, `transactions/created`) num item sem
+            # conexão significa item que JÁ TEVE conexão e foi removida — adotar
+            # ali ressuscita o banco que o usuário acabou de tirar, com sync
+            # agendado, que é o buraco que o `_disconnect_sob_lock` fechou pelo
+            # outro lado. O delete do item na Pluggy é best-effort
+            # (`delete_pluggy_items_best_effort`): o item sobrevive à falha e
+            # continua mandando evento.
+            adotado = (await _adota_item_orfao(item_id, event_name)
+                       if event_name == "item/created" else None)
+            if adotado is None:
+                # Sem adoção: registra (o GET /items lista devolve 401, então este
+                # é o único jeito de saber que ele existe) e NÃO sincroniza.
+                # ponytail: INSERT puro, sem teto — sob entrega at-least-once,
+                # cada retentativa de um item que já tem dono soma mais uma linha
+                # `origin='webhook'`/`user_id NULL` aqui. Igual à `main` (não é
+                # regressão) e inofensivo para os dois leitores, que perguntam
+                # por rastro COM dono; se o volume incomodar, é um upsert por
+                # (provider, item, origin) com contador.
+                await log_system_event(
+                    "warning", "of_webhook_item_unknown",
+                    "Webhook de item sem conexão local",
+                    source="open_finance", details={"item_id": item_id, "event": event_name},
+                )
+                try:
+                    await asyncio.to_thread(
+                        register_item, None, provider_item_id=item_id,
+                        origin="webhook", last_event=event_name,
+                    )
+                except Exception as exc:  # noqa: BLE001 — rastro nunca derruba o 200
+                    # Mesmo contrato do `of_item_registry_failed` na emissão do
+                    # connect token: 5xx aqui vira retentativa em laço da Pluggy.
+                    await log_system_event(
+                        "warning", "of_item_registry_failed",
+                        "Falha ao registrar item sem conexão",
+                        source="open_finance",
+                        details={"item_id": item_id, "error": str(exc)[:200]},
+                    )
         else:
             # Dois donos possíveis: sincronizar um deles é sincronizar a carteira
             # do usuário errado. Recusa.

--- a/scripts/adotar_items_of_orfaos.py
+++ b/scripts/adotar_items_of_orfaos.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Adota (ou apaga na Pluggy) os items de Open Finance que ficaram órfãos.
+
+O problema que ele destrava está descrito em UM lugar (CLAUDE.md §0.7): a
+docstring de `frontend/routes/open_finance._adota_item_orfao`, "Por que existe".
+Resumo de uma linha: item vivo na Pluggy sem linha local nenhuma aqui.
+
+O webhook passou a adotar sozinho (`_adota_item_orfao`), mas isso só vale de agora
+em diante: este script é o one-shot que destrava quem já está travado.
+
+O ÚNICO rastro de um item órfão é o `open_finance_item_registry` — o `GET /items`
+da Pluggy devolve 401 (docs/CLAUDE.md, db/open_finance_state.py), então o universo
+remoto não é enumerável. Se o dry-run vier VAZIO, a leitura correta não é "não há
+item órfão": é que o webhook não estava configurado quando o item foi criado, e
+então não existe rastro nenhum dele em lugar nenhum.
+
+Rodar de novo é BARULHENTO, não destrutivo — em nenhum dos dois modos ele é
+idempotente no EFEITO. Adotado o item, ele deixa de aparecer na lista (ganhou
+conexão e rastro com dono), mas `register_item` é INSERT puro: uma tentativa que
+falhe no meio deixa mais uma linha de rastro por rodada. Com `--delete`, nada
+apaga a linha do registry — que é justamente o rastro que se quer manter —, então
+cada rodada nova imprime o erro do `get_pluggy_item` (404, item já apagado lá).
+
+Escrever exige SEMPRE `--apply` — inclusive para apagar, que é a operação
+irreversível.
+
+Uso:
+    .venv/bin/python -m scripts.adotar_items_of_orfaos                    # dry-run (DEFAULT)
+    .venv/bin/python -m scripts.adotar_items_of_orfaos --apply            # adota
+    .venv/bin/python -m scripts.adotar_items_of_orfaos --apply --delete   # apaga na Pluggy
+    .venv/bin/python -m scripts.adotar_items_of_orfaos --item ID --apply --delete   # um item
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+import db
+from db.open_finance_state import ITEMS_SEM_CONEXAO
+
+
+def listar_items_orfaos() -> list[str]:
+    """Item que o webhook viu e NUNCA conseguiu atribuir a um dono.
+
+    Parte do mesmo predicado do painel (`ITEMS_SEM_CONEXAO`, uma fonte só) e
+    aperta por cima dele com o MESMO `db.item_registry_origins` que a adoção pelo
+    webhook usa (CLAUDE.md §0.7 — o `having count(r.user_id) = 0` que morava aqui
+    era uma segunda versão da mesma regra em SQL): vazio = nenhuma linha de
+    rastro deste item tem dono.
+
+    A diferença é a que separa adotar de RESSUSCITAR, e a regra mora na docstring
+    de `db.item_registry_origins` (por que banco REMOVIDO casa com o predicado do
+    painel para sempre). O que ela custa AQUI: um `--apply` sobre um removido o
+    reataria com sync agendado, re-importando na carteira que o usuário limpou.
+
+    Filtra por `user_id`, não por `origin`: item que teve as duas coisas (webhook
+    sem dono e, depois, conexão pelo navegador) tem linha dos dois tipos, e é a
+    presença de QUALQUER dono que decide.
+
+    ponytail: o teto é a adoção que falhou DEPOIS do `register_item` (a ordem é
+    de propósito, ver `_adota_item_orfao`) — ela deixa rastro com dono e sem
+    conexão, indistinguível de banco removido, e este script deixa de vê-la.
+    Trocar "não ressuscita o que o usuário removeu" por "não perde o item de uma
+    adoção que falhou" seria o negócio errado. Separar os dois exige o disconnect
+    deixar o próprio rastro no registry (`origin='disconnect'`) — mudança de
+    escrita em outro fluxo, outro PR. A saída para esse item é operacional e
+    explícita: `--item ID --apply --delete` (ver `parse_args`).
+
+    Só items da PLUGGY: `ITEMS_SEM_CONEXAO` é compartilhado com o painel e não
+    restringe provider (de propósito — o painel conta todos), mas tudo que este
+    script faz com o id (`_adota_item_orfao`, `delete_pluggy_item`) fala com a
+    Pluggy. Sem o filtro, um item de outro provider entrava na lista e o
+    `--apply` gastava auth + GET para logar 404. Não é alcançável hoje (nenhum
+    chamador de produção passa `provider=` a `register_item`), e é exatamente por
+    isso que viraria erro silencioso no dia do segundo provider.
+
+    ponytail: uma query por item candidato em vez de um `having` no mesmo SELECT.
+    Num one-shot sobre um punhado de items é mais barato que manter duas versões
+    do predicado; se a lista crescer para milhares, é `where not exists`.
+    """
+    provider = "pluggy"
+    with db.get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            f"select distinct r.provider_item_id as item {ITEMS_SEM_CONEXAO}"
+            " and r.provider = %s order by 1", (provider,))
+        vistos = [r["item"] for r in (cur.fetchall() or [])]
+    return [i for i in vistos if not db.item_registry_origins(i, provider=provider)]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true", help="escreve de verdade (sem isto, dry-run)")
+    ap.add_argument("--delete", action="store_true",
+                    help="com --apply: apaga o item na Pluggy em vez de adotar "
+                         "(libera o avoidDuplicates). É irreversível.")
+    # A ÚNICA saída para o item que ficou com rastro COM dono e SEM conexão (a
+    # adoção que falhou entre o `register_item` e a escrita da conexão): a lista
+    # não o mostra — é indistinguível de banco removido — e a retentativa do
+    # `item/created` não o readota (guarda do `_adota_item_orfao`). Adotar por
+    # aqui também é recusado, de propósito: `--apply --delete` apaga o item na
+    # Pluggy, o `avoidDuplicates` libera, e o usuário reconecta pelo widget.
+    # Fora do default e com id explícito digitado pelo operador: nada aqui
+    # ressuscita nada sozinho.
+    ap.add_argument("--item", metavar="ITEM_ID",
+                    help="opera SÓ neste item, pulando a lista. Para o item que a "
+                         "lista não vê (rastro com dono, sem conexão): use com "
+                         "--apply --delete e peça a reconexão ao usuário. Item com "
+                         "conexão LOCAL viva é recusado (ver main).")
+    args = ap.parse_args(argv)
+    if args.delete and not args.apply:
+        # `--delete` sozinho já apagava item na Pluggy na PRIMEIRA invocação, sem
+        # nenhuma confirmação — só o `--apply` (que é o menos destrutivo dos dois)
+        # exigia flag. Uma porta, uma chave.
+        ap.error("--delete apaga item na Pluggy: use junto com --apply.")
+    return args
+
+
+async def _executar(items: list[str], *, apply: bool, delete: bool) -> None:
+    # Import tardio só para manter o app FastAPI fora de quem não o usa (`--help`,
+    # `parse_args`, dry-run): ele custa ~3× os módulos de `import db` (medido em
+    # 2026-09-08 com `python -c "import sys; import M; print(len(sys.modules))"`;
+    # remede antes de reusar o número, CLAUDE.md §2).
+    # NÃO é por variável de ambiente: a versão anterior deste comentário dizia
+    # que o import "exige DATABASE_URL/JWT_SECRET" e que "o dry-run tem de rodar
+    # sem isso", e as duas metades são falsas — o import roda com as duas APAGADAS do
+    # ambiente, e o dry-run lê o banco (`listar_items_orfaos` abre `db.get_conn()`).
+    from core.services.pluggy import delete_pluggy_item, get_pluggy_item
+    from frontend.routes.open_finance import _adota_item_orfao
+
+    for item_id in items:
+        # UM try por ITEM, cobrindo o corpo inteiro: com ele só no
+        # `get_pluggy_item`, uma falha do `delete_pluggy_item` (ou da adoção) no
+        # item 2 subia e o item 3 nunca era processado — num one-shot que se roda
+        # para destravar N usuários, isso é o pior desfecho possível.
+        try:
+            if delete:
+                remote = await asyncio.to_thread(get_pluggy_item, item_id)
+                dono = remote.get("clientUserId")
+                conector = (remote.get("connector") or {}).get("name")
+                print(f"{item_id}: status={remote.get('status')} banco={conector} dono={dono}")
+                # Sem chave pré-fabricada: `delete_pluggy_item` cria a dele
+                # (`api_key or create_pluggy_api_key()`). Uma chave só, montada
+                # antes do laço, ficava FORA de todo `try` — falha dela (401,
+                # timeout) derrubava o one-shot com ZERO item processado, que é
+                # exatamente o desfecho que o `try` por item veio evitar.
+                # ponytail: MEDIDO — 2 POST /auth por item aqui (um do
+                # `get_pluggy_item`, outro do `delete_pluggy_item`). Num one-shot
+                # de punhado de items é mais barato que a rodada perdida.
+                await asyncio.to_thread(delete_pluggy_item, item_id)
+                print("   apagado na Pluggy")
+            elif apply:
+                # O `GET /items` que imprimia status/banco/dono saiu daqui: o
+                # `_adota_item_orfao` faz o MESMO GET logo em seguida, e eram 2
+                # POST /auth + 2 GET por item para imprimir uma linha. Agora é 1
+                # de cada, e o dono sai no print abaixo.
+                adotado = await _adota_item_orfao(item_id, "script_adopt")
+                print(f"{item_id}: adotado por {adotado}" if adotado else
+                      f"{item_id}: NÃO adotado (sem dono, já teve dono, usuário "
+                      "inexistente ou teto do plano — ver system_event_logs)")
+        except Exception as exc:  # noqa: BLE001 — one-shot: reporta e segue
+            print(f"{item_id}: ERRO ({type(exc).__name__}: {exc}) — segue para o próximo")
+
+    # A adoção agenda o sync numa task de fundo (`_schedule_pluggy_sync`); sem
+    # esperar, o `asyncio.run` fecha o loop e mata a coleta pela metade.
+    pendentes = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pendentes:
+        await asyncio.gather(*pendentes, return_exceptions=True)
+
+
+def main() -> None:
+    args = parse_args()
+    items = [args.item] if args.item else listar_items_orfaos()
+
+    # `--item` pula a LISTA, logo pula o predicado dela: um id digitado errado
+    # mandava para a Pluggy o item de um usuário SAUDÁVEL. Com `--delete` isso é
+    # IRREVERSÍVEL — o item morre lá, a linha local continua apontando para ele,
+    # e o usuário não recebe aviso nenhum na tela. Recusa aqui, antes de qualquer
+    # escrita (operação irreversível em caminho de dinheiro é carve-out do §0.2).
+    if args.item and db.get_connections_by_item_id(args.item):
+        raise SystemExit(
+            f"{args.item} tem conexão LOCAL viva: não é órfão, e este script não "
+            "é a porta para removê-lo. Confira o id; se o usuário quer mesmo "
+            "removê-lo, o caminho é o app (DELETE /open-finance/{uid}), que apaga "
+            "os dois lados.")
+    if not items:
+        print("Nenhum item órfão no registry.")
+        print("ATENÇÃO: registry vazio NÃO prova que não há item órfão na Pluggy — o "
+              "GET /items dela devolve 401 e o registry só tem o que o webhook viu. "
+              "Item criado com o webhook desconfigurado não deixou rastro nenhum.")
+        return
+
+    print(f"{len(items)} item(s) órfão(s): {', '.join(items)}")
+    if not args.apply:
+        print("Dry-run (default). Rode com --apply para adotar, "
+              "ou --apply --delete para apagar na Pluggy.")
+        return
+    asyncio.run(_executar(items, apply=args.apply, delete=args.delete))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_poisoned_category_rules.py
+++ b/scripts/cleanup_poisoned_category_rules.py
@@ -24,10 +24,10 @@ colisão, mas apagá-la seria perder config do usuário. Por isso `--apply` exig
 `--user`: rode global em dry-run, revise a lista, e só então aplique cliente a
 cliente conferindo que nenhuma daquelas regras é intencional.
 
-O dry-run é READ-ONLY de verdade: nenhuma das duas leituras (`_all_user_ids`,
-`_rules_somente_leitura`) escreve, e `--user` inexistente aborta em vez de ser
-criado. Sem isso o próprio conselho de segurança deste script ("rode o dry-run
-primeiro") criava dado em produção.
+O dry-run é READ-ONLY de verdade: nenhuma das três leituras (`_all_user_ids`,
+`_rules_somente_leitura`, `db.user_exists`) escreve, e `--user` inexistente aborta
+em vez de ser criado. Sem isso o próprio conselho de segurança deste script ("rode
+o dry-run primeiro") criava dado em produção.
 
 Uso:
     .venv/bin/python -m scripts.cleanup_poisoned_category_rules              # dry-run global (só reporta)
@@ -48,12 +48,6 @@ def _all_user_ids() -> list[int]:
         cur.execute("select id from users order by id")
         rows = cur.fetchall() or []
     return [r["id"] if isinstance(r, dict) else r[0] for r in rows]
-
-
-def _user_existe(user_id: int) -> bool:
-    with db.get_conn() as conn, conn.cursor() as cur:
-        cur.execute("select 1 from users where id=%s", (user_id,))
-        return cur.fetchone() is not None
 
 
 def _rules_somente_leitura(user_id: int) -> list[tuple[str, str]]:
@@ -121,7 +115,7 @@ def main() -> None:
     # `--user` digitado errado não pode virar "0 regras, nada a fazer": aborta.
     # (O write que ele causava morreu em `_rules_somente_leitura`; isto é o
     # aviso, pra não confundir "cliente limpo" com "cliente que não existe".)
-    if args.user is not None and not _user_existe(args.user):
+    if args.user is not None and not db.user_exists(args.user):
         ap.error(f"user {args.user} não existe — confira o id.")
 
     user_ids = [args.user] if args.user else _all_user_ids()

--- a/tests/frontend/onboarding_visibility.test.mjs
+++ b/tests/frontend/onboarding_visibility.test.mjs
@@ -7,7 +7,7 @@
  * por especificidade (ambas 0,1,0), mas porque folha de autor vence folha de
  * user-agent. Como `.onb-done` declara `display:flex` e `.btn` declara
  * `display:inline-flex`, quatro elementos ficavam SEMPRE visíveis:
- * "Você já tem saldo lançado", "WhatsApp já conectado", o botão do WhatsApp e
+ * "Saldo lançado com sucesso", "WhatsApp conectado com sucesso", o botão do WhatsApp e
  * o "+ Adicionar cartão". O usuário viu o primeiro no passo 2, antes de lançar
  * qualquer saldo.
  *
@@ -80,6 +80,33 @@ async function abrirWizard({ balance = 0, waLinked = false } = {}) {
 const display = (page, role) =>
   page.$eval(`[data-role="${role}"]`, (e) => getComputedStyle(e).display);
 
+/**
+ * Contraste WCAG do texto do elemento contra o fundo REAL (composto).
+ * `.onb-done` pinta o próprio fundo com alpha (.08 de neon), então comparar a
+ * cor do texto com `background-color` cru daria o valor errado: as camadas são
+ * compostas até a primeira opaca, que aqui é o `--bg` (#0c0c0d) do site.
+ */
+const contraste = (page, role) => page.$eval(`[data-role="${role}"]`, (el) => {
+  const canal = (s) => (s.match(/[\d.]+/g) || []).map(Number);
+  const sobre = ([r, g, b, a = 1], bg) => [r, g, b].map((v, i) => v * a + bg[i] * (1 - a));
+  const lum = (c) => {
+    const [r, g, b] = c.map((v) => (v /= 255) <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  };
+  const camadas = [];
+  for (let n = el; n; n = n.parentElement) {
+    const c = canal(getComputedStyle(n).backgroundColor);
+    const a = c.length === 4 ? c[3] : 1;
+    if (a > 0) camadas.push(c);
+    if (a === 1) break;
+  }
+  let bg = camadas.pop() || [255, 255, 255];
+  while (camadas.length) bg = sobre(camadas.pop(), bg);
+  const [claro, escuro] = [lum(sobre(canal(getComputedStyle(el).color), bg)), lum(bg)]
+    .sort((x, y) => y - x);
+  return Math.round(((claro + 0.05) / (escuro + 0.05)) * 100) / 100;
+});
+
 async function irPara(page, passo) {
   await page.click(`.onb-step[data-step="${passo - 1}"] [data-action="next"]`);
   await page.waitForSelector(`.onb-step[data-step="${passo}"]:not([hidden])`);
@@ -87,7 +114,7 @@ async function irPara(page, passo) {
 
 // ── Passo 2 ─────────────────────────────────────────────────────────────────
 
-test("conta sem saldo NÃO mostra o aviso de saldo já lançado", async () => {
+test("conta sem saldo NÃO mostra o aviso de saldo lançado", async () => {
   const page = await abrirWizard({ balance: 0 });
   await irPara(page, 2);
   await page.waitForFunction(() =>
@@ -134,7 +161,7 @@ test("sem WhatsApp vinculado, mostra o código e esconde a confirmação", async
     !document.querySelector('[data-role="wa-pending"]').hasAttribute("hidden"));
 
   assert.equal(await display(page, "wa-linked"), "none",
-    '"WhatsApp já conectado" aparecia junto com o pedido de vínculo');
+    '"WhatsApp conectado com sucesso" aparecia junto com o pedido de vínculo');
   assert.notEqual(await display(page, "wa-pending"), "none");
   assert.equal(await page.$eval('[data-role="wa-code"]', (e) => e.textContent), "link 482913");
   await page.close();
@@ -149,6 +176,25 @@ test("com WhatsApp vinculado, mostra a confirmação e esconde o código", async
 
   assert.equal(await display(page, "wa-linked"), "flex");
   assert.equal(await display(page, "wa-pending"), "none");
+  await page.close();
+});
+
+// ── A cor do aviso ──────────────────────────────────────────────────────────
+
+test("o aviso de sucesso é legível sobre o fundo escuro", async () => {
+  // A única mudança funcional deste PR era `color: var(--neon-ink, var(--neon))`
+  // → `var(--neon)`, e nenhum teste a via. Em `site.css` (a folha que o
+  // comecar.html carrega) `--neon-ink` é #10140a, quase o próprio `--bg`
+  // (#0c0c0d): medido, o texto "Saldo lançado com sucesso." saía a 1,25:1 —
+  // presente no DOM, invisível na tela. Com `--neon` (#C6F11A) dá 11,4:1.
+  // Medido em 2026-09-08 pelo próprio teste; remeça antes de reusar o número.
+  const page = await abrirWizard({ balance: 1250.4 });
+  await irPara(page, 2);
+  await page.waitForFunction(() =>
+    document.querySelector('[data-role="balance-form"]').hasAttribute("hidden"));
+
+  const c = await contraste(page, "balance-done");
+  assert.ok(c >= 4.5, `contraste do aviso: ${c}:1 (WCAG AA para texto normal exige 4,5:1)`);
   await page.close();
 });
 

--- a/tests/test_adotar_items_of_orfaos.py
+++ b/tests/test_adotar_items_of_orfaos.py
@@ -1,0 +1,271 @@
+"""G5e — o one-shot `scripts/adotar_items_of_orfaos.py`.
+
+Arquivo próprio (CLAUDE.md §0.5): o assunto aqui é o SCRIPT, não o webhook — os
+três arquivos `test_of_webhook_adopt*.py` cobrem a adoção pela porta do webhook.
+Os helpers vêm de `test_of_webhook_adopt_guards.py`, que é a fonte única deles
+(CLAUDE.md §0.1); copiá-los para cá seria a mesma duplicação que já custou uma
+rodada.
+
+Por que o `--apply` precisa de teste PRÓPRIO, e não herda o do webhook: o
+conserto do webhook só vale para conexão FUTURA (o `item/created` de quem já
+está travado passou faz tempo). Quem destrava o usuário travado HOJE é este
+script, e a sequência inteira que o destrava — adota → o card aparece na tela →
+"Remover todas as conexões" enumera e APAGA o item na Pluggy → o
+`avoidDuplicates` libera a reconexão — estava provada ponta a ponta só pela
+versão via webhook (`test_adotado_o_delete_enumera_e_apaga_o_item_na_pluggy`).
+O ramo `elif apply:` de `_executar` não era executado por teste nenhum: o único
+que chamava `_executar` passava `apply=False, delete=True`.
+
+CONTROLE NEGATIVO do grupo: trocar `elif apply:` por `elif False:` em
+`_executar` (ou devolver `None` de `_adota_item_orfao`) deixa
+`test_script_apply_adota_e_destrava_a_reconexao_do_dono` e
+`test_script_apply_com_status_de_item_created_real_nao_agenda_sync` vermelhos —
+os dois estão VERDES hoje, que é o que os torna discriminantes.
+CONTROLE POSITIVO do grupo: o mesmo
+`test_script_apply_adota_e_destrava_a_reconexao_do_dono` — sem ele, o caso de
+recusa abaixo passaria num script que não adota NADA, que é pior que o bug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+from test_of_item_ownership import _auth, eventos  # noqa: F401
+from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
+
+
+# ── o `--apply`: a única porta que destrava quem JÁ está travado ─────────────
+
+def test_script_apply_adota_e_destrava_a_reconexao_do_dono(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """A sequência inteira pela porta do SCRIPT, com banco real.
+
+    O assert que importa não é o da conexão — é o `list_pluggy_item_ids`: é ele
+    que o `_disconnect_sob_lock` usa para enumerar o que apagar na Pluggy. Sem a
+    linha local, ele devolvia `[]`, o item continuava vivo lá e o
+    `avoidDuplicates` do connect token recusava item novo: o usuário ficava
+    travado sem saída pelo produto.
+    """
+    from scripts.adotar_items_of_orfaos import _executar
+
+    item = "s-apply"
+    _mock_item(monkeypatch, user_id)
+    apagados: list[str] = []
+    monkeypatch.setattr("frontend.routes.open_finance.create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr("frontend.routes.open_finance.delete_pluggy_item",
+                        lambda item_id, api_key=None: apagados.append(item_id))
+    # o rastro do bug antigo: o webhook viu o item e NÃO conseguiu atribuir dono
+    db.register_item(None, provider_item_id=item, origin="webhook")
+    client = TestClient(dashboard.app)
+    try:
+        assert db.get_connections_by_item_id(item) == [], "pré-condição: nenhuma linha local"
+        assert item not in db.list_pluggy_item_ids(user_id), \
+            "pré-condição: o delete não alcança o item"
+
+        asyncio.run(_executar([item], apply=True, delete=False))
+
+        linhas = db.get_connections_by_item_id(item)
+        assert len(linhas) == 1 and int(linhas[0]["user_id"]) == user_id, linhas
+        assert [r["origin"] for r in _registry(item)] == ["webhook", "webhook_adopt"], \
+            _registry(item)
+        assert db.list_pluggy_item_ids(user_id) == [item], (
+            "'Remover todas as conexões' continua sem enxergar o item: a Pluggy "
+            "segue com ele vivo e o avoidDuplicates recusa a reconexão")
+
+        # o card na tela do dono
+        snap = client.get(f"/open-finance/{user_id}", headers=_auth(client, user_id)).json()
+        assert [c["provider_item_id"] for c in snap["connections"]] == [item], snap
+
+        # e o delete pelo app enumera e apaga do lado da Pluggy
+        resp = client.delete(f"/open-finance/{user_id}", headers=_auth(client, user_id))
+        assert resp.status_code == 200, resp.text
+        assert apagados == [item], "o item ficaria órfão na Pluggy, travando a reconexão"
+        assert db.get_connections_by_item_id(item) == []
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item(item)
+
+
+def test_script_apply_nao_ressuscita_o_banco_que_o_usuario_removeu(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """CONTROLE NEGATIVO da guarda, pela porta do SCRIPT (o webhook tem o par dele).
+
+    Banco conectado e depois REMOVIDO fica sem conexão local e COM rastro de dono
+    — indistinguível, para o predicado, de item órfão (docstring de
+    `db.item_registry_origins`). A lista não o oferece; mas `--item` PULA a
+    lista, e é por lá que um `--apply` reataria a conexão e agendaria sync,
+    re-importando na carteira que o usuário acabou de limpar.
+    """
+    from scripts.adotar_items_of_orfaos import _executar, listar_items_orfaos
+
+    item = "s-removido"
+    _mock_item(monkeypatch, user_id)
+    db.register_item(user_id, provider_item_id=item, origin="pluggy_item")
+    try:
+        assert item not in listar_items_orfaos(), "a lista não podia oferecê-lo"
+
+        asyncio.run(_executar([item], apply=True, delete=False))
+
+        assert db.get_connections_by_item_id(item) == [], \
+            "o banco que o usuário REMOVEU voltou pelo script"
+        assert db.list_pluggy_item_ids(user_id) == []
+        assert webhook_pluggy == [], "e com sync agendado, que re-importa o que ele apagou"
+        motivos = [e["details"].get("motivo") for e in eventos
+                   if e["event"] == "of_webhook_adopt_skipped"]
+        assert motivos == ["rastro_com_dono"], motivos
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item(item)
+
+
+def test_script_apply_com_status_de_item_created_real_nao_agenda_sync(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """O status realista de quem ficou travado é `CREATED`/`UPDATING`, não `UPDATED`.
+
+    O `_item_remoto` dos outros arquivos devolve `UPDATED` — o ramo que AGENDA
+    sync. Quem fechou a aba no meio do widget (o caso que este script existe para
+    destravar) está no ramo oposto: adota e NÃO agenda, porque a Pluggy ainda
+    está montando o item e o sync acharia zero conta.
+    """
+    from scripts.adotar_items_of_orfaos import _executar
+
+    item = "s-created"
+    monkeypatch.setattr("frontend.routes.open_finance.get_pluggy_item",
+                        lambda item_id, api_key=None: {"id": item_id, "status": "CREATED",
+                                                       "clientUserId": str(user_id),
+                                                       "connector": {"id": 612, "name": "Nubank"}})
+    db.register_item(None, provider_item_id=item, origin="webhook")
+    try:
+        asyncio.run(_executar([item], apply=True, delete=False))
+
+        assert len(db.get_connections_by_item_id(item)) == 1, "a adoção acontece"
+        assert db.list_pluggy_item_ids(user_id) == [item]
+        assert webhook_pluggy == [], "sync agendado num item que a Pluggy ainda está montando"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item(item)
+
+
+# ── a lista, os args e o laço (vindos de `test_of_webhook_adopt.py`) ─────────
+
+def test_script_lista_so_o_item_sem_conexao_e_o_default_e_dry_run(user_id, monkeypatch):
+    """UM check do que decide o script: o predicado e o default dos args.
+
+    Se o predicado quebrar, o `--apply` passa a mexer em item que JÁ tem conexão;
+    se o default deixar de ser dry-run, um `-m scripts.…` sem flag escreve.
+    """
+    from scripts.adotar_items_of_orfaos import listar_items_orfaos, parse_args
+
+    assert parse_args([]).apply is False and parse_args([]).delete is False
+    assert parse_args(["--apply"]).apply is True
+
+    _mock_item(monkeypatch, user_id)
+    # o rastro do bug antigo: o webhook viu e NÃO conseguiu atribuir
+    db.register_item(None, provider_item_id="item-orfao-script", origin="webhook")
+    db.save_pluggy_open_finance_item(
+        user_id, {"id": "item-com-conexao", "status": "UPDATED",
+                  "connector": {"id": 612, "name": "Nubank"}})
+    db.register_item(user_id, provider_item_id="item-com-conexao", origin="pluggy_item")
+    # banco CONECTADO e depois REMOVIDO (o porquê de ele ficar assim para sempre:
+    # docstring de `db.item_registry_origins`): sem conexão, COM rastro de dono.
+    db.register_item(user_id, provider_item_id="item-removido", origin="pluggy_item")
+    # e o item que passou pelos dois estados: rastro sem dono E rastro com dono
+    db.register_item(None, provider_item_id="item-removido-2", origin="webhook")
+    db.register_item(user_id, provider_item_id="item-removido-2", origin="webhook_adopt")
+    # item de OUTRO provider: `ITEMS_SEM_CONEXAO` é compartilhado com o painel e
+    # não restringe provider — sem o filtro do script, ele entra na lista e o
+    # `--apply` manda o id para a Pluggy (auth + GET, 404 no log).
+    db.register_item(None, provider_item_id="item-belvo", origin="webhook", provider="belvo")
+    try:
+        orfaos = listar_items_orfaos()
+        assert "item-orfao-script" in orfaos
+        assert "item-com-conexao" not in orfaos, "item COM conexão não é órfão"
+        # `--apply` sobre estes dois RESSUSCITARIA o removido (ver
+        # `listar_items_orfaos`), e inflaria o número que o operador lê para
+        # decidir rodar o `--apply --delete`, que é irreversível.
+        assert "item-removido" not in orfaos, "banco REMOVIDO pelo usuário virou alvo de adoção"
+        assert "item-removido-2" not in orfaos, "basta UMA linha com dono para não ser órfão"
+        assert "item-belvo" not in orfaos, "item de outro provider virou alvo da Pluggy"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        for i in ("item-orfao-script", "item-com-conexao", "item-removido",
+                  "item-removido-2", "item-belvo"):
+            _limpa_item(i)
+
+
+def test_script_apagar_na_pluggy_exige_apply(capsys):
+    """`--delete` sozinho já era destrutivo na PRIMEIRA invocação — só o
+    `--apply`, que é o menos destrutivo dos dois, exigia flag."""
+    from scripts.adotar_items_of_orfaos import parse_args
+
+    with pytest.raises(SystemExit):
+        parse_args(["--delete"])
+    assert "--apply" in capsys.readouterr().err
+    assert parse_args(["--apply", "--delete"]).delete is True
+
+
+def test_script_item_explicito_pula_a_lista_menos_o_que_tem_conexao_viva(
+        user_id, monkeypatch, capsys):
+    """A única saída do item que a lista NÃO vê (rastro com dono e sem conexão, de
+    uma adoção que falhou no meio): explícito, operacional, sem reabrir a lista.
+
+    Pular a lista é pular o predicado dela: com um id digitado errado, `--item
+    --apply --delete` apagava na Pluggy — IRREVERSÍVEL — o item de um usuário
+    SAUDÁVEL, e a linha local ficava apontando para item morto, sem aviso na tela.
+    """
+    import scripts.adotar_items_of_orfaos as script
+
+    monkeypatch.setattr(script, "listar_items_orfaos",
+                        lambda: pytest.fail("consultou a lista em vez de usar o --item"))
+    monkeypatch.setattr(script, "_executar",
+                        lambda *a, **k: pytest.fail("mexeu em item COM conexão viva"))
+    monkeypatch.setattr("sys.argv", ["adotar", "--item", "z-preso"])
+
+    script.main()   # dry-run: sem --apply, não escreve nada
+
+    # CONTROLE POSITIVO da guarda abaixo: item SEM conexão local continua passando
+    # — sem ele, tudo passaria numa guarda que recusa todo `--item`.
+    assert "z-preso" in capsys.readouterr().out
+
+    db.save_pluggy_open_finance_item(user_id, {"id": "z-vivo", "status": "UPDATED",
+                                               "connector": {"id": 612, "name": "Nubank"}})
+    try:
+        assert db.get_connections_by_item_id("z-vivo"), "pré-condição: conexão viva"
+        monkeypatch.setattr("sys.argv", ["adotar", "--item", "z-vivo", "--apply", "--delete"])
+        with pytest.raises(SystemExit):
+            script.main()
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-vivo")
+
+
+def test_script_segue_para_o_proximo_item_quando_um_falha(monkeypatch, capsys):
+    """O try cobria só o `get_pluggy_item`: falha do `delete_pluggy_item` no item
+    2 subia e o item 3 nunca era processado — num one-shot que existe para
+    destravar N usuários, esse é o pior desfecho."""
+    import core.services.pluggy as pluggy_svc
+    import scripts.adotar_items_of_orfaos as script
+
+    # A chave da Pluggy FALHANDO: ela era montada uma vez, antes do laço e fora de
+    # todo `try` — 401/timeout dela derrubava o one-shot com ZERO item processado,
+    # o mesmo desfecho que o `try` por item veio evitar.
+    monkeypatch.setattr(pluggy_svc, "create_pluggy_api_key",
+                        lambda: (_ for _ in ()).throw(RuntimeError("Pluggy 401")))
+    monkeypatch.setattr(pluggy_svc, "get_pluggy_item",
+                        lambda i, api_key=None: {"id": i, "status": "UPDATED",
+                                                 "clientUserId": "1",
+                                                 "connector": {"name": "Nubank"}})
+    monkeypatch.setattr(pluggy_svc, "delete_pluggy_item",
+                        lambda item_id, api_key=None: (_ for _ in ()).throw(RuntimeError("Pluggy 500"))
+                        if item_id == "i2" else None)
+
+    asyncio.run(script._executar(["i1", "i2", "i3"], apply=False, delete=True))
+
+    saida = capsys.readouterr().out
+    assert "i3" in saida, f"o loop parou no i2 e nunca chegou no i3:\n{saida}"
+    assert "i1" in saida, f"o run morreu antes do primeiro item:\n{saida}"

--- a/tests/test_cleanup_poisoned_category_rules.py
+++ b/tests/test_cleanup_poisoned_category_rules.py
@@ -61,9 +61,12 @@ def _conta(tabela: str) -> int:
 
 
 def _existe(user_id: int) -> bool:
-    # SELECT local de propósito: importar o `_user_existe` do script faria o
-    # teste morrer de ImportError antes de chegar na asserção que interessa —
-    # e ImportError não prova nada sobre escrita no banco.
+    # SELECT local de propósito, e o motivo é ORÁCULO INDEPENDENTE, não import: a
+    # checagem do script é hoje `db.user_exists` (CLAUDE.md §0.7 — era uma cópia
+    # byte a byte dela), e é justamente o que este teste exercita. Perguntar
+    # "existe?" com a mesma função sob teste tornaria a asserção circular: se
+    # `user_exists` passasse a responder False sempre, o `assert not _existe(...)`
+    # continuaria verde enquanto a linha em `users` ESTIVESSE lá.
     import db
     with db.get_conn() as conn, conn.cursor() as cur:
         cur.execute("select 1 from users where id=%s", (user_id,))

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -468,7 +468,8 @@ def test_reconexao_retenta_o_lock_antes_de_desistir(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
 
-    def _libera_na_segunda(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _libera_na_segunda(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False,
+                           criar_usuario=True, adocao_registro_id=None):
         tentativas.append(item_id)
         if len(tentativas) == 1:
             return None, False
@@ -501,7 +502,8 @@ def test_lock_ocupado_ate_o_fim_recusa_com_503(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
     monkeypatch.setattr(of_routes, "_salva_item_sob_lock",
-                        lambda uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True: (None, False))
+                        lambda uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False,
+                        criar_usuario=True, adocao_registro_id=None: (None, False))
 
     with pytest.raises(HTTPException) as exc:
         asyncio.run(of_routes._grava_reconexao(user_id, {"id": "i"}, "item-preso"))
@@ -652,7 +654,7 @@ def test_prazo_nao_reinicia_a_cada_tentativa(user_id, monkeypatch):
 
     inicio = relogio.agora
 
-    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         orcamentos.append((budget_ms, relogio.agora - inicio))
         # Gasta METADE do que recebeu: se gastasse tudo não haveria 2ª tentativa
         # (e é assim mesmo — `test_prazo_estourado_nem_tenta_de_novo` cobre esse
@@ -717,7 +719,7 @@ def test_backoff_nao_dorme_por_cima_do_que_o_log_gastou(user_id, monkeypatch):
         sonos.append(s)
         relogio.anda(s)
 
-    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         relogio.anda(9.8)
         return None, False
 
@@ -752,7 +754,7 @@ def test_prazo_estourado_nem_tenta_de_novo(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _dorme)
 
-    def _come_tudo(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _come_tudo(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         chamadas.append(budget_ms)
         relogio.anda(30.0)               # estourou o prazo sozinha
         return None, False
@@ -774,7 +776,7 @@ def test_lock_livre_grava_na_primeira_sem_esperar_nada(user_id, monkeypatch):
 
     vistos = []
 
-    def _livre(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _livre(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         vistos.append(budget_ms)
         return {"id": 42}, True
 
@@ -875,9 +877,10 @@ def test_lock_ocupado_de_verdade_ainda_retenta_e_loga(user_id, monkeypatch):
 
     real = of_routes._salva_item_sob_lock
 
-    def _espiao(uid, remote, iid, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _espiao(uid, remote, iid, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         orcamentos.append(budget_ms)
-        return real(uid, remote, iid, budget_ms, tinha_conexao_propria)
+        return real(uid, remote, iid, budget_ms, tinha_conexao_propria,
+                    criar_usuario, adocao_registro_id)
 
     monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _espiao)
 
@@ -1408,7 +1411,7 @@ def test_log_diz_QUAL_falha_e_nao_so_lock_ocupado(
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         if modo == "infra":
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
         return None, False
@@ -1461,7 +1464,7 @@ def test_causa_e_a_da_ultima_tentativa(user_id, monkeypatch):
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         tentativas.append(item_id)
         if len(tentativas) == 1:
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
@@ -1512,7 +1515,7 @@ def test_causa_sobrevive_ao_log_system_event_que_nao_grava(user_id, monkeypatch,
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         raise psycopg.errors.TooManyConnections("sorry, too many clients already")
 
     monkeypatch.setattr(of_routes, "log_system_event", _log_que_engole)
@@ -1557,7 +1560,7 @@ def test_infra_na_1a_que_some_na_2a_ainda_deixa_rastro(user_id, monkeypatch, cap
 
     tentativas = {"n": 0}
 
-    def _falha_depois_grava(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _falha_depois_grava(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         tentativas["n"] += 1
         if tentativas["n"] == 1:
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
@@ -1612,7 +1615,7 @@ def test_log_do_diagnostico_nao_fura_o_prazo(user_id, monkeypatch, caplog):
         logs.append(a[1] if len(a) > 1 else None)
         await asyncio.sleep(5)          # INSERT que não volta
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
         raise psycopg.errors.TooManyConnections("sorry, too many clients already")
 
     monkeypatch.setattr(of_routes, "log_system_event", _log_travado)

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -469,7 +469,7 @@ def test_reconexao_retenta_o_lock_antes_de_desistir(user_id, monkeypatch):
     monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
 
     def _libera_na_segunda(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False,
-                           criar_usuario=True, adocao_registro_id=None):
+                           criar_usuario=True, adocao_registro_id=None, **kw):
         tentativas.append(item_id)
         if len(tentativas) == 1:
             return None, False
@@ -503,7 +503,7 @@ def test_lock_ocupado_ate_o_fim_recusa_com_503(user_id, monkeypatch):
     monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
     monkeypatch.setattr(of_routes, "_salva_item_sob_lock",
                         lambda uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False,
-                        criar_usuario=True, adocao_registro_id=None: (None, False))
+                        criar_usuario=True, adocao_registro_id=None, **kw: (None, False))
 
     with pytest.raises(HTTPException) as exc:
         asyncio.run(of_routes._grava_reconexao(user_id, {"id": "i"}, "item-preso"))
@@ -654,7 +654,7 @@ def test_prazo_nao_reinicia_a_cada_tentativa(user_id, monkeypatch):
 
     inicio = relogio.agora
 
-    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         orcamentos.append((budget_ms, relogio.agora - inicio))
         # Gasta METADE do que recebeu: se gastasse tudo não haveria 2ª tentativa
         # (e é assim mesmo — `test_prazo_estourado_nem_tenta_de_novo` cobre esse
@@ -719,7 +719,7 @@ def test_backoff_nao_dorme_por_cima_do_que_o_log_gastou(user_id, monkeypatch):
         sonos.append(s)
         relogio.anda(s)
 
-    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         relogio.anda(9.8)
         return None, False
 
@@ -754,7 +754,7 @@ def test_prazo_estourado_nem_tenta_de_novo(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _dorme)
 
-    def _come_tudo(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _come_tudo(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         chamadas.append(budget_ms)
         relogio.anda(30.0)               # estourou o prazo sozinha
         return None, False
@@ -776,7 +776,7 @@ def test_lock_livre_grava_na_primeira_sem_esperar_nada(user_id, monkeypatch):
 
     vistos = []
 
-    def _livre(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _livre(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         vistos.append(budget_ms)
         return {"id": 42}, True
 
@@ -877,10 +877,10 @@ def test_lock_ocupado_de_verdade_ainda_retenta_e_loga(user_id, monkeypatch):
 
     real = of_routes._salva_item_sob_lock
 
-    def _espiao(uid, remote, iid, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _espiao(uid, remote, iid, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         orcamentos.append(budget_ms)
         return real(uid, remote, iid, budget_ms, tinha_conexao_propria,
-                    criar_usuario, adocao_registro_id)
+                    criar_usuario, adocao_registro_id, **kw)
 
     monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _espiao)
 
@@ -1411,7 +1411,7 @@ def test_log_diz_QUAL_falha_e_nao_so_lock_ocupado(
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         if modo == "infra":
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
         return None, False
@@ -1464,7 +1464,7 @@ def test_causa_e_a_da_ultima_tentativa(user_id, monkeypatch):
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         tentativas.append(item_id)
         if len(tentativas) == 1:
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
@@ -1515,7 +1515,7 @@ def test_causa_sobrevive_ao_log_system_event_que_nao_grava(user_id, monkeypatch,
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         raise psycopg.errors.TooManyConnections("sorry, too many clients already")
 
     monkeypatch.setattr(of_routes, "log_system_event", _log_que_engole)
@@ -1560,7 +1560,7 @@ def test_infra_na_1a_que_some_na_2a_ainda_deixa_rastro(user_id, monkeypatch, cap
 
     tentativas = {"n": 0}
 
-    def _falha_depois_grava(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _falha_depois_grava(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         tentativas["n"] += 1
         if tentativas["n"] == 1:
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
@@ -1615,7 +1615,7 @@ def test_log_do_diagnostico_nao_fura_o_prazo(user_id, monkeypatch, caplog):
         logs.append(a[1] if len(a) > 1 else None)
         await asyncio.sleep(5)          # INSERT que não volta
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True, adocao_registro_id=None, **kw):
         raise psycopg.errors.TooManyConnections("sorry, too many clients already")
 
     monkeypatch.setattr(of_routes, "log_system_event", _log_travado)

--- a/tests/test_of_concurrency.py
+++ b/tests/test_of_concurrency.py
@@ -468,7 +468,7 @@ def test_reconexao_retenta_o_lock_antes_de_desistir(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
 
-    def _libera_na_segunda(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _libera_na_segunda(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         tentativas.append(item_id)
         if len(tentativas) == 1:
             return None, False
@@ -501,7 +501,7 @@ def test_lock_ocupado_ate_o_fim_recusa_com_503(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _sleep_rapido)
     monkeypatch.setattr(of_routes, "_salva_item_sob_lock",
-                        lambda uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False: (None, False))
+                        lambda uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True: (None, False))
 
     with pytest.raises(HTTPException) as exc:
         asyncio.run(of_routes._grava_reconexao(user_id, {"id": "i"}, "item-preso"))
@@ -652,7 +652,7 @@ def test_prazo_nao_reinicia_a_cada_tentativa(user_id, monkeypatch):
 
     inicio = relogio.agora
 
-    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         orcamentos.append((budget_ms, relogio.agora - inicio))
         # Gasta METADE do que recebeu: se gastasse tudo não haveria 2ª tentativa
         # (e é assim mesmo — `test_prazo_estourado_nem_tenta_de_novo` cobre esse
@@ -717,7 +717,7 @@ def test_backoff_nao_dorme_por_cima_do_que_o_log_gastou(user_id, monkeypatch):
         sonos.append(s)
         relogio.anda(s)
 
-    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _ocupado(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         relogio.anda(9.8)
         return None, False
 
@@ -752,7 +752,7 @@ def test_prazo_estourado_nem_tenta_de_novo(user_id, monkeypatch):
     monkeypatch.setattr(of_routes, "log_system_event", _log)
     monkeypatch.setattr(of_routes.asyncio, "sleep", _dorme)
 
-    def _come_tudo(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _come_tudo(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         chamadas.append(budget_ms)
         relogio.anda(30.0)               # estourou o prazo sozinha
         return None, False
@@ -774,7 +774,7 @@ def test_lock_livre_grava_na_primeira_sem_esperar_nada(user_id, monkeypatch):
 
     vistos = []
 
-    def _livre(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _livre(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         vistos.append(budget_ms)
         return {"id": 42}, True
 
@@ -875,7 +875,7 @@ def test_lock_ocupado_de_verdade_ainda_retenta_e_loga(user_id, monkeypatch):
 
     real = of_routes._salva_item_sob_lock
 
-    def _espiao(uid, remote, iid, budget_ms=None, tinha_conexao_propria=False):
+    def _espiao(uid, remote, iid, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         orcamentos.append(budget_ms)
         return real(uid, remote, iid, budget_ms, tinha_conexao_propria)
 
@@ -1408,7 +1408,7 @@ def test_log_diz_QUAL_falha_e_nao_so_lock_ocupado(
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         if modo == "infra":
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
         return None, False
@@ -1461,7 +1461,7 @@ def test_causa_e_a_da_ultima_tentativa(user_id, monkeypatch):
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         tentativas.append(item_id)
         if len(tentativas) == 1:
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
@@ -1512,7 +1512,7 @@ def test_causa_sobrevive_ao_log_system_event_que_nao_grava(user_id, monkeypatch,
     async def _dorme(_s):
         return None
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         raise psycopg.errors.TooManyConnections("sorry, too many clients already")
 
     monkeypatch.setattr(of_routes, "log_system_event", _log_que_engole)
@@ -1557,7 +1557,7 @@ def test_infra_na_1a_que_some_na_2a_ainda_deixa_rastro(user_id, monkeypatch, cap
 
     tentativas = {"n": 0}
 
-    def _falha_depois_grava(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _falha_depois_grava(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         tentativas["n"] += 1
         if tentativas["n"] == 1:
             raise psycopg.errors.TooManyConnections("sorry, too many clients already")
@@ -1612,7 +1612,7 @@ def test_log_do_diagnostico_nao_fura_o_prazo(user_id, monkeypatch, caplog):
         logs.append(a[1] if len(a) > 1 else None)
         await asyncio.sleep(5)          # INSERT que não volta
 
-    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False):
+    def _falha(uid, remote, item_id, budget_ms=None, tinha_conexao_propria=False, criar_usuario=True):
         raise psycopg.errors.TooManyConnections("sorry, too many clients already")
 
     monkeypatch.setattr(of_routes, "log_system_event", _log_travado)

--- a/tests/test_of_webhook_adopt.py
+++ b/tests/test_of_webhook_adopt.py
@@ -9,7 +9,9 @@ docstring de `frontend/routes/open_finance._adota_item_orfao`, "Por que existe".
 
 CONTROLE NEGATIVO do grupo:
   • `test_adocao_desligada_volta_a_deixar_o_dono_sem_linha` desliga
-    `_adota_item_orfao` e o caso do teste positivo volta a `connections == []`.
+    `_adota_item_orfao` e o caso do teste positivo volta a `connections == []`;
+  • `test_conta_apagada_no_meio_da_adocao_nao_ressuscita` tem o seu: tirar o
+    `criar_usuario=False` da adoção e ele volta a achar a conta recriada.
 CONTROLE POSITIVO (a adoção RESTRINGE nada, mas ADICIONA escrita num caminho de
 posse): `test_item_sem_client_user_id_mantem_o_comportamento_de_hoje` prova que
 o ramo antigo continua de pé quando não há dono a resolver.
@@ -27,7 +29,8 @@ from test_of_item_ownership import _auth, _webhook, eventos  # noqa: F401
 # Helpers de _guards, como o `_dupe.py` já fazia: eram cópias byte a byte aqui
 # (CLAUDE.md §0.1). `_limpa_item` apaga registry E conexão — antes havia um
 # `_limpa_registry` local que só apagava metade, com outro nome.
-from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
+from test_of_webhook_adopt_guards import (  # noqa: F401
+    _existe_user, _limpa_item, _mock_item, _registry, webhook_pluggy)
 
 
 def test_webhook_adota_item_orfao_e_a_tela_passa_a_mostrar_o_banco(
@@ -213,3 +216,50 @@ def test_adocao_nao_agenda_sync_de_item_que_a_pluggy_ainda_esta_montando(
     finally:
         db.disconnect_open_finance_connection(user_id)
         _limpa_item("item-updating")
+
+
+def test_conta_apagada_no_meio_da_adocao_nao_ressuscita(monkeypatch, eventos, webhook_pluggy):
+    """A JANELA entre o `user_exists` e a escrita da conexão (Codex #313, P1).
+
+    `user_exists` lê em transação própria, e `register_item`/`save_pluggy_open_
+    finance_item` escrevem em outras duas. O interleaving que o Codex nomeou:
+    rastro gravado → `delete_user_data` roda INTEIRO (a cascata leva o rastro
+    junto) → a escrita da conexão. Aqui a exclusão é disparada de dentro do
+    `register_item` justamente para cair nessa ordem, sem sleep.
+
+    Com `ensure_user_tx` no caminho, essa última escrita RECRIAVA a linha de
+    `users` que a LGPD acabou de apagar e pendurava a conexão nela — a guarda de
+    identidade não alcança, porque no instante em que ela leu a conta existia.
+    Quem alcança é a FK, e só com `criar_usuario=False`.
+    """
+    fantasma = 987654321988
+    db.ensure_user(fantasma)
+    _mock_item(monkeypatch, fantasma)
+
+    real_register = of_routes.register_item
+
+    def _apaga_a_conta_no_meio(*a, **k):
+        rid = real_register(*a, **k)
+        with get_conn() as c:      # a exclusão commita DEPOIS do user_exists
+            c.execute("delete from users where id=%s", (fantasma,))
+            c.commit()
+        return rid
+
+    monkeypatch.setattr(of_routes, "register_item", _apaga_a_conta_no_meio)
+    try:
+        r = _webhook(TestClient(dashboard.app), "item/created", "item-lgpd-corrida")
+
+        assert r.status_code == 200, f"{r.status_code}: a Pluggy retenta em laço"
+        assert not _existe_user(fantasma), (
+            "a escrita da conexão RECRIOU a conta que a exclusão apagou no meio")
+        assert db.get_connections_by_item_id("item-lgpd-corrida") == [], \
+            "conexão pendurada numa conta que não existe mais"
+        motivos = [e["details"].get("motivo") for e in eventos
+                   if e["event"] == "of_webhook_adopt_skipped"]
+        assert motivos == ["ForeignKeyViolation"], (
+            f"a FK tinha de ser quem recusa nesta janela: {motivos}")
+    finally:
+        _limpa_item("item-lgpd-corrida")
+        with get_conn() as c:
+            c.execute("delete from users where id=%s", (fantasma,))
+            c.commit()

--- a/tests/test_of_webhook_adopt.py
+++ b/tests/test_of_webhook_adopt.py
@@ -1,0 +1,215 @@
+"""G5b — o webhook ADOTA o item órfão que ninguém reivindicou.
+
+Continuação de `test_of_item_ownership.py` (helpers de lá e de
+`test_of_webhook_adopt_guards.py`; separado só porque o arquivo bateria no teto
+de 350 linhas do `test_max_lines_python.py`).
+
+O buraco que estes testes fecham está escrito em UM lugar (CLAUDE.md §0.7): a
+docstring de `frontend/routes/open_finance._adota_item_orfao`, "Por que existe".
+
+CONTROLE NEGATIVO do grupo:
+  • `test_adocao_desligada_volta_a_deixar_o_dono_sem_linha` desliga
+    `_adota_item_orfao` e o caso do teste positivo volta a `connections == []`.
+CONTROLE POSITIVO (a adoção RESTRINGE nada, mas ADICIONA escrita num caminho de
+posse): `test_item_sem_client_user_id_mantem_o_comportamento_de_hoje` prova que
+o ramo antigo continua de pé quando não há dono a resolver.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.open_finance as of_routes
+from db.connection import get_conn
+from test_of_item_ownership import _auth, _webhook, eventos  # noqa: F401
+# Helpers de _guards, como o `_dupe.py` já fazia: eram cópias byte a byte aqui
+# (CLAUDE.md §0.1). `_limpa_item` apaga registry E conexão — antes havia um
+# `_limpa_registry` local que só apagava metade, com outro nome.
+from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
+
+
+def test_webhook_adota_item_orfao_e_a_tela_passa_a_mostrar_o_banco(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        resp = _webhook(client, "item/created", "item-orfao")
+        assert resp.status_code == 200, resp.text
+
+        linhas = db.get_connections_by_item_id("item-orfao")
+        assert len(linhas) == 1 and int(linhas[0]["user_id"]) == user_id, linhas
+        assert webhook_pluggy == ["item-orfao"], "o sync não precisa mais do navegador"
+        assert [r["origin"] for r in _registry("item-orfao")] == ["webhook_adopt"]
+
+        snap = client.get(f"/open-finance/{user_id}", headers=_auth(client, user_id)).json()
+        assert [c["ui"]["state"] for c in snap["connections"]] == ["updating"], snap
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("item-orfao")
+
+
+def test_adocao_desligada_volta_a_deixar_o_dono_sem_linha(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """CONTROLE NEGATIVO, injetado no caso que estava VERDE (o de cima)."""
+    _mock_item(monkeypatch, user_id)
+
+    async def _sem_adocao(item_id, last_event=None):
+        return None
+    monkeypatch.setattr(of_routes, "_adota_item_orfao", _sem_adocao)
+    try:
+        assert _webhook(TestClient(dashboard.app), "item/created", "item-orfao").status_code == 200
+        assert db.get_connections_by_item_id("item-orfao") == [], "sem o fix, nenhuma linha nasce"
+        assert webhook_pluggy == []
+        assert any(e["event"] == "of_webhook_item_unknown" for e in eventos), eventos
+    finally:
+        _limpa_item("item-orfao")
+
+
+def test_adocao_respeita_o_dono_remoto_e_nao_vaza_para_o_usuario_errado(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """O dono vem do `clientUserId` REMOTO — o corpo do webhook não decide posse."""
+    dono = user_id + 1
+    db.ensure_user(dono)
+    _mock_item(monkeypatch, dono)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "item-do-outro").status_code == 200
+
+        linhas = db.get_connections_by_item_id("item-do-outro")
+        assert len(linhas) == 1 and int(linhas[0]["user_id"]) == dono, linhas
+
+        snap = client.get(f"/open-finance/{user_id}", headers=_auth(client, user_id)).json()
+        assert snap["connections"] == [], "item de outra conta não pode aparecer aqui"
+    finally:
+        db.disconnect_open_finance_connection(dono)
+        with get_conn() as c:
+            c.execute("delete from users where id=%s", (dono,))
+            c.commit()
+        _limpa_item("item-do-outro")
+
+
+def test_item_sem_client_user_id_mantem_o_comportamento_de_hoje(
+        monkeypatch, eventos, webhook_pluggy):
+    monkeypatch.setattr(of_routes, "get_pluggy_item",
+                        lambda item_id, api_key=None: {"id": item_id, "status": "UPDATING"})
+    try:
+        r = _webhook(TestClient(dashboard.app), "item/created", "item-sem-dono")
+        assert r.status_code == 200, r.text
+        assert db.get_connections_by_item_id("item-sem-dono") == []
+        assert webhook_pluggy == []
+        assert any(e["event"] == "of_webhook_item_unknown" for e in eventos), eventos
+        assert _registry("item-sem-dono") == [{"origin": "webhook", "user_id": None}]
+    finally:
+        _limpa_item("item-sem-dono")
+
+
+def test_teto_de_bancos_estourado_nao_adota_e_o_webhook_responde_200(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """402 para a Pluggy viraria retentativa em laço: o webhook engole e registra."""
+    from fastapi import HTTPException
+
+    _mock_item(monkeypatch, user_id)
+
+    async def _estoura(uid, new_item_id=None):
+        raise HTTPException(status_code=402, detail={"code": "OF_BANK_LIMIT"})
+    monkeypatch.setattr(of_routes, "_enforce_bank_limit", _estoura)
+    try:
+        r = _webhook(TestClient(dashboard.app), "item/created", "item-no-teto")
+        assert r.status_code == 200, r.text
+        assert db.get_connections_by_item_id("item-no-teto") == [], "nada podia ser gravado"
+        assert webhook_pluggy == []
+        pulado = [e for e in eventos if e["event"] == "of_webhook_adopt_skipped"]
+        assert pulado, eventos
+        # `motivo="HTTPException"` sozinho é o nome de TRÊS desfechos com ações
+        # de operador diferentes — 402 (teto do plano), 409 (o estado sumiu) e
+        # 503 (lock ocupado). Sem o status/detail, o log não separa nenhum deles.
+        assert pulado[0]["details"]["error"].startswith("402"), pulado[0]["details"]
+        assert "OF_BANK_LIMIT" in pulado[0]["details"]["error"], pulado[0]["details"]
+        assert [r["origin"] for r in _registry("item-no-teto")] == ["webhook"]
+    finally:
+        _limpa_item("item-no-teto")
+
+
+def test_adotado_o_delete_enumera_e_apaga_o_item_na_pluggy(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """É ESTE assert que prova que o dono consegue reconectar.
+
+    Sem a linha local, `list_pluggy_item_ids` devolvia `[]`, o item continuava
+    vivo na Pluggy e o `avoidDuplicates` do connect token recusava item novo.
+    """
+    _mock_item(monkeypatch, user_id)
+    apagados: list[str] = []
+    monkeypatch.setattr(of_routes, "create_pluggy_api_key", lambda: "api-key-fake")
+    monkeypatch.setattr(of_routes, "delete_pluggy_item",
+                        lambda item_id, api_key=None: apagados.append(item_id))
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "item-travado").status_code == 200
+
+        resp = client.delete(f"/open-finance/{user_id}", headers=_auth(client, user_id))
+
+        assert resp.status_code == 200, resp.text
+        assert apagados == ["item-travado"], "o item ficaria órfão na Pluggy"
+        assert db.get_connections_by_item_id("item-travado") == []
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("item-travado")
+
+
+def test_pluggy_item_depois_da_adocao_nao_duplica_a_conexao(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """O webhook adota e DEPOIS o `onSuccess` do widget posta o mesmo item.
+
+    As duas escritas passam por `_grava_reconexao` → `pluggy_item_lock` do MESMO
+    item, e o upsert casa em `uq_of_conn_provider_item`. Uma linha só.
+
+    NÃO é a corrida (isto é sequencial, num processo só) — o nome antigo dizia
+    "corrida" e o assert final (`len == 1`) ficava VERDE com a adoção desligada,
+    porque o POST sozinho também escreve uma linha. O assert do MEIO é o que
+    discrimina: sem adoção, ali há zero linhas.
+    """
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "item-corrida").status_code == 200
+        assert len(db.get_connections_by_item_id("item-corrida")) == 1, \
+            "pré-condição: a adoção gravou a linha ANTES do POST do navegador"
+
+        resp = client.post(f"/open-finance/{user_id}/pluggy-item",
+                           json={"item": {"id": "item-corrida"}},
+                           headers=_auth(client, user_id))
+
+        assert resp.status_code == 200, resp.text
+        assert len(db.get_connections_by_item_id("item-corrida")) == 1
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("item-corrida")
+
+
+def test_adocao_nao_agenda_sync_de_item_que_a_pluggy_ainda_esta_montando(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Em `item/created` o status normal é `CREATED`/`UPDATING`: o item ainda não
+    tem conta nem transação, e pode estar esperando MFA.
+
+    Agendar sync ali é uma task esperando o item sair de UPDATING para achar
+    zero conta. O `item/updated` seguinte sincroniza sozinho — e a essa altura a
+    conexão JÁ existe, então ele entra pelo caminho comum (`len(conexoes) == 1`),
+    que é o assert final aqui.
+    """
+    monkeypatch.setattr(of_routes, "get_pluggy_item",
+                        lambda item_id, api_key=None: {"id": item_id, "status": "UPDATING",
+                                                       "clientUserId": str(user_id),
+                                                       "connector": {"id": 612, "name": "Nubank"}})
+    try:
+        assert _webhook(TestClient(dashboard.app), "item/created", "item-updating").status_code == 200
+        assert len(db.get_connections_by_item_id("item-updating")) == 1, "a adoção acontece"
+        assert webhook_pluggy == [], "sync agendado num item que a Pluggy ainda está montando"
+
+        assert _webhook(TestClient(dashboard.app), "item/updated", "item-updating").status_code == 200
+        assert webhook_pluggy == ["item-updating"], (
+            "o evento seguinte tinha de sincronizar pelo caminho comum")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("item-updating")

--- a/tests/test_of_webhook_adopt_503.py
+++ b/tests/test_of_webhook_adopt_503.py
@@ -1,0 +1,291 @@
+"""G5f — o MECANISMO do desfazimento da reivindicação no 503 de `_grava_reconexao`.
+
+Separado de `test_of_webhook_adopt_race.py` por assunto (e porque aquele estava a
+346 linhas com teto de 350, `tests/test_max_lines_python.py`): lá ficam as
+INTERCALAÇÕES de duas entregas concorrentes; aqui fica a pergunta que o
+desfazimento faz — "alguma tentativa do prazo pode ter ESCRITO?" — e as duas
+metades da resposta.
+
+  • PRAZO INTEIRO — a marca é LATCHED, e por isso não é `causa is None`, que é só
+    a da ÚLTIMA tentativa (`test_causa_e_a_da_ultima_tentativa`).
+  • PRECISÃO (Codex #313, P1) — quem responde é a marca feita na linha ANTES do
+    `save_pluggy_open_finance_item`, não o TIPO da exceção. `OperationalError`
+    sai igual do commit ambíguo e de tudo que roda ANTES da escrita: o
+    `psycopg.connect` dedicado do `pluggy_item_lock` (medido: host inalcançável
+    → `psycopg.OperationalError` subindo do `with`), o `set_config` inicial
+    (medido: backend derrubado no meio → `AdminShutdown`, subclasse de
+    `OperationalError`) e as leituras das duas revalidações. Preservar a
+    reivindicação nessas reconstruía o estado TERMINAL que o P0 fechou: zero
+    conexões + rastro com dono, a 1ª guarda de `_adota_item_orfao` recusando a
+    retentativa e o `scripts/adotar_items_of_orfaos.py` sem enxergar a linha
+    (o filtro dele exclui rastro com dono).
+
+CONTROLES do grupo (medidos, não deduzidos):
+  • negativo (a PRECISÃO) — voltar o latch para "todo `OperationalError` é
+    escrita incerta" (marcar no `except` de `_grava_reconexao` em vez de ler a
+    marca) → vermelho em `test_infra_ANTES_da_escrita_nao_deixa_reivindicacao`
+    (o rastro sobra e a retentativa é recusada: 0 conexões) e em
+    `[pre-pre]`/`[pre-escrita]`... — o `[pre-pre]` é a linha do Codex;
+  • negativo (o LATCH) — trocar `not escrita_tentada` por `causa is None` →
+    vermelho em `[escrita-ocupado]`, a única linha que separa os dois gates;
+  • negativo (o desfazimento inteiro) — `if False and ...` na condição →
+    vermelho em `[so-lock]` e `[pre-pre]`;
+  • positivo — `test_infra_DENTRO_da_escrita_preserva_a_reivindicacao` roda o
+    `_salva_item_sob_lock` REAL com o lock REAL e exige que a reivindicação FIQUE:
+    um conserto que apagasse sempre (o over-correct óbvio) fica vermelho nele —
+    medido: alargar o `except (PoolTimeout, PoolClosed)` para
+    `psycopg.OperationalError` deixa SÓ ele vermelho;
+  • negativo (o POOL) — tirar o `except (PoolTimeout, PoolClosed)` do
+    `_salva_item_sob_lock` → vermelho em
+    `test_pool_esgotado_no_get_conn_nao_deixa_reivindicacao`, que é o membro mais
+    provável da classe pré-escrita: o `get_conn` do `save_...` é a primeira linha
+    com I/O dele, e o piso de 1 ms do `resto` manda `get_conn(timeout=0.001)`
+    quando a espera do lock comeu o prazo.
+
+  • negativo (o `pop()`) — trocar `escrita_tentada.pop()` por `.clear()` →
+    vermelho em `test_pool_na_2a_tentativa_nao_apaga_a_marca_AMBIGUA_da_1a`, o
+    único caso em que as duas tentativas marcam e só uma desfaz.
+
+A invariante que sustenta esse discriminador — `get_conn` ser a ÚNICA aquisição
+de pool do `save_pluggy_open_finance_item` — tem guarda própria aqui
+(`test_o_save_tem_uma_unica_aquisicao_de_pool`): um segundo `get_conn` DEPOIS do
+upsert tornaria `PoolTimeout` pós-escrita, e aí desfazer viraria adoção dupla.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import textwrap
+from contextlib import contextmanager
+
+import psycopg
+import pytest
+from fastapi import HTTPException
+from psycopg_pool import PoolTimeout
+
+import db
+import frontend.routes.open_finance as of_routes
+from db.open_finance import save_pluggy_open_finance_item
+from test_of_item_ownership import SEGREDO, _item_remoto, eventos  # noqa: F401
+from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
+
+
+@pytest.mark.parametrize("sequencia, sobra", [
+    (["ocupado", "ocupado"], False),   # nenhuma passou do `if not locked`: desfaz
+    (["escrita", "ocupado"], True),    # a 1ª pode ter COMMITADO — separa do `causa is None`
+    (["ocupado", "escrita"], True),    # idem, e aqui `causa is None` seguraria também
+    (["pre", "pre"], False),           # Codex #313: infra ANTES da escrita, desfaz
+    (["pre", "escrita"], True),        # a 2ª chegou a escrever: ambíguo, preserva
+], ids=["so-lock", "escrita-ocupado", "ocupado-escrita", "pre-pre", "pre-escrita"])
+def test_desfazimento_do_503_olha_o_prazo_INTEIRO(user_id, monkeypatch, eventos,
+                                                  sequencia, sobra):
+    """A tabela dos dois eixos: QUANDO no prazo, e ONDE na função.
+
+    `escrita` é o `OperationalError` que sobe de DENTRO do
+    `save_pluggy_open_finance_item` (o stub marca a lista, como o código real faz
+    na linha anterior à chamada); `pre` é o MESMO tipo de erro subindo do que roda
+    antes dela — lock, `set_config`, revalidações — e aí a escrita provadamente
+    não aconteceu. A distinção não existia: os dois eram "infra" e os dois
+    preservavam.
+    """
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 3000)
+    item, chamadas = "z-prazo-" + "-".join(sequencia), []
+
+    def _script(*a, escrita_tentada=None):
+        acao = sequencia[min(len(chamadas), len(sequencia) - 1)]
+        chamadas.append(acao)
+        if acao == "escrita":
+            escrita_tentada.append(True)    # a execução CHEGOU ao `save_...`
+        if acao in ("escrita", "pre"):
+            raise psycopg.errors.TooManyConnections("sorry, too many clients already")
+        return None, False              # lock ocupado: a escrita nem foi TENTADA
+
+    monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _script)
+    registro = db.register_item(user_id, provider_item_id=item, origin="webhook_adopt")
+    try:
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(of_routes._grava_reconexao(
+                user_id, {"id": item}, item, criar_usuario=False,
+                adocao_registro_id=registro))
+        assert exc.value.status_code == 503
+        assert chamadas == sequencia, chamadas
+        assert bool(_registry(item)) is sobra, f"{sequencia}: {_registry(item)}"
+    finally:
+        _limpa_item(item)
+
+
+def test_infra_ANTES_da_escrita_nao_deixa_reivindicacao(user_id, monkeypatch, eventos,
+                                                        webhook_pluggy):
+    """Codex #313, P1 — e aqui o `_salva_item_sob_lock` é o REAL.
+
+    O `pluggy_item_lock` estoura na ENTRADA, que é o que o `psycopg.connect`
+    dedicado dele faz quando o banco recusa conexão (medido: host inalcançável →
+    `psycopg.OperationalError` subindo do `with`; backend derrubado no meio do
+    `set_config` → `AdminShutdown`). A escrita não foi tentada, então a
+    reivindicação que o `register_item` acabou de commitar TEM de sumir — senão a
+    retentativa do `item/created` bate na 1ª guarda (rastro com dono) e o usuário
+    fica sem banco e sem saída pelo produto.
+
+    O 2º ato é o que mede isso: com a infra de volta, a MESMA entrega adota.
+    """
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 1000)
+    real_lock, quebrado = of_routes.pluggy_item_lock, [True]
+
+    @contextmanager
+    def _lock_sem_banco(item_id, **kw):
+        if quebrado[0]:
+            raise psycopg.errors.TooManyConnections("sorry, too many clients already")
+        with real_lock(item_id, **kw) as got:
+            yield got
+
+    monkeypatch.setattr(of_routes, "pluggy_item_lock", _lock_sem_banco)
+    try:
+        assert asyncio.run(of_routes._adota_item_orfao("z-pre-escrita", "item/created")) is None
+        assert db.get_connections_by_item_id("z-pre-escrita") == []
+        assert _registry("z-pre-escrita") == [], _registry("z-pre-escrita")
+
+        quebrado[0] = False             # a infra voltou: a retentativa da Pluggy
+        assert asyncio.run(
+            of_routes._adota_item_orfao("z-pre-escrita", "item/created")) == user_id
+        assert len(db.get_connections_by_item_id("z-pre-escrita")) == 1, \
+            "a retentativa foi recusada: 0 conexões, o usuário sem banco e sem saída"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-pre-escrita")
+
+
+def test_infra_DENTRO_da_escrita_preserva_a_reivindicacao(user_id, monkeypatch, eventos,
+                                                          webhook_pluggy):
+    """O outro lado, com o MESMO caminho real: só o `save_...` falha.
+
+    O lock é o de verdade e a marca é a do código (linha anterior à chamada), não
+    a de um stub. Desfecho DESCONHECIDO — o upsert pode ter commitado e a resposta
+    ter se perdido —, e apagar a reivindicação aqui soltaria uma segunda adoção
+    por cima de uma conexão que existe. CONTROLE POSITIVO do grupo: um conserto
+    que apagasse sempre deixa este teste vermelho.
+    """
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 1000)
+
+    def _escrita_estoura(*a, **kw):
+        raise psycopg.errors.TooManyConnections("sorry, too many clients already")
+
+    monkeypatch.setattr(of_routes, "save_pluggy_open_finance_item", _escrita_estoura)
+    try:
+        assert asyncio.run(of_routes._adota_item_orfao("z-na-escrita", "item/created")) is None
+        assert db.get_connections_by_item_id("z-na-escrita") == []
+        assert [r["origin"] for r in _registry("z-na-escrita")] == ["webhook_adopt"], \
+            "a reivindicação sumiu num desfecho AMBÍGUO"
+    finally:
+        _limpa_item("z-na-escrita")
+
+
+def test_pool_esgotado_no_get_conn_nao_deixa_reivindicacao(user_id, monkeypatch, eventos,
+                                                           webhook_pluggy):
+    """O membro MAIS PROVÁVEL da classe pré-escrita — e o que o tipo do erro
+    esconde melhor.
+
+    `PoolTimeout` é subclasse de `psycopg.OperationalError` (medido:
+    PoolTimeout → OperationalError → DatabaseError), então até aqui ele saía do
+    `save_...` com a marca já feita e a reivindicação FICAVA — rastro
+    `webhook_adopt` com dono e ZERO conexões, o estado terminal que o P0 fechou.
+    E não precisa de infra doente: com o piso de 1 ms do `resto`, uma espera longa
+    pelo lock manda `get_conn(timeout=0.001)` — medido em 2026-09-08 no Postgres
+    local SAUDÁVEL: pool frio → `PoolTimeout` (1,4 ms numa medição, 4,2 ms em
+    outra; o tempo varia com a carga, o desfecho não), pool quente → ok.
+
+    O 2º ato mede o que importa: com o pool de volta, a MESMA entrega adota.
+    """
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 1000)
+    real_save, sem_pool = of_routes.save_pluggy_open_finance_item, [True]
+
+    def _save(*a, **kw):
+        if sem_pool[0]:
+            raise PoolTimeout("couldn't get a connection after 0.00 sec")
+        return real_save(*a, **kw)
+
+    monkeypatch.setattr(of_routes, "save_pluggy_open_finance_item", _save)
+    try:
+        assert asyncio.run(of_routes._adota_item_orfao("z-pool", "item/created")) is None
+        assert db.get_connections_by_item_id("z-pool") == []
+        assert _registry("z-pool") == [], _registry("z-pool")
+
+        sem_pool[0] = False             # o pool respirou: a retentativa da Pluggy
+        assert asyncio.run(of_routes._adota_item_orfao("z-pool", "item/created")) == user_id
+        assert len(db.get_connections_by_item_id("z-pool")) == 1, \
+            "a retentativa foi recusada: 0 conexões, o usuário sem banco e sem saída"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-pool")
+
+
+def test_pool_na_2a_tentativa_nao_apaga_a_marca_AMBIGUA_da_1a(user_id, monkeypatch,
+                                                              eventos, webhook_pluggy):
+    """Por que o desfazimento é `pop()` e não `clear()`.
+
+    A lista é do PRAZO INTEIRO e as duas tentativas escrevem nela. Aqui a 1ª
+    chega ao `save_...` e morre de commit AMBÍGUO (`TooManyConnections`, que o
+    `except (PoolTimeout, PoolClosed)` não pega, então a marca dela FICA); a 2ª
+    chega e leva `PoolTimeout`, provadamente pré-escrita. `pop()` desfaz só a
+    marca DELA e a reivindicação continua — `clear()` levaria a da 1ª junto e
+    apagaria uma reivindicação de desfecho desconhecido, soltando a segunda
+    adoção por cima de uma conexão que pode existir: a ressurreição que é o P1.
+
+    O `_salva_item_sob_lock` é o REAL, com o lock REAL — um caso na tabela
+    parametrizada NÃO serviria, porque lá o stub substitui a função inteira e o
+    `pop()` de produção nunca roda. Medido: `pop()` → `clear()` deixava o grupo
+    OF inteiro VERDE (315 passed), com o comportamento certo e sem controle.
+
+    O `assert` das DUAS chamadas é o que impede o teste de passar à toa: com uma
+    tentativa só, `pop()` e `clear()` dão o mesmo resultado.
+    """
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 2000)
+    chamadas = []
+
+    def _save(*a, **kw):
+        chamadas.append(1)
+        if len(chamadas) == 1:
+            raise psycopg.errors.TooManyConnections("commit de desfecho DESCONHECIDO")
+        raise PoolTimeout("couldn't get a connection after 0.00 sec")
+
+    monkeypatch.setattr(of_routes, "save_pluggy_open_finance_item", _save)
+    try:
+        assert asyncio.run(of_routes._adota_item_orfao("z-pop", "item/created")) is None
+        assert len(chamadas) == 2, f"as duas tentativas têm de rodar: {chamadas}"
+        assert db.get_connections_by_item_id("z-pop") == []
+        assert [r["origin"] for r in _registry("z-pop")] == ["webhook_adopt"], \
+            "a marca AMBÍGUA da 1ª tentativa foi apagada pelo desfazimento da 2ª"
+    finally:
+        _limpa_item("z-pop")
+
+
+def test_o_save_tem_uma_unica_aquisicao_de_pool():
+    """A invariante que dá validade ao `except (PoolTimeout, PoolClosed)`.
+
+    Se um dia aparecer um SEGUNDO `get_conn` no `save_pluggy_open_finance_item`,
+    `PoolTimeout` deixa de provar "pré-escrita" — poderia vir depois de um upsert
+    commitado, e aí desfazer a reivindicação solta uma segunda adoção por cima de
+    uma conexão que existe. Este teste é o que faz esse dia aparecer em vermelho
+    aqui, e não em produção (§0.7: a regra mora em dois arquivos, um teste
+    compara os dois).
+
+    `unparse().split('.')` e não `n.func.id`: a forma `modulo.get_conn(...)` é um
+    `ast.Attribute` e o `.id` não existe nela — a guarda passava verde num
+    segundo `get_conn` escrito assim.
+
+    CEGO a uma classe, de propósito: ele lê o corpo do `save_...`, então uma
+    função CHAMADA por ele que adquira o pool por dentro passa. Hoje o corpo tem
+    um `with get_conn(...)` só, e o `ensure_user_tx` recebe o cursor pronto — se
+    um dia entrar chamada nova aqui, a pergunta "ela pega conexão?" é de quem
+    escreve, não deste teste.
+    """
+    arvore = ast.parse(textwrap.dedent(inspect.getsource(save_pluggy_open_finance_item)))
+    aquisicoes = [n for n in ast.walk(arvore)
+                  if isinstance(n, ast.Call)
+                  and ast.unparse(n.func).split(".")[-1] == "get_conn"]
+    assert len(aquisicoes) == 1, f"{len(aquisicoes)} aquisições de pool no save_"

--- a/tests/test_of_webhook_adopt_dupe.py
+++ b/tests/test_of_webhook_adopt_dupe.py
@@ -48,6 +48,10 @@ CONTROLES do grupo:
   • positivo: `test_rastro_sem_dono_nao_bloqueia_a_adocao_legitima` prova que a
     guarda nova recusa por DONO, não por "tem rastro" — senão ela mataria
     justamente o usuário que o PR veio destravar.
+  • negativo (janela do handoff): tirar o `and e["created_at"] >= handoff_desde`
+    → `test_reconexao_muito_depois_da_adocao_audita` vermelho (0 eventos da
+    rota), num caso VERDE hoje; o positivo do par é o handoff LEGÍTIMO
+    (`test_webhook_antes_do_navegador_audita_uma_vez_por_conexao`, guards);
 """
 
 from __future__ import annotations
@@ -301,3 +305,46 @@ def test_details_escalar_no_rastro_nao_derruba_o_post(
             c.commit()
         db.disconnect_open_finance_connection(user_id)
         _limpa_item("z-escalar")
+
+
+def test_reconexao_muito_depois_da_adocao_audita(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Adotado pelo webhook, navegador NUNCA postou: o registry fica sem
+    `pluggy_item` PARA SEMPRE, e toda reconexão futura cai no predicado. Sem
+    correlação de TEMPO, a de dias depois consumia a auditoria histórica como
+    duplicata da adoção de agora: a 1ª reconexão real sumia do log (Codex #313).
+
+    O relógio não é tocado: quem anda é o `created_at` do evento, 2 dias para
+    trás contra uma janela de 1h — sem borda, sem flake. O evento velho continua
+    DENTRO dos 50 últimos: o que discrimina é a janela, não o limite da consulta.
+    """
+    from core.audit import AuditEvent, list_audit_events
+
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "z-tarde").status_code == 200
+        assert [r["origin"] for r in _registry("z-tarde")] == ["webhook_adopt"], \
+            "pré-condição: adotou e o navegador nunca postou (sem `pluggy_item`)"
+        with get_conn() as c:
+            c.execute("update audit_events set created_at = now() - interval '2 days' "
+                      "where user_id = %s and event = %s",
+                      (user_id, AuditEvent.OPEN_FINANCE_CONNECTED))
+            c.commit()
+
+        r = client.post(f"/open-finance/{user_id}/pluggy-item",
+                        json={"item": {"id": "z-tarde"}}, headers=_auth(client, user_id))
+        assert r.status_code == 200, r.text
+
+        da_rota = [e for e in list_audit_events(user_id, limit=50)
+                   if e["event"] == AuditEvent.OPEN_FINANCE_CONNECTED
+                   and isinstance(e.get("details"), dict)
+                   and e["details"].get("item_id") == "z-tarde"
+                   and e["details"].get("origin") != "webhook_adopt"]
+        assert len(da_rota) == 1, (
+            f"{len(da_rota)} eventos da rota: a 1ª reconexão real sumiu de "
+            "'Atividade da conta' — a auditoria de 2 dias atrás foi lida como "
+            "duplicata DESTE POST")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-tarde")

--- a/tests/test_of_webhook_adopt_dupe.py
+++ b/tests/test_of_webhook_adopt_dupe.py
@@ -36,6 +36,15 @@ CONTROLES do grupo:
     _vez` vermelho, e o `test_webhook_antes_do_navegador_audita_uma_vez_por_
     conexao` (guards) continua verde — é ele que cobre os outros dois casos:
     conexão nova COM webhook antes, e conexão nova SEM webhook antes;
+  • negativo (evidência durável): tirar o `if conexao_recem_adotada:` que exige a
+    auditoria do webhook PERSISTIDA →
+    `test_auditoria_engolida_no_webhook_nao_apaga_a_da_rota` e
+    `test_reconexao_de_conexao_anterior_ao_registry_audita` vermelhos (0 eventos),
+    nos dois casos que estão VERDES hoje;
+  • negativo (`details` escalar): voltar o `isinstance(e.get("details"), dict)`
+    para `(e.get("details") or {})` →
+    `test_details_escalar_no_rastro_nao_derruba_o_post` vermelho
+    (`AttributeError`), com os outros casos do arquivo verdes;
   • positivo: `test_rastro_sem_dono_nao_bloqueia_a_adocao_legitima` prova que a
     guarda nova recusa por DONO, não por "tem rastro" — senão ela mataria
     justamente o usuário que o PR veio destravar.
@@ -48,6 +57,7 @@ import asyncio
 import db
 import frontend.finance_bot_websocket_custom as dashboard
 import frontend.routes.open_finance as of_routes
+from db.connection import get_conn
 from fastapi.testclient import TestClient
 from test_of_item_ownership import SEGREDO, _auth, _item_remoto, _webhook, eventos  # noqa: F401
 from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
@@ -188,3 +198,106 @@ def test_segunda_entrega_inteira_dentro_do_get_da_primeira_audita_uma_vez(
     finally:
         db.disconnect_open_finance_connection(user_id)
         _limpa_item("z-corrida")
+
+
+def test_auditoria_engolida_no_webhook_nao_apaga_a_da_rota(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """`record_audit_event` ENGOLE falha de banco (core/audit.py:152).
+
+    Se o insert dele falhar DENTRO da adoção, o rastro `webhook_adopt` fica lá
+    dizendo "o webhook auditou" — e a guarda do `POST /pluggy-item` suprimia a
+    auditoria da rota por causa dele. Desfecho: conexão viva e NENHUM
+    `OPEN_FINANCE_CONNECTED` em "Atividade da conta" (Codex #313, P2).
+    """
+    from core.audit import AuditEvent, list_audit_events
+
+    real_audit = of_routes.record_audit_event
+
+    def _engole_a_do_webhook(uid, evento, **kw):
+        if (kw.get("details") or {}).get("origin") == "webhook_adopt":
+            return                      # o insert falhou e ninguém ficou sabendo
+        return real_audit(uid, evento, **kw)
+
+    monkeypatch.setattr(of_routes, "record_audit_event", _engole_a_do_webhook)
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "z-sem-audit").status_code == 200
+        assert len(db.get_connections_by_item_id("z-sem-audit")) == 1, "pré-condição: adotou"
+
+        r = client.post(f"/open-finance/{user_id}/pluggy-item",
+                        json={"item": {"id": "z-sem-audit"}}, headers=_auth(client, user_id))
+        assert r.status_code == 200, r.text
+
+        gravados = [e for e in list_audit_events(user_id, limit=50)
+                    if e["event"] == AuditEvent.OPEN_FINANCE_CONNECTED
+                    and (e.get("details") or {}).get("item_id") == "z-sem-audit"]
+        assert len(gravados) == 1, (
+            f"{len(gravados)} eventos: a conexão nasceu e não aparece em "
+            "'Atividade da conta' — duplicata é ruído, buraco é perda")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-sem-audit")
+
+
+def test_reconexao_de_conexao_anterior_ao_registry_audita(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Conexão que existe SEM rastro nenhum (nasceu antes do registry): a guarda
+    lia "sem `pluggy_item`" como "o webhook auditou", e o webhook nunca existiu.
+
+    É a 2ª metade do mesmo achado do Codex, e não estava no `ponytail:` que a
+    rodada anterior declarou: ali o teto era só o item ADOTADO cujo navegador
+    nunca postou.
+    """
+    from core.audit import AuditEvent, list_audit_events
+
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        db.save_pluggy_open_finance_item(
+            user_id, {"id": "z-legado", "status": "UPDATED",
+                      "connector": {"id": 612, "name": "Nubank"}})
+        assert _registry("z-legado") == [], "pré-condição: conexão sem rastro"
+
+        r = client.post(f"/open-finance/{user_id}/pluggy-item",
+                        json={"item": {"id": "z-legado"}}, headers=_auth(client, user_id))
+        assert r.status_code == 200, r.text
+
+        gravados = [e for e in list_audit_events(user_id, limit=50)
+                    if e["event"] == AuditEvent.OPEN_FINANCE_CONNECTED
+                    and (e.get("details") or {}).get("item_id") == "z-legado"]
+        assert len(gravados) == 1, f"a reconexão sumiu de 'Atividade da conta': {gravados}"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-legado")
+
+
+def test_details_escalar_no_rastro_nao_derruba_o_post(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Uma linha de `audit_events` com `details` ESCALAR (`'"texto"'::jsonb`)
+    fazia o `.get` da guarda estourar `AttributeError` dentro do laço — 500
+    PERMANENTE no `POST /pluggy-item` daquele usuário, para sempre, por causa de
+    um dado. Nenhum escritor de hoje grava assim; é fronteira de leitura do banco.
+    """
+    from core.audit import AuditEvent
+
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "z-escalar").status_code == 200
+        with get_conn() as c:                       # mais NOVA que a do webhook: o
+            c.execute(                              # laço bate nela primeiro
+                "insert into audit_events (user_id, event, details) values (%s,%s,%s::jsonb)",
+                (user_id, AuditEvent.OPEN_FINANCE_CONNECTED, '"texto"'))
+            c.commit()
+
+        r = client.post(f"/open-finance/{user_id}/pluggy-item",
+                        json={"item": {"id": "z-escalar"}}, headers=_auth(client, user_id))
+        assert r.status_code == 200, r.text
+    finally:
+        with get_conn() as c:
+            c.execute("delete from audit_events where user_id=%s and details=%s::jsonb",
+                      (user_id, '"texto"'))
+            c.commit()
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-escalar")

--- a/tests/test_of_webhook_adopt_dupe.py
+++ b/tests/test_of_webhook_adopt_dupe.py
@@ -1,0 +1,190 @@
+"""G5d — entrega DUPLICADA e auditoria de RECONEXÃO.
+
+Terceiro arquivo do mesmo assunto (caminho feliz em `test_of_webhook_adopt.py`,
+guardas em `test_of_webhook_adopt_guards.py`), separado só pelo teto de 350
+linhas do `tests/test_max_lines_python.py`. Helpers importados de lá — os dois
+casos aqui usam exatamente o mesmo cenário, e uma segunda cópia deles seria
+duplicação (CLAUDE.md §0.1).
+
+O que cada bloco prende:
+
+  • DUPLICATA DE `item/created` — webhook é entrega AT-LEAST-ONCE, e este
+    endpoint devolve 401/400/503 (e pode dar 500 antes do ramo de adoção), o que
+    faz a Pluggy retentar o MESMO evento. "Dispara uma vez" era premissa errada:
+    a 2ª entrega, depois de o usuário remover o banco, readotava a conexão E
+    agendava sync — re-importando lançamento e compra de cartão na carteira que
+    ele acabou de limpar. Quem tiver o `PLUGGY_WEBHOOK_SECRET` (que trafega em
+    `?token=`) disparava isso à vontade contra um item conhecido.
+  • DUAS ENTREGAS AO MESMO TEMPO — a janela entre a leitura do rastro e a escrita
+    dela (descrita no "LIMITE CONHECIDO" de `_adota_item_orfao`, fonte única):
+    com a leitura antes do `GET /items`, ela era um round-trip HTTP inteiro.
+  • RECONEXÃO AUDITADA — a guarda que deduplica a auditoria no
+    `POST /pluggy-item` não pode engolir o re-consentimento (o widget reconecta
+    banco existente e o `avoidDuplicates` devolve o MESMO itemId), senão
+    re-autorizar o banco some de "Atividade da conta" (settings → Segurança).
+
+CONTROLES do grupo:
+  • negativo (duplicata): trocar a guarda de `_adota_item_orfao` por `origens =
+    set()` → `test_duplicata_de_item_created_nao_ressuscita_banco_removido`
+    vermelho, num caso que está VERDE hoje;
+  • negativo (concorrência): mover a leitura de `item_registry_origins` de volta
+    para ANTES do `get_pluggy_item` →
+    `test_segunda_entrega_inteira_dentro_do_get_da_primeira_audita_uma_vez`
+    vermelho (2 auditorias), num caso que está VERDE hoje;
+  • negativo (auditoria): voltar o `if not conexao_recem_adotada:` para
+    `if not tinha_conexao_propria:` → `test_reconexao_do_mesmo_banco_audita_toda
+    _vez` vermelho, e o `test_webhook_antes_do_navegador_audita_uma_vez_por_
+    conexao` (guards) continua verde — é ele que cobre os outros dois casos:
+    conexão nova COM webhook antes, e conexão nova SEM webhook antes;
+  • positivo: `test_rastro_sem_dono_nao_bloqueia_a_adocao_legitima` prova que a
+    guarda nova recusa por DONO, não por "tem rastro" — senão ela mataria
+    justamente o usuário que o PR veio destravar.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.open_finance as of_routes
+from fastapi.testclient import TestClient
+from test_of_item_ownership import SEGREDO, _auth, _item_remoto, _webhook, eventos  # noqa: F401
+from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
+
+
+def test_duplicata_de_item_created_nao_ressuscita_banco_removido(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """O repro do Tester: adota → o usuário remove → a MESMA entrega chega de novo."""
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "z-res").status_code == 200
+        assert len(db.get_connections_by_item_id("z-res")) == 1, "pré-condição: adotou"
+
+        db.disconnect_open_finance_connection(user_id)
+        assert db.get_connections_by_item_id("z-res") == [], "pré-condição: o usuário removeu"
+        webhook_pluggy.clear()
+
+        r = _webhook(client, "item/created", "z-res")   # duplicata (at-least-once)
+
+        assert r.status_code == 200, f"{r.status_code}: a Pluggy retenta em laço"
+        volta = db.get_connections_by_item_id("z-res")
+        assert volta == [], (
+            f"banco REMOVIDO ressuscitou por uma duplicata de item/created: {len(volta)}")
+        assert webhook_pluggy == [], "e com sync agendado, que re-importa o que ele apagou"
+        motivos = [e["details"].get("motivo") for e in eventos
+                   if e["event"] == "of_webhook_adopt_skipped"]
+        assert motivos == ["rastro_com_dono"], motivos
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-res")
+
+
+def test_rastro_sem_dono_nao_bloqueia_a_adocao_legitima(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """CONTROLE POSITIVO: o item do bug antigo tem rastro (`origin='webhook'`,
+    `user_id IS NULL`) e continua adotável — a guarda pergunta por DONO."""
+    _mock_item(monkeypatch, user_id)
+    db.register_item(None, provider_item_id="z-null", origin="webhook", last_event="item/updated")
+    try:
+        assert _webhook(TestClient(dashboard.app), "item/created", "z-null").status_code == 200
+        linhas = db.get_connections_by_item_id("z-null")
+        assert len(linhas) == 1 and int(linhas[0]["user_id"]) == user_id, linhas
+        assert [r["origin"] for r in _registry("z-null")] == ["webhook", "webhook_adopt"]
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-null")
+
+
+def test_reconexao_do_mesmo_banco_audita_toda_vez(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Re-consentimento / conserto de `LOGIN_ERROR`: o widget reconecta o banco
+    existente e o `avoidDuplicates` devolve o MESMO itemId — dois
+    `POST /pluggy-item` do mesmo item, e a conexão já está de pé no segundo.
+
+    Medido com a guarda antiga (`if not tinha_conexao_propria:`): 1 evento para
+    2 reconexões. O 1º POST aqui é também o caso "conexão nova, sem webhook
+    antes" (1 evento), então este teste sozinho não passa num código que parou
+    de auditar a rota.
+    """
+    from core.audit import AuditEvent
+
+    auditados: list[int] = []
+    monkeypatch.setattr(of_routes, "record_audit_event",
+                        lambda uid, evento, **kw: auditados.append(uid)
+                        if evento == AuditEvent.OPEN_FINANCE_CONNECTED else None)
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        for tentativa in (1, 2):
+            r = client.post(f"/open-finance/{user_id}/pluggy-item",
+                            json={"item": {"id": "z-recon"}}, headers=_auth(client, user_id))
+            assert r.status_code == 200, f"POST {tentativa}: {r.text}"
+            assert auditados == [user_id] * tentativa, (
+                f"reconexão {tentativa}: {len(auditados)} OPEN_FINANCE_CONNECTED — "
+                "re-autorizar o banco sumiu de 'Atividade da conta'")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-recon")
+
+
+def test_segunda_entrega_inteira_dentro_do_get_da_primeira_audita_uma_vez(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """UM interleaving, e o nome diz qual: a 2ª entrega roda INTEIRA enquanto a
+    1ª está parada dentro do `GET /items` (at-least-once + retentativa da
+    Pluggy). O nome antigo ("entrega concorrente") prometia a classe toda; os
+    outros entrelaçamentos — os dois presos DEPOIS da leitura do rastro, que é a
+    janela do "LIMITE CONHECIDO" — continuam sem cobertura, de propósito.
+
+    Sem sleep: o mock da Pluggy PRENDE a 1ª entrega num `threading.Event` (ela
+    roda em `asyncio.to_thread`, o loop segue livre), a 2ª roda inteira, e só
+    então a 1ª volta. Determinístico — o que se mede é a ORDEM das operações, não
+    o relógio.
+
+    A conexão é uma só nas duas ordens (upsert em `uq_of_conn_provider_item`); o
+    que discrimina é a AUDITORIA, que fica fora do `pluggy_item_lock`.
+    """
+    import threading
+
+    from core.audit import AuditEvent
+
+    auditados: list[int] = []
+    monkeypatch.setattr(of_routes, "record_audit_event",
+                        lambda uid, evento, **kw: auditados.append(uid)
+                        if evento == AuditEvent.OPEN_FINANCE_CONNECTED else None)
+
+    liberar = threading.Event()
+    chamadas: list[str] = []
+
+    def get_preso(item_id, api_key=None):
+        chamadas.append(item_id)
+        if len(chamadas) == 1:                      # a 1ª entrega fica presa no HTTP
+            assert liberar.wait(10), "a 2ª entrega nunca terminou"
+        return _item_remoto(item_id, user_id)
+
+    monkeypatch.setattr(of_routes, "get_pluggy_item", get_preso)
+
+    async def cenario():
+        primeira = asyncio.create_task(of_routes._adota_item_orfao("z-corrida", "item/created"))
+        for _ in range(1000):                       # espera a 1ª ENTRAR no GET
+            if chamadas:
+                break
+            await asyncio.sleep(0.01)
+        assert chamadas, "a 1ª entrega não chegou ao GET /items"
+        await of_routes._adota_item_orfao("z-corrida", "item/created")   # 2ª, inteira
+        liberar.set()
+        await primeira
+
+    try:
+        asyncio.run(cenario())
+
+        assert auditados == [user_id], (
+            f"{len(auditados)} OPEN_FINANCE_CONNECTED para UMA conexão: "
+            "as duas entregas leram o rastro vazio")
+        assert [r["origin"] for r in _registry("z-corrida")] == ["webhook_adopt"], \
+            _registry("z-corrida")
+        assert len(db.get_connections_by_item_id("z-corrida")) == 1
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-corrida")

--- a/tests/test_of_webhook_adopt_guards.py
+++ b/tests/test_of_webhook_adopt_guards.py
@@ -1,0 +1,336 @@
+"""G5c — as GUARDAS da adoção de item órfão pelo webhook da Pluggy.
+
+O caminho feliz mora em `test_of_webhook_adopt.py`; aqui ficam os casos que o
+Tester provou rodando contra a 1ª versão da adoção, e que ela perdia. Arquivo
+separado porque os dois juntos passam do teto de 350 linhas
+(`tests/test_max_lines_python.py`), não por assunto diferente.
+
+O que cada bloco prende (todos já foram vermelhos):
+
+  • RESSURREIÇÃO DE CONTA APAGADA — `save_pluggy_open_finance_item` chama
+    `ensure_user_tx`, que INSERE em `users`. A FK de
+    `open_finance_connections.user_id` nunca dispara, então "a constraint
+    resolve" era falso: um webhook com `clientUserId` de conta apagada por LGPD
+    (`db/privacy.py` faz `delete from users`, e o item na Pluggy só some em
+    best-effort) recriava a linha de `users` e pendurava uma conexão nela.
+  • RESSURREIÇÃO DE BANCO REMOVIDO — adotar em QUALQUER evento de
+    `PLUGGY_SYNC_EVENTS` reabria pelo webhook o buraco que o
+    `_disconnect_sob_lock` fechou pelo lado do disconnect.
+  • 5xx PARA A PLUGGY — falha de escrita depois da conexão commitada devolvia
+    500 (retentativa em laço) e deixava conexão sem rastro no registry.
+  • Auditoria e a régua de posse: as duas portas (`POST /pluggy-item` e a
+    adoção) têm de decidir igual sobre o MESMO `clientUserId`.
+
+CONTROLE POSITIVO do grupo: `test_item_created_continua_adotando_o_dono_legitimo`
+— sem ele, tudo aqui passaria num código que simplesmente não adota nada.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.open_finance as of_routes
+from db.connection import get_conn
+from test_of_item_ownership import SEGREDO, _auth, _item_remoto, _webhook, eventos  # noqa: F401
+
+
+@pytest.fixture()
+def webhook_pluggy(monkeypatch):
+    """Webhook autorizado e sync inerte. Devolve a lista de ids agendados."""
+    agendados: list[str] = []
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", SEGREDO)
+    monkeypatch.setattr(of_routes, "_schedule_pluggy_sync", lambda i: agendados.append(i))
+    return agendados
+
+
+def _mock_item(monkeypatch, client_user_id):
+    monkeypatch.setattr(of_routes, "get_pluggy_item",
+                        lambda item_id, api_key=None: _item_remoto(item_id, client_user_id))
+
+
+def _limpa_item(item_id: str):
+    """Apaga TUDO daquele item — rastro no registry E conexão —, para os 3 arquivos.
+
+    Eram dois nomes para duas limpezas QUASE iguais (este e um `_limpa_registry`
+    que não apagava a conexão): `handlers/credit.py` × `core/handlers/credit.py`
+    em miniatura (CLAUDE.md §0.1). Apagar a conexão a mais é seguro no teardown.
+    """
+    with get_conn() as c:
+        c.execute("delete from open_finance_item_registry where provider_item_id=%s", (item_id,))
+        c.execute("delete from open_finance_connections where provider_item_id=%s", (item_id,))
+        c.commit()
+
+
+def _registry(item_id: str) -> list[dict]:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("select origin, user_id from open_finance_item_registry "
+                        "where provider_item_id=%s order by id", (item_id,))
+            return [dict(r) for r in (cur.fetchall() or [])]
+
+
+def _existe_user(uid: int) -> bool:
+    with get_conn() as c:
+        with c.cursor() as cur:
+            cur.execute("select 1 from users where id=%s", (uid,))
+            return cur.fetchone() is not None
+
+
+# ── controle POSITIVO: a adoção legítima continua acontecendo ────────────────
+
+def test_item_created_continua_adotando_o_dono_legitimo(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Sem este caso, todo o resto do arquivo passaria com a adoção deletada."""
+    _mock_item(monkeypatch, user_id)
+    try:
+        assert _webhook(TestClient(dashboard.app), "item/created", "g-ok").status_code == 200
+        linhas = db.get_connections_by_item_id("g-ok")
+        assert len(linhas) == 1 and int(linhas[0]["user_id"]) == user_id, linhas
+        assert webhook_pluggy == ["g-ok"]
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-ok")
+
+
+# ── conta apagada (LGPD) não pode voltar a existir ───────────────────────────
+
+def test_usuario_inexistente_nao_e_criado_pelo_webhook(monkeypatch, eventos, webhook_pluggy):
+    """`ensure_user_tx` CRIA a linha de `users`: a FK nunca chega a ser testada.
+
+    Medido antes da guarda: 200, linha nova em `users` e conexão OF pendurada
+    nela, com `origin='webhook_adopt'` no registry.
+    """
+    fantasma = 987654321987
+    _mock_item(monkeypatch, fantasma)
+    try:
+        assert not _existe_user(fantasma), "pré-condição: a conta não existe"
+
+        r = _webhook(TestClient(dashboard.app), "item/created", "g-fantasma")
+
+        assert r.status_code == 200, r.text
+        assert not _existe_user(fantasma), (
+            "o webhook RECRIOU a linha de `users` de uma conta que não existe "
+            "(é assim que uma conta apagada por LGPD ressuscita)")
+        assert db.get_connections_by_item_id("g-fantasma") == []
+        assert _registry("g-fantasma") == [{"origin": "webhook", "user_id": None}], \
+            "sem dono adotável, o rastro é o mesmo de antes da adoção"
+        # O MOTIVO, não só o desfecho: com a guarda desligada o desfecho continua
+        # certo por acidente — a FK de `open_finance_item_registry.user_id` recusa
+        # o rastro e a adoção morre ali. Duas defesas para o mesmo estrago é bom;
+        # depender só da segunda é o que já falhou uma vez (a FK da conexão nunca
+        # dispara, porque `ensure_user_tx` cria a linha antes). Este assert é o
+        # que separa "recusamos por identidade" de "o banco recusou por acaso".
+        motivos = [e["details"].get("motivo") for e in eventos
+                   if e["event"] == "of_webhook_adopt_skipped"]
+        assert motivos == ["usuario_inexistente"], motivos
+    finally:
+        _limpa_item("g-fantasma")
+        with get_conn() as c:
+            c.execute("delete from users where id=%s", (fantasma,))
+            c.commit()
+
+
+# ── banco removido pelo usuário não pode voltar sozinho ──────────────────────
+
+def test_evento_posterior_nao_ressuscita_o_banco_que_o_usuario_removeu(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """`delete_pluggy_items_best_effort` engole a falha e apaga só o local.
+
+    O item continua VIVO na Pluggy e continua mandando evento. Adotar em
+    `transactions/created` reatava a conexão E agendava sync — que re-importa
+    lançamento e compra de cartão na carteira que o usuário acabou de limpar.
+    É o mesmo buraco que o `_disconnect_sob_lock` fecha pelo outro lado.
+    """
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "create_pluggy_api_key", lambda: "k")
+    monkeypatch.setattr(of_routes, "delete_pluggy_item",
+                        lambda i, api_key=None: (_ for _ in ()).throw(RuntimeError("Pluggy 503")))
+    client = TestClient(dashboard.app)
+    try:
+        db.save_pluggy_open_finance_item(
+            user_id, {"id": "g-zumbi", "status": "UPDATED",
+                      "connector": {"id": 612, "name": "Nubank"}})
+        assert db.get_connections_by_item_id("g-zumbi"), "pré-condição: conectado"
+
+        assert client.delete(f"/open-finance/{user_id}",
+                             headers=_auth(client, user_id)).status_code == 200
+        assert db.get_connections_by_item_id("g-zumbi") == [], "pré-condição: removeu o local"
+        webhook_pluggy.clear()
+
+        assert _webhook(client, "transactions/created", "g-zumbi").status_code == 200
+
+        volta = db.get_connections_by_item_id("g-zumbi")
+        assert volta == [], (
+            f"o banco que o usuário REMOVEU voltou sozinho: {len(volta)} conexão(ões)")
+        assert webhook_pluggy == [], "e com sync agendado, que re-importa o que ele apagou"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-zumbi")
+
+
+@pytest.mark.parametrize("evento", ["item/updated", "transactions/created", "transactions/updated"])
+def test_so_item_created_adota(user_id, monkeypatch, eventos, webhook_pluggy, evento):
+    """A categoria inteira, não só o evento do repro: item sem conexão que recebe
+    evento POSTERIOR é item que JÁ TEVE conexão e foi removida."""
+    _mock_item(monkeypatch, user_id)
+    try:
+        assert _webhook(TestClient(dashboard.app), evento, "g-evento").status_code == 200
+        assert db.get_connections_by_item_id("g-evento") == [], f"{evento} adotou"
+        assert _registry("g-evento") == [{"origin": "webhook", "user_id": None}]
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-evento")
+
+
+# ── nada pode virar 5xx para a Pluggy, nem estado parcial ────────────────────
+
+def test_registry_fora_do_ar_nao_vaza_500_nem_grava_conexao_sem_rastro(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """`register_item` levantando dava 500 — a Pluggy retenta em laço — e, na
+    ordem antiga (conexão primeiro), deixava conexão commitada com registry
+    VAZIO: item adotado sem nenhum rastro para o script achar."""
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "register_item",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("registry fora do ar")))
+    try:
+        r = _webhook(TestClient(dashboard.app), "item/created", "g-reg")
+
+        assert r.status_code == 200, f"{r.status_code}: a Pluggy retenta em laço"
+        linhas = db.get_connections_by_item_id("g-reg")
+        assert not linhas or _registry("g-reg"), (
+            f"conexão gravada ({len(linhas)}) e NENHUM rastro no registry")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-reg")
+
+
+def test_sync_falhando_nao_vaza_500_e_a_adocao_fica_de_pe(
+        user_id, monkeypatch, eventos):
+    """`_schedule_pluggy_sync` estava FORA do try: exceção dele = 500. E, como a
+    conexão já está gravada quando ele roda, a adoção não pode ser desfeita."""
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", SEGREDO)
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "_schedule_pluggy_sync",
+                        lambda i: (_ for _ in ()).throw(RuntimeError("loop fechado")))
+    try:
+        r = _webhook(TestClient(dashboard.app), "item/created", "g-sched")
+
+        assert r.status_code == 200, f"{r.status_code}: a Pluggy retenta em laço"
+        assert len(db.get_connections_by_item_id("g-sched")) == 1, "a adoção aconteceu"
+        assert [x["origin"] for x in _registry("g-sched")] == ["webhook_adopt"]
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-sched")
+
+
+# ── auditoria e régua de posse ───────────────────────────────────────────────
+
+def test_adocao_grava_a_mesma_auditoria_do_pluggy_item(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Conexão de Open Finance nascendo sem `OPEN_FINANCE_CONNECTED` é conexão
+    que não aparece no histórico de segurança do usuário."""
+    from core.audit import AuditEvent
+
+    auditados: list[tuple] = []
+    monkeypatch.setattr(of_routes, "record_audit_event",
+                        lambda uid, evento, **kw: auditados.append((uid, evento, kw)))
+    _mock_item(monkeypatch, user_id)
+    try:
+        assert _webhook(TestClient(dashboard.app), "item/created", "g-audit").status_code == 200
+        assert db.get_connections_by_item_id("g-audit"), "pré-condição: adotou"
+        assert [(a[0], a[1]) for a in auditados] == \
+            [(user_id, AuditEvent.OPEN_FINANCE_CONNECTED)], auditados
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-audit")
+
+
+# TODOS os cinco derivam do id do usuário que EXISTE no teste: é isso que os
+# torna discriminantes. Com literais fixos (`'١٢'`, `'1_2'`), o `int()` dava 12,
+# `user_exists(12)` era falso no banco de teste e o caso passava VERDE com a
+# régua desligada — 2 dos 5 anunciavam discriminação e não mediam nada.
+_FORJA = {
+    "espacos": lambda u: f" {u} ",
+    "mais": lambda u: f"+{u}",
+    "zero_a_esquerda": lambda u: f"0{u}",
+    "arabe_indico": lambda u: str(u).translate(str.maketrans("0123456789", "٠١٢٣٤٥٦٧٨٩")),
+    "pep515": lambda u: "_".join(str(u)),   # 12345 → '1_2_3_4_5', que int() lê como 12345
+}
+
+
+@pytest.mark.parametrize("forja", list(_FORJA), ids=list(_FORJA))
+def test_as_duas_portas_decidem_igual_sobre_o_mesmo_client_user_id(
+        user_id, monkeypatch, eventos, webhook_pluggy, forja):
+    """A docstring prometia "a mesma discriminação do POST /pluggy-item", e a
+    rota compara STRING enquanto a adoção fazia `int()`.
+
+    `int()` aceita mais: `' 5 '`, `'+5'`, `'007'`, dígitos árabe-índicos e o
+    sublinhado da PEP 515 — e os cinco viram o id do usuário REAL do teste, que
+    passa em `user_exists`. Nenhum é escolhido por atacante hoje (nós setamos o
+    `clientUserId` em `core/services/pluggy.py`), mas duas portas divergindo no
+    MESMO valor é a definição de dupla fonte de verdade.
+    """
+    valor = _FORJA[forja](user_id)
+    assert valor != str(user_id) and int(valor) == user_id, (
+        f"o caso {forja} não discrimina: {valor!r}")
+    monkeypatch.setattr(of_routes, "get_pluggy_item",
+                        lambda item_id, api_key=None: {"id": item_id, "status": "UPDATED",
+                                                       "clientUserId": valor,
+                                                       "connector": {"id": 612, "name": "Nubank"}})
+    client = TestClient(dashboard.app)
+    try:
+        rota = client.post(f"/open-finance/{user_id}/pluggy-item",
+                           json={"item": {"id": "g-regua"}}, headers=_auth(client, user_id))
+        rota_aceitou = rota.status_code == 200
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-regua")
+
+        _webhook(client, "item/created", "g-regua")
+        adocao_aceitou = bool(db.get_connections_by_item_id("g-regua"))
+
+        assert rota_aceitou == adocao_aceitou, (
+            f"clientUserId={valor!r}: /pluggy-item aceitou={rota_aceitou} "
+            f"({rota.status_code}) e a adoção aceitou={adocao_aceitou}")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-regua")
+
+
+def test_webhook_antes_do_navegador_audita_uma_vez_por_conexao(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """`item/created` dispara na CRIAÇÃO do item; o `onSuccess` do widget (que
+    chama o `POST /pluggy-item`) só dispara em status final — a ordem NORMAL em
+    produção é webhook primeiro. Então a adoção roda no fluxo comum, e as duas
+    portas gravavam `OPEN_FINANCE_CONNECTED` para a MESMA conexão: o histórico
+    de segurança do usuário mentia sobre quantas vezes ele conectou o banco.
+    """
+    from core.audit import AuditEvent
+
+    auditados: list[int] = []
+    monkeypatch.setattr(of_routes, "record_audit_event",
+                        lambda uid, evento, **kw: auditados.append(uid)
+                        if evento == AuditEvent.OPEN_FINANCE_CONNECTED else None)
+    _mock_item(monkeypatch, user_id)
+    client = TestClient(dashboard.app)
+    try:
+        assert _webhook(client, "item/created", "g-2x").status_code == 200
+        r = client.post(f"/open-finance/{user_id}/pluggy-item",
+                        json={"item": {"id": "g-2x"}}, headers=_auth(client, user_id))
+        assert r.status_code == 200, r.text
+        assert auditados == [user_id], (
+            f"{len(auditados)} OPEN_FINANCE_CONNECTED para UMA conexão: {auditados}")
+
+        # CONTROLE POSITIVO: sem webhook antes, o POST continua auditando — senão
+        # o assert acima passaria num código que parou de auditar a rota.
+        auditados.clear()
+        assert client.post(f"/open-finance/{user_id}/pluggy-item",
+                           json={"item": {"id": "g-so-post"}},
+                           headers=_auth(client, user_id)).status_code == 200
+        assert auditados == [user_id], auditados
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("g-2x")
+        _limpa_item("g-so-post")

--- a/tests/test_of_webhook_adopt_guards.py
+++ b/tests/test_of_webhook_adopt_guards.py
@@ -121,7 +121,8 @@ def test_usuario_inexistente_nao_e_criado_pelo_webhook(monkeypatch, eventos, web
         # certo por acidente — a FK de `open_finance_item_registry.user_id` recusa
         # o rastro e a adoção morre ali. Duas defesas para o mesmo estrago é bom;
         # depender só da segunda é o que já falhou uma vez (a FK da conexão nunca
-        # dispara, porque `ensure_user_tx` cria a linha antes). Este assert é o
+        # dispara — hoje ela dispara: a adoção grava com `criar_usuario=False`,
+        # e esse é o conserto do P1 do Codex #313, não desta guarda). Este assert é o
         # que separa "recusamos por identidade" de "o banco recusou por acaso".
         motivos = [e["details"].get("motivo") for e in eventos
                    if e["event"] == "of_webhook_adopt_skipped"]
@@ -306,13 +307,23 @@ def test_webhook_antes_do_navegador_audita_uma_vez_por_conexao(
     produção é webhook primeiro. Então a adoção roda no fluxo comum, e as duas
     portas gravavam `OPEN_FINANCE_CONNECTED` para a MESMA conexão: o histórico
     de segurança do usuário mentia sobre quantas vezes ele conectou o banco.
+
+    O espião GRAVA de verdade (ele chama o `record_audit_event` real) porque a
+    guarda passou a exigir evidência DURÁVEL da auditoria do webhook — um stub que
+    só anota numa lista deixava `audit_events` vazio, e a rota (com razão) auditava
+    de novo. Com o stub mudo este caso ficaria verde num código sem dedup nenhuma.
     """
     from core.audit import AuditEvent
 
     auditados: list[int] = []
-    monkeypatch.setattr(of_routes, "record_audit_event",
-                        lambda uid, evento, **kw: auditados.append(uid)
-                        if evento == AuditEvent.OPEN_FINANCE_CONNECTED else None)
+    real_audit = of_routes.record_audit_event
+
+    def _espia(uid, evento, **kw):
+        if evento == AuditEvent.OPEN_FINANCE_CONNECTED:
+            auditados.append(uid)
+        return real_audit(uid, evento, **kw)
+
+    monkeypatch.setattr(of_routes, "record_audit_event", _espia)
     _mock_item(monkeypatch, user_id)
     client = TestClient(dashboard.app)
     try:

--- a/tests/test_of_webhook_adopt_race.py
+++ b/tests/test_of_webhook_adopt_race.py
@@ -1,0 +1,346 @@
+"""G5e — as CORRIDAS da adoção de item órfão, e o que sobra depois delas.
+
+Arquivo separado de `test_of_webhook_adopt_dupe.py` porque aquele está a 303
+linhas e o teto é 350 (`tests/test_max_lines_python.py`) — não por assunto
+diferente. Aqui ficam os entrelaçamentos que acontecem DEPOIS da leitura do
+rastro, que é a janela que a leitura movida para junto do `register_item` não
+fecha (o "LIMITE CONHECIDO" de `_adota_item_orfao` é a fonte única do texto).
+
+O que cada teste prende:
+
+  • ENTREGA ATRASADA (Codex #313, P1) — a 2ª entrega lê o rastro vazio, a 1ª
+    adota e o usuário DESCONECTA antes de ela escrever. Ela chegava ao
+    `_salva_item_sob_lock` com `tinha_conexao_propria=False` (honesto: item
+    órfão nunca teve conexão), pulava a revalidação de estado e RECRIAVA a
+    conexão com sync agendado, na carteira que o usuário acabou de limpar.
+  • ABORTO MÚTUO (P0 do Tester, 30/30 rodadas) — duas entregas simultâneas, sem
+    gate nenhum. Cada uma grava o rastro antes de qualquer uma pegar o lock,
+    cada uma enxerga o rastro da OUTRA e aborta: sobrava rastro COM dono e ZERO
+    conexão, estado TERMINAL — a 1ª guarda recusa toda retentativa e o
+    `scripts/adotar_items_of_orfaos.py` filtra fora rastro com dono, então o
+    usuário ficava com 0 bancos e sem saída pelo produto. O conserto é o aborto
+    desfazer a PRÓPRIA reivindicação ainda sob o lock: quem entra depois não vê
+    reivindicação nenhuma e adota.
+  • PERDER O LOCK (achado do Tester contra a 1ª versão do conserto, e regressão
+    contra a `main`) — na intercalação em que quem PEGA o lock é quem aborta, a
+    outra entrega leva 503 sem nunca ter tentado escrever. Consertar só o aborto
+    sob o lock TROCAVA o dono do estado terminal em vez de fechá-lo: a
+    reivindicação da perdedora do lock ficava para trás. O desfazimento vale nos
+    DOIS desfechos em que a escrita provadamente não aconteceu.
+
+CONTROLES do grupo (medidos, não deduzidos):
+  • negativo (desfazimento): trocar `unregister_item(adocao_registro_id,
+    user_id)` por `pass` em `_salva_item_sob_lock` → discrimina
+    `test_aborto_mutuo_...`, que falha em "rodada 0: 0 conexões", o P0
+    reproduzido; os outros vermelhos caem no rastro que sobra. Sem CONTAR os
+    vermelhos: o número envelhece a cada teste novo aqui (CLAUDE.md §2);
+  • negativo (desfazimento no 503): `if False and ...` no `if adocao_registro_id
+    is not None and not escrita_incerta` do fim de `_grava_reconexao` →
+    discrimina `test_quem_perde_o_lock_...`, no assert de rastro
+    (`[{'origin': 'webhook_adopt', 'user_id': ...}] == []`). Desligando TAMBÉM
+    esse assert, o vermelho seguinte é a retentativa devolvendo `None` — o P0 em
+    pessoa, e a razão de os dois asserts ficarem no mesmo teste;
+  • negativo (revalidação): `if False and adocao_registro_id is not None:` →
+    discrimina `test_entrega_atrasada_...`, que falha em "a entrega atrasada
+    adotou", o bug do Codex de volta;
+  • negativo (o LATCH): trocar `not escrita_incerta` por `causa is None` no
+    mesmo `if` → discrimina `test_desfazimento_do_503_olha_o_prazo_INTEIRO
+    [infra-ocupado]`. Antes dele a troca deixava o grupo OF inteiro VERDE: o
+    latch era comportamento correto sem controle negativo nenhum;
+  • positivo: o teste do aborto mútuo exige UMA conexão criada. Num código que
+    recusasse toda adoção — o risco de uma guarda nova — ele fica vermelho pelo
+    mesmo assert. `test_item_created_continua_adotando_o_dono_legitimo`
+    (`test_of_webhook_adopt_guards.py`) é o controle positivo do caminho comum.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import psycopg
+import pytest
+from fastapi import HTTPException
+
+import db
+import frontend.routes.open_finance as of_routes
+from test_of_item_ownership import SEGREDO, _auth, _item_remoto, _webhook, eventos  # noqa: F401
+from test_of_webhook_adopt_guards import _limpa_item, _mock_item, _registry, webhook_pluggy  # noqa: F401
+
+
+def test_entrega_atrasada_nao_ressuscita_o_banco_desconectado(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """A 2ª entrega leu o rastro VAZIO e só chega na escrita depois do disconnect.
+
+    Sem sleep: `user_exists` PRENDE a 1ª a rodar num `threading.Event` (ela está
+    num `asyncio.to_thread`, o loop segue livre) já com o rastro lido; a outra
+    roda inteira e adota; o usuário desconecta; só então a presa escreve.
+    """
+    _mock_item(monkeypatch, user_id)
+    real, chamadas, chegou, liberar = (of_routes.user_exists, [],
+                                       threading.Event(), threading.Event())
+
+    def _preso(uid):
+        chamadas.append(uid)
+        if len(chamadas) == 1:                      # a 1ª a rodar espera aqui
+            chegou.set()
+            assert liberar.wait(10), "a outra entrega nunca terminou"
+        return real(uid)
+
+    monkeypatch.setattr(of_routes, "user_exists", _preso)
+
+    async def cenario():
+        presa = asyncio.create_task(of_routes._adota_item_orfao("z-tarde", "item/created"))
+        assert await asyncio.to_thread(chegou.wait, 10), "a 1ª não chegou ao user_exists"
+        await of_routes._adota_item_orfao("z-tarde", "item/created")    # adota inteira
+        assert len(db.get_connections_by_item_id("z-tarde")) == 1, "pré-condição: adotou"
+        db.disconnect_open_finance_connection(user_id)
+        liberar.set()
+        assert await presa is None, "a entrega atrasada adotou"
+
+    try:
+        asyncio.run(cenario())
+        assert db.get_connections_by_item_id("z-tarde") == [], \
+            "banco REMOVIDO ressuscitou pela entrega atrasada"
+        assert webhook_pluggy == ["z-tarde"], f"{webhook_pluggy}: sync re-importa o apagado"
+        skips = [e["details"] for e in eventos if e["event"] == "of_webhook_adopt_skipped"]
+        assert len(skips) == 1 and "abortada sob o lock" in skips[0]["error"], skips
+        # A entrega atrasada apagou a reivindicação DELA e só ela: o rastro da
+        # adoção que valeu continua lá, e é ele que recusa a próxima duplicata
+        # (senão o conserto do P0 reabriria justamente este bug).
+        assert [r["origin"] for r in _registry("z-tarde")] == ["webhook_adopt"], \
+            _registry("z-tarde")
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-tarde")
+
+
+def test_aborto_mutuo_nao_deixa_o_item_reivindicado_e_sem_conexao(
+        user_id, monkeypatch, eventos, webhook_pluggy):
+    """Duas entregas do MESMO `item/created` ao mesmo tempo, sem gate nenhum.
+
+    O repro do Tester (`asyncio.gather`), rodado 5 vezes para pegar mais de um
+    entrelaçamento: quem chega primeiro à leitura do rastro varia, e o desfecho
+    tem de ser o mesmo nos dois casos — UMA conexão, UMA reivindicação viva.
+
+    O que discrimina não é a contagem de rastro, é a de CONEXÃO: com a
+    revalidação sozinha (sem o desfazimento) o resultado era `[None, None]` e
+    zero conexão em 30/30 rodadas do Tester.
+    """
+    _mock_item(monkeypatch, user_id)
+
+    async def duas(item_id):
+        return await asyncio.gather(
+            of_routes._adota_item_orfao(item_id, "item/created"),
+            of_routes._adota_item_orfao(item_id, "item/created"))
+
+    for rodada in range(5):
+        item = f"z-gather-{rodada}"
+        try:
+            donos = asyncio.run(duas(item))
+
+            conexoes = db.get_connections_by_item_id(item)
+            assert len(conexoes) == 1, (
+                f"rodada {rodada}: {len(conexoes)} conexões — 0 é o usuário com "
+                "0 bancos e sem saída pelo produto (P0), 2 é o upsert furado")
+            assert int(conexoes[0]["user_id"]) == user_id, conexoes
+            assert [d for d in donos if d is not None] == [user_id], donos
+            # A perdedora apagou a própria reivindicação: rastro com dono só o
+            # da que ganhou. Reivindicação abandonada é o que tornava o estado
+            # TERMINAL (a 1ª guarda recusa a retentativa e o script one-shot
+            # filtra fora rastro com dono).
+            assert [r["origin"] for r in _registry(item)] == ["webhook_adopt"], _registry(item)
+
+            # E o item continua respondendo como banco adotado, não como órfão:
+            # a duplicata seguinte é recusada por DONO, sem tocar na conexão.
+            assert asyncio.run(of_routes._adota_item_orfao(item, "item/created")) is None
+            assert len(db.get_connections_by_item_id(item)) == 1
+        finally:
+            db.disconnect_open_finance_connection(user_id)
+            _limpa_item(item)
+
+    # Todo skip tem de ser um dos DOIS desfechos previstos, e nenhum outro
+    # (`usuario_inexistente`, erro de escrita): a perdedora ou nem chega a
+    # reivindicar (1ª guarda, quando a outra já gravou) ou aborta sob o lock. A
+    # proporção entre os dois varia com o escalonamento — por isso não se conta.
+    motivos = [(e["details"].get("motivo"), e["details"].get("error", ""))
+               for e in eventos if e["event"] == "of_webhook_adopt_skipped"]
+    assert motivos and all(m == "rastro_com_dono" or "abortada sob o lock" in err
+                           for m, err in motivos), motivos
+
+
+def test_quem_aborta_sob_o_lock_some_do_rastro(user_id, monkeypatch, eventos, webhook_pluggy):
+    """O MECANISMO que tira o estado de terminal, medido sozinho.
+
+    A rival é plantada DEPOIS da 1ª guarda (dentro do `user_exists`, que roda
+    entre a leitura do rastro e o `register_item`): é o único jeito de forçar o
+    aborto sob o lock sem concorrência de verdade. O que se mede é o que sobra —
+    o rastro fica com UMA linha, a da rival, e nenhuma da entrega que abortou.
+    Com a reivindicação abandonada de volta ao registry, este mesmo item é
+    inalcançável: a 1ª guarda recusa e `ITEMS_SEM_CONEXAO` + o filtro de rastro
+    com dono do `scripts/adotar_items_of_orfaos.py` não o listam.
+    """
+    _mock_item(monkeypatch, user_id)
+    real, rival = of_routes.user_exists, []
+
+    def _planta(uid):
+        if not rival:
+            rival.append(db.register_item(uid, provider_item_id="z-abandono",
+                                          origin="pluggy_item"))
+        return real(uid)
+
+    monkeypatch.setattr(of_routes, "user_exists", _planta)
+    try:
+        assert asyncio.run(of_routes._adota_item_orfao("z-abandono", "item/created")) is None
+        assert db.get_connections_by_item_id("z-abandono") == []
+        assert [r["origin"] for r in _registry("z-abandono")] == ["pluggy_item"], \
+            _registry("z-abandono")
+
+        # Sem a rival não sobra reivindicação nenhuma, e o item volta a ser
+        # ADOTÁVEL — é a saída que o aborto mútuo não tinha.
+        assert db.unregister_item(rival[0], user_id) == 1
+        assert db.item_registry_origins("z-abandono") == set(), "o item voltou a ser órfão"
+        assert asyncio.run(of_routes._adota_item_orfao("z-abandono", "item/created")) == user_id
+        assert len(db.get_connections_by_item_id("z-abandono")) == 1
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-abandono")
+
+
+def test_unregister_item_nao_apaga_linha_de_outro_usuario(user_id):
+    """Isolamento por usuário (CLAUDE.md §0) num DELETE que recebe `id` cru."""
+    linha = db.register_item(user_id, provider_item_id="z-iso", origin="webhook_adopt")
+    try:
+        assert db.unregister_item(linha, user_id + 10_000_000) == 0
+        assert db.item_registry_origins("z-iso") == {"webhook_adopt"}
+        # e o par (`exceto_registro_id`, `exceto_user_id`) só ignora a linha do
+        # PRÓPRIO dono: com outro user_id ela continua contando.
+        assert db.item_registry_origins(
+            "z-iso", exceto_registro_id=linha, exceto_user_id=user_id + 10_000_000) == \
+            {"webhook_adopt"}
+        assert db.item_registry_origins(
+            "z-iso", exceto_registro_id=linha, exceto_user_id=user_id) == set()
+        # MEIO par era pior que nenhum: so o `id` fazia o `user_id = null` levar
+        # o `not (...)` a NULL e descartar TODA linha - "nunca teve dono" para um
+        # item que TEM. Hoje e `ValueError` na fronteira (CLAUDE.md 0.2).
+        for kw in ({"exceto_registro_id": linha}, {"exceto_user_id": user_id}):
+            with pytest.raises(ValueError):
+                db.item_registry_origins("z-iso", **kw)
+    finally:
+        _limpa_item("z-iso")
+
+
+def test_quem_perde_o_lock_tambem_some_do_rastro(user_id, monkeypatch, eventos, webhook_pluggy):
+    """A 3ª intercalação: quem PEGA o lock é justamente quem aborta.
+
+    Achado do Tester contra a 1ª versão do conserto, e era REGRESSÃO contra a
+    `main`: as duas entregas reivindicam, a que pega o lock vê o rastro da outra,
+    aborta e apaga o dela — e a outra PERDE o lock (503). A reivindicação da
+    perdedora ficava para trás, e o desfecho medido em duas colunas era
+    `0 conexões + rastro com dono + retentativa recusada` (o estado terminal do
+    P0) onde a `main` dava 1 conexão saudável e 2 rastros.
+
+    Determinismo sem sleep, duas barreiras: a de `user_exists` prende as duas
+    ENTRE a leitura do rastro e o `register_item` (então as duas passam a 1ª
+    guarda com o registry vazio e as duas reivindicam); a do
+    `_salva_item_sob_lock` prende as duas no lock. A 1ª a chegar delega para o
+    real (vai abortar), a 2ª devolve `(None, False)` em TODAS as tentativas —
+    lock ocupado, escrita nunca tentada. A 3ª entrega (a retentativa da Pluggy)
+    não espera barreira nenhuma e roda o caminho real inteiro.
+
+    CONTROLES: negativo — `if False and ...` na condição do desfazimento no 503
+    deixa este teste vermelho no assert de RASTRO, o 1º a bater (o vermelho
+    seguinte e por que os dois asserts moram juntos: docstring do módulo);
+    positivo — a retentativa exige UMA conexão, e derruba quem recusar tudo.
+    """
+    _mock_item(monkeypatch, user_id)
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 2000)
+    real_lock, real_user = of_routes._salva_item_sob_lock, of_routes.user_exists
+    b_leitura, b_lock = threading.Barrier(2, timeout=10), threading.Barrier(2, timeout=10)
+    vistos, chegadas, trava = {}, [], threading.Lock()
+
+    def _pareia(uid):
+        with trava:
+            n = len(chegadas)
+            chegadas.append(uid)
+        if n < 2:
+            b_leitura.wait()            # as duas passaram a 1ª guarda; agora reivindicam
+        return real_user(uid)
+
+    def _intercala(*a):                 # `real_lock(*a)` repassa TUDO: nada some no meio
+        registro = a[6]                 # `adocao_registro_id`: identifica a ENTREGA
+        with trava:
+            nova = registro not in vistos
+            if nova:
+                vistos[registro] = len(vistos)
+            ordem = vistos[registro]
+        if nova and ordem < 2:
+            b_lock.wait()
+        return (None, False) if ordem == 1 else real_lock(*a)
+
+    monkeypatch.setattr(of_routes, "user_exists", _pareia)
+    monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _intercala)
+
+    async def duas():
+        return await asyncio.gather(
+            of_routes._adota_item_orfao("z-perde-lock", "item/created"),
+            of_routes._adota_item_orfao("z-perde-lock", "item/created"))
+
+    try:
+        assert asyncio.run(duas()) == [None, None], "ninguém devia ter gravado"
+        assert db.get_connections_by_item_id("z-perde-lock") == []
+        # O ponto do conserto: NENHUMA reivindicação sobrou. Sem ele fica a da
+        # perdedora do lock (a que abortou já apagava a dela).
+        assert _registry("z-perde-lock") == [], _registry("z-perde-lock")
+        erros = [e["details"].get("error", "") for e in eventos
+                 if e["event"] == "of_webhook_adopt_skipped"]
+        assert any("503" in e for e in erros) and any("409" in e for e in erros), erros
+
+        # RETENTATIVA: é ela que o estado terminal recusava. Aqui adota.
+        assert asyncio.run(
+            of_routes._adota_item_orfao("z-perde-lock", "item/created")) == user_id
+        assert len(db.get_connections_by_item_id("z-perde-lock")) == 1, \
+            "a retentativa foi recusada: 0 conexões, o usuário sem banco e sem saída"
+    finally:
+        db.disconnect_open_finance_connection(user_id)
+        _limpa_item("z-perde-lock")
+
+
+@pytest.mark.parametrize("sequencia, sobra", [
+    (["ocupado", "ocupado"], False),   # nenhuma passou do `if not locked`: desfaz
+    (["infra", "ocupado"], True),      # a 1ª pode ter COMMITADO — a que discrimina
+    (["ocupado", "infra"], True),      # idem, e aqui `causa is None` seguraria também
+], ids=["so-lock", "infra-ocupado", "ocupado-infra"])
+def test_desfazimento_do_503_olha_o_prazo_INTEIRO(user_id, monkeypatch, eventos,
+                                                  sequencia, sobra):
+    """A tabela que separa `escrita_incerta` (latch) de `causa is None`.
+
+    `causa` é só a da ÚLTIMA tentativa, de propósito
+    (`test_causa_e_a_da_ultima_tentativa`): infra na 1ª + lock ocupado na 2ª
+    chega ao 503 com `causa is None` TENDO passado por escrita de desfecho
+    desconhecido, e apagar a reivindicação ali soltaria uma segunda adoção por
+    cima de conexão que existe. `infra-ocupado` é a ÚNICA linha que separa os
+    dois gates — sem ela a troca passa com o grupo OF inteiro no verde.
+    """
+    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 3000)
+    item, chamadas = "z-prazo-" + "-".join(sequencia), []
+
+    def _script(*a):
+        acao = sequencia[min(len(chamadas), len(sequencia) - 1)]
+        chamadas.append(acao)
+        if acao == "infra":
+            raise psycopg.errors.TooManyConnections("sorry, too many clients already")
+        return None, False              # lock ocupado: a escrita nem foi TENTADA
+
+    monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _script)
+    registro = db.register_item(user_id, provider_item_id=item, origin="webhook_adopt")
+    try:
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(of_routes._grava_reconexao(
+                user_id, {"id": item}, item, criar_usuario=False,
+                adocao_registro_id=registro))
+        assert exc.value.status_code == 503
+        assert chamadas == sequencia, chamadas
+        assert bool(_registry(item)) is sobra, f"{sequencia}: {_registry(item)}"
+    finally:
+        _limpa_item(item)

--- a/tests/test_of_webhook_adopt_race.py
+++ b/tests/test_of_webhook_adopt_race.py
@@ -35,7 +35,7 @@ CONTROLES do grupo (medidos, não deduzidos):
     reproduzido; os outros vermelhos caem no rastro que sobra. Sem CONTAR os
     vermelhos: o número envelhece a cada teste novo aqui (CLAUDE.md §2);
   • negativo (desfazimento no 503): `if False and ...` no `if adocao_registro_id
-    is not None and not escrita_incerta` do fim de `_grava_reconexao` →
+    is not None and not escrita_tentada` do fim de `_grava_reconexao` →
     discrimina `test_quem_perde_o_lock_...`, no assert de rastro
     (`[{'origin': 'webhook_adopt', 'user_id': ...}] == []`). Desligando TAMBÉM
     esse assert, o vermelho seguinte é a retentativa devolvendo `None` — o P0 em
@@ -43,10 +43,9 @@ CONTROLES do grupo (medidos, não deduzidos):
   • negativo (revalidação): `if False and adocao_registro_id is not None:` →
     discrimina `test_entrega_atrasada_...`, que falha em "a entrega atrasada
     adotou", o bug do Codex de volta;
-  • negativo (o LATCH): trocar `not escrita_incerta` por `causa is None` no
-    mesmo `if` → discrimina `test_desfazimento_do_503_olha_o_prazo_INTEIRO
-    [infra-ocupado]`. Antes dele a troca deixava o grupo OF inteiro VERDE: o
-    latch era comportamento correto sem controle negativo nenhum;
+  • o MECANISMO do desfazimento no 503 — o latch do prazo inteiro e a marca que
+    separa infra ANTES da escrita de infra DENTRO dela — mudou de arquivo:
+    `test_of_webhook_adopt_503.py`, com os controles negativos dele;
   • positivo: o teste do aborto mútuo exige UMA conexão criada. Num código que
     recusasse toda adoção — o risco de uma guarda nova — ele fica vermelho pelo
     mesmo assert. `test_item_created_continua_adotando_o_dono_legitimo`
@@ -58,9 +57,7 @@ from __future__ import annotations
 import asyncio
 import threading
 
-import psycopg
 import pytest
-from fastapi import HTTPException
 
 import db
 import frontend.routes.open_finance as of_routes
@@ -267,7 +264,7 @@ def test_quem_perde_o_lock_tambem_some_do_rastro(user_id, monkeypatch, eventos, 
             b_leitura.wait()            # as duas passaram a 1ª guarda; agora reivindicam
         return real_user(uid)
 
-    def _intercala(*a):                 # `real_lock(*a)` repassa TUDO: nada some no meio
+    def _intercala(*a, **kw):           # repassa TUDO (args E kwargs): nada some no meio
         registro = a[6]                 # `adocao_registro_id`: identifica a ENTREGA
         with trava:
             nova = registro not in vistos
@@ -276,7 +273,7 @@ def test_quem_perde_o_lock_tambem_some_do_rastro(user_id, monkeypatch, eventos, 
             ordem = vistos[registro]
         if nova and ordem < 2:
             b_lock.wait()
-        return (None, False) if ordem == 1 else real_lock(*a)
+        return (None, False) if ordem == 1 else real_lock(*a, **kw)
 
     monkeypatch.setattr(of_routes, "user_exists", _pareia)
     monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _intercala)
@@ -304,43 +301,3 @@ def test_quem_perde_o_lock_tambem_some_do_rastro(user_id, monkeypatch, eventos, 
     finally:
         db.disconnect_open_finance_connection(user_id)
         _limpa_item("z-perde-lock")
-
-
-@pytest.mark.parametrize("sequencia, sobra", [
-    (["ocupado", "ocupado"], False),   # nenhuma passou do `if not locked`: desfaz
-    (["infra", "ocupado"], True),      # a 1ª pode ter COMMITADO — a que discrimina
-    (["ocupado", "infra"], True),      # idem, e aqui `causa is None` seguraria também
-], ids=["so-lock", "infra-ocupado", "ocupado-infra"])
-def test_desfazimento_do_503_olha_o_prazo_INTEIRO(user_id, monkeypatch, eventos,
-                                                  sequencia, sobra):
-    """A tabela que separa `escrita_incerta` (latch) de `causa is None`.
-
-    `causa` é só a da ÚLTIMA tentativa, de propósito
-    (`test_causa_e_a_da_ultima_tentativa`): infra na 1ª + lock ocupado na 2ª
-    chega ao 503 com `causa is None` TENDO passado por escrita de desfecho
-    desconhecido, e apagar a reivindicação ali soltaria uma segunda adoção por
-    cima de conexão que existe. `infra-ocupado` é a ÚNICA linha que separa os
-    dois gates — sem ela a troca passa com o grupo OF inteiro no verde.
-    """
-    monkeypatch.setattr(of_routes, "_RECONNECT_DEADLINE_MS", 3000)
-    item, chamadas = "z-prazo-" + "-".join(sequencia), []
-
-    def _script(*a):
-        acao = sequencia[min(len(chamadas), len(sequencia) - 1)]
-        chamadas.append(acao)
-        if acao == "infra":
-            raise psycopg.errors.TooManyConnections("sorry, too many clients already")
-        return None, False              # lock ocupado: a escrita nem foi TENTADA
-
-    monkeypatch.setattr(of_routes, "_salva_item_sob_lock", _script)
-    registro = db.register_item(user_id, provider_item_id=item, origin="webhook_adopt")
-    try:
-        with pytest.raises(HTTPException) as exc:
-            asyncio.run(of_routes._grava_reconexao(
-                user_id, {"id": item}, item, criar_usuario=False,
-                adocao_registro_id=registro))
-        assert exc.value.status_code == 503
-        assert chamadas == sequencia, chamadas
-        assert bool(_registry(item)) is sobra, f"{sequencia}: {_registry(item)}"
-    finally:
-        _limpa_item(item)

--- a/tests/test_pluggy_webhook_security.py
+++ b/tests/test_pluggy_webhook_security.py
@@ -138,3 +138,50 @@ def test_pluggy_webhook_rejects_non_ascii_credentials(monkeypatch):
         headers={"X-Pluggy-Signature": "sha256=café".encode("latin-1")},
     )
     assert por_assinatura.status_code == 401
+
+
+# ── o `itemId` do CORPO vira URL na API da Pluggy (com a NOSSA chave) ────────
+
+def _webhook_com_item(monkeypatch, item_id: str) -> list[str]:
+    """Manda `item/created` com este `itemId` e devolve as URLs que saíram."""
+    import httpx
+
+    import core.services.pluggy as pluggy_svc
+
+    monkeypatch.setenv("PLUGGY_WEBHOOK_SECRET", "test-webhook-secret")
+    monkeypatch.setattr(open_finance_routes, "_schedule_pluggy_sync", lambda i: None)
+    monkeypatch.setattr(pluggy_svc, "create_pluggy_api_key", lambda: "k")
+    urls: list[str] = []
+
+    def _get(self, url, **kw):
+        urls.append(str(httpx.URL(url)))
+        raise RuntimeError("parou aqui: o teste só quer a URL")
+
+    monkeypatch.setattr(httpx.Client, "get", _get)
+    r = TestClient(dashboard.app).post(
+        "/open-finance/pluggy/webhook?token=test-webhook-secret",
+        content=json.dumps({"event": "item/created", "itemId": item_id}).encode(),
+        headers={"Content-Type": "application/json"})
+    assert r.status_code == 200, r.text
+    return urls
+
+
+def test_item_id_do_corpo_nao_forja_url_na_pluggy(monkeypatch):
+    """Antes da adoção de item órfão, o `itemId` do corpo do webhook NUNCA virava
+    HTTP para a Pluggy; agora vira, e `get_pluggy_item` monta `/items/{id}`.
+
+    Medido sem a régua de `core/services/pluggy.py`: `itemId='../../accounts'`
+    saía como `GET https://api.pluggy.ai/accounts` — requisição forjada por um
+    corpo de fora, com a nossa chave (o secret do webhook trafega em `?token=`,
+    logo vaza em log de proxy).
+    """
+    for hostil in ["../../accounts", "x?include=all", "abc#frag", "a b", "..", "%2e%2e"]:
+        assert _webhook_com_item(monkeypatch, hostil) == [], (
+            f"itemId={hostil!r} virou requisição na API da Pluggy")
+
+
+def test_item_id_valido_continua_consultando_a_pluggy(monkeypatch):
+    """CONTROLE POSITIVO do par acima: sem ele, os dois passariam num código que
+    simplesmente parou de consultar a Pluggy."""
+    assert _webhook_com_item(monkeypatch, "item-valido_9") == \
+        ["https://api.pluggy.ai/items/item-valido_9"]


### PR DESCRIPTION
Vem de um relato do dono com prints: o aviso de saldo do passo 2 aparecia
ilegível e com texto errado, o logo do modal de conectar banco estava
pequeno, e uma conexão do Nubank que parou em 49% deixou a conta travada —
o modal passou a dizer "Tem outra conexão em progresso desta mesma conta" e
não havia lugar nenhum no app que mostrasse esse progresso.

## Aviso de saldo e de WhatsApp (itens 1, 2 e 4)

`.onb-done` pintava `var(--neon-ink, var(--neon))`, e o fallback nunca
entrava: `comecar.html` carrega `site.css`, onde `--neon-ink` é `#10140a` —
a tinta escura para escrever *em cima* do neon. Quem redefine essa variável
como legível no escuro é a `dashboard.css`, que esta página não carrega.

| | contraste sobre o fundo composto |
|---|---|
| antes (`--neon-ink`) | **1,25:1** |
| depois (`--neon`) | **11,4:1** |

`.onb-done` tem exatamente 2 instâncias, então uma linha de CSS fecha a
categoria. Categoria reconferida na auditoria final: todos os `--neon-ink`
restantes das folhas do site estão pareados com `background: var(--neon)` —
uso correto de "tinta sobre neon". O `comecar.css:126` era o único usando a
variável como cor de texto sobre fundo escuro.

## Item de Open Finance órfão (item 5)

A linha em `open_finance_connections` só nascia no `POST /pluggy-item`, que
é o **navegador** quem chama, no `onSuccess` do widget. Fechou a aba durante
a coleta → a linha nunca existe → a tela mostra zero bancos →
`list_pluggy_item_ids` (que enumera a partir dessa tabela) devolve vazio →
"Remover todas as conexões" não apaga nada na Pluggy → o `avoidDuplicates`
recusa item novo. O usuário fica sem saída.

O ramo `elif not conexoes:` do webhook, que só logava e desistia, passa a
adotar o item pelo `clientUserId` da resposta **remota** da Pluggy — nunca
do corpo do webhook —, com a mesma régua de string que a rota `/pluggy-item`
já usava. **Zero linha de frontend.**

`scripts/adotar_items_of_orfaos.py` destrava quem já está preso: dry-run é o
default, `--apply` adota, `--item ID` aceita id do painel da Pluggy quando
não há rastro nosso, e `--delete` (que exige `--apply`) apaga o item lá.

## O que o ataque interno pegou antes do primeiro push

Cinco defeitos, todos criados pelas próprias correções, todos com controle
negativo na suíte: o webhook **recriava conta apagada por LGPD** (a FK não
protegia — `ensure_user_tx` insere antes do upsert); o banco removido
**voltava sozinho com sync agendado**, por duas portas diferentes; o
`itemId` do corpo do webhook ia **cru para a URL da Pluggy**
(`'../../accounts'` → `https://api.pluggy.ai/accounts` com a nossa chave);
o webhook devolvia **500** e deixava conexão sem rastro, fazendo a Pluggy
retentar em laço; e a correção da auditoria dobrada apagou junto a auditoria
da **reconexão legítima**.

## As 6 rodadas de revisão do Codex, todas procedentes

1. **P1** — a guarda de identidade fechava a identidade, não a corrida: numa
   exclusão de conta sobreposta ao webhook, o `ensure_user_tx` recriava o
   usuário. A adoção passa a gravar com `criar_usuario=False`, e a FK decide
   na mesma transação do insert — atômico por construção.
2. **P2** — a dedup de auditoria lia a origem do registry como prova de que
   o webhook auditou, mas `record_audit_event` engole falha de banco. Passa
   a exigir o evento persistido.
3. **P1** — duas entregas concorrentes de `item/created` ressuscitavam banco
   removido. **Duas tentativas de conserto foram derrubadas pelo próprio
   ataque, as duas piores que o bug**: só revalidar fazia as duas entregas
   abortarem mutuamente (30/30 rodadas sem conexão, estado terminal); e
   desfazer só no aborto sob o lock ainda regredia contra a `main` com o
   lock ocupado. A versão final desfaz a reivindicação nos dois desfechos em
   que a escrita comprovadamente não ocorreu.
4. **P1** — o latch marcava qualquer `OperationalError` como "pode ter
   escrito", e **5 dos 6** pontos do caminho são pré-escrita. Virou sinal
   explícito, marcado antes da chamada de escrita.
5. **P2** (achado do ataque, fechado junto) — `get_conn()` é a primeira linha
   com I/O do `save_`, e `PoolTimeout` é subclasse de `OperationalError`;
   a marca já estava feita. E não precisa de infra doente: o orçamento tem
   piso de 1 ms e o pool frio estoura em 1,4–4,2 ms num Postgres saudável.
6. **P2** — a supressão de auditoria casava só item + origem, sem tempo,
   então o uso único podia ser consumido por uma reconexão dias depois, e o
   teto dependia do histórico do usuário. Fechado com uma janela de 1 h.

## Revisão

O Codex revisou até o commit `dadd582` e **esgotou a cota da conta** antes de
ver os dois últimos. O head foi auditado internamente no lugar dele, com as
mutações refeitas em vez de lidas — a auditoria reprovou em três afirmações
falsas de comentário, corrigidas no último commit.

## Limites assumidos, escritos no código

Uma janela estreita de auditoria duplicada (a auditoria do webhook é gravada
depois do commit da conexão); a 1ª reconexão dentro da janela de handoff não
audita; e só `item/created` adota, então item cujo `item/created` se perdeu
não é adotado por evento posterior — a recuperação é o one-shot. Nenhum é
regressão contra a `main`.

## Medido

- `pytest -q` (sem `--ignore`), no head: **6628 passed, 4 xfailed, 0 failed**
- `npm run test:frontend`: **326 tests, 319 pass, 0 fail, 7 skipped**
- o teste de contraste é sensível: revertendo só a `comecar.css:126` ele
  acusa 1,25:1 e fica vermelho
- as três corridas têm prova determinística (barreiras, sem `sleep`), e a
  coluna dupla dá `1 conexão / 1 rastro` em 360 rodadas
- a janela de handoff foi medida **dentro da janela 00–03 UTC**, com offsets
  de −12:00 a +05:30 e `TZ`/`PGTZ` assimétricos

## Não verificado

- **nenhuma chamada real à Pluggy** — `get_pluggy_item` e `delete_pluggy_item`
  estão mockados em 100% do que rodou;
- **o script nunca rodou contra produção**;
- **o card "Atualizando…" está provado na API, não na tela**: os testes
  asseguram `ui.state == "updating"` no `GET /open-finance/{uid}`, mas
  ninguém verificou que o `dashboard.js` o pinta;
- **entrega fora de ordem** (`item/updated` primeiro, `item/created` que
  nunca chega) **não tem teste**;
- **o CSS/texto só aparece depois do deploy** (o app carrega o site ao vivo),
  e não foi aberto no aparelho — o teste de contraste roda em Chromium
  headless;
- **o item 3 (logo pequeno) não tem código aqui.** O SDK `pluggy-connect
  v2.7.0` não expõe prop de logo/branding e o `<img>` está dentro do iframe
  de `connect.pluggy.ai`, cross-origin. A ação é subir arte quadrada
  (`frontend/brand/icon-512.png`) no painel da Pluggy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
