### PR TITLE
A poda das três tabelas passa a rodar de verdade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,14 @@ GA4_API_SECRET=
 # Limite de contas removidas por execução do job dedicado no Railway.
 ACCOUNT_DELETION_JOB_LIMIT=50
 
+# KILL SWITCH da poda de tabelas (core/services/table_cleanup.py): tarefa de
+# fundo do app que APAGA LINHA em auth_refresh_tokens, mfa_login_challenges e
+# pending_google_signups. Roda em boot+122s e a cada N horas. Default 24 se
+# ausente; 0 (ou negativo) DESLIGA — a corrotina termina em vez de dormir.
+# Valor não-inteiro cai no default 24 sem reclamar. Para podar na hora, sem
+# esperar o tick: `python scripts/cleanup_job.py --dry-run` (e sem a flag).
+# TABLE_CLEANUP_INTERVAL_HOURS=24
+
 # E-mail público exibido nos avisos de suporte.
 SUPPORT_EMAIL=contato@pigbankai.com
 

--- a/core/refresh_tokens.py
+++ b/core/refresh_tokens.py
@@ -251,11 +251,16 @@ def revoke_user_refresh_tokens(user_id: int) -> int:
 
 
 def cleanup_expired_refresh_tokens() -> int:
-    """Limpeza periódica de refresh tokens expirados/revogados há mais de 30d.
+    """Limpeza periódica: revogado há mais de 30d OU expirado há mais de 7d.
 
-    Chamada pelo cron de manutenção (scripts/cleanup_job.py, railway.cleanup.toml).
-    A falha PROPAGA de propósito: engolir a exceção e devolver 0 deixaria o cron
-    verde enquanto a tabela cresce sem poda. Quem chama já loga e sai rc=1.
+    Os dois prazos são diferentes de propósito e o SQL abaixo é a fonte: token
+    REVOGADO ainda serve de trilha de auditoria de logout/roubo por 30 dias;
+    token que só EXPIROU não prova nada depois de 7.
+
+    Chamada pela tarefa de fundo do app (core/services/table_cleanup.py) e, à
+    mão, por scripts/cleanup_job.py. A falha PROPAGA de propósito: engolir a
+    exceção e devolver 0 deixaria o job verde enquanto a tabela cresce sem
+    poda. Quem chama já loga (e o script sai rc=1).
     """
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(

--- a/core/services/table_cleanup.py
+++ b/core/services/table_cleanup.py
@@ -1,0 +1,166 @@
+"""
+core/services/table_cleanup.py — Poda das três tabelas que só crescem.
+
+As três funções de limpeza já existiam e ninguém as chamava; o cron do Railway
+que deveria chamá-las nunca foi criado no painel (e, desde 2026-08-28, serviço
+novo não consegue mais optar por Config as Code). Por isso a poda passou a
+rodar como tarefa de fundo do próprio app, no lifespan:
+
+  core/refresh_tokens.py  cleanup_expired_refresh_tokens  → auth_refresh_tokens
+  db/mfa.py               cleanup_expired_challenges      → mfa_login_challenges
+  db/google_auth.py       cleanup_expired_pending_signups → pending_google_signups
+
+Uma fonte de verdade, dois consumidores: `run_table_cleanup` é chamada pelo loop
+daqui (`_table_cleanup` no lifespan) e por `scripts/cleanup_job.py` (execução
+manual, `--dry-run`).
+
+As três funções são SÍNCRONAS e usam `get_conn()` bloqueante — o loop as chama
+por `asyncio.to_thread`, senão o event loop do app inteiro trava durante o
+DELETE.
+
+Horário: o laço roda em boot+122s e a cada TABLE_CLEANUP_INTERVAL_HOURS — 122 e não
+120 porque o wrapper do lifespan dorme 2s antes do import tardio
+(`frontend/finance_bot_websocket_custom.py:1893`) e só então entra no `sleep(120)`
+daqui. Ou seja
+NO HORÁRIO DO ÚLTIMO DEPLOY, e de novo a cada deploy. A propriedade das 04:00 UTC
+que o `railway.cleanup.toml` apagado justificava ("duas horas antes do job de
+exclusão, no vale de tráfego") foi ABANDONADA de propósito: ela já era falsa
+quando escrita — o `_account_deletion_worker` roda de hora em hora dentro do app
+e `auth_refresh_tokens` tem cascade por `user_id`, então DELETE nessa tabela já
+acontece em horário arbitrário 24×/dia.
+
+Config (env, opcional):
+  - TABLE_CLEANUP_INTERVAL_HOURS (default '24') — 0 (ou negativo) desliga o job.
+
+ponytail: tetos conhecidos, não implementados (P2/P3 do Tester) — sem
+`lock_timeout` no DELETE, sem cancelar a thread do `to_thread` quando a task cai,
+e sem validar a env (valor não-inteiro cai no default 24, negativo desliga como
+0). Intervalo FRACIONÁRIO não sai de validação nenhuma: o `int()` de
+`_interval_hours` (`:79`) é quem trunca, e quem pedir 0,5h troca esse `int` por
+`float`. Validar a env é outro pedido — o de recusar lixo em vez de cair no 24
+calado.
+
+O teto do lock NÃO tem gatilho vindo daqui, e isso é a parte que importa: se a
+poda travar segurando lock, o laço fica preso DENTRO do `to_thread` — o `while`
+só relê `TABLE_CLEANUP_INTERVAL_HOURS` quando o `await` volta, então zerar a env
+não desliga nada, e nenhum log sai (o `log_event` do fim da volta nunca é
+alcançado). Não existe instrumento no app que informe que aconteceu: quem mostra
+é o banco (`pg_stat_activity` / `pg_locks`), e a evidência de fora é a poda
+parar de gravar o evento `cleanup_job` no painel.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from core.observability import get_logger
+
+logger = get_logger(__name__)
+
+
+def log_event(level: str, message: str, details: dict) -> None:
+    """Registra em `system_event_logs` — é de lá que o painel lê.
+
+    Uma fonte, dois consumidores: o laço daqui e `scripts/cleanup_job.py`.
+    `logger.info` NÃO serve: o `_DashboardHandler` (`core/observability.py`) só
+    espelha registro >= WARNING, então a falha da poda não chegava ao painel
+    pelo caminho do app (o `rc=1` do script cobria só a execução manual)."""
+    try:
+        from core.observability import log_system_event_sync
+
+        log_system_event_sync(
+            level,
+            "cleanup_job",
+            message,
+            source="core.services.table_cleanup",
+            details=details,
+        )
+    except Exception:
+        pass
+
+
+def _interval_hours() -> int:
+    try:
+        return int(os.getenv("TABLE_CLEANUP_INTERVAL_HOURS", "24"))
+    except (TypeError, ValueError):
+        return 24
+
+
+def _cleanups() -> list[tuple[str, object]]:
+    from core.refresh_tokens import cleanup_expired_refresh_tokens
+    from db.google_auth import cleanup_expired_pending_signups
+    from db.mfa import cleanup_expired_challenges
+
+    return [
+        ("auth_refresh_tokens", cleanup_expired_refresh_tokens),
+        ("mfa_login_challenges", cleanup_expired_challenges),
+        ("pending_google_signups", cleanup_expired_pending_signups),
+    ]
+
+
+def run_table_cleanup(*, dry_run: bool = False) -> dict:
+    """Poda as três tabelas. Síncrona; devolve {"removed", "errors", "dry_run"}."""
+    removed: dict[str, int] = {}
+    errors: list[dict] = []
+
+    for table, fn in _cleanups():
+        if dry_run:
+            # ponytail: dry-run só lista o que seria podado. Contar as linhas
+            # exigiria repetir o predicado de cada DELETE aqui (segunda fonte
+            # de verdade, CLAUDE.md §0.7). Se a contagem for necessária, ela
+            # nasce dentro de cada função de limpeza, não aqui.
+            print(f"[cleanup_job] dry-run: {table} seria podada (nada apagado)", flush=True)
+            continue
+        try:
+            n = int(fn() or 0)  # type: ignore[operator]
+        except Exception as exc:
+            # Uma tabela que falha não pode impedir a poda das outras duas.
+            errors.append({"table": table, "error": repr(exc)})
+            print(f"[cleanup_job] {table}: FALHOU — {exc}", file=sys.stderr, flush=True)
+            continue
+        removed[table] = n
+        print(f"[cleanup_job] {table}: {n} linha(s) removida(s)", flush=True)
+
+    return {"removed": removed, "errors": errors, "dry_run": dry_run}
+
+
+async def run_table_cleanup_loop() -> None:
+    """Loop perpétuo (asyncio task no lifespan). Roda a poda 1x/dia.
+
+    Com TABLE_CLEANUP_INTERVAL_HOURS <= 0 a corrotina TERMINA (não fica
+    dormindo). A condição é relida a cada volta, então intervalo zerado em
+    tempo de execução também encerra em vez de virar laço quente.
+
+    CLASSE CEGA — o valor da espera não é medido por teste nenhum. Os testes
+    trocam `asyncio.sleep` por um no-op para não esperar os 120s + 24h, então
+    trocar `espera = _interval_hours() * 3600` por `espera = 1` (poda a cada
+    segundo, em produção) deixa os 10 de `tests/test_table_cleanup.py` +
+    `tests/test_cleanup_job.py` VERDES — medido, 10 passed. Eles provam O QUE o
+    laço faz por volta, nunca QUANDO. Um teste de relógio aqui seria cerimônia
+    (mockar o `sleep` para conferir o argumento afirma a própria linha); quem
+    confere é a leitura. Não leia "testes com controle de mutação" como se o
+    intervalo estivesse coberto — só o `<= 0` do kill switch está (T4)."""
+    espera = 120  # deixa o boot assentar antes do 1º tick
+    while _interval_hours() > 0:
+        await asyncio.sleep(espera)
+        try:
+            resumo = await asyncio.to_thread(run_table_cleanup)
+            # `to_thread` também aqui: o INSERT de `log_event` é bloqueante
+            # (ponytail do `_DashboardHandler`) e isto roda no event loop do app.
+            await asyncio.to_thread(
+                log_event,
+                "error" if resumo["errors"] else "info",
+                f"Poda de tabelas concluída: {resumo}",
+                resumo,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensivo
+            # `to_thread` aqui também, e pelo MESMO motivo do `log_event`:
+            # `get_logger` deixa o `_DashboardHandler` no root logger, e o
+            # `emit` dele chama `log_system_event_sync` → `psycopg.connect` +
+            # INSERT na thread do caller. Um `logger.warning` daqui é o mesmo
+            # INSERT bloqueante, dentro do event loop do app.
+            await asyncio.to_thread(logger.warning, "[table_cleanup] erro: %s", exc)
+        espera = _interval_hours() * 3600

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -211,8 +211,13 @@ por isso recusa com 409 quando `last_payment_status` é `trialing|active|past_du
 
 Sobem no startup do app quando `RUN_BACKGROUND_TASKS != "0"`: rendimento de
 investimento, Open Finance (abaixo), cobrança de recorrentes, agendadores de
-engajamento e de IA proativa, retenção de eventos de login. Em teste e no
-`dashboard_dev.py` ficam desligadas.
+engajamento e de IA proativa, retenção de eventos de login, poda das tabelas de
+refresh token / challenge de MFA / cadastro Google pendente
+(`core/services/table_cleanup.py`). Ficam desligadas só onde
+`RUN_BACKGROUND_TASKS=0` é forçado: `dashboard_dev.py` e
+`scripts/whatsapp_qa_vault_harness.py`. O `tests/conftest.py` **não** força, então
+teste que sobe o `app` herda o default (`1`) — `tests/test_table_cleanup.py` passa
+`"1"` de propósito, para ver a tarefa subir.
 
 O Open Finance tem **três** trabalhos, não dois: expiração de trial
 (`_open_finance_trial_expiry`), refresh proativo e **job de saúde** — os dois últimos no
@@ -316,7 +321,9 @@ Grupos: `DATABASE_URL`/`DB_POOL_*` · `JWT_SECRET`/`DASHBOARD_*` ·
 `PII_ENCRYPTION_KEY`/`PII_HASH_PEPPER`/`PII_AUDIT_DISABLED` · `MFA_ENCRYPTION_KEY` ·
 `WA_*` · `DISCORD_BOT_TOKEN` · `OPENAI_*`/`AI_*`/`AGENTS_*` · `STRIPE_*`/`PLANS_V2_ENABLED` ·
 `PLUGGY_*`/`OF_*` · `RESEND_API_KEY`/`EMAIL_FROM*` · `APNS_*` · `ADMIN_DASHBOARD_*` ·
-`META_PIXEL_ID` · `RUN_BACKGROUND_TASKS`/`SKIP_INIT_DB`/`ENABLE_DEV_ENDPOINTS`.
+`META_PIXEL_ID` · `RUN_BACKGROUND_TASKS`/`SKIP_INIT_DB`/`ENABLE_DEV_ENDPOINTS` ·
+`ACCOUNT_DELETION_JOB_LIMIT`/`TABLE_CLEANUP_INTERVAL_HOURS` (os dois kill switches
+de job que apaga linha; `TABLE_CLEANUP_INTERVAL_HOURS=0` desliga a poda).
 
 ---
 

--- a/docs/armadilhas.md
+++ b/docs/armadilhas.md
@@ -347,6 +347,11 @@ fixo de toda mudança de layout.
 - **`launch.py` sobe dois processos**: o uvicorn (que atende o `$PORT` do Railway) e o
   `bot.py` do Discord. Um `web` no Procfile, dois processos filhos.
 - **Tarefas de fundo sobem no startup do app** quando `RUN_BACKGROUND_TASKS != "0"`
-  (agendadores de investimento, Open Finance, engajamento, cobrança recorrente…).
-  Em teste e no `dashboard_dev.py` isso é desligado — se você ligar sem querer num
-  ambiente com banco real, elas escrevem.
+  (agendadores de investimento, Open Finance, engajamento, cobrança recorrente, poda
+  das tabelas de token/challenge…). Dois arquivos põem o `0`, e por `setdefault`
+  (o ambiente ganha deles): `dashboard_dev.py:69` e
+  `scripts/whatsapp_qa_vault_harness.py:69`. **Em teste NÃO é desligado** — o
+  `tests/conftest.py` não põe nada, então teste que sobe o `app` herda o default
+  (`1`) e as tarefas escrevem no banco daquela execução, a menos que ele mesmo
+  passe `0` na env do subprocesso (`tests/test_log_falha_nivel.py:183`). A versão
+  longa está no `docs/CLAUDE.md`, seção "Tarefas de fundo".

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -1885,6 +1885,17 @@ async def lifespan(app: FastAPI):
         except Exception as exc:
             print(f"[login_events_retention] erro: {exc}", file=sys.stderr)
 
+    async def _table_cleanup():
+        # Poda de auth_refresh_tokens/mfa_login_challenges/pending_google_signups.
+        # As três funções são síncronas (get_conn bloqueante); o loop as chama por
+        # asyncio.to_thread — ver core/services/table_cleanup.py.
+        try:
+            await asyncio.sleep(2)
+            from core.services.table_cleanup import run_table_cleanup_loop  # noqa: PLC0415
+            await run_table_cleanup_loop()
+        except Exception as exc:
+            print(f"[table_cleanup] erro: {exc}", file=sys.stderr)
+
     async def _plan_grants_reprojection():
         """Reprojeta acesso de quem teve grant começando ou vencendo (§4.3).
 
@@ -2012,6 +2023,7 @@ async def lifespan(app: FastAPI):
                 asyncio.create_task(_news_bot(), name="news_bot"),
                 asyncio.create_task(_piggy_agents(), name="piggy_agents"),
                 asyncio.create_task(_login_events_retention(), name="login_events_retention"),
+                asyncio.create_task(_table_cleanup(), name="table_cleanup"),
                 asyncio.create_task(_plan_grants_reprojection(), name="plan_grants_reprojection"),
             ]
         )

--- a/railway.cleanup.toml
+++ b/railway.cleanup.toml
@@ -1,7 +1,0 @@
-# Poda de auth_refresh_tokens, mfa_login_challenges e pending_google_signups.
-# 04:00 UTC (01:00 BRT): duas horas antes do job de exclusão de conta
-# (railway.account-deletion.toml, 06:00 UTC) e no vale de tráfego do WhatsApp.
-[deploy]
-startCommand = "python scripts/cleanup_job.py"
-cronSchedule = "0 4 * * *"
-restartPolicyType = "NEVER"

--- a/scripts/cleanup_job.py
+++ b/scripts/cleanup_job.py
@@ -1,16 +1,12 @@
 """
 Job de manutenção: poda as três tabelas que só crescem.
 
-Projetado para Railway Cron: executa uma vez, fecha recursos e encerra.
+Execução MANUAL (e `--dry-run`): roda uma vez, fecha recursos e encerra.
 
-As três funções de limpeza já existiam e ninguém as chamava:
-  core/refresh_tokens.py  cleanup_expired_refresh_tokens  → auth_refresh_tokens
-  db/mfa.py               cleanup_expired_challenges      → mfa_login_challenges
-  db/google_auth.py       cleanup_expired_pending_signups → pending_google_signups
-
-Horário (railway.cleanup.toml): 04:00 UTC = 01:00 BRT. Duas horas antes do job
-de exclusão de conta (06:00 UTC), então os dois nunca competem por conexão nem
-por lock; e é o vale de tráfego do WhatsApp (madrugada no Brasil).
+Em produção quem agenda a poda NÃO é cron: é a tarefa de fundo do próprio app
+(`core/services/table_cleanup.py`, registrada no lifespan). A lógica mora lá —
+aqui restou só a casca de linha de comando, para podar na hora sem esperar o
+tick e para ver o que seria podado.
 """
 from __future__ import annotations
 
@@ -24,69 +20,27 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
 from config.env import load_app_env
-
-
-def _log_event(level: str, message: str, details: dict) -> None:
-    try:
-        from core.observability import log_system_event_sync
-
-        log_system_event_sync(
-            level,
-            "cleanup_job",
-            message,
-            source="scripts.cleanup_job",
-            details=details,
-        )
-    except Exception:
-        pass
-
-
-def _cleanups() -> list[tuple[str, object]]:
-    from core.refresh_tokens import cleanup_expired_refresh_tokens
-    from db.google_auth import cleanup_expired_pending_signups
-    from db.mfa import cleanup_expired_challenges
-
-    return [
-        ("auth_refresh_tokens", cleanup_expired_refresh_tokens),
-        ("mfa_login_challenges", cleanup_expired_challenges),
-        ("pending_google_signups", cleanup_expired_pending_signups),
-    ]
+# `log_event` mora no serviço (uma fonte, dois consumidores): o laço do app
+# também precisa registrar a falha em `system_event_logs`, não só este script.
+# Sem underscore de propósito — é contrato entre módulos, não detalhe interno.
+# (O `_log_event` de `scripts/account_deletion_job.py` continua privado: tem um
+# consumidor só, o próprio arquivo.)
+from core.services.table_cleanup import log_event, run_table_cleanup
 
 
 def run(*, dry_run: bool = False) -> int:
     started_at = datetime.now(timezone.utc).isoformat()
     print(f"[cleanup_job] iniciado em {started_at}; dry_run={dry_run}", flush=True)
 
-    removed: dict[str, int] = {}
-    errors: list[dict] = []
-
-    for table, fn in _cleanups():
-        if dry_run:
-            # ponytail: dry-run só lista o que seria podado. Contar as linhas
-            # exigiria repetir o predicado de cada DELETE aqui (segunda fonte
-            # de verdade, CLAUDE.md §0.7). Se a contagem for necessária, ela
-            # nasce dentro de cada função de limpeza, não aqui.
-            print(f"[cleanup_job] dry-run: {table} seria podada (nada apagado)", flush=True)
-            continue
-        try:
-            n = int(fn() or 0)  # type: ignore[operator]
-        except Exception as exc:
-            # Uma tabela que falha não pode impedir a poda das outras duas.
-            errors.append({"table": table, "error": repr(exc)})
-            print(f"[cleanup_job] {table}: FALHOU — {exc}", file=sys.stderr, flush=True)
-            continue
-        removed[table] = n
-        print(f"[cleanup_job] {table}: {n} linha(s) removida(s)", flush=True)
-
-    summary = {"removed": removed, "errors": errors, "dry_run": dry_run}
-    _log_event(
-        "error" if errors else "info",
+    summary = run_table_cleanup(dry_run=dry_run)
+    log_event(
+        "error" if summary["errors"] else "info",
         f"Job de limpeza concluído: {summary}",
         summary,
     )
     print(f"[cleanup_job] concluído: {summary}", flush=True)
 
-    return 1 if errors else 0
+    return 1 if summary["errors"] else 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_cleanup_job.py
+++ b/tests/test_cleanup_job.py
@@ -16,8 +16,8 @@ def test_falha_em_uma_tabela_nao_impede_as_outras(monkeypatch, capsys):
         chamadas.append("mfa_login_challenges")
         raise RuntimeError("conexão caiu no meio")
 
-    monkeypatch.setattr(cleanup_job, "_log_event", lambda *a, **k: None)
-    monkeypatch.setattr(cleanup_job, "_cleanups", lambda: [
+    monkeypatch.setattr(cleanup_job, "log_event", lambda *a, **k: None)
+    monkeypatch.setattr("core.services.table_cleanup._cleanups", lambda: [
         ("auth_refresh_tokens", _ok("auth_refresh_tokens", 3)),
         ("mfa_login_challenges", _explode),
         ("pending_google_signups", _ok("pending_google_signups", 0)),
@@ -30,7 +30,7 @@ def test_falha_em_uma_tabela_nao_impede_as_outras(monkeypatch, capsys):
     assert "auth_refresh_tokens: 3 linha(s) removida(s)" in saida.out
     assert "pending_google_signups: 0 linha(s) removida(s)" in saida.out
     assert "mfa_login_challenges: FALHOU" in saida.err
-    assert rc == 1  # o cron precisa marcar a execução como falha
+    assert rc == 1  # a execução manual precisa sair vermelha
 
 
 def test_falha_no_delete_de_refresh_tokens_chega_ao_resultado(monkeypatch, capsys):
@@ -47,12 +47,12 @@ def test_falha_no_delete_de_refresh_tokens_chega_ao_resultado(monkeypatch, capsy
     monkeypatch.setattr("db.google_auth.cleanup_expired_pending_signups", lambda: 0)
 
     eventos: list[tuple[str, dict]] = []
-    monkeypatch.setattr(cleanup_job, "_log_event", lambda level, msg, det: eventos.append((level, det)))
+    monkeypatch.setattr(cleanup_job, "log_event", lambda level, msg, det: eventos.append((level, det)))
 
     rc = cleanup_job.run()
     saida = capsys.readouterr()
 
-    assert rc == 1, "cron ficaria verde sobre tabela que não foi podada"
+    assert rc == 1, "o job ficaria verde sobre tabela que não foi podada"
     assert [(lvl, [e["table"] for e in det["errors"]]) for lvl, det in eventos] == [
         ("error", ["auth_refresh_tokens"])
     ]

--- a/tests/test_table_cleanup.py
+++ b/tests/test_table_cleanup.py
@@ -1,0 +1,334 @@
+"""core/services/table_cleanup.py — a poda apaga o que deve e NÃO apaga o resto.
+
+Isto APAGA LINHA EM PRODUÇÃO, então cada tabela tem os dois lados: uma linha
+que TEM de cair e pelo menos uma que TEM de ficar (sessão viva, MFA em curso,
+cadastro Google em curso).
+
+Isolamento: toda linha entra com chave `uuid4` e toda asserção conta por essa
+chave (`where token(_hash) = %s`), nunca `count(*)` da tabela. O motivo NÃO é
+outra execução de suíte — cada execução cria o próprio database `pytest_<uuid>`
+(`tests/conftest.py:146`). É que a poda é GLOBAL e roda no mesmo database dos
+demais testes da MESMA execução: qualquer um deles pode ter deixado token,
+challenge ou cadastro pendente nessas três tabelas, e `count(*)` os contaria.
+
+Rodar:
+  DATABASE_URL=... PYTHONPATH=. .venv/bin/python -m pytest tests/test_table_cleanup.py -q
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+from _billing_grants_helpers import garantir_system_event_logs
+from core.services.table_cleanup import run_table_cleanup, run_table_cleanup_loop
+from db.connection import get_conn
+
+
+def _existe(tabela: str, coluna: str, chave: str) -> bool:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(f"select count(*) as n from {tabela} where {coluna} = %s", (chave,))
+        return int(cur.fetchone()["n"]) == 1
+
+
+def _eventos(marcador: str) -> list[tuple[str, str, str]]:
+    """O que a poda gravou no painel — filtrado pela chave, nunca a tabela toda."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "select level, event_type, source from system_event_logs"
+            " where message like %s order by id",
+            (f"%{marcador}%",),
+        )
+        return [(r["level"], r["event_type"], r["source"]) for r in cur.fetchall()]
+
+
+def test_refresh_tokens_poda_expirado_e_preserva_sessao_viva(user_id):
+    casos = {
+        "A_revogado_31d": ("now() - interval '31 days'", "now() + interval '1 day'", False),
+        "B_expirado_8d": (None, "now() - interval '8 days'", False),
+        "C_revogado_29d": ("now() - interval '29 days'", "now() + interval '1 day'", True),
+        "D_expirado_6d": (None, "now() - interval '6 days'", True),
+        "E_sessao_viva": (None, "now() + interval '10 days'", True),
+    }
+    chaves = {nome: uuid.uuid4().hex for nome in casos}
+
+    with get_conn() as conn, conn.cursor() as cur:
+        for nome, (revoked, expires, _) in casos.items():
+            cur.execute(
+                f"""
+                insert into auth_refresh_tokens
+                    (token_hash, user_id, session_jti, expires_at, revoked_at)
+                values (%s, %s, %s, {expires}, {revoked or 'null'})
+                """,
+                (chaves[nome], user_id, uuid.uuid4().hex),
+            )
+        conn.commit()
+
+    run_table_cleanup()
+
+    sobreviveu = {n: _existe("auth_refresh_tokens", "token_hash", chaves[n]) for n in casos}
+    assert sobreviveu == {n: casos[n][2] for n in casos}
+
+
+def test_mfa_challenges_poda_o_velho_e_preserva_quem_esta_no_meio_do_mfa(user_id):
+    casos = {
+        "expirou_2d": ("now() - interval '2 days'", False),
+        "expirou_2h": ("now() - interval '2 hours'", True),
+        "em_curso": ("now() + interval '5 minutes'", True),
+    }
+    chaves = {nome: uuid.uuid4().hex for nome in casos}
+
+    with get_conn() as conn, conn.cursor() as cur:
+        for nome, (expires, _) in casos.items():
+            cur.execute(
+                f"insert into mfa_login_challenges (token, user_id, expires_at)"
+                f" values (%s, %s, {expires})",
+                (chaves[nome], user_id),
+            )
+        conn.commit()
+
+    run_table_cleanup()
+
+    sobreviveu = {n: _existe("mfa_login_challenges", "token", chaves[n]) for n in casos}
+    assert sobreviveu == {n: casos[n][1] for n in casos}
+
+
+def test_pending_google_poda_o_expirado_e_preserva_cadastro_em_curso():
+    casos = {
+        "expirou_1min": ("now() - interval '1 minute'", False),
+        "em_curso": ("now() + interval '10 minutes'", True),
+    }
+    chaves = {nome: uuid.uuid4().hex for nome in casos}
+
+    with get_conn() as conn, conn.cursor() as cur:
+        for nome, (expires, _) in casos.items():
+            cur.execute(
+                f"""
+                insert into pending_google_signups
+                    (token, provider, provider_sub, email, expires_at)
+                values (%s, 'google', %s, %s, {expires})
+                """,
+                (chaves[nome], uuid.uuid4().hex, f"{chaves[nome]}@example.test"),
+            )
+        conn.commit()
+
+    try:
+        run_table_cleanup()
+        sobreviveu = {n: _existe("pending_google_signups", "token", chaves[n]) for n in casos}
+        assert sobreviveu == {n: casos[n][1] for n in casos}
+    finally:
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "delete from pending_google_signups where token = any(%s)",
+                (list(chaves.values()),),
+            )
+            conn.commit()
+
+
+def test_intervalo_zero_desliga_o_loop_sem_podar(monkeypatch):
+    """Kill switch: a corrotina RETORNA e não chama a poda uma vez sequer."""
+    import core.services.table_cleanup as tc
+
+    chamadas: list[int] = []
+    monkeypatch.setenv("TABLE_CLEANUP_INTERVAL_HOURS", "0")
+    monkeypatch.setattr(tc, "run_table_cleanup", lambda **kw: chamadas.append(1))
+
+    asyncio.run(asyncio.wait_for(run_table_cleanup_loop(), timeout=5))
+
+    assert chamadas == []
+
+
+# T5 — a tarefa SOBE no lifespan. É o teste que prende o bug original: as três
+# funções de poda existiam e ninguém as chamava. Ler o arquivo com `read_text()`
+# procurando o nome da função não mede nada (CLAUDE.md §3), então isto sobe um
+# processo com o `app` de verdade e vê a corrotina ser executada. O loop real é
+# trocado por um marcador ANTES do import do app — o wrapper do lifespan faz
+# import tardio, que resolve o atributo do módulo na hora da chamada.
+_SUBPROCESSO = r'''
+import os
+_ENV_INICIAL = set(os.environ)   # antes de tudo; o diff no fim acusa o disco
+
+# PRIMEIRA linha de projeto, antes de tudo: `config/env.py:95-97` faz
+# `os.environ.setdefault` com o `.env` do DISCO, e `load_app_env` roda no IMPORT de
+# `core.observability`, `frontend.routes.shared` e do monólito. Sem isto, as 17
+# tarefas de fundo sobem com o `.env` inteiro na mão — não só as chaves de saída:
+# medido no checkout principal, `load_app_env` acendeu 9 segredos (SMTP_PASSWORD,
+# MFA_ENCRYPTION_KEY, WA_APP_SECRET, GOOGLE_CLIENT_SECRET…) que a env montada
+# abaixo nunca passou. `ROOT_DIR` é o único ponto por onde o disco entra
+# (`config/env.py:32-39`); apontá-lo para um diretório vazio faz `merged = {}` e
+# fecha a CATEGORIA, em vez de nomear chaves uma a uma.
+# A ordem é o contrato: qualquer import de projeto ACIMA desta linha reabre o buraco.
+import pathlib, tempfile
+import config.env
+config.env.ROOT_DIR = pathlib.Path(tempfile.mkdtemp())
+
+import json, time
+import core.services.table_cleanup as tc
+
+estado = {"iniciou": False}
+
+async def _marcador():
+    estado["iniciou"] = True
+
+tc.run_table_cleanup_loop = _marcador
+
+import frontend.finance_bot_websocket_custom as m
+from fastapi.testclient import TestClient
+
+with TestClient(m.app):          # lifespan de verdade, como no processo web
+    for _ in range(80):          # o wrapper dorme 2s antes do import tardio
+        if estado["iniciou"]:
+            break
+        time.sleep(0.25)
+
+# Prova que o disco não entrou: `load_app_env` já rodou (o import do monólito o
+# chama), então qualquer chave lida do `.env` estaria aqui. A lista é DERIVADA do
+# ambiente — não há nomes de segredo a manter, então ela não envelhece junto com o
+# `.env`. Os três excluídos são escritos pelo próprio `config/env.py`, com ou sem
+# disco: `APP_ENV` (`:108`), `TZ` (import de `utils_date`) e `PGTZ`
+# (`align_process_tz`, `:121`). Se um quarto aparecer, isto fica VERMELHO — que é
+# a direção certa da falha, ao contrário da lista de 5 nomes que estava aqui e
+# passava verde deixando o resto do `.env` vivo.
+estado["do_disco"] = sorted(set(os.environ) - _ENV_INICIAL - {"APP_ENV", "TZ", "PGTZ"})
+print("RESULTADO:" + json.dumps(estado))
+'''
+
+
+def test_processo_do_app_liga_a_poda_no_lifespan():
+    """CONTRATO: um processo que serve o `app` com RUN_BACKGROUND_TASKS=1
+    executa o loop de poda. Sem o `create_task`, `{"iniciou": false}`."""
+    raiz = Path(__file__).resolve().parent.parent
+    # env MONTADA, não `{**os.environ}`: com `RUN_BACKGROUND_TASKS=1` este é o
+    # único teste do repositório que sobe as 17 tarefas de fundo, e herdar o
+    # ambiente entregava as credenciais de terceiros VIVAS a elas por ~6s.
+    # Enxugar a env SOZINHO não protegia nada — o `.env` do disco repunha o que
+    # faltasse. Quem fecha o disco é o `ROOT_DIR` do `_SUBPROCESSO` acima; esta
+    # env é a outra metade (o que o processo pai NÃO repassa).
+    # É o MÍNIMO medido para o boot chegar ao lifespan: sem `JWT_SECRET` o
+    # processo aborta ("Refusing to start with insecure default"); com estas
+    # quatro chaves ele sobe e imprime RESULTADO (medido: `iniciou: true`).
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": ".",
+        "RUN_BACKGROUND_TASKS": "1",
+        "DATABASE_URL": os.environ.get("DATABASE_URL", ""),
+        "JWT_SECRET": os.environ.get("JWT_SECRET", ""),
+    }
+    proc = subprocess.run(
+        [sys.executable, "-c", _SUBPROCESSO], cwd=raiz, env=env,
+        capture_output=True, text=True, timeout=180,
+    )
+    linha = next((l for l in proc.stdout.splitlines()
+                  if l.startswith("RESULTADO:")), None)
+    assert linha, f"subprocesso não chegou ao fim:\n{proc.stdout[-2000:]}\n{proc.stderr[-2000:]}"
+    assert json.loads(linha[len("RESULTADO:"):]) == {
+        "iniciou": True, "do_disco": []
+    }, (
+        "a poda existe e ninguém a chama (lifespan sem a tarefa de fundo), OU "
+        "o `.env` do disco entrou e as 17 tarefas de fundo subiram com "
+        "credencial de terceiro viva.\n"
+        f"{proc.stderr[-2000:]}"
+    )
+
+
+# T6 — o CORPO do laço. T1/T2/T3 chamam `run_table_cleanup()` direto e T4 põe
+# intervalo 0 (o `while` nem entra): trocar o corpo por `pass` deixava tudo
+# verde. Aqui o laço roda LIGADO, com a espera curto-circuitada.
+def test_laco_ligado_executa_a_poda(monkeypatch):
+    """Com intervalo válido, uma volta do laço chama a poda de fato.
+
+    Mutação: corpo do `while` → `pass` deixa `chamadas` vazia (e o laço nunca
+    encerra, porque quem zera a env é a própria poda) → vermelho."""
+    import core.services.table_cleanup as tc
+
+    chamadas: list[dict] = []
+    espera_real = asyncio.sleep
+    monkeypatch.setenv("TABLE_CLEANUP_INTERVAL_HOURS", "24")
+
+    def _poda(**kw):
+        chamadas.append(kw)
+        os.environ["TABLE_CLEANUP_INTERVAL_HOURS"] = "0"  # 2ª volta encerra
+        return {"removed": {"auth_refresh_tokens": 1}, "errors": [], "dry_run": False}
+
+    monkeypatch.setattr(tc, "run_table_cleanup", _poda)
+    monkeypatch.setattr(tc, "log_event", lambda *a, **k: None)
+
+    async def _sem_esperar(_segundos):
+        await espera_real(0)  # cede o loop sem os 120s do boot nem as 24h
+
+    monkeypatch.setattr(asyncio, "sleep", _sem_esperar)
+
+    asyncio.run(asyncio.wait_for(run_table_cleanup_loop(), timeout=5))
+
+    assert chamadas == [{}], "o corpo do laço não executou a poda"
+
+
+# T7 — o ALERTA. T6 (acima) desliga o `log_event` de propósito, e era o único
+# teste a rodar o corpo do laço: apagar o `await asyncio.to_thread(log_event, …)`
+# deixava a suíte inteira verde. Aqui ele fica LIGADO e a asserção é a linha em
+# `system_event_logs` — que é de onde o painel lê.
+def test_falha_da_poda_grava_alerta_de_error_no_painel(monkeypatch):
+    """Poda que volta com `errors` vira linha de nível `error` no painel.
+
+    Mutação: apagar o bloco `await asyncio.to_thread(log_event, …)` do laço →
+    `depois == []` → vermelho."""
+    import core.services.table_cleanup as tc
+
+    garantir_system_event_logs()  # a tabela nasce no startup, não no init_db
+    marcador = uuid.uuid4().hex   # a tabela é global: a busca é pela chave
+    espera_real = asyncio.sleep
+    monkeypatch.setenv("TABLE_CLEANUP_INTERVAL_HOURS", "24")
+
+    def _poda(**kw):
+        os.environ["TABLE_CLEANUP_INTERVAL_HOURS"] = "0"  # 2ª volta encerra
+        return {"removed": {}, "errors": [{"table": marcador, "error": "boom"}],
+                "dry_run": False}
+
+    monkeypatch.setattr(tc, "run_table_cleanup", _poda)  # `log_event` NÃO se desliga
+
+    async def _sem_esperar(_segundos):
+        await espera_real(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _sem_esperar)
+
+    assert _eventos(marcador) == []
+    try:
+        asyncio.run(asyncio.wait_for(run_table_cleanup_loop(), timeout=10))
+
+        assert _eventos(marcador) == [
+            ("error", "cleanup_job", "core.services.table_cleanup")
+        ], "a poda falhou e o painel não ficou sabendo"
+    finally:
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "delete from system_event_logs where message like %s", (f"%{marcador}%",)
+            )
+            conn.commit()
+
+
+def test_dry_run_nao_apaga_nada(user_id):
+    """A única válvula do operador: `--dry-run` LISTA e não apaga.
+
+    Mutação: `if dry_run:` → `if False:` apaga o token abaixo → vermelho."""
+    chave = uuid.uuid4().hex
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            insert into auth_refresh_tokens
+                (token_hash, user_id, session_jti, expires_at)
+            values (%s, %s, %s, now() - interval '8 days')
+            """,
+            (chave, user_id, uuid.uuid4().hex),
+        )
+        conn.commit()
+
+    resumo = run_table_cleanup(dry_run=True)
+
+    assert _existe("auth_refresh_tokens", "token_hash", chave), (
+        "dry-run APAGOU linha que a poda de verdade levaria"
+    )
+    assert resumo == {"removed": {}, "errors": [], "dry_run": True}


### PR DESCRIPTION
Três funções de limpeza existiam e **nunca foram chamadas**. Este PR faz elas rodarem.

## O que estava acontecendo

O `railway.cleanup.toml` (commit `e33e578`) dependia de um serviço Cron no painel do Railway que **nunca foi criado** — o próprio commit avisou que o `.toml` *"não liga nada sozinho"*. Confirmado no painel: cinco serviços, nenhum de cleanup.

**Medido no Postgres de produção em 2026-09-08** (remedir antes de reusar):

```
auth_refresh_tokens      526 de 780 podáveis   mais antiga 2026-05-20
mfa_login_challenges      25 de  25 (100%)     mais antiga 2026-05-08
pending_google_signups     3 de   3 (100%)     mais antiga 2026-06-01
```

Duas das três são **100% lixo**. O volume é pequeno e não é problema de disco — **é retenção de dado pessoal**: `auth_refresh_tokens` guarda `ip` e `user_agent`; `pending_google_signups` guarda `email` e `name_hint` **em texto** de quem começou cadastro pelo Google e nunca terminou.

## Por que não é mais cron do Railway

O Railway descontinuou `Config as Code`: desde **2026-08-28**, serviço que nunca usou **não pode optar**. O caminho documentado no repositório está morto para serviço novo.

A poda vira um laço no lifespan do app, no molde de `core/services/login_events_retention.py` — **sem passo manual no painel**, que é exatamente o que falhou da última vez. `asyncio.to_thread` porque as três funções são síncronas com `get_conn()` bloqueante; copiar o molde async travaria o event loop do app.

A lógica **mudou de casa, não foi copiada**: `_cleanups` e o laço try/except-por-tabela saíram de `scripts/cleanup_job.py` para `core/services/table_cleanup.py`, e o script virou consumidor fino. Uma fonte, dois consumidores.

## Quatro rodadas de revisão, e três acharam a mesma forma de defeito

O conserto entrava e **nada provava que ele continuaria lá**:

1. **O corpo do laço não era exercitado por teste nenhum.** Trocá-lo por `pass` deixava tudo verde — o bug deste PR um nível abaixo.
2. **A falha da poda não chegava a `system_event_logs`.** O `logger.info` fica abaixo do WARNING do `_DashboardHandler`, e o cron apagado dava dois sinais que sumiram: `rc=1` e o evento de erro. Medido em duas colunas: `[]` × `[('error','cleanup_job',…)]`.
3. **O conserto de (2) não tinha teste**, porque o único teste do laço fazia monkeypatch do `log_event` para no-op.

Os três têm teste agora, cada um com a mutação que o deixa vermelho.

## O teste que sobe o app, e o que a medição revelou

O teste que prova que a tarefa **sobe** precisa de `RUN_BACKGROUND_TASKS=1`, e com isso era o primeiro do repositório a subir o app com as 17 tarefas ligadas.

Enxugar a env **não bastava**: `config/env.py` faz `setdefault` com o `.env` do **disco**, então nome ausente é repreenchido com a chave viva. Só medindo isso aparece.

O conserto é apontar `config.env.ROOT_DIR` para um diretório vazio — **medido: 40 chaves do disco → 0** — e a asserção é **derivada** (o que apareceu além do que foi passado), não uma lista de nomes que envelheceria verde. Variável nova deixa o teste **vermelho**, que é a direção certa da falha.

## Classe cega, registrada e sem teste de propósito

**O intervalo não é medido por nada.** Trocar 24h por 1 segundo deixa 10/10 verdes, porque os testes anulam o `asyncio.sleep`. Relógio falso para um laço diário seria cerimônia — mas ninguém deve ler "10 testes com mutação conferida" como se cobrisse o horário. Está escrito no docstring.

Também sai o `railway.cleanup.toml`: ninguém o consumia, e mantê-lo seria um arquivo dizendo que a poda roda às 04:00 UTC quando ela roda por outro mecanismo — a armadilha que o `e33e578` nomeou com todas as letras.

## Medição

**6636 passed, 4 xfailed, 0 failed**, já rebaseada na `main`.

**NÃO VERIFICADO:** que a poda rodou **em produção**. Só pós-deploy — os 526+25+3 têm de cair em até ~24h do primeiro boot, e a verificação é `select count(*)` nas três tabelas. Nada aqui foi exercitado no Railway.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)