### PR TITLE
O último railway.toml sai, e os portões param de mentir sobre o próprio alcance

### DIFF
--- a/docs/railway_account_deletion_job.md
+++ b/docs/railway_account_deletion_job.md
@@ -7,16 +7,21 @@ Ele foi feito para Railway Cron: roda uma vez, processa as contas vencidas, envi
 
 Crie um serviço separado no mesmo projeto Railway, apontando para este mesmo repositório.
 
-Configuração recomendada:
+A configuração é toda pelo painel do Railway, em Settings do serviço:
 
 - Nome do serviço: `account-deletion-job`
-- Config as Code file path: `/railway.account-deletion.toml`
-- Start command: `python scripts/account_deletion_job.py`
-- Cron schedule: `0 6 * * *`
-- Restart policy: `NEVER`
+- Custom Start Command: `python scripts/account_deletion_job.py`
+- Cron Schedule: `0 6 * * *`
+- Restart Policy: não se aplica — o painel avisa que "Services with a cron schedule do not have a restart policy"
+- Config-as-code → Railway Config File: deixar **vazio**
 
-O arquivo `railway.account-deletion.toml` já define o start command, o cron diário e a política de restart.
 O cron do Railway usa UTC; `0 6 * * *` roda uma vez por dia às 06:00 UTC, aproximadamente 03:00 no horário de Brasília.
+
+## Por que não se usa Config as Code
+
+O Railway descontinuou o Config as Code: arquivos de configuração existentes **param de funcionar em 2026-12-01**, e serviço que nunca usou não pode mais optar por ele desde 2026-08-28. Este serviço era configurado por um `railway.account-deletion.toml` na raiz; ele foi migrado para o painel e o arquivo foi apagado, para que ninguém reconfigure pelo caminho que morre em dezembro.
+
+Migração conferida no painel em 2026-09-09: os avisos "The value is set in /railway.account-deletion.toml" sumiram do Custom Start Command e do Cron Schedule, o campo Railway Config File está vazio, a execução das 06:03 UTC de 2026-09-09 saiu verde em 2s e a aba Cron Runs seguia agendando a próxima para 06:00 UTC.
 
 ## Variáveis necessárias
 

--- a/railway.account-deletion.toml
+++ b/railway.account-deletion.toml
@@ -1,4 +1,0 @@
-[deploy]
-startCommand = "python scripts/account_deletion_job.py"
-cronSchedule = "0 6 * * *"
-restartPolicyType = "NEVER"

--- a/tests/test_pix_destino_inerte.py
+++ b/tests/test_pix_destino_inerte.py
@@ -1,8 +1,9 @@
 """Portão de DESTINO: nada de produção fala com o Asaas (PR 1b-A).
 
 Assunto próprio, e não uma seção de `tests/test_pix_inerte.py`, porque o
-UNIVERSO e o MECANISMO são outros: lá são os 395 `.py` lidos com `ast`; aqui são
-os **433 arquivos rastreados** fora de `tests/`, lidos como TEXTO.
+UNIVERSO e o MECANISMO são outros: lá são os `.py` lidos com `ast`; aqui é
+**todo arquivo rastreado** fora de `tests/`, de qualquer formato, lido como
+TEXTO — `git ls-files | grep -vc '^tests/'` conta quantos são hoje.
 
 ## Por que existe: os portões de import veem NOME DE MÓDULO
 
@@ -17,20 +18,25 @@ de rota e de import ficaram verdes.
 
 Porque este portão é textual e não precisa de `ast`, então limitá-lo a Python
 era restrição sem contrapartida — e a contrapartida existia do outro lado:
-**236 arquivos rastreados não são `.py`**, e um deles basta. O Manager plantou
-`railway.pix-manager-probe.toml` nomeando `api.asaas.com`, `ASAAS_API_KEY` e as
-três tabelas: 49 verdes.
+**há arquivo rastreado que não é `.py`** (`git ls-files | grep -vc '[.]py$'`), e
+um deles basta. O Manager plantou `railway.pix-manager-probe.toml` nomeando
+`api.asaas.com`, `ASAAS_API_KEY` e as três tabelas: 49 verdes.
 
-**Não é hipótese exótica.** `railway.account-deletion.toml` já tem
-`startCommand = "python scripts/account_deletion_job.py"` com `cronSchedule` —
-o repositório JÁ roda Python em produção por esse caminho, fora do app. Um
-`railway.pix-drain.toml` chamando `db.pix_charges` emitiria cobrança sem uma
-linha vermelha.
+**Não é hipótese exótica.** O `Procfile` (`web: python launch.py`) é rastreado,
+não é `.py`, e é ele quem dá o start command de produção: o repositório JÁ roda
+Python por um caminho que o `ast` não lê. Um arquivo desse tipo chamando
+`db.pix_charges` emitiria cobrança sem uma linha vermelha.
+
+O exemplo anterior aqui era `railway.account-deletion.toml`, apagado quando o
+`account-deletion-job` migrou para configuração nativa do painel do Railway
+(Config as Code descontinuado, arquivos existentes param em 2026-12-01). A troca
+de exemplo NÃO reduz a cegueira, muda ela de lado: o start command daquele job
+não está mais em arquivo nenhum, o que cai na terceira cegueira abaixo.
 
 CEGUEIRAS DECLARADAS: host montado em partes (`"api." + "asaas" + ".com"`) ou
 env de outro nome; tabela com outro nome; arquivo NÃO rastreado — inclusive um
-script Python fora do git chamado por um `startCommand`. Para essas o método é
-revisão de diff.
+script Python fora do git chamado por um `startCommand`, ou um start command que
+só existe no painel do Railway. Para essas o método é revisão de diff.
 """
 
 import pathlib
@@ -84,9 +90,11 @@ def _producao_todos_os_formatos() -> list[str]:
     """TODO arquivo rastreado fora de `tests/` — o universo do portão de DESTINO.
 
     Ele é TEXTUAL e não precisa de `ast`, então limitá-lo a `.py` era restrição
-    sem contrapartida: sobravam **236** rastreados não-Python, e um basta para
-    emitir cobrança (ver `startCommand`, no cabeçalho). Entram 433; binário é
-    pulado por `UnicodeDecodeError`, sem lista de exceções por nome.
+    sem contrapartida: sobrava todo rastreado não-Python, contado por
+    `git ls-files | grep -vc '[.]py$'`, e um basta para emitir cobrança (ver
+    `startCommand`, no cabeçalho). Entra o que `git ls-files | grep -vc
+    '^tests/'` conta; binário é pulado por `UnicodeDecodeError`, sem lista de
+    exceções por nome.
     """
     return [rel for rel in _rastreados() if not rel.startswith("tests/")]
 

--- a/tests/test_pix_inerte.py
+++ b/tests/test_pix_inerte.py
@@ -9,11 +9,13 @@ aceitação do dono:
 Checkout e webhook não se separam — os dois são o 1b-B. Enquanto isso, os quatro
 módulos novos existem e ninguém os chama.
 
-**"Ninguém os chama" vale para os 216 `.py` de PRODUÇÃO — não para o repositório
-inteiro.** A versão anterior dizia "repositório INTEIRO" e era falso: o git
-rastreia 631 arquivos, 395 `.py`, 216 fora de `tests/`. Foi por essa frase que o
-Manager entrou (ver a cegueira do `startCommand`). Alcance se mede com varredura
-e com número medido, nunca de memória (§2).
+**"Ninguém os chama" vale para os `.py` de PRODUÇÃO — não para o repositório
+inteiro.** A versão anterior dizia "repositório INTEIRO" e era falso: o universo
+deste portão é `git ls-files '*.py' | grep -vc '^tests/'`, e o repositório
+rastreia bem mais que isso (`git ls-files | wc -l`). Foi por essa frase que o
+Manager entrou (ver a cegueira do `startCommand`). Alcance se mede rodando a
+varredura na hora, nunca de memória — nem de número escrito aqui, que envelhece
+em silêncio (§2).
 
 ## Quatro caminhos de alcance, um arquivo cada
 
@@ -23,11 +25,13 @@ e com número medido, nunca de memória (§2).
      como o próprio app chegaria, inclusive por `background_tasks` e pelo loop
      de 60 s — os dois precisam do import para chamar;
   3. **destino** — `tests/test_pix_destino_inerte.py`, que vê o HOST e não o
-     nome do módulo, e cujo universo são os 433 rastreados, não só `.py`;
+     nome do módulo, e cujo universo é todo rastreado fora de `tests/`
+     (`git ls-files | grep -vc '^tests/'`), não só `.py`;
   4. **boot** — `tests/test_pix_ddl_sem_escrita.py`.
 
 Arquivos separados porque os universos e os mecanismos são diferentes: este lê
-395 `.py` com `ast`; o de destino lê 433 arquivos como texto.
+os `.py` com `ast`; o de destino lê como texto todo rastreado, de qualquer
+formato.
 
 **A varredura de import se AUTOVALIDA por dois caminhos**, os dois necessários:
 `_quem_importa` sobre `tests/` (tem de vir NÃO-VAZIA) e `_importa_algum` sobre
@@ -44,16 +48,20 @@ estes chamam", que continua sendo uma propriedade.
 
   * **import dinâmico** (`importlib.import_module("db." + nome)`): `ast` vê a
     árvore, não o valor. Nenhum existe hoje.
-  * **NÃO-`.py` rastreado**: este portão precisa de `ast`, então os **236**
-    arquivos rastreados que não são Python ficam fora dele. Não é teórico — o
-    Manager plantou `railway.pix-manager-probe.toml` nomeando `api.asaas.com` e
-    as três tabelas, com 49 verdes, e `railway.account-deletion.toml` já usa
-    `startCommand = "python scripts/account_deletion_job.py"` com `cronSchedule`
-    (o repositório JÁ roda Python em produção fora do app). Quem fecha esse caso
-    é o portão de DESTINO, que varre os 433; aqui ele fica declarado porque é
-    ESTE portão que a frase "ninguém importa" pode fazer parecer completo.
+  * **NÃO-`.py` rastreado**: este portão precisa de `ast`, então todo arquivo
+    rastreado que não é Python (`git ls-files | grep -vc '[.]py$'`) fica fora
+    dele. Não é teórico — o Manager plantou `railway.pix-manager-probe.toml`
+    nomeando `api.asaas.com` e as três tabelas, com 49 verdes, e o `Procfile`
+    (`web: python launch.py`) já dá o start command de produção num arquivo que
+    o `ast` não lê (o repositório JÁ roda Python por um caminho não-`.py`). Quem
+    fecha esse caso é o portão de DESTINO, que varre todo formato; aqui fica
+    declarado porque é ESTE portão que a frase "ninguém importa" pode fazer
+    parecer completo.
   * **arquivo NÃO rastreado**: o universo é `git ls-files`, então um script
-    Python fora do git chamado por um `startCommand` escapa dos dois.
+    Python fora do git chamado por um `startCommand` escapa dos dois. Esta
+    cegueira CRESCEU: o `account-deletion-job` migrou para configuração nativa
+    do painel do Railway (Config as Code descontinuado), então o start command
+    dele não está mais em arquivo nenhum — só no painel.
 
 Para todas, o método é revisão de diff, não mais varredura.
 """


### PR DESCRIPTION
O `account-deletion-job` foi migrado para configuração nativa do painel do Railway. O `railway.account-deletion.toml` virou **arquivo morto** — o campo `Railway Config File` do serviço está vazio, então ele não controlava mais nada.

**Migração conferida no painel em 2026-09-09**, e provada por execução, não por configuração parecendo certa:

- os avisos *"The value is set in /railway.account-deletion.toml"* sumiram do `Custom Start Command` e do `Cron Schedule`;
- `Railway Config File` vazio;
- a execução das **06:03 UTC de 2026-09-09** — **posterior** à migração — saiu **verde em 2s**, e a aba Cron Runs seguia agendando a próxima para 06:00 UTC.

Motivo: o Railway descontinuou `Config as Code`. Arquivos existentes **param em 2026-12-01**, e serviço que nunca usou **não pode optar** desde 2026-08-28. Manter o `.toml` faria a próxima pessoa reconfigurar pelo caminho que morre em dezembro.

## A cegueira que a migração criou — escrita, em vez de descoberta daqui a seis meses

Com o start command fora do git, ele passa a existir **só no painel**, e nenhum portão deste repositório alcança isso. Está registrado nos dois arquivos de portão, ao lado das cegueiras que eles já declaravam.

**A deleção não criou essa cegueira** — quem criou foi a migração, que era forçada. A deleção só parou de disfarçá-la: um `.toml` versionado descrevendo configuração que não está em vigor é pior que a ausência dele, porque parece cobertura.

As duas docstrings citavam o `.toml` como prova de que *"existe arquivo rastreado não-`.py` que executa Python em produção"*. O argumento **continua verdadeiro** e o exemplo foi trocado pelo **`Procfile`** (`web: python launch.py`) — rastreado, não-`.py`, e é ele quem dá o start command de produção.

## Os 11 números podres (§2 do CLAUDE.md)

Os mesmos docstrings afirmavam contagens da árvore. **Nove das dez estavam erradas:**

```
git ls-files | wc -l                      681   a prosa dizia 631
git ls-files '*.py' | wc -l               442   dizia 395
git ls-files '*.py' | grep -vc '^tests/'  224   dizia 216
git ls-files | grep -vc '[.]py$'          239   dizia 236
```

A frase mais irônica pregava *"número medido, nunca de memória"* **três linhas depois** de três números podres.

Os 11 sites viraram o **comando** que os produz. Testado se algum número era necessário para o argumento se sustentar — nenhum era, então nenhum usou a saída de escape do §2 (número + data + comando).

Ficam de fora `49 verdes` e `34 testes verdes`: não são contagem da árvore, são resultado de dois experimentos passados, irreproduzíveis por `grep`. Trocá-los por comando apagaria a medição em vez de atualizá-la.

## Um defeito que a suíte não pegaria

A primeira versão escreveu `grep -vc '\.py$'` dentro de docstring. `\.` é sequência de escape inválida — hoje `SyntaxWarning`, erro numa versão futura do Python — e **`SyntaxWarning` não reprova teste**. Só `python -W error -m py_compile` mostrou, reprovando os dois arquivos.

Corrigido para `[.]py$`: mesma regex, zero contrabarra, sem precisar de `r"""`.

Os quatro comandos que ficaram na prosa foram **rodados**, não copiados de cabeça.

## Medição

**6704 passed, 4 xfailed, 0 failed.** Baseline tirada em árvore **estável antes de editar** (a rodada anterior tinha pego parte da árvore já editada, e isso foi corrigido), mesmo número depois. Teto de 350: `test_pix_inerte.py` 256, `test_pix_destino_inerte.py` 156.

Nenhuma linha executável muda — o diff é uma deleção de arquivo e prosa. `docs/railway_account_deletion_job.md` foi reescrito para o caminho nativo; a lista de variáveis e a seção de teste manual estão byte a byte iguais.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)