### PR TITLE
Onda C da faxina: 3 pacotes órfãos saem, a starlette entra, e o npm ganha vigilância

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,49 @@ updates:
           - "minor"
           - "patch"
 
+  # Dependências npm da raiz (tooling de teste/lint do frontend: Playwright, ESLint).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Dependências npm do app iOS (casca Capacitor). São poucas e diretas, mas a
+  # cadeia de build é o que assina o binário — CVE aqui é supply-chain de release.
+  - package-ecosystem: "npm"
+    directory: "/mobile"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    groups:
+      mobile-npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
   # Actions usadas nos workflows (.github/workflows)
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -469,3 +469,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip pip-audit
           pip-audit -r requirements.txt || echo "::warning title=pip-audit::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."
+
+      # Sem `setup-node`: o ubuntu-latest ja traz npm, e `--package-lock-only`
+      # le so o lock — nao instala nada. Inclui devDependencies (padrao do
+      # comando): no mobile/ a cadeia de build e quem assina o binario.
+      - name: npm audit raiz (informativo, nao bloqueia)
+        run: npm audit --package-lock-only || echo "::warning title=npm-audit (raiz)::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."
+
+      - name: npm audit mobile (informativo, nao bloqueia)
+        working-directory: mobile
+        run: npm audit --package-lock-only || echo "::warning title=npm-audit (mobile)::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -470,12 +470,19 @@ jobs:
           python -m pip install --upgrade pip pip-audit
           pip-audit -r requirements.txt || echo "::warning title=pip-audit::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."
 
-      # Sem `setup-node`: o ubuntu-latest ja traz npm, e `--package-lock-only`
-      # le so o lock — nao instala nada. Inclui devDependencies (padrao do
-      # comando): no mobile/ a cadeia de build e quem assina o binario.
+      # Sem `setup-node`: o ubuntu-latest ja traz npm e node, e o
+      # `--package-lock-only` do script le so o lock — nao instala nada. Inclui
+      # devDependencies (padrao do comando): no mobile/ a cadeia de build e quem
+      # assina o binario.
+      #
+      # E por que um script, e nao `npm audit ... || echo "::warning ..."`: o npm
+      # sai 1 tanto quando ACHA vulnerabilidade quanto quando o audit nao roda
+      # (registry fora, 403, JSON truncado). O `|| echo` tratava os dois igual —
+      # queda de registry saia verde anunciando "vulnerabilidades encontradas",
+      # com o lock nunca escaneado. O script decide pelo payload e avisa "NAO
+      # RODOU" com titulo proprio. Nao bloqueia: sai 0 sempre.
       - name: npm audit raiz (informativo, nao bloqueia)
-        run: npm audit --package-lock-only || echo "::warning title=npm-audit (raiz)::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."
+        run: node scripts/npm_audit_report.mjs .
 
       - name: npm audit mobile (informativo, nao bloqueia)
-        working-directory: mobile
-        run: npm audit --package-lock-only || echo "::warning title=npm-audit (mobile)::Vulnerabilidades conhecidas encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de correcao)."
+        run: node scripts/npm_audit_report.mjs mobile

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,10 @@ yarl==1.24.5
 ofxparse==0.21
 pypdf==6.16.2
 fastapi==0.141.1
+# Import direto nosso (frontend/finance_bot_websocket_custom.py:42). A fastapi
+# declara `starlette>=0.46.0` SEM teto, entao o pin exato e nosso: sem ele, uma
+# resolucao limpa sobe de major sozinha.
+starlette==1.6.0
 uvicorn[standard]==0.52.4
 websockets==17.1
 slowapi==0.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ distro==1.9.0
 et_xmlfile==2.0.0
 frozenlist==1.8.0
 google-auth==2.57.0
-google-auth-oauthlib==1.4.1
 h11==0.16.0
 h2==4.4.1
 httpcore==1.0.9
@@ -25,7 +24,6 @@ idna==3.19
 iniconfig==2.3.0
 jiter==0.16.0
 multidict==6.7.1
-oauthlib==3.3.1
 openai==3.6.0
 openpyxl==3.1.5
 packaging==26.3
@@ -44,7 +42,6 @@ pytest==9.1.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.3
 requests==2.34.2
-requests-oauthlib==2.0.0
 rsa==4.9.1
 six==1.17.0
 sniffio==1.3.1

--- a/scripts/npm_audit_report.mjs
+++ b/scripts/npm_audit_report.mjs
@@ -1,0 +1,83 @@
+/**
+ * `npm audit` de um lock, com a diferença que o exit code do npm não conta:
+ * distingue "achou vulnerabilidade" de "o audit NÃO RODOU".
+ *
+ * O npm sai 1 nos DOIS casos. O `npm audit ... || echo "::warning ..."` que
+ * este script substituiu tratava os dois igual, então uma queda do registry
+ * (indisponível, 403, resposta truncada) deixava o check verde anunciando
+ * "vulnerabilidades encontradas" — com o lock nunca escaneado. Silêncio no
+ * lugar do escaneamento é pior que a vulnerabilidade, porque ninguém procura.
+ *
+ * Quem discrimina é o PAYLOAD: `metadata.vulnerabilities.total` só existe num
+ * relatório de verdade (`auditReportVersion`). Erro do npm sai como
+ * `{"message":...,"error":{...}}`, sem `metadata`; saída truncada nem parseia.
+ *
+ * Sempre sai 0: a varredura é informativa por decisão do dono — ela sinaliza,
+ * não trava o merge.
+ *
+ *     node scripts/npm_audit_report.mjs .        # lock da raiz
+ *     node scripts/npm_audit_report.mjs mobile   # lock do app
+ */
+import { spawnSync } from "node:child_process";
+import { basename, resolve } from "node:path";
+
+const dir = process.argv[2] || ".";
+const rotulo = dir === "." ? "raiz" : basename(resolve(dir));
+
+// `--package-lock-only`: lê só o lock, não instala nada. Inclui
+// devDependencies (padrão do comando) — no mobile/ a cadeia de build é quem
+// assina o binário.
+const npm = spawnSync("npm", ["audit", "--package-lock-only", "--json"], {
+  cwd: dir,
+  encoding: "utf8",
+  maxBuffer: 32 * 1024 * 1024,
+});
+
+// `npm.status` é ignorado DE PROPÓSITO: vale 1 tanto com vulnerabilidade
+// quanto com o audit fora do ar, então não carrega informação nenhuma.
+let total = null;
+try {
+  total = JSON.parse(npm.stdout).metadata.vulnerabilities.total;
+} catch {
+  // payload de erro, saída truncada, ou npm ausente do PATH — todos "não rodou".
+}
+
+if (typeof total !== "number") {
+  console.log(
+    `::warning title=npm-audit NAO RODOU (${rotulo})::O audit falhou antes de` +
+      ` produzir relatorio: o lock NAO foi escaneado (nenhuma conclusao sobre` +
+      ` vulnerabilidades pode ser tirada deste run).`,
+  );
+  // O motivo, para não precisar reproduzir o run só para saber o que caiu.
+  //
+  // Isto é saída de TERCEIRO: quem escolhe o texto do stderr do npm é o
+  // registry. `::error`/`::add-mask` e `##[error]` são COMANDOS do runner, e
+  // quem os reconhece é o ActionCommandManager (`!TryParseV2(...) &&
+  // !TryParse(...)`, ActionCommandManager.cs:70).
+  //
+  // Por que o token e não a posição: indentar NÃO protege. O V2 faz
+  // `message.TrimStart()` ANTES de testar `StartsWith("::")`
+  // (ActionCommand.cs, TryParseV2), então o espaço que se põe na frente ele
+  // mesmo tira; e o V1 procura o prefixo `##[` com `IndexOf` — em QUALQUER
+  // posição da linha, sem âncora nenhuma. O que sobra é quebrar o token: sem
+  // `::` e sem `##[` colados, nenhum dos dois parsers casa, e o texto continua
+  // legível no log.
+  //
+  // Alcançabilidade com o npm real nunca foi provada (ele prefixa o corpo do
+  // registry com `npm warn audit `). Fronteira de confiança não se simplifica
+  // por falta de exploit (CLAUDE.md §0.2).
+  const motivo = (npm.stderr || npm.error?.message || "")
+    .trim()
+    .slice(0, 500)
+    .replaceAll("::", ": :")
+    .replaceAll("##[", "## [");
+  if (motivo) console.log(`npm audit (${rotulo}) falhou: ${motivo}`);
+} else if (total > 0) {
+  console.log(
+    `::warning title=npm-audit (${rotulo})::Vulnerabilidades conhecidas` +
+      ` encontradas (informativo, nao bloqueia; o Dependabot abre os PRs de` +
+      ` correcao).`,
+  );
+} else {
+  console.log(`npm audit (${rotulo}): 0 vulnerabilidades conhecidas no lock.`);
+}

--- a/tests/frontend/npm_audit_report.test.mjs
+++ b/tests/frontend/npm_audit_report.test.mjs
@@ -1,0 +1,259 @@
+// O aviso de CVE tem de saber a diferença entre "achou" e "nem rodou".
+//
+// `npm audit` sai 1 nos dois casos, então o `npm audit || echo "::warning ..."`
+// que existia aqui deixava o check verde anunciando "vulnerabilidades
+// encontradas" quando o registry caía — com o lock NUNCA escaneado.
+//
+// Sem rede e sem registry: um `npm` FALSO entra na frente do PATH, imprime o
+// payload de cada cenário e REGISTRA o que recebeu (`argv` e `pwd`). O registro
+// não é enfeite: sem ele, tirar `--json`, `--package-lock-only` ou o `cwd` do
+// spawn deixava o grupo 5/5 verde — e sem o `cwd` o mobile passa a reportar
+// "0 vulnerabilidades" com o lock dele nunca lido, que é falso limpo, pior que
+// o falso alarme que este conserto existe para matar.
+//
+// Rodar:  npm run test:frontend
+//         (ou só este: node --test tests/frontend/npm_audit_report.test.mjs)
+import nodeTest from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RAIZ = fileURLToPath(new URL("../..", import.meta.url));
+const SCRIPT = join(RAIZ, "scripts/npm_audit_report.mjs");
+
+const TITULO_VULN = (rotulo) => `title=npm-audit (${rotulo})::`;
+const TITULO_NAO_RODOU = "title=npm-audit NAO RODOU (raiz)::";
+
+/**
+ * Roda o script com um `npm` falso que imprime `payload`, sai com `codigo`, e
+ * anota em disco o `argv` e o `pwd` com que foi chamado.
+ */
+function comNpmFalso(payload, codigo, { dir = ".", stderr = "" } = {}) {
+  const bin = mkdtempSync(join(tmpdir(), "npm-falso-"));
+  try {
+    const registro = join(bin, "recebido.txt");
+    const falso = join(bin, "npm");
+    writeFileSync(
+      falso,
+      [
+        "#!/bin/sh",
+        `{ echo "argv: $@"; echo "pwd: $(pwd)"; } > '${registro}'`,
+        `cat >&2 <<'FIM_ERR'\n${stderr}\nFIM_ERR`,
+        `cat <<'FIM_OUT'\n${payload}\nFIM_OUT`,
+        `exit ${codigo}`,
+      ].join("\n"),
+    );
+    chmodSync(falso, 0o755);
+    const r = spawnSync(process.execPath, [SCRIPT, dir], {
+      cwd: RAIZ,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}` },
+    });
+    return { ...r, recebido: readFileSync(registro, "utf8") };
+  } finally {
+    // Sem isto, quatro tmpdirs vazados por rodada da suíte.
+    rmSync(bin, { recursive: true, force: true });
+  }
+}
+
+const RELATORIO = (total) =>
+  JSON.stringify({
+    auditReportVersion: 2,
+    metadata: { vulnerabilities: { moderate: 3, high: 1, total }, dependencies: { total: 184 } },
+  });
+
+nodeTest("achou vulnerabilidade: avisa, e não é o aviso de 'não rodou'", () => {
+  const r = comNpmFalso(RELATORIO(4), 1);
+  assert.equal(r.status, 0, "o step é informativo: o script nunca pode reprovar o job");
+  assert.ok(r.stdout.includes(TITULO_VULN("raiz")), r.stdout);
+  assert.ok(!r.stdout.includes(TITULO_NAO_RODOU), r.stdout);
+});
+
+nodeTest("audit não rodou (erro do registry): avisa que o lock NÃO foi escaneado", () => {
+  const r = comNpmFalso(
+    JSON.stringify({ message: "connect ECONNREFUSED 127.0.0.1:1", error: { code: "ECONNREFUSED" } }),
+    1,
+  );
+  assert.equal(r.status, 0);
+  assert.ok(r.stdout.includes(TITULO_NAO_RODOU), r.stdout);
+  assert.ok(/lock NAO foi escaneado/.test(r.stdout), r.stdout);
+  assert.ok(!r.stdout.includes(TITULO_VULN("raiz")), r.stdout);
+});
+
+nodeTest("payload truncado no meio também é 'não rodou', não 'zero vulnerabilidades'", () => {
+  const r = comNpmFalso('{"auditReportVersion":2,"metad', 1);
+  assert.equal(r.status, 0);
+  assert.ok(r.stdout.includes(TITULO_NAO_RODOU), r.stdout);
+  assert.ok(!r.stdout.includes(TITULO_VULN("raiz")), r.stdout);
+});
+
+// Relatório com forma de relatório e SEM o número: afrouxar a guarda para
+// `total === null` faz isto virar "0 vulnerabilidades" — falso limpo.
+nodeTest("relatório sem o total é 'não rodou', nunca 'lock limpo'", () => {
+  for (const payload of [
+    '{"auditReportVersion":2,"metadata":{"vulnerabilities":{}}}',
+    '{"auditReportVersion":2,"metadata":{"vulnerabilities":{"total":"4"}}}',
+  ]) {
+    const r = comNpmFalso(payload, 1);
+    assert.equal(r.status, 0);
+    assert.ok(r.stdout.includes(TITULO_NAO_RODOU), `${payload}\n${r.stdout}`);
+    assert.ok(!/0 vulnerabilidades/.test(r.stdout), `${payload}\n${r.stdout}`);
+  }
+});
+
+// O `npm.status` é ignorado DE PROPÓSITO, e essa decisão só existia em
+// comentário: sem este caso, voltar a olhar o exit code (`&& npm.status !== 0`
+// na guarda) deixava o grupo inteiro verde e transformava erro do registry em
+// "0 vulnerabilidades" — o falso limpo que este conserto existe para matar.
+nodeTest("exit 0 com payload ruim ainda é 'não rodou' — o exit code não decide", () => {
+  for (const payload of ['{"message":"boom"}', '{"auditReportVersion":2,"metad']) {
+    const r = comNpmFalso(payload, 0);
+    assert.equal(r.status, 0);
+    assert.ok(r.stdout.includes(TITULO_NAO_RODOU), `${payload}\n${r.stdout}`);
+    assert.ok(!/0 vulnerabilidades/.test(r.stdout), `${payload}\n${r.stdout}`);
+  }
+});
+
+// Controle positivo: sem ele o grupo passaria num script que grita em tudo.
+nodeTest("lock limpo: nenhum ::warning", () => {
+  const r = comNpmFalso(RELATORIO(0), 0);
+  assert.equal(r.status, 0);
+  assert.ok(!r.stdout.includes("::warning"), r.stdout);
+  assert.match(r.stdout, /0 vulnerabilidades/);
+});
+
+// O que o npm RECEBE. Sem estas asserções, tirar `--json`, tirar
+// `--package-lock-only` ou tirar o `cwd` não acende uma linha vermelha.
+nodeTest("o npm é chamado com --json e --package-lock-only", () => {
+  const { recebido } = comNpmFalso(RELATORIO(0), 0);
+  const argv = recebido.split("\n")[0];
+  assert.match(argv, /(^|\s)audit(\s|$)/, argv);
+  assert.match(argv, /--json/, argv);
+  assert.match(argv, /--package-lock-only/, argv);
+  // `--omit=dev` zera o relatório do mobile: o comentário do script promete
+  // devDependencies ("a cadeia de build é quem assina o binário") e sem esta
+  // linha nada mede a promessa. Medido em 2026-09-09 com
+  // `npm audit --package-lock-only [--omit=dev] --json` em `mobile/`: sem a
+  // flag o `metadata.vulnerabilities.total` era 4, com ela 0. Não confie no 4:
+  // o advisory database é vivo e o número já oscilou entre execuções deste
+  // mesmo ciclo — remeça com o comando acima. O que não oscila é o ZERO.
+  assert.doesNotMatch(argv, /--omit|--production/, argv);
+});
+
+// O diretório do argumento é onde o npm RODA — é o que decide qual lock é lido.
+// Provado com os dois diretórios que o CI usa: sem o `cwd`, o step do mobile
+// leria o lock da raiz e reportaria sobre o lock errado.
+nodeTest("o argumento vira o diretório do npm — e o rótulo do aviso", () => {
+  const naRaiz = comNpmFalso(RELATORIO(0), 0, { dir: "." });
+  assert.equal(naRaiz.recebido.split("\n")[1], `pwd: ${RAIZ.replace(/\/$/, "")}`, naRaiz.recebido);
+
+  const noMobile = comNpmFalso(RELATORIO(4), 1, { dir: "mobile" });
+  assert.equal(
+    noMobile.recebido.split("\n")[1],
+    `pwd: ${join(RAIZ, "mobile")}`,
+    noMobile.recebido,
+  );
+  assert.ok(noMobile.stdout.includes(TITULO_VULN("mobile")), noMobile.stdout);
+  assert.ok(!noMobile.stdout.includes(TITULO_VULN("raiz")), noMobile.stdout);
+});
+
+// O stderr do npm carrega texto que o REGISTRY escolheu, e o runner trata duas
+// formas como COMANDO. O oráculo aqui é o do runner, não "começa com `::`":
+//
+//   V2 (ActionCommand.cs, TryParseV2): `message.TrimStart()` e SÓ ENTÃO
+//       `StartsWith("::")` — indentar não protege, o runner tira o espaço.
+//   V1 (mesmo arquivo): `message.IndexOf("##[")` — em qualquer posição da linha.
+//
+// Por isso a asserção é sobre a linha TRIMADA (é o que o runner enxerga) e
+// cobre as duas formas.
+//
+// O trim aqui NÃO é `trimStart()`: o `Char.IsWhiteSpace` do .NET inclui
+// U+0085 (NEL) e o `\s` do JS não (`/\s/.test("\u0085")` é `false`), então
+// `trimStart()` diria "seguro" para uma linha que o runner executaria. O
+// `[\s\u0085]` cobre a classe do .NET com folga (o JS ainda tem U+FEFF a
+// mais, o que só reprova de sobra, nunca de menos).
+const NOSSO_AVISO = "::warning title=npm-audit ";
+const trimComoRunner = (l) => l.replace(/^[\s\u0085]+/, "");
+function comandosVazados(stdout) {
+  return stdout
+    .split("\n")
+    .map(trimComoRunner)
+    .filter((l) => !l.startsWith(NOSSO_AVISO))
+    .filter((l) => l.startsWith("::") || l.includes("##["));
+}
+
+nodeTest("stderr do npm não vira comando do Actions", () => {
+  const PAYLOADS = [
+    ["::error title=A::x", "title=A"],
+    ["  ::error title=B::x", "title=B"],
+    ["\r::error title=C::x", "title=C"],
+    ["\t::add-mask::segredo", "segredo"],
+    ["##[error]D", "error]D"],
+    ["npm error 403 blah ##[error]E no meio", "error]E"],
+    // DUAS injeções na mesma saída: com `.replace` no lugar de `.replaceAll`
+    // só a primeira é desarmada e a segunda vaza (`::endgroup::` sozinho já
+    // fecha o grupo do log; `::stop-commands::` desliga o parser inteiro).
+    ["::stop-commands::abc\n::endgroup::\n##[error]F\n##[warning]G", "endgroup"],
+    // U+0085 (NEL) é espaço para o `TrimStart()` do .NET e NÃO é para o
+    // `trimStart()` do JS: com o oráculo ingênuo esta linha passava por segura.
+    ["\u0085::error title=NEL::x", "title=NEL"],
+  ];
+  for (const [injecao, pedaco] of PAYLOADS) {
+    // A linha comum na frente: sem ela o `.trim()` do script comeria o \r/\t
+    // da injeção e o caso 3/4 mediria outra coisa.
+    const r = comNpmFalso('{"message":"boom"}', 1, {
+      stderr: `npm error 403 Forbidden\n${injecao}`,
+    });
+    assert.equal(r.status, 0);
+    assert.deepEqual(comandosVazados(r.stdout), [], `${JSON.stringify(injecao)}\n${r.stdout}`);
+    assert.ok(r.stdout.includes(pedaco), `${JSON.stringify(injecao)}: o texto sumiu do log em vez de ser desarmado`);
+  }
+});
+
+// ── Fiação ────────────────────────────────────────────────────────────────
+// Cinto, não a prova: os testes acima medem o script; este garante que é ELE
+// que o CI chama. Parse de verdade, não `includes`: com busca por substring, os
+// dois steps podiam ser APAGADOS e o mesmo texto deixado num comentário do YAML
+// que o teste continuava verde — e o CI parava de auditar npm.
+//
+// ponytail: js-yaml é dependência TRANSITIVA do eslint (eslint > @eslint/eslintrc
+// > js-yaml), instalada pelo mesmo `npm ci` do job `frontend`, e está no
+// package-lock.json. Não é declarada nossa: se um bump do eslint a deixar cair, a
+// saída é declarar `js-yaml` em devDependencies. Não usei `yaml.safe_load` do
+// Python: PyYAML NÃO é premissa paga aqui (ausente do requirements.txt, zero
+// imports no repo, `Required-by:` vazio) — o teste ficaria vermelho no CI.
+let YAML;
+try {
+  YAML = (await import("js-yaml")).default;
+} catch (erro) {
+  if (process.env.CI) throw erro;
+}
+const semYaml = YAML
+  ? false
+  : "js-yaml não está no node_modules: rode `npm ci` na raiz (no CI a ausência REPROVA, não pula)";
+
+nodeTest("o workflow chama o script nos dois locks, sem `|| echo`", { skip: semYaml }, () => {
+  const doc = YAML.load(readFileSync(join(RAIZ, ".github/workflows/tests.yml"), "utf8"));
+  assert.ok(doc.jobs.audit, "o job `audit` sumiu (ou foi renomeado) no workflow");
+  // Step/job com `if:` existe e não roda — o audit sairia do ar sem sumir do YAML.
+  assert.equal(doc.jobs.audit.if, undefined, "o job `audit` ficou condicional");
+  const steps = doc.jobs.audit.steps;
+
+  // Só os steps que chamam ESTE script. O `pip-audit` fica de fora de propósito
+  // (mantém o `|| echo`, fora do escopo), e um `npm audit fix || echo ...` que
+  // alguém adicione amanhã também não é problema deste teste.
+  const meus = steps.filter((s) => (s.run || "").includes("npm_audit_report.mjs"));
+  assert.deepEqual(
+    meus.map((s) => s.run.trim()),
+    ["node scripts/npm_audit_report.mjs .", "node scripts/npm_audit_report.mjs mobile"],
+  );
+  for (const s of meus) {
+    assert.ok(!s.run.includes("|| echo"), `${s.name}: o \`|| echo\` voltou`);
+    // O diretório é argumento; `working-directory` fixaria o step num lock só.
+    assert.equal(s["working-directory"], undefined, s.name);
+    assert.equal(s.if, undefined, `${s.name}: step condicional não audita nada`);
+  }
+});


### PR DESCRIPTION
Terceira e última leva de código da faxina do `01-project-sanitation.md`. Três commits, 57 linhas, **nenhuma linha de código de produção alterada** — só manifesto de dependência e configuração de CI.

## `ee76d2c` — os 184 pacotes npm entram na vigilância de CVE

O `dependabot.yml` declarava só `pip` e `github-actions`; o job `audit` roda só `pip-audit`, que não lê `package-lock.json`. Os dois locks npm (90 na raiz, 94 em `mobile/`) não eram olhados por ninguém.

**Medido, e corrige a moldura com que este item entrou na faxina:** os 5 pacotes de **produção** do mobile estão **limpos**, e a raiz também. O achado vivo é 1 HIGH em `@xmldom/xmldom`, **`dev: true`** — build-time, não vai no binário assinado, mas está na cadeia que **assina** o binário.

**Por que os dois, e não um só.** O Dependabot traz o conserto e pega deriva sem CVE. O `npm audit` no CI pega o que o Dependabot não conserta — e o caso de hoje é exatamente esse: nenhum bump das 5 diretas resolve o `@xmldom/xmldom`, e o `npm audit fix --dry-run` também não (a HIGH sobrevive). O que resolve é refresh transitivo do lock, que ninguém faz sozinho.

O `exit 1` do audit do mobile prova que o passo **discrimina** — se saísse 0 nos dois diretórios, não estaria medindo nada — e é a razão do `|| echo`, sem o qual o job nasceria vermelho hoje.

## `7dc5adc` — a `starlette` que o código importa passa a estar declarada

O `requirements.txt` tem `==` em todas as linhas e **parece um freeze. Não é.** A `fastapi==0.141.1` declara `starlette>=0.46.0` **sem teto**, e uma resolução limpa hoje entrega **`starlette 1.6.0`** — um major que ninguém escolheu. O CI e a produção já rodam com ele; o `.venv` local tem `0.41.3`, então verde local nunca diria nada sobre isso.

Pinar troca uma quebra silenciosa em produção por um **erro alto na instalação**, no CI do PR. **Prova de no-op:** as árvores resolvidas com e sem a linha são idênticas — 87 pacotes, nada entra, nada sai, nenhuma versão muda.

As outras 17 transitivas não declaradas ficam fora: nenhuma é importada pelo repositório, e o `pip-audit` **já as audita** (resolve a árvore inteira, 84 pacotes). A classe "importada e não declarada" tem um membro só.

## `d6f4958` — a ilha `oauthlib` sai

Três pacotes com zero referências, formando ilha fechada. O projeto **faz** um flow OAuth completo, escrito à mão com `httpx`; o `google-auth` puro entra só para validar a assinatura do `id_token`.

**A prova que vale é a ausência simulada**, não a suíte depois de editar o arquivo — o `.venv` continua com os pacotes, então o pytest passa com e sem a edição. Com um bloqueio no `sys.meta_path`: (1) `import oauthlib` dá `ImportError` com o bloqueio e sai 0 sem ele — o controle morde; (2) os quatro módulos da área importam sob bloqueio; (3) a suíte inteira sob bloqueio dá **6716 passed, 4 xfailed**, idêntica à baseline.

Resolução: **87 → 84**, saem exatamente os três.

## Verificação

| o quê | resultado |
|---|---|
| `pytest` (baseline e final) | 6716 passed, 4 xfailed, 0 failed |
| `pytest` sob bloqueio do oauthlib | 6716 passed, 4 xfailed — zero nomes novos |
| `npm run test:frontend` | 327/327 |
| `npx eslint .` | exit 0 |

## Não verificável aqui

Que o **Dependabot** enxergue os dois ecossistemas npm só se confirma no GitHub depois do merge (Insights → Dependency graph → Dependabot). Os passos `npm audit` nunca rodaram no runner — comando e exit code foram provados nesta máquina. E a **starlette 1.6.0 não é exercitada por teste nenhum aqui**: os 6716 verdes rodaram contra 0.41.3, que é o que o `.venv` local tem.

## Deixado de fora, de propósito

- **O refresh do `mobile/package-lock.json`**, que limparia a HIGH hoje (`npm update @xmldom/xmldom` → 0.9.12, medido numa cópia). É arquivo de outra natureza e merece commit próprio.
- **A remoção do `discord.py`** — o maior ganho disponível, 9 pacotes que só existem por causa dele. Está travada por um `import` no caminho do WhatsApp (`core/reports/reports_daily.py` faz `from discord.ext import tasks` e é importado por `adapters/whatsapp/wa_app.py`), e o bot sobe em todo deploy pelo `Procfile`. Desbloquear é mexer em código de produção: onda própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)