### PR TITLE
A tela do Pix anual: botão, QR e o campo que faltava

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,43 @@ export default defineConfig([
     },
   },
   {
+    // Bloco PRÓPRIO, e não nomes soltos no `frontend/**` acima: global
+    // declarada lá enfraquece o `no-undef` do repositório INTEIRO — `showToast`
+    // ou `getCsrfToken` escrito por engano num arquivo que não os carrega
+    // passaria calado. Aqui o alcance é o par de arquivos que de fato os usa.
+    //
+    // `currentCycle` e `PLAN_NAMES` vêm do <script> inline da precos.html: são
+    // `let`/`const` de topo de script clássico, que vão para o escopo léxico
+    // global e NÃO viram propriedade de `window` — por isso, nome nu.
+    // O resto é o que um destes dois arquivos publica e o outro consome: eles
+    // são um módulo só, partido pelo teto de 350 linhas.
+    files: ["frontend/pix-checkout.js", "frontend/pix-poll.js"],
+    languageOptions: {
+      globals: {
+        currentCycle: "readonly",
+        PLAN_NAMES: "readonly",
+        fmtBrDate: "readonly",
+        getCsrfToken: "readonly",
+        showToast: "readonly",
+        pixBrl: "readonly",
+        pixLinha: "readonly",
+        pixBotao: "readonly",
+        pixRotular: "readonly",
+        pixOverlay: "readonly",
+        pixCheckout: "readonly",
+        pixModalQr: "readonly",
+        pixEncerrar: "readonly",
+        // Declarado no pix-checkout.js e chamado pelo `pixApagarQr` do
+        // pix-poll.js: o documento e o payload saem do DOM na mesma hora.
+        pixApagarDoc: "readonly",
+        // "writable" porque é o pix-poll.js que declara e reatribui o `pixPoll`
+        // (o `let` do topo dele é ESTE nome, não outro). O pix-checkout.js só
+        // LÊ, para não abrir um segundo QR por cima do primeiro.
+        pixPoll: "writable",
+      },
+    },
+  },
+  {
     // Harness de testes e scripts de smoke: Node com ESM.
     files: ["**/*.mjs"],
     languageOptions: {

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -1,0 +1,323 @@
+/**
+ * Pix anual na /precos — o CTA nos cards, o overlay e o checkout.
+ *
+ * O QR, a cópia e o poll moram no pix-poll.js (par deste arquivo; os dois
+ * dividem o escopo global e a divisão é do teto de 350 linhas do
+ * `quality/max-lines`).
+ *
+ * Script CLÁSSICO (sem módulo ES) de propósito: a precos.html chama
+ * `pbPixInit`/`pbPixRefresh` do escopo global e este arquivo lê de lá o que ela já
+ * tem (`currentCycle`, `PLAN_NAMES`, `fmtBrDate`, `getCsrfToken`, `showToast`) —
+ * nenhum fetch novo, nenhuma segunda tabela de preços.
+ *
+ * Duas regras não negociáveis, as duas do docs/plano_pix_anual_asaas.md:
+ *  1. §13.6 — o `qr_payload` é INSTRUMENTO AO PORTADOR: só memória e DOM (nada de
+ *     localStorage, sessionStorage, cookie, history.state, query string ou log), e
+ *     sai do DOM ao pagar, expirar ou fechar. Quem viaja na URL é o `public_token`,
+ *     que vira o `sid` do pixel da Meta e do GA4 na home.html — nunca o id do
+ *     pagamento no provedor.
+ *  2. Sem `pix_annual_available` no /billing/plans-config, NENHUM botão nasce: a
+ *     página é a de hoje. É o que deixa este PR ir para a main antes do backend.
+ *  3. O CPF/CNPJ do pagador — que o Asaas exige e que NÓS não persistimos — segue
+ *     a MESMA disciplina do item 1: só memória e DOM, e some dos dois ao fechar
+ *     o modal, ao aparecer o QR e ao terminar a compra. Nunca em storage, nunca
+ *     na URL, nunca em `console`, nunca no GA4 nem na CAPI.
+ *
+ * 401 não se trata na mão além do redirect do checkout: o auth-refresh.js renova e
+ * refaz a requisição sozinho, e o que chega aqui como 401 é o que SOBROU dele.
+ */
+"use strict";
+
+// Pix é só anual (§7 do plano). O Premium não tem preço, então fica de fora.
+const PIX_PLANOS = ["essencial", "plus", "pro"];
+
+let pixCfg = null;
+let pixSub = null;
+
+// Fronteira de confiança de valor monetário: sem `amount_cents` o
+// `toLocaleString` escrevia "R$ NaN" no título do modal de pagamento. Devolve
+// string vazia, e quem chama decide o que mostrar sem o número.
+const pixBrl = (c) => (Number.isFinite(Number(c))
+  ? (Number(c) / 100).toLocaleString("pt-BR", { style: "currency", currency: "BRL" })
+  : "");
+
+/**
+ * Ícone + texto de uma vez. Por `createElement` e não por markup em string: o
+ * handlers_inline.test.mjs levanta handler de dentro das strings dos `.js`, e sem
+ * markup gerado a `handlers_inline.baseline.json` não muda.
+ * Só ícones do subset de frontend/phosphor.css — o de QR code, por exemplo, não
+ * está lá. E o nome não se escreve nem em COMENTÁRIO: o extrator de
+ * scripts/build_phosphor_subset.py é `\bph-([a-z0-9-]+)` sobre o texto do
+ * arquivo, então citá-lo em prosa já o torna "usado" e deixa o
+ * test_phosphor_subset.py vermelho (medido).
+ */
+function pixRotular(el, icone, texto) {
+  const i = document.createElement("i");
+  i.className = "ph " + icone;
+  i.setAttribute("aria-hidden", "true");
+  el.replaceChildren(i, document.createTextNode(" " + texto));
+}
+
+function pixLinha(texto) {
+  const p = document.createElement("p");
+  p.className = "pix-line";
+  p.textContent = texto;
+  return p;
+}
+
+function pixBotao(classe, texto) {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "btn btn-block " + classe;
+  b.textContent = texto;
+  return b;
+}
+
+// ── O CTA nos cards ─────────────────────────────────────────────────────────
+
+/** Chamado pelo loadPlansState da precos.html, com o que ela já buscou. */
+function pbPixInit(cfg, sub) {
+  pixCfg = cfg || null;
+  pixSub = sub || null;
+  pbPixRefresh();
+}
+
+/** Chamado pelo setCycle: o CTA de Pix só existe no ciclo anual. */
+function pbPixRefresh() {
+  // `!== true` e não `!`: portão de venda não abre com valor truthy qualquer.
+  if (!pixCfg || pixCfg.pix_annual_available !== true) return;
+  const anual = currentCycle === "annual";
+  for (const plano of PIX_PLANOS) {
+    const existente = document.querySelector('[data-pix-cta="' + plano + '"]');
+    // Sai do DOM no mensal em vez de ficar escondido: escondido ainda recebe Tab.
+    if (!anual) { if (existente) existente.remove(); continue; }
+    const b = existente || pixCriarCta(plano);
+    if (!b) continue;
+    const renova = !!pixSub && pixSub.gateway === "pix" && pixSub.plan === plano;
+    pixRotular(b, "ph-lightning", (renova ? "Renovar" : "Pagar") + " no Pix (à vista)");
+  }
+}
+
+function pixCriarCta(plano) {
+  // Só nos cards: o tfoot da tabela comparativa tem as células asseveradas pelo
+  // precos_sem_plano_gratis.test.mjs, e uma célula nova o deixa vermelho.
+  const cartao = document.querySelector('#plans-v2 [data-plan-btn="' + plano + '"]');
+  if (!cartao) return null;
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "btn btn-outline btn-block pix-cta";
+  b.dataset.pixCta = plano;
+  b.addEventListener("click", () => pixCheckout(plano));
+  cartao.after(b);
+  return b;
+}
+
+// ── Overlay: fundo + caixa + Esc + Tab preso + devolução do foco ────────────
+function pixOverlay(titulo, aoFechar) {
+  const foco = document.activeElement;
+  const ov = document.createElement("div");
+  ov.className = "pix-ov";
+  ov.setAttribute("role", "dialog");
+  ov.setAttribute("aria-modal", "true");
+  ov.setAttribute("aria-labelledby", "pix-modal-titulo");
+  const box = document.createElement("div");
+  box.className = "pix-box";
+  const h = document.createElement("h3");
+  h.id = "pix-modal-titulo";
+  h.textContent = titulo;
+  box.appendChild(h);
+  ov.appendChild(box);
+  const tecla = (e) => {
+    if (e.key === "Escape") { fechar(); return; }
+    // Trap de Tab do modals.js (§0.1 — o mesmo helper que o modal_keys.test.mjs
+    // e o settings_security_fanout.test.mjs já asseveram). Sem ele o Tab
+    // alcançava o CTA ATRÁS do overlay e o Enter abria um SEGUNDO QR por cima:
+    // dois instrumentos ao portador na tela e duas cobranças no provedor.
+    if (window.pigTrapTab) window.pigTrapTab(e, ov);
+  };
+  function fechar() {
+    document.removeEventListener("keydown", tecla);
+    ov.remove();
+    if (aoFechar) aoFechar();
+    if (foco && foco.focus) foco.focus();
+  }
+  ov.addEventListener("click", (e) => { if (e.target === ov) fechar(); });
+  document.addEventListener("keydown", tecla);
+  document.body.appendChild(ov);
+  // `titulo` sai daqui porque o modal tem DOIS estados (formulário e QR) e o
+  // segundo reescreve o cabeçalho do primeiro em vez de abrir outra caixa.
+  return { box, fechar, titulo: h };
+}
+
+// ── Checkout: o documento primeiro, o QR depois ─────────────────────────────
+
+/**
+ * O `<input>` do CPF/CNPJ enquanto o formulário está na tela.
+ *
+ * O Asaas EXIGE o documento do pagador para criar a cobrança, e NÓS não o
+ * persistimos em lugar nenhum. Aqui vale a mesma disciplina do `qr_payload`
+ * (§13.6): só memória e DOM — nada de localStorage, sessionStorage, cookie,
+ * history.state, query string, console, GA4 ou CAPI —, e ele sai dos dois assim
+ * que não há mais uso legítimo: modal fechado, QR na tela, compra terminada.
+ */
+let pixDoc = null;
+
+/**
+ * Par do `pixApagarQr`, e chamado por ele: tira o documento do DOM.
+ *
+ * O `value = ""` vem ANTES do `remove()` de propósito. Nó destacado continua
+ * guardando o `value`, e quem segura a referência é este módulo — foi
+ * exatamente assim que o wipe do QR passou a ser medível (`retido`, no PT7).
+ */
+function pixApagarDoc() {
+  if (!pixDoc) return;
+  pixDoc.value = "";
+  pixDoc.remove();
+  pixDoc = null;
+}
+
+/**
+ * Só a FORMA: 11 dígitos (CPF) ou 14 (CNPJ), depois de tirar a pontuação.
+ *
+ * O dígito verificador NÃO se confere aqui: quem valida documento é o Asaas, e
+ * uma segunda cópia da regra recusaria na tela o que o provedor aceita (§0.7).
+ */
+const pixDigitos = (v) => String(v || "").replace(/\D/g, "");
+const pixFormaOk = (d) => d.length === 11 || d.length === 14;
+
+/**
+ * O clique no CTA NÃO cobra mais: ele abre o formulário. O `POST` sai no submit
+ * dele, com o documento — sem ele o Asaas recusa a cobrança.
+ */
+function pixCheckout(plano) {
+  // Um modal por vez, nos DOIS estados. Com o QR na tela cada checkout é uma
+  // COBRANÇA NOVA no provedor; com o formulário aberto, um segundo overlay
+  // deixaria o primeiro órfão no DOM com o documento digitado dentro dele.
+  if (pixPoll || document.querySelector(".pix-ov")) return;
+  const nome = (PLAN_NAMES && PLAN_NAMES[plano]) || plano;
+  // Um `aoFechar` só para os dois estados: o `pixEncerrar` é inerte sem
+  // `pixPoll`, então fechar no formulário limpa o documento e mais nada.
+  const ctx = pixOverlay(nome + " anual no Pix", () => {
+    pixApagarDoc();
+    pixEncerrar();
+  });
+  pixFormulario(plano, ctx);
+}
+
+/** Estado 1 do modal: o documento. `<form>` de verdade — o submit nativo dá o
+ *  Enter de graça e não custa um listener de tecla a mais dentro do overlay. */
+function pixFormulario(plano, ctx) {
+  const f = document.createElement("form");
+  f.className = "pix-form";
+  const rot = document.createElement("label");
+  rot.className = "pix-rot";
+  rot.htmlFor = "pix-doc";
+  rot.textContent = "CPF ou CNPJ de quem vai pagar";
+  const campo = document.createElement("input");
+  campo.id = "pix-doc";
+  campo.className = "pix-doc";
+  campo.type = "text";
+  // `inputmode` e não `type="number"`: o number come zero à esquerda, aceita
+  // `e`/`+`/`-` e ignora `maxLength`. Teclado numérico no celular sem nada disso.
+  campo.inputMode = "numeric";
+  campo.autocomplete = "off";
+  campo.maxLength = 18;              // 14 dígitos + os 4 separadores de um CNPJ
+  campo.placeholder = "Só os números";
+  campo.setAttribute("aria-label", "CPF ou CNPJ de quem vai pagar");
+  campo.setAttribute("aria-describedby", "pix-doc-erro");
+  const erro = document.createElement("p");
+  erro.className = "pix-erro";
+  erro.id = "pix-doc-erro";
+  erro.setAttribute("role", "alert");
+  const enviar = pixBotao("btn-primary", "Gerar código Pix");
+  enviar.type = "submit";
+  f.append(rot, campo, erro, enviar);
+  const sair = pixBotao("pix-ghost", "Cancelar");
+  sair.addEventListener("click", () => ctx.fechar());
+  ctx.box.append(pixLinha("O Pix pede o CPF ou CNPJ de quem paga. A gente não"
+    + " guarda esse número — ele vai só para emitir a cobrança."), f, sair);
+  pixDoc = campo;
+  campo.focus();
+  f.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const d = pixDigitos(campo.value);
+    if (!pixFormaOk(d)) {
+      erro.textContent = "Informe os 11 dígitos do CPF ou os 14 do CNPJ.";
+      campo.focus();
+      return;
+    }
+    erro.textContent = "";
+    pixEnviar(plano, d, false, ctx, enviar);
+  });
+}
+
+/**
+ * O `POST`. `documento` viaja por ARGUMENTO — memória, nunca DOM: a caixa da
+ * migração troca o corpo do modal e o número precisa sobreviver ao segundo
+ * envio sem voltar para um campo na tela.
+ */
+async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, botao) {
+  if (botao.disabled) return;   // Enter repetido não vira duas cobranças
+  botao.disabled = true;
+  const rotulo = botao.textContent;
+  pixRotular(botao, "ph-clock", "Gerando o código…");
+  const corpo = { plan: plano, interval: "annual", cpf_cnpj: documento };
+  if (confirmarCancelamentoStripe) corpo.confirm_cancel_stripe = true;
+  try {
+    const r = await fetch("/billing/pix/checkout", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json", "x-csrf-token": getCsrfToken() },
+      body: JSON.stringify(corpo),
+    });
+    // Fechou no meio: nada de QR desenhado numa caixa já destacada — seria um
+    // instrumento ao portador fora da tela, com o poll rodando por trás dele.
+    // A cobrança criada lá expira sozinha; o que não pode é sobrar aqui.
+    if (!ctx.box.isConnected) return;
+    if (r.status === 401) {
+      showToast("Faça login pra continuar a assinatura.", "err");
+      setTimeout(() => {
+        window.location.href = "/login?next=" + encodeURIComponent("/precos");
+      }, 900);
+      return;
+    }
+    const d = await r.json().catch(() => ({}));
+    const det = (d && d.detail) || {};
+    if (r.status === 409 && det.error === "stripe_active") {
+      return pixModalMigracao(plano, det, documento, ctx);
+    }
+    if (!r.ok) return showToast(det.message || "Não consegui gerar o código Pix agora.", "err");
+    pixApagarDoc();          // o QR vai entrar: o documento sai da tela antes
+    pixModalQr(d, plano, ctx);
+  } catch {
+    showToast("Erro de conexão. Tente novamente.", "err");
+  } finally {
+    // `isConnected`: deu certo, este botão já saiu do modal junto com o
+    // formulário e reanimá-lo seria escrever num nó que ninguém vê.
+    if (botao.isConnected) { botao.disabled = false; botao.textContent = rotulo; }
+  }
+}
+
+/** 409 stripe_active: a migração cartão → Pix (§9 do plano). Mesmo modal. */
+function pixModalMigracao(plano, det, documento, ctx) {
+  const { box, fechar, titulo } = ctx;
+  // O documento sai da tela agora — esta caixa decide sobre o Stripe, e o número
+  // segue vivo só na closure do botão abaixo.
+  pixApagarDoc();
+  titulo.textContent = "Trocar o cartão pelo Pix?";
+  box.replaceChildren(titulo);
+  const data = fmtBrDate(String(det.current_period_end || "").slice(0, 10));
+  box.append(
+    pixLinha("Sua assinatura no cartão é cancelada no fim do período que você já"
+      + " pagou (" + data + "). Não existe cobrança dupla."),
+    pixLinha("Não cancele pelo painel do Stripe: quem cancela somos nós, na data"
+      + " certa. Cancelando por lá você perde o acesso antes."),
+    pixLinha("Seu ano de Pix começa em " + data + ", quando o cartão termina."),
+  );
+  const ok = pixBotao("btn-primary", "Continuar no Pix");
+  ok.addEventListener("click", () => pixEnviar(plano, documento, true, ctx, ok));
+  const nao = pixBotao("pix-ghost", "Manter o cartão");
+  nao.addEventListener("click", () => fechar());
+  box.append(ok, nao);
+  ok.focus();
+}

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -86,7 +86,12 @@ function pbPixInit(cfg, sub) {
 function pbPixRefresh() {
   // `!== true` e não `!`: portão de venda não abre com valor truthy qualquer.
   if (!pixCfg || pixCfg.pix_annual_available !== true) return;
-  const anual = currentCycle === "annual";
+  // Vitalício NÃO compra: o `refreshPlanButtons` da precos.html já marca os
+  // cards como acesso permanente, e o backend recusa o checkout com 409
+  // `lifetime` — um CTA aqui é um clique rumo ao erro, com CPF digitado antes.
+  // Mesmo caminho do mensal: sai do DOM (escondido ainda recebe Tab), o que
+  // também apaga o CTA já criado quando a assinatura chega depois do cfg.
+  const anual = currentCycle === "annual" && !(pixSub && pixSub.lifetime === true);
   for (const plano of PIX_PLANOS) {
     const existente = document.querySelector('[data-pix-cta="' + plano + '"]');
     // Sai do DOM no mensal em vez de ficar escondido: escondido ainda recebe Tab.
@@ -270,9 +275,12 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
       headers: { "Content-Type": "application/json", "x-csrf-token": getCsrfToken() },
       body: JSON.stringify(corpo),
     });
-    // Fechou no meio: nada de QR desenhado numa caixa já destacada — seria um
-    // instrumento ao portador fora da tela, com o poll rodando por trás dele.
-    // A cobrança criada lá expira sozinha; o que não pode é sobrar aqui.
+    const d = await r.json().catch(() => ({}));
+    // Fechou no meio — e a conferência vem DEPOIS do corpo, não antes: dá para
+    // fechar entre a chegada dos cabeçalhos e o fim do download do JSON, e aí o
+    // QR ia para uma caixa já destacada, com o poll rodando por trás dela e o
+    // `pixPoll` invisível bloqueando o próximo checkout até vencer. A cobrança
+    // criada lá expira sozinha; o que não pode é sobrar aqui.
     if (!ctx.box.isConnected) return;
     if (r.status === 401) {
       showToast("Faça login pra continuar a assinatura.", "err");
@@ -281,7 +289,6 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
       }, 900);
       return;
     }
-    const d = await r.json().catch(() => ({}));
     const det = (d && d.detail) || {};
     if (r.status === 409 && det.error === "stripe_active") {
       return pixModalMigracao(plano, det, documento, ctx);
@@ -321,3 +328,10 @@ function pixModalMigracao(plano, det, documento, ctx) {
   box.append(ok, nao);
   ok.focus();
 }
+
+// A precos.html chama o `pbPixInit` depois de duas requisições, guardada por
+// `typeof pbPixInit === "function"` — e estes dois scripts ainda podem estar
+// sendo BAIXADOS quando elas terminam: ali a guarda daria falso e ninguém
+// tentaria de novo, deixando a página sem CTA nenhum com a flag ligada. Então
+// quem chegar por ÚLTIMO lê o estado que o outro deixou, seja qual for a ordem.
+if (window.pbPixState) pbPixInit(window.pbPixState.cfg, window.pbPixState.sub);

--- a/frontend/pix-poll.js
+++ b/frontend/pix-poll.js
@@ -1,0 +1,252 @@
+/**
+ * O QR do Pix anual da /precos: o modal, a cópia, o poll e o §13.6.
+ *
+ * Metade de trás do pix-checkout.js, e não um arquivo por gosto: juntos os dois
+ * passam das 350 linhas do `quality/max-lines`. Os dois são script CLÁSSICO e
+ * dividem o mesmo escopo global — daqui saem `pixModalQr` e `pixEncerrar`, e de
+ * lá vêm `pixLinha`, `pixBotao`, `pixRotular`, `pixBrl`, `pixApagarDoc` e
+ * `pixCheckout`. O `pixPoll` (estado do modal aberto) mora SÓ aqui; o `pixDoc`
+ * mora SÓ lá: nenhum dos dois arquivos escreve variável do outro.
+ *
+ * O modal é UM só, com dois estados: o pix-checkout.js abre a caixa pedindo o
+ * CPF/CNPJ (o Asaas exige o documento do pagador) e o `pixModalQr` daqui troca o
+ * corpo dela pelo QR. Por isso ele recebe o `ctx` do overlay em vez de abrir
+ * outro — e por isso o `pixApagarQr` limpa o documento junto com o payload.
+ *
+ * §13.6 — o `qr_payload` é INSTRUMENTO AO PORTADOR: só memória e DOM (nada de
+ * localStorage, sessionStorage, cookie, history.state, query string ou log), e
+ * sai do DOM ao pagar, expirar ou fechar. Quem viaja na URL é o `public_token`.
+ */
+"use strict";
+
+// Terminais que não são pagamento: o QR morre e não há o que esperar.
+const PIX_TERMINAIS = new Set(["canceled", "expired", "refunded", "chargeback"]);
+// Teto do cliente, e SÓ para `expires_at` ausente/ilegível — o teto de verdade é
+// o do servidor (fonte única, CLAUDE.md §0.7). Era um `Math.min` com este valor,
+// que atropelava o servidor: com `expires_at` de +1h a tela parava aos 15 min e
+// declarava expirada uma cobrança que o backend ainda aceitava pagar.
+const PIX_TETO_MS = 15 * 60 * 1000;
+
+let pixPoll = null;   // estado do modal aberto; null = não há QR na tela
+
+function pixModalQr(d, plano, ctx) {
+  const nome = (PLAN_NAMES && PLAN_NAMES[plano]) || plano;
+  const valor = pixBrl(d.amount_cents);
+  // `ctx` é o modal que o pixCheckout já abriu para pedir o CPF/CNPJ: o QR é o
+  // SEGUNDO ESTADO dele, não uma segunda caixa. Reescreve o cabeçalho e troca o
+  // corpo. O `aoFechar` daquele overlay já chama o `pixEncerrar` — não há
+  // listener novo a registrar aqui, e nem um segundo lugar de onde fechar.
+  const { box, fechar, titulo } = ctx;
+  titulo.textContent = nome + " anual" + (valor ? " · " + valor : "");
+  box.replaceChildren(titulo);
+
+  // Tudo que morre junto com o código num container só: expirar é trocar o
+  // conteúdo dele, não caçar cinco elementos soltos na caixa.
+  const vivo = document.createElement("div");
+  const credito = pixBrl(d.credit_cents);
+  if (credito && d.credit_cents > 0) {
+    vivo.appendChild(pixLinha("Já com " + credito + " de crédito do seu plano atual."));
+  }
+  vivo.appendChild(pixLinha(d.starts_at
+    ? "Seu ano começa em " + fmtBrDate(String(d.starts_at).slice(0, 10)) + "."
+    : "Seu ano começa agora, assim que o pagamento cair."));
+
+  // Sem `qr_image` o <img> nem entra: vazio ele desenha um quadrado BRANCO de
+  // 230px (o fundo claro que o leitor de QR exige) com cara de código ilegível.
+  const img = document.createElement("img");
+  img.className = "pix-qr";
+  img.alt = "QR Code do Pix";
+  if (d.qr_image) { img.src = d.qr_image; vivo.appendChild(img); }
+
+  const code = document.createElement("input");
+  code.className = "pix-code";
+  code.readOnly = true;
+  code.setAttribute("aria-label", "Código Pix copia e cola");
+  code.value = d.qr_payload || "";
+
+  // Copiar é a ação PRIMÁRIA (§16.1): dentro do app o aparelho não se escaneia.
+  const copiar = pixBotao("btn-primary", "");
+  pixRotular(copiar, "ph-clipboard-text", "Copiar código Pix");
+  copiar.addEventListener("click", () => pixCopiar(code, copiar));
+  const status = document.createElement("p");
+  status.className = "pix-status";
+  pixRotular(status, "ph-clock", "Esperando o pagamento…");
+  // Fora do `vivo` de propósito: fechar tem de continuar possível depois que o
+  // código expira e o corpo é trocado.
+  const sair = pixBotao("pix-ghost", "Fechar");
+  sair.addEventListener("click", () => fechar());
+
+  vivo.append(code, copiar, status);
+  box.append(vivo, sair);
+  copiar.focus();
+
+  pixPoll = {
+    token: d.public_token, plano, vivo, img, code, status, fechar,
+    inicio: Date.now(), falhas: 0, timer: null,
+    // `Date.parse(undefined)` é NaN, e NaN é falsy: sem `expires_at` legível
+    // sobra o teto do cliente. COM ele, quem manda é o servidor.
+    deadline: Date.parse(d.expires_at) || Date.now() + PIX_TETO_MS,
+  };
+  document.addEventListener("visibilitychange", pixVisivel);
+  pixAgendar(0);
+}
+
+/**
+ * Só diz "Copiado" quando copiou.
+ *
+ * `execCommand("copy")` devolve `false` quando não copia, e pode LEVANTAR — o
+ * retorno ignorado era a tela mentindo sobre a ação primária de um pagamento.
+ *
+ * ponytail: teto conhecido e não provável aqui — no WKWebView do iOS (a /precos
+ * abre dentro do app) `select()` + `execCommand` num `<input readonly>` é caso
+ * clássico de falha silenciosa, e `execCommand` chega a devolver `true` sem ter
+ * copiado. Não dá para medir em Chromium headless; o que dá é não mentir quando
+ * ele devolve `false`, e deixar o campo selecionado para a cópia à mão.
+ */
+function pixCopiar(code, botao) {
+  const ok = () => {
+    pixRotular(botao, "ph-check-circle", "Copiado ✓");
+    setTimeout(() => pixRotular(botao, "ph-clipboard-text", "Copiar código Pix"), 1600);
+  };
+  const manual = () => {
+    code.select();
+    let copiou = false;
+    try { copiou = document.execCommand("copy") === true; } catch { copiou = false; }
+    if (copiou) { ok(); return; }
+    pixRotular(botao, "ph-warning", "Não consegui copiar — o código está"
+      + " selecionado, copie à mão");
+  };
+  if (navigator.clipboard) navigator.clipboard.writeText(code.value).then(ok, manual);
+  else manual();
+}
+
+/** §13.6: o copia-e-cola sai do DOM assim que não há mais uso legítimo dele. */
+function pixApagarQr() {
+  // O CPF/CNPJ vai junto, e ANTES do `return`: a mesma disciplina, a mesma hora.
+  // Sem esta linha, "pagou" e "expirou" limpavam o payload e deixavam o
+  // documento no `<input>` destacado que o pix-checkout.js ainda segura.
+  pixApagarDoc();
+  if (!pixPoll) return;
+  pixPoll.code.value = "";
+  pixPoll.img.removeAttribute("src");
+  pixPoll.img.remove();
+  pixPoll.code.remove();
+}
+
+/** Fechou o modal (Esc, fundo, botão): para o poll e apaga o código. */
+function pixEncerrar() {
+  if (!pixPoll) return;
+  clearTimeout(pixPoll.timer);
+  document.removeEventListener("visibilitychange", pixVisivel);
+  pixApagarQr();
+  pixPoll = null;
+}
+
+// ── O poll ──────────────────────────────────────────────────────────────────
+
+// O Pix liquida em segundos; a cauda não merece 3 s por 15 minutos.
+const pixIntervalo = () => (Date.now() - pixPoll.inicio < 120000 ? 3000 : 10000);
+
+function pixAgendar(ms) {
+  clearTimeout(pixPoll.timer);
+  pixPoll.timer = setTimeout(pixBater, ms);
+}
+
+/** Voltou para a aba: confirma na hora (saiu para o app do banco e pagou). */
+function pixVisivel() {
+  if (!document.hidden && pixPoll) pixAgendar(0);
+}
+
+async function pixBater() {
+  if (!pixPoll) return;
+  // O deadline NÃO expira sozinho. Na cauda o poll é de 10 s: a cobrança liquida
+  // dentro dessa janela, depois do último poll, e a tela dizia "expirou e nada
+  // foi cobrado" sobre cobrança PAGA — com um "Gerar novo código" ao lado, que
+  // CANCELA a cobrança remota (§10). Vencido, pergunta-se uma última vez.
+  const venceu = Date.now() >= pixPoll.deadline;
+  // Aba escondida não gasta requisição: quem retoma é o visibilitychange. A
+  // última pergunta é a exceção — é ela que decide a mensagem.
+  if (document.hidden && !venceu) { pixAgendar(pixIntervalo()); return; }
+
+  let corpo = null;
+  let desistir = false;
+  try {
+    const r = await fetch("/billing/pix/" + encodeURIComponent(pixPoll.token),
+      { credentials: "same-origin" });
+    if (!pixPoll) return;                       // fechou durante a requisição
+    if (r.status === 401) desistir = true;      // sobrou do auth-refresh: não insiste
+    else if (!r.ok) throw new Error("http " + r.status);
+    else corpo = await r.json();
+  } catch {
+    if (!pixPoll) return;
+    if (++pixPoll.falhas >= 3) desistir = true;
+  }
+  if (!pixPoll) return;
+  if (corpo) {
+    pixPoll.falhas = 0;
+    if (corpo.status === "paid") { pixPago(); return; }
+    if (PIX_TERMINAIS.has(corpo.status)) { pixExpirou("Esta cobrança não vale mais.", true); return; }
+  }
+  // Só o "não" do servidor autoriza afirmar que nada foi cobrado — e só ele
+  // autoriza oferecer código novo, porque gerar outro cancela este.
+  if (venceu) {
+    pixExpirou(corpo
+      ? "Este código expirou e nada foi cobrado."
+      : "Este código venceu e não deu pra confirmar por aqui. Se você pagou,"
+        + " seu acesso é liberado sozinho.", !!corpo);
+    return;
+  }
+  if (desistir) { pixDesistir(); return; }
+  pixAgendar(pixIntervalo());
+}
+
+function pixPago() {
+  const { token, plano, status } = pixPoll;
+  clearTimeout(pixPoll.timer);
+  document.removeEventListener("visibilitychange", pixVisivel);
+  pixRotular(status, "ph-check-circle", "Pagamento confirmado! Liberando seu acesso…");
+  status.classList.add("ok");
+  pixApagarQr();
+  // `sid` = public_token (§13.6): vira o eventID do pixel da Meta e o
+  // transaction_id do GA4 na /home. Sem `ia=` — a home.html trata a ausência.
+  window.location.href = "/home?upgrade=success&sid=" + encodeURIComponent(token)
+    + "&ev=purchase&td=0&pl=" + encodeURIComponent(plano);
+}
+
+/**
+ * `confirmado` = o servidor respondeu que esta cobrança não foi paga. Só nesse
+ * caso nasce o "Gerar novo código": ele CANCELA a cobrança remota e cria outra
+ * (§10), e oferecer isso a quem talvez tenha pago é o caminho do pagamento
+ * duplicado / `paid_orphan`. Sem confirmação sobra o "Fechar", que nunca sai da
+ * caixa.
+ */
+function pixExpirou(motivo, confirmado) {
+  if (!pixPoll) return;
+  clearTimeout(pixPoll.timer);
+  // Sem isto, voltar para a aba depois de expirar remontava o corpo e roubava o
+  // foco de quem já estava lendo a mensagem.
+  document.removeEventListener("visibilitychange", pixVisivel);
+  const { vivo, plano, fechar } = pixPoll;
+  pixApagarQr();
+  vivo.replaceChildren(pixLinha(motivo));
+  if (!confirmado) return;
+  const novo = pixBotao("btn-primary", "Gerar novo código");
+  // Reabre no ESTADO 1: o documento não ficou guardado, então é pedido de novo.
+  novo.addEventListener("click", () => { fechar(); pixCheckout(plano); });
+  vivo.appendChild(novo);
+  novo.focus();
+}
+
+/**
+ * Parou de conseguir perguntar (401 que passou pelo auth-refresh, ou rede fora).
+ * O código NÃO some agora: é pagável sem sessão nenhuma, e apagá-lo puniria quem
+ * está com o app do banco aberto. Mas o poll não morre — ele DORME até o
+ * vencimento, e lá tenta de novo (a rede pode ter voltado) e, dando ou não, o
+ * payload sai do DOM. Sem isso o copia-e-cola ficava na tela para sempre, com a
+ * mensagem "o código continua válido" uma hora depois de vencer.
+ */
+function pixDesistir() {
+  pixRotular(pixPoll.status, "ph-clock", "Não consegui confirmar por aqui — o"
+    + " código continua válido. Entre de novo e a gente confirma.");
+  pixAgendar(Math.max(0, pixPoll.deadline - Date.now()));
+}

--- a/frontend/pix-poll.js
+++ b/frontend/pix-poll.js
@@ -158,12 +158,18 @@ function pixVisivel() {
 }
 
 async function pixBater() {
-  if (!pixPoll) return;
+  // A cobrança que ESTA pergunta é sobre. Fechar o modal com a requisição no ar
+  // e abrir outro checkout deixava `pixPoll` NÃO-NULO de novo — e a resposta da
+  // cobrança VELHA passava pela guarda: um `paid` antigo redirecionava com o
+  // `sid` da outra, e um terminal antigo apagava o QR novo. Identidade do
+  // objeto, não `token`: duas cobranças podem trazer o mesmo.
+  const meu = pixPoll;
+  if (!meu) return;
   // O deadline NÃO expira sozinho. Na cauda o poll é de 10 s: a cobrança liquida
   // dentro dessa janela, depois do último poll, e a tela dizia "expirou e nada
   // foi cobrado" sobre cobrança PAGA — com um "Gerar novo código" ao lado, que
   // CANCELA a cobrança remota (§10). Vencido, pergunta-se uma última vez.
-  const venceu = Date.now() >= pixPoll.deadline;
+  const venceu = Date.now() >= meu.deadline;
   // Aba escondida não gasta requisição: quem retoma é o visibilitychange. A
   // última pergunta é a exceção — é ela que decide a mensagem.
   if (document.hidden && !venceu) { pixAgendar(pixIntervalo()); return; }
@@ -171,19 +177,19 @@ async function pixBater() {
   let corpo = null;
   let desistir = false;
   try {
-    const r = await fetch("/billing/pix/" + encodeURIComponent(pixPoll.token),
+    const r = await fetch("/billing/pix/" + encodeURIComponent(meu.token),
       { credentials: "same-origin" });
-    if (!pixPoll) return;                       // fechou durante a requisição
+    if (pixPoll !== meu) return;                // fechou ou trocou de cobrança
     if (r.status === 401) desistir = true;      // sobrou do auth-refresh: não insiste
     else if (!r.ok) throw new Error("http " + r.status);
     else corpo = await r.json();
   } catch {
-    if (!pixPoll) return;
-    if (++pixPoll.falhas >= 3) desistir = true;
+    if (pixPoll !== meu) return;
+    if (++meu.falhas >= 3) desistir = true;
   }
-  if (!pixPoll) return;
+  if (pixPoll !== meu) return;
   if (corpo) {
-    pixPoll.falhas = 0;
+    meu.falhas = 0;
     if (corpo.status === "paid") { pixPago(); return; }
     if (PIX_TERMINAIS.has(corpo.status)) { pixExpirou("Esta cobrança não vale mais.", true); return; }
   }

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -943,6 +943,17 @@ async function cancelChange(btn) {
 
 (async function loadPlansState(){
   let cfgPlanos = null;   // o mesmo corpo alimenta os CTAs de cartão e o de Pix
+  // Pix anual: reusa o `plans-config` e o `subscription` que esta página já
+  // buscou — nenhum fetch novo. Sem `pix_annual_available` no cfg, o pbPixInit
+  // não cria botão nenhum e a página fica igual à de hoje.
+  // Publica em `window` ANTES de chamar: os scripts do Pix podem ainda estar
+  // sendo baixados quando as requisições daqui terminam, e aí é o pix-checkout.js
+  // que lê este estado ao carregar. Sem isso o `typeof` abaixo dava falso e
+  // ninguém tentava de novo — página sem CTA de Pix com a flag ligada.
+  const publicarPix = (sub) => {
+    window.pbPixState = { cfg: cfgPlanos, sub };
+    if (typeof pbPixInit === "function") pbPixInit(cfgPlanos, sub);
+  };
   try {
     const resp = await fetch("/billing/plans-config", { credentials: "same-origin" });
     if (resp.ok) {
@@ -959,13 +970,16 @@ async function cancelChange(btn) {
       if (!cfg.plus_available) markUnavailable('[data-plan-btn="plus"]');
       if (!cfg.pro_available) markUnavailable('[data-plan-btn="pro"]');
     }
+    // O CTA de Pix nasce AQUI, antes do /billing/subscription: para quem já é
+    // cliente do Stripe aquela chamada consulta o Stripe e pode demorar ou
+    // travar, e era justamente a migração cartão → Pix que ficava sem botão
+    // enquanto o Stripe está ruim. Os rótulos ("Renovar", vitalício) são
+    // corrigidos na segunda chamada, quando a assinatura chega.
+    publicarPix(null);
     // Assinante logado: botões viram "Seu plano atual / Trocar / Agendado".
     await loadSubscription();
     refreshPlanButtons();
-    // Pix anual: reusa o `plans-config` e o `subscription` que esta página já
-    // buscou — nenhum fetch novo. Sem `pix_annual_available` no cfg, o
-    // pbPixInit não cria botão nenhum e a página fica igual à de hoje.
-    if (typeof pbPixInit === "function") pbPixInit(cfgPlanos, subState);
+    publicarPix(subState);
   } catch {}
 })();
 
@@ -1079,10 +1093,9 @@ enviarViewItemList();
        primeiro alertModal/confirmModal, que esta página não usa. -->
   <script src="/modals.js?v=1"></script>
   <!-- Pix anual: CTA, modal do QR e poll. Scripts clássicos e SEM `defer` logo
-       depois do bloco inline de propósito — eles publicam pbPixInit/pbPixRefresh
-       no escopo global, e o loadPlansState acima só os chama depois de dois
-       awaits de rede. Com `defer` a execução seria adiada para depois do parse e
-       o `typeof pbPixInit === "function"` poderia perder a corrida.
+       depois do bloco inline — eles publicam pbPixInit/pbPixRefresh no escopo
+       global. A corrida com o loadPlansState acima não depende desta ordem: quem
+       chegar por último lê o `window.pbPixState` que o outro deixou.
        O pix-poll.js vem ANTES: ele declara o `pixPoll` que o pix-checkout.js lê,
        e `let` de topo de script clássico tem TDZ até o script rodar. -->
   <script src="/pix-poll.js?v=1"></script>

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -68,6 +68,79 @@
      nascia 2px mais baixo que os outros três. Borda transparente iguala. */
   #plans-v2 .plan .btn-primary, .cmp-table tfoot .btn-primary { border: 1px solid transparent; }
   #plans-v2 .plan .btn:focus-visible { outline: 2px solid var(--pink); outline-offset: 2px; }
+  /* ── Pix anual ─────────────────────────────────────────────────────────
+     Mora aqui, e não em arquivo próprio: é CSS de uma página só, e um .css
+     novo pediria uma segunda rota em routes/static_pages.py sem ganho (§0.2).
+     O CTA do Pix é o SEGUNDO botão do card, e os cards são flex-column com
+     `.plan .btn { margin-top:auto }` — o auto do primeiro já empurra o par
+     inteiro para o rodapé, então basta o respiro entre os dois. */
+  #plans-v2 .plan .pix-cta { margin-top: 8px; }
+
+  /* O overlay é `position: fixed`, então NÃO herda o padding de área segura do
+     body (docs/armadilhas.md, "o app é o mesmo site"): ele reserva os quatro
+     lados sozinho. A /precos é alcançável de dentro do app iOS pelo "Ver
+     planos" do paywall. */
+  .pix-ov {
+    position: fixed; inset: 0; z-index: 999; display: flex;
+    align-items: center; justify-content: center;
+    background: rgba(0,0,0,.72); backdrop-filter: blur(4px);
+    padding: calc(20px + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right))
+             calc(20px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
+  }
+  /* max-height + overflow: em paisagem no celular a caixa passava da tela. */
+  .pix-box {
+    background: var(--card); border: 1px solid var(--line-2); border-radius: 18px;
+    padding: 24px; width: 100%; max-width: 400px; max-height: 100%;
+    overflow-y: auto; text-align: center;
+  }
+  .pix-box h3 { margin: 0 0 10px; font-size: 1.15rem; }
+  .pix-line { color: var(--ink-2); font-size: .86rem; line-height: 1.55; margin: 0 0 6px; }
+  /* Fundo branco: leitor de QR não lê código claro sobre fundo escuro. */
+  .pix-qr {
+    display: block; width: min(230px,100%); height: auto; aspect-ratio: 1;
+    background: #fff; border-radius: 12px; padding: 8px; margin: 14px auto 12px;
+  }
+  .pix-code {
+    width: 100%; padding: 9px 10px; border-radius: 10px; border: 1px solid var(--line-2);
+    background: rgba(255,255,255,.05); color: var(--ink); font-family: var(--font);
+    font-size: .68rem; text-overflow: ellipsis;
+  }
+  /* Estado 1 do modal: o CPF/CNPJ. `text-align: left` porque a caixa é centrada
+     e rótulo de formulário centrado é o que faz uma tela de pagamento parecer
+     um pop-up. */
+  .pix-form { margin-top: 16px; text-align: left; }
+  .pix-rot { display: block; font-size: .76rem; font-weight: 600; color: var(--ink-2); margin-bottom: 6px; }
+  .pix-doc {
+    width: 100%; padding: 12px; border-radius: 10px; border: 1px solid var(--line-2);
+    background: rgba(255,255,255,.05); color: var(--ink); font-family: var(--font);
+    font-size: 1rem; letter-spacing: .04em;
+  }
+  /* 16px de fonte no campo evita o zoom automático do Safari no iOS ao focar —
+     a /precos abre dentro do app. O `1rem` acima já é isso; não baixe. */
+  .pix-doc::placeholder { color: var(--ink-3); letter-spacing: normal; }
+  .pix-doc:focus-visible { outline: 2px solid var(--pink); outline-offset: 2px; }
+  /* Mesmo par de cores do `.contact-msg.err` do site.css (§0.7): vermelho de
+     erro é um só. `:empty` some para a caixa não nascer com um buraco. */
+  .pix-erro { color: #ffb4b4; font-size: .78rem; line-height: 1.45; margin: 8px 0 0; }
+  .pix-erro:empty { display: none; }
+  /* `white-space: normal` pelo mesmo motivo do tfoot logo abaixo: `.btn` é
+     nowrap no site.css e o rótulo destes é REESCRITO em runtime. O de falha da
+     cópia ("Não consegui copiar — o código está selecionado, copie à mão")
+     vazava 60px para fora do botão e para fora do card em 390px (medido). */
+  .pix-box .btn { margin-top: 10px; white-space: normal; line-height: 1.35; }
+  .pix-ghost { background: transparent; border: 1px solid var(--line); color: var(--ink-2); }
+  .pix-ghost:hover { background: rgba(255,255,255,.06); }
+  .pix-status {
+    display: flex; align-items: center; justify-content: center; gap: 7px;
+    color: var(--ink-3); font-size: .82rem; margin: 14px 0 0;
+  }
+  /* Verde só no sucesso. */
+  .pix-status.ok { color: var(--neon); }
+  @media (prefers-reduced-motion: no-preference) {
+    .pix-ov { animation: pix-in 160ms var(--ease); }
+    @keyframes pix-in { from { opacity: 0; } }
+  }
+
   /* O badge é absoluto com left:50%, então a largura disponível é metade do
      card e "Mais popular" quebrava em duas linhas. Com 4 colunas ainda quebra:
      medido 2026-09-02 em Chromium headless, o badge pede 139,5px e a metade do
@@ -635,6 +708,8 @@ function setCycle(cycle) {
   document.querySelectorAll("[data-price-monthly]").forEach(el => { el.style.display = cycle === "monthly" ? "" : "none"; });
   document.querySelectorAll("[data-price-annual]").forEach(el => { el.style.display = cycle === "annual" ? "" : "none"; });
   if (typeof refreshPlanButtons === "function") refreshPlanButtons();
+  // O CTA de Pix só existe no ciclo anual (Pix é à vista, §7 do plano).
+  if (typeof pbPixRefresh === "function") pbPixRefresh();
   // Trocar de ciclo é uma impressão NOVA: outros preços na tela. Sem isto o
   // `view_item_list` do load (sempre "monthly", que é o estado inicial) seria o
   // único, e a comparação mensal × anual nunca teria o lado anual.
@@ -711,6 +786,17 @@ function refreshPlanButtons() {
     if (subState.lifetime) {
       btn.disabled = true;
       btn.textContent = "Você tem acesso vitalício";
+      btn.onclick = null;
+      return;
+    }
+    // Assinante do Pix: NÃO existe troca de plano por aqui. O /billing/change-plan
+    // recusa com `no_subscription` (não há stripe_customer_id), então oferecer
+    // "Trocar pro Pro" mandaria o clique para um erro. Quem troca é o CTA do Pix.
+    // Fora do `if` de ciclo de propósito: no MENSAL o `currentCycle !==
+    // subState.interval` faria o código abaixo voltar a oferecer a troca.
+    if (subState.gateway === "pix") {
+      btn.disabled = true;
+      btn.textContent = p === subState.plan ? "✓ Seu plano atual" : "Disponível no Pix";
       btn.onclick = null;
       return;
     }
@@ -856,10 +942,12 @@ async function cancelChange(btn) {
 })();
 
 (async function loadPlansState(){
+  let cfgPlanos = null;   // o mesmo corpo alimenta os CTAs de cartão e o de Pix
   try {
     const resp = await fetch("/billing/plans-config", { credentials: "same-origin" });
     if (resp.ok) {
-      const cfg = await resp.json();
+      cfgPlanos = await resp.json();
+      const cfg = cfgPlanos;
       // Plano sem price configurado no Stripe → botão vira "Indisponível" (não
       // deixa o usuário clicar pra tomar um erro). querySelectorAll, não
       // querySelector: cada plano pago tem DOIS botões (card + rodapé da
@@ -874,6 +962,10 @@ async function cancelChange(btn) {
     // Assinante logado: botões viram "Seu plano atual / Trocar / Agendado".
     await loadSubscription();
     refreshPlanButtons();
+    // Pix anual: reusa o `plans-config` e o `subscription` que esta página já
+    // buscou — nenhum fetch novo. Sem `pix_annual_available` no cfg, o
+    // pbPixInit não cria botão nenhum e a página fica igual à de hoje.
+    if (typeof pbPixInit === "function") pbPixInit(cfgPlanos, subState);
   } catch {}
 })();
 
@@ -981,6 +1073,20 @@ function enviarViewItemList() {
 }
 enviarViewItemList();
 </script>
+  <!-- Só pelo `pigTrapTab`: o modal do QR é um instrumento ao portador e o Tab
+       tem de ficar preso dentro dele (é o mesmo helper do modal_keys.test.mjs).
+       Nada é injetado no carregamento — o CSS dos modais dele só entra no
+       primeiro alertModal/confirmModal, que esta página não usa. -->
+  <script src="/modals.js?v=1"></script>
+  <!-- Pix anual: CTA, modal do QR e poll. Scripts clássicos e SEM `defer` logo
+       depois do bloco inline de propósito — eles publicam pbPixInit/pbPixRefresh
+       no escopo global, e o loadPlansState acima só os chama depois de dois
+       awaits de rede. Com `defer` a execução seria adiada para depois do parse e
+       o `typeof pbPixInit === "function"` poderia perder a corrida.
+       O pix-poll.js vem ANTES: ele declara o `pixPoll` que o pix-checkout.js lê,
+       e `let` de topo de script clássico tem TDZ até o script rodar. -->
+  <script src="/pix-poll.js?v=1"></script>
+  <script src="/pix-checkout.js?v=1"></script>
   <script src="/nav-auth.js?v=7" defer></script>
 </body>
 </html>

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -563,6 +563,28 @@ async def serve_of_connect_js():
     )
 
 
+@router.get("/pix-checkout.js")
+async def serve_pix_checkout_js():
+    """CTA, overlay e checkout do Pix anual da /precos. Sem esta rota o arquivo
+    dá 404 e o sintoma só aparece no navegador — não há StaticFiles mount aqui."""
+    return FileResponse(
+        FRONTEND_DIR / "pix-checkout.js",
+        media_type="application/javascript",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+@router.get("/pix-poll.js")
+async def serve_pix_poll_js():
+    """Par do /pix-checkout.js: o modal do QR, a cópia e o poll da cobrança.
+    São dois arquivos porque juntos passam do teto de 350 linhas do lint."""
+    return FileResponse(
+        FRONTEND_DIR / "pix-poll.js",
+        media_type="application/javascript",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
 @router.get("/open-finance-connect.css")
 async def serve_of_connect_css():
     """CSS do modal de conectar banco (ver /open-finance-connect.js)."""

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -1,0 +1,920 @@
+/**
+ * O Pix anual na /precos: o CTA, o modal do QR, o poll e o §13.6.
+ *
+ * Backend inteiro por `page.route` — o `POST /billing/pix/checkout` e o
+ * `GET /billing/pix/{token}` estão sendo escritos em outro branch, e este PR é
+ * seguro de mergear antes deles justamente porque sem `pix_annual_available` a
+ * página é a de hoje. Contagem por INTERCEPTAÇÃO, não por efeito visível.
+ *
+ * Os dois controles do CLAUDE.md §3:
+ *   · negativo — PT1, PT2, PT4 e PT7 têm mutação nomeada na tabela do plano, e a
+ *     do PT2 é injetada num caso que estava VERDE;
+ *   · positivo — PT2b (sem `expires_at` o poll RODA; sem ele, um poll que nunca
+ *     começa passaria no PT2), PT2d (com `expires_at` longo o poll CONTINUA),
+ *     PT5 (o caminho do cartão continua inteiro) e os dois primeiros casos do
+ *     PT8 (copiar de verdade continua dizendo "Copiado").
+ *
+ * O que o grupo do §13.6 NÃO media, e agora mede: com `pixApagarQr` virando
+ * `{ return; }` os três casos do PT7 saíam 12/12 VERDES — o overlay, o
+ * `replaceChildren` e a navegação removiam o payload por cima do wipe, e a
+ * asserção de DOM nunca via o `value` de um `<input>`. Quem discrimina o wipe é
+ * o `retido`/`valores` do `vestigios` e o PT10 (modal aberto, nada removendo por
+ * cima). Os casos "fechando" e "pagando" continuam medindo o §13.6 inteiro
+ * (nada em storage, nada na URL), não o wipe.
+ *
+ * O que estes testes NÃO alcançam, e precisa de outro método (aparelho, pós-deploy):
+ *   · a pausa/retomada por `document.hidden` — o Playwright não emula visibilidade
+ *     de forma confiável;
+ *   · o padding de área segura — `env(safe-area-inset-*)` vale 0 no headless;
+ *   · a leitura do QR por câmera e o pagamento de verdade.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+// O copia-e-cola de verdade tem esta cara. É a string que o PT7 procura em todo
+// canto depois que a cobrança sai de cena.
+const PAYLOAD = "00020126580014BR.GOV.BCB.PIX0136pigbank-teste-qr-payload-52040000AAAA";
+// data: URI de 1x1 — o QR real é um `data:image/svg+xml` gerado pelo servidor
+// (qr_svg_data_url, core/services/pix_brcode.py). O que se mede aqui é que o
+// atributo SOME, não o desenho.
+const QR_IMG = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+// O documento do pagador. Dígito verificador NÃO é conferido na tela (quem
+// valida é o Asaas, §0.7), então o que importa aqui é a FORMA: 11 e 14 dígitos.
+// São strings improváveis de aparecer por acaso — o PT12d procura por elas no
+// storage, no DOM, no console e no corpo de TODA requisição da página.
+const CPF = "11122233344";
+const CNPJ = "11222333000181";
+
+/**
+ * Abre a /precos com o backend mockado e devolve a página + os contadores.
+ *
+ * `pix` controla o que o `POST /billing/pix/checkout` responde; `status` é a
+ * função que decide o corpo de cada poll (recebe o número da chamada) e, quando
+ * devolve `null`, a requisição é ABORTADA — é assim que se mede rede fora.
+ *
+ * `pix.expiresAt` aceita função: aí o deadline é contado a partir da RESPOSTA do
+ * checkout, e não de antes de o navegador abrir. Sem isso, os 1–2 s de `goto` +
+ * `waitForTimeout` comiam parte da janela que o teste quer medir.
+ */
+async function abrirPrecos({
+  sub = { active: false },
+  plansConfig = { essencial_available: true, plus_available: true,
+                  pro_available: true, pix_annual_available: true },
+  pix = {},
+  status = () => ({ status: "pending" }),
+  viewport = { width: 1280, height: 900 },
+  relogio = false,
+} = {}) {
+  const page = await browser.newPage({ viewport });
+  // Relógio falso: o teto do CLIENTE é de 15 minutos, e a única forma de medir
+  // que ele existe sem esperar 15 minutos é adiantar o relógio da página. Com
+  // ele instalado o setTimeout do poll só anda por `fastForward` — nenhuma
+  // requisição sai em tempo real.
+  if (relogio) await page.clock.install();
+  const chamadas = { checkout: 0, pixCheckout: 0, poll: 0, changePlan: 0 };
+  const corposPix = [];
+
+  await page.route("**/auth/me", (r) => r.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ user_id: 42, needs_plan_selection: true }),
+  }));
+  await page.route("**/billing/plans-config", (r) => r.fulfill({
+    contentType: "application/json", body: JSON.stringify(plansConfig),
+  }));
+  await page.route("**/billing/subscription", (r) => r.fulfill({
+    contentType: "application/json", body: JSON.stringify(sub),
+  }));
+  await page.route("**/billing/change-plan", (r) => {
+    chamadas.changePlan += 1;
+    return r.fulfill({ contentType: "application/json", body: "{}" });
+  });
+  await page.route("**/billing/create-checkout", (r) => {
+    chamadas.checkout += 1;
+    return r.fulfill({ contentType: "application/json",
+                       body: JSON.stringify({ checkout_url: `${ORIGIN}/precos.html?stripe=1` }) });
+  });
+
+  await page.route("**/billing/pix/checkout", (r) => {
+    chamadas.pixCheckout += 1;
+    corposPix.push(JSON.parse(r.request().postData() || "{}"));
+    const { httpStatus = 200, corpo } = pix;
+    return r.fulfill({
+      status: httpStatus, contentType: "application/json",
+      body: JSON.stringify(corpo || {
+        public_token: "tok_abc123", qr_payload: PAYLOAD, qr_image: QR_IMG,
+        amount_cents: 19900, credit_cents: 0, starts_at: null, plan: "plus",
+        // O corpo traz DE PROPÓSITO o id do provedor: o PT6 prova que ele não
+        // vai para a URL de sucesso (§13.6).
+        asaas_payment_id: "pay_9999",
+        ...(pix.expiresAt === undefined ? {} : {
+          expires_at: typeof pix.expiresAt === "function" ? pix.expiresAt() : pix.expiresAt,
+        }),
+      }),
+    });
+  });
+  // Depois do `checkout` na ordem de registro: o Playwright usa a ÚLTIMA rota
+  // que casa, então o padrão mais amplo tem de vir por último para não engolir
+  // o `/billing/pix/checkout`. Este `if` é o que devolve o checkout para ele.
+  await page.route("**/billing/pix/*", (r) => {
+    if (r.request().url().endsWith("/checkout")) return r.fallback();
+    chamadas.poll += 1;
+    const corpo = status(chamadas.poll);
+    if (!corpo) return r.abort();          // rede fora: o fetch REJEITA
+    return r.fulfill({ contentType: "application/json", body: JSON.stringify(corpo) });
+  });
+  // A volta do sucesso: sem isto o `/home?upgrade=success` daria 404 do
+  // http.server e o PT7 leria o corpo de uma página de erro.
+  await page.route("**/home*", (r) => r.fulfill({
+    contentType: "text/html", body: "<html><body>home</body></html>",
+  }));
+
+  await page.goto(`${ORIGIN}/precos.html`);
+  await page.waitForSelector("#plans-v2 .plan");
+  await page.waitForTimeout(600);     // loadPlansState = 2 awaits de rede
+  return { page, chamadas, corposPix };
+}
+
+const contarCtas = (page) => page.$$eval("[data-pix-cta]", (e) => e.length);
+
+/**
+ * Estado 1 do modal: o CPF/CNPJ. É AQUI que o POST sai — o clique no CTA só abre
+ * a caixa, porque o Asaas exige o documento do pagador para criar a cobrança.
+ */
+async function enviarDoc(page, valor = CPF) {
+  await page.fill(".pix-doc", valor);
+  await page.click('.pix-form button[type="submit"]');
+}
+
+/** Abre o modal do QR: CTA do Plus no anual, documento, submit. */
+async function abrirQr(ctx = {}) {
+  const r = await abrirPrecos(ctx);
+  await r.page.click("#cycle-annual");
+  await r.page.click('[data-pix-cta="plus"]');
+  await r.page.waitForSelector(".pix-doc");
+  await enviarDoc(r.page, ctx.doc);
+  await r.page.waitForTimeout(300);
+  return r;
+}
+
+// ── PT1: o CTA só existe no ciclo anual ─────────────────────────────────────
+// O bug barato é aparecer e não sumir na volta, então o mensal é medido DUAS
+// vezes: na abertura e depois de voltar do anual.
+test("PT1: nenhum CTA de Pix no mensal, 3 no anual, e some na volta", async () => {
+  const { page } = await abrirPrecos();
+  assert.equal(await contarCtas(page), 0, "o ciclo mensal nasceu com CTA de Pix");
+
+  await page.click("#cycle-annual");
+  assert.equal(await contarCtas(page), 3, "o ciclo anual devia ter 3 CTAs de Pix");
+  const planos = await page.$$eval("[data-pix-cta]", (e) => e.map((b) => b.dataset.pixCta));
+  assert.deepEqual(planos, ["essencial", "plus", "pro"]);
+  // Nos cards, nunca no tfoot: o precos_sem_plano_gratis.test.mjs assevera as 5
+  // células daquele rodapé, e uma célula nova o deixa vermelho.
+  assert.equal(await page.$$eval("#plans-v2 [data-pix-cta]", (e) => e.length), 3);
+  assert.equal(await page.$$eval(".cmp-table [data-pix-cta]", (e) => e.length), 0,
+    "CTA de Pix vazou para a tabela comparativa");
+
+  await page.click("#cycle-monthly");
+  assert.equal(await contarCtas(page), 0, "o CTA de Pix não sumiu na volta pro mensal");
+  await page.close();
+});
+
+// A OUTRA metade do que torna este PR seguro de mergear antes do backend.
+//
+// Os dois últimos casos existem para prender a ESTRICTUDE do `!== true`: com os
+// dois primeiros, trocar a guarda por `!pixCfg.pix_annual_available` deixava o
+// arquivo inteiro verde. Portão de venda não abre com valor truthy qualquer —
+// `1` e `"true"` são o que um backend novo devolve quando alguém troca o tipo da
+// flag sem querer, e aí a venda de Pix abriria sozinha em produção.
+test("PT1b: sem pix_annual_available === true, nenhum botão nasce em ciclo nenhum", async () => {
+  const base = { essencial_available: true, plus_available: true, pro_available: true };
+  for (const cfg of [
+    base,
+    { ...base, pix_annual_available: false },
+    { ...base, pix_annual_available: 1 },
+    { ...base, pix_annual_available: "true" },
+  ]) {
+    const { page } = await abrirPrecos({ plansConfig: cfg });
+    assert.equal(await contarCtas(page), 0);
+    await page.click("#cycle-annual");
+    assert.equal(await contarCtas(page), 0,
+      `com ${JSON.stringify(cfg)} o anual criou CTA de Pix`);
+    await page.close();
+  }
+});
+
+// ── PT2: o poll tem TETO ────────────────────────────────────────────────────
+test("PT2: o poll para no deadline do expires_at e o código some da tela", async () => {
+  const { page, chamadas } = await abrirQr({
+    pix: { expiresAt: () => new Date(Date.now() + 6000).toISOString() },
+  });
+  await page.waitForTimeout(9000);
+  const noTeto = chamadas.poll;
+  assert.ok(noTeto >= 2, `o poll rodou só ${noTeto} vez(es) dentro dos 6 s`);
+  await page.waitForTimeout(6000);
+  assert.equal(chamadas.poll, noTeto,
+    `o poll continuou depois do deadline: ${noTeto} -> ${chamadas.poll}`);
+
+  assert.match(await page.textContent(".pix-box"), /expirou/i);
+  assert.equal(await page.$$eval(".pix-code", (e) => e.length), 0,
+    "o <input> com o copia-e-cola continua na tela depois de expirar");
+  // Pelo TEXTO, não por `$(".pix-box button")`: o "Fechar" nunca sai da caixa, e
+  // a asserção antiga passaria com o "Gerar novo código" ausente.
+  const botoes = await page.$$eval(".pix-box button", (e) => e.map((b) => b.textContent.trim()));
+  assert.ok(botoes.includes("Gerar novo código"),
+    `sumiu o botão de gerar novo código: ${JSON.stringify(botoes)}`);
+
+  // Voltar para a aba DEPOIS de expirar não pode ressuscitar o poll nem remontar
+  // o corpo por cima de quem está lendo: o listener de `visibilitychange` sai
+  // junto com o poll. O evento é despachado à mão de propósito — o Playwright
+  // não emula visibilidade (é o limite anotado no topo deste arquivo), e o que
+  // se mede aqui é o HANDLER, não o `document.hidden`.
+  await page.evaluate(() => document.dispatchEvent(new Event("visibilitychange")));
+  await page.waitForTimeout(500);
+  assert.equal(chamadas.poll, noTeto,
+    `voltar para a aba ressuscitou o poll depois de expirar: ${noTeto} -> ${chamadas.poll}`);
+  await page.close();
+});
+
+/**
+ * PT2c — A CORRIDA DO ÚLTIMO INTERVALO, e é a de dinheiro.
+ *
+ * Na cauda o poll é de 10 s: a cobrança liquida DENTRO dessa janela, depois do
+ * último poll. O código testava o deadline ANTES de perguntar ao servidor, então
+ * a tela dizia "Este código expirou e nada foi cobrado" sobre cobrança PAGA — e
+ * oferecia "Gerar novo código" ao lado, que CANCELA a cobrança remota e cria
+ * outra (§10). Pagamento duplicado / `paid_orphan`.
+ *
+ * Aqui o servidor só responde `paid` DEPOIS do vencimento: quem passa é a
+ * última pergunta, não o poll de antes. *Negativo: volte o `if (Date.now() >=
+ * deadline) { pixExpirou(...); return; }` para o topo do `pixBater` → o
+ * `waitForURL` estoura.*
+ */
+test("PT2c: liquidou dentro do último intervalo — pergunta antes de dizer que expirou",
+  async () => {
+    let vence = 0;
+    const { page } = await abrirQr({
+      pix: { expiresAt: () => { vence = Date.now() + 5000; return new Date(vence).toISOString(); } },
+      status: () => (Date.now() >= vence ? { status: "paid" } : { status: "pending" }),
+    });
+    await page.waitForURL(/upgrade=success/, { timeout: 15000 });
+    await page.close();
+  });
+
+/**
+ * PT2d — QUEM MANDA É O SERVIDOR (o conflito dos dois tetos).
+ *
+ * O `Math.min(Date.parse(expires_at) || Infinity, Date.now() + PIX_TETO_MS)`
+ * fazia o teto de 15 min do cliente atropelar o do servidor: com `expires_at` de
+ * +1 h a tela parava aos 15 min e declarava expirada uma cobrança que o backend
+ * ainda aceitava pagar. O comentário do arquivo já dizia que o teto de verdade é
+ * o do servidor (§0.7) — o código é que fazia o contrário.
+ *
+ * O PT2b é o par deste: SEM `expires_at`, o teto do cliente continua valendo.
+ */
+test("PT2d: com expires_at longo, o teto de 15 min do cliente não atropela o servidor",
+  async () => {
+    const { page, chamadas } = await abrirQr({
+      pix: { expiresAt: () => new Date(Date.now() + 3600000).toISOString() },
+      relogio: true,
+    });
+    for (let i = 0; i < 20; i++) {
+      await page.clock.fastForward(60000);
+      await page.waitForTimeout(60);
+    }
+    await page.waitForTimeout(300);
+    const aos20min = chamadas.poll;
+    const texto = await page.textContent(".pix-box");
+    assert.doesNotMatch(texto, /expirou|venceu/i,
+      `aos 20 min, com 1 h de validade no servidor, a tela disse: "${texto}"`);
+    assert.equal(await page.$$eval(".pix-code", (e) => e.length), 1,
+      "o copia-e-cola sumiu aos 20 min de uma cobrança válida por 1 h");
+    await page.clock.fastForward(60000);
+    await page.waitForTimeout(300);
+    assert.ok(chamadas.poll > aos20min,
+      `o poll morreu no teto do cliente: ${aos20min} -> ${chamadas.poll}`);
+    await page.close();
+  });
+
+/**
+ * PT2b — as DUAS metades do `Date.parse(...) || Infinity`, e é o par que faz o
+ * grupo medir alguma coisa:
+ *
+ *  · POSITIVO — sem `expires_at` o poll RODA. Sem esta metade, o PT2 sozinho
+ *    passaria feliz num poll que nunca começa (basta o deadline nascer no
+ *    passado);
+ *  · o TETO DO CLIENTE ainda vale. Esta metade nasceu de uma medição: a mutação
+ *    "tirar o `|| Infinity`" que o plano previa saía VERDE, porque
+ *    `Math.min(NaN, x)` é `NaN` e `Date.now() >= NaN` é sempre falso — o efeito
+ *    real de perder o fallback não é um poll que não começa, é um poll que NUNCA
+ *    PARA. Só o relógio adiantado enxerga isso.
+ */
+test("PT2b: sem expires_at o poll roda e ainda para no teto do cliente", async () => {
+  const { page, chamadas } = await abrirQr({ pix: { expiresAt: undefined }, relogio: true });
+
+  // 12 s de relógio falso, em passos: cada `fastForward` dispara os timers
+  // vencidos, e o respiro real deixa o fetch resolver e agendar o próximo.
+  for (let i = 0; i < 4; i++) {
+    await page.clock.fastForward(3000);
+    await page.waitForTimeout(150);
+  }
+  const cedo = chamadas.poll;
+  assert.ok(cedo >= 2, `sem expires_at o poll rodou só ${cedo} vez(es) em 12 s`);
+  assert.equal(await page.$$eval(".pix-code", (e) => e.length), 1,
+    "o código sumiu sem ter expirado");
+
+  // Passa dos 15 minutos do teto do cliente.
+  for (let i = 0; i < 20; i++) {
+    await page.clock.fastForward(60000);
+    await page.waitForTimeout(60);
+  }
+  await page.waitForTimeout(300);
+  const noTeto = chamadas.poll;
+  assert.match(await page.textContent(".pix-box"), /expirou/i,
+    `passados 20 min sem expires_at, a tela não mostrou o teto do cliente`);
+  await page.clock.fastForward(120000);
+  await page.waitForTimeout(300);
+  assert.equal(chamadas.poll, noTeto,
+    `sem expires_at o poll não tem teto nenhum: ${noTeto} -> ${chamadas.poll}`);
+  await page.close();
+});
+
+// ── PT3: a migração cartão -> Pix (§9) ──────────────────────────────────────
+test("PT3: 409 stripe_active abre o modal com o aviso do Stripe e a data formatada",
+  async () => {
+    const { page } = await abrirPrecos({
+      sub: { active: true, plan: "plus", interval: "monthly",
+             current_period_end: "2026-12-05" },
+      pix: { httpStatus: 409,
+             corpo: { detail: { error: "stripe_active",
+                                current_period_end: "2026-12-05" } } },
+    });
+    await page.click("#cycle-annual");
+    await page.click('[data-pix-cta="plus"]');
+    await page.waitForSelector(".pix-doc");
+    await enviarDoc(page);
+    await page.waitForTimeout(300);
+    const texto = await page.textContent(".pix-box");
+    // Mesma CAIXA do formulário, com o corpo trocado: nunca duas na tela.
+    assert.equal(await page.$$eval(".pix-ov", (e) => e.length), 1,
+      "a migração abriu um SEGUNDO overlay por cima do formulário");
+    assert.equal(await page.$$eval(".pix-doc", (e) => e.length), 0,
+      "o campo do CPF ficou na tela por baixo do aviso do Stripe");
+    assert.match(texto, /não cancele pelo painel do stripe/i,
+      `o modal de migração perdeu o aviso do Stripe: "${texto}"`);
+    assert.ok(texto.includes("05/12/2026"), `data não formatada: "${texto}"`);
+    assert.ok(!texto.includes("2026-12-05"), `o ISO cru vazou para a tela: "${texto}"`);
+    await page.close();
+  });
+
+// ── PT4: assinante do Pix não recebe oferta de troca no Stripe ──────────────
+const SUB_PIX = { active: true, gateway: "pix", plan: "plus", interval: "annual",
+                  current_period_end: "2027-01-10" };
+
+test("PT4: no anual o Plus diz Renovar, os outros Pagar, e nada bate no change-plan",
+  async () => {
+    const { page, chamadas } = await abrirPrecos({ sub: SUB_PIX });
+    await page.click("#cycle-annual");
+    const rotulos = await page.$$eval("[data-pix-cta]", (e) =>
+      e.map((b) => [b.dataset.pixCta, b.textContent.trim()]));
+    assert.deepEqual(rotulos.map(([p]) => p), ["essencial", "plus", "pro"]);
+    assert.match(rotulos[1][1], /^Renovar no Pix/, `Plus leu "${rotulos[1][1]}"`);
+    for (const i of [0, 2]) {
+      assert.match(rotulos[i][1], /^Pagar no Pix/, `${rotulos[i][0]} leu "${rotulos[i][1]}"`);
+    }
+
+    // Nenhum [data-plan-btn] oferece troca: todos desabilitados, e o clique em
+    // cada um deles não produz UMA requisição de troca.
+    const cartao = await page.$$eval("#plans-v2 [data-plan-btn]", (e) => e.map((b) => ({
+      plano: b.dataset.planBtn, off: b.disabled === true, txt: b.textContent.trim(),
+    })));
+    assert.deepEqual(cartao, [
+      { plano: "essencial", off: true, txt: "Disponível no Pix" },
+      { plano: "plus", off: true, txt: "✓ Seu plano atual" },
+      { plano: "pro", off: true, txt: "Disponível no Pix" },
+    ]);
+    for (const p of ["essencial", "pro"]) {
+      await page.click(`#plans-v2 [data-plan-btn="${p}"]`, { force: true }).catch(() => {});
+    }
+    await page.waitForTimeout(300);
+    assert.equal(chamadas.changePlan, 0,
+      `assinante Pix bateu ${chamadas.changePlan}x no /billing/change-plan`);
+    await page.close();
+  });
+
+// O irmão que o CLAUDE.md §2 manda varrer: no MENSAL o `currentCycle !==
+// subState.interval` fazia o código de hoje cair no ramo "Trocar pro X".
+test("PT4b: assinante Pix no ciclo MENSAL — zero CTA de Pix e zero change-plan",
+  async () => {
+    const { page, chamadas } = await abrirPrecos({ sub: SUB_PIX });
+    assert.equal(await contarCtas(page), 0, "o mensal criou CTA de Pix");
+    const cartao = await page.$$eval("#plans-v2 [data-plan-btn]", (e) => e.map((b) => ({
+      plano: b.dataset.planBtn, off: b.disabled === true, txt: b.textContent.trim(),
+    })));
+    assert.deepEqual(cartao, [
+      { plano: "essencial", off: true, txt: "Disponível no Pix" },
+      { plano: "plus", off: true, txt: "✓ Seu plano atual" },
+      { plano: "pro", off: true, txt: "Disponível no Pix" },
+    ]);
+    for (const p of ["essencial", "plus", "pro"]) {
+      await page.click(`#plans-v2 [data-plan-btn="${p}"]`, { force: true }).catch(() => {});
+    }
+    await page.waitForTimeout(300);
+    assert.equal(chamadas.changePlan, 0,
+      `no mensal o assinante Pix bateu ${chamadas.changePlan}x no /billing/change-plan`);
+    await page.close();
+  });
+
+// ── PT5: controle POSITIVO — o caminho do cartão continua inteiro ───────────
+test("PT5: 'Assinar Plus' no anual dispara 1 create-checkout e 0 pix/checkout",
+  async () => {
+    const { page, chamadas } = await abrirPrecos();
+    await page.click("#cycle-annual");
+    await Promise.all([
+      page.waitForURL(/stripe=1/, { timeout: 5000 }),
+      page.click('#plans-v2 [data-plan-btn="plus"]'),
+    ]);
+    assert.equal(chamadas.checkout, 1, `foram ${chamadas.checkout} POSTs de cartão`);
+    assert.equal(chamadas.pixCheckout, 0, "o botão de cartão bateu no checkout do Pix");
+    await page.close();
+  });
+
+// ── PT6: o sid do sucesso é o public_token, nunca o id do provedor ──────────
+test("PT6: pago -> /home?upgrade=success com sid = public_token", async () => {
+  const { page, corposPix } = await abrirQr({
+    status: (n) => (n >= 2 ? { status: "paid" } : { status: "pending" }),
+  });
+  await page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  const url = new URL(page.url());
+  assert.equal(url.searchParams.get("sid"), "tok_abc123");
+  assert.equal(url.searchParams.get("ev"), "purchase");
+  assert.equal(url.searchParams.get("pl"), "plus");
+  // D3: sem `ia=` — a home.html trata a ausência sem inventar número.
+  assert.equal(url.searchParams.get("ia"), null, `sobrou ia= na URL: ${page.url()}`);
+  assert.ok(!page.url().includes("pay_"), `o id do provedor vazou: ${page.url()}`);
+  assert.ok(!page.url().includes("9999"), `o id do provedor vazou: ${page.url()}`);
+  assert.deepEqual(corposPix[0],
+    { plan: "plus", interval: "annual", cpf_cnpj: CPF });
+  await page.close();
+});
+
+// ── PT8: "Copiar código Pix" não pode mentir ────────────────────────────────
+/**
+ * A ação PRIMÁRIA do modal (§16.1: dentro do app o aparelho não se escaneia) não
+ * tinha um único teste. E ela mentia: o `ok()` rodava incondicionalmente, então
+ * com o clipboard recusando e o `execCommand` devolvendo `false` o botão dizia
+ * "Copiado ✓" sem nada no clipboard — e o usuário voltava do app do banco sem
+ * código nenhum para colar. Com o `execCommand` LANÇANDO era pior: `pageerror`
+ * não tratado e zero feedback.
+ *
+ * O clipboard e o `execCommand` são trocados na página porque nenhum dos dois é
+ * controlável de fora: em Chromium headless o `writeText` já recusa sozinho, o
+ * que deixaria o caso feliz impossível de escrever.
+ */
+async function prepararCopia(page, clipboard, exec) {
+  await page.evaluate(({ clipboard, exec }) => {
+    window.__execs = 0;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: clipboard === "ausente" ? undefined : {
+        writeText: () => (clipboard === "ok"
+          ? Promise.resolve() : Promise.reject(new Error("negado"))),
+      },
+    });
+    document.execCommand = () => {
+      window.__execs += 1;
+      if (exec === "lanca") throw new Error("execCommand explodiu");
+      return exec === "ok";
+    };
+  }, { clipboard, exec });
+}
+
+for (const [rotulo, clipboard, exec, copiou] of [
+  ["clipboard aceita", "ok", "nao", true],
+  ["clipboard recusa e o execCommand copia", "recusa", "ok", true],
+  ["clipboard recusa e o execCommand também", "recusa", "nao", false],
+  ["clipboard ausente e o execCommand LANÇA", "ausente", "lanca", false],
+]) {
+  test(`PT8: ${rotulo} -> o botão diz ${copiou ? "copiado" : "a verdade"}`, async () => {
+    const { page } = await abrirQr();
+    const erros = [];
+    page.on("pageerror", (e) => erros.push(String(e)));
+    await prepararCopia(page, clipboard, exec);
+
+    await page.click(".pix-box .btn-primary");
+    await page.waitForTimeout(400);
+    const texto = (await page.textContent(".pix-box .btn-primary")).trim();
+    if (copiou) {
+      assert.match(texto, /^Copiado/, `copiou de verdade e o botão diz "${texto}"`);
+    } else {
+      assert.doesNotMatch(texto, /Copiado/,
+        `NÃO copiou e o botão disse "${texto}" — é a tela mentindo sobre a ação primária`);
+      assert.match(texto, /copie à mão/i, `sem saída para o usuário: "${texto}"`);
+      // A saída oferecida tem de existir de fato: o campo fica SELECIONADO.
+      const sel = await page.$eval(".pix-code", (e) => e.selectionEnd - e.selectionStart);
+      assert.ok(sel > 0, "mandou copiar à mão sem selecionar o campo");
+      // …e tem de caber. `.btn` é `white-space: nowrap` no site.css e este
+      // rótulo é 3x mais longo que "Copiar código Pix": sem o `normal` do CSS
+      // ele vazava para fora do botão E do card (medido em 390px).
+      const vaza = await page.$eval(".pix-box .btn-primary", (e) => {
+        const r = e.getBoundingClientRect();
+        const caixa = e.closest(".pix-box").getBoundingClientRect();
+        return { larg: Math.round(r.width), conteudo: e.scrollWidth,
+                 esq: Math.round(caixa.left - r.left), dir: Math.round(r.right - caixa.right) };
+      });
+      assert.ok(vaza.conteudo <= vaza.larg + 1 && vaza.esq <= 0 && vaza.dir <= 0,
+        `o rótulo de falha vazou do botão/card: ${JSON.stringify(vaza)}`);
+    }
+    // O `execCommand` só é tentado quando o clipboard não resolveu — e quando é
+    // tentado, o retorno dele MANDA (era o valor ignorado).
+    assert.equal(await page.evaluate(() => window.__execs), clipboard === "ok" ? 0 : 1);
+    assert.deepEqual(erros, [], `sobrou erro não tratado na página: ${erros}`);
+    await page.close();
+  });
+}
+
+// ── PT9: um QR por vez — o Tab preso e a guarda do segundo checkout ─────────
+/**
+ * Sem trap de Tab o foco alcançava o CTA ATRÁS do overlay; Enter ali abria um
+ * SEGUNDO modal, o `pixPoll` global era sobrescrito e o PRIMEIRO overlay ficava
+ * órfão no DOM com o copia-e-cola visível para sempre — dois instrumentos ao
+ * portador na tela e duas cobranças no provedor.
+ *
+ * O trap é o `pigTrapTab` do modals.js, o mesmo que o modal_keys.test.mjs e o
+ * settings_security_fanout.test.mjs asseveram (§0.1). *Negativo: tire a chamada
+ * do `pixOverlay` — ou o `<script src="/modals.js">` da precos.html — e o Tab
+ * escapa.*
+ */
+test("PT9: o Tab não sai do modal do QR, e um segundo checkout não nasce", async () => {
+  const { page, chamadas } = await abrirQr();
+  const fora = [];
+  for (let i = 0; i < 12; i++) {
+    await page.keyboard.press("Tab");
+    const onde = await page.evaluate(() => {
+      const a = document.activeElement;
+      const ov = document.querySelector(".pix-ov");
+      return ov && ov.contains(a)
+        ? null
+        : { tag: a.tagName, txt: (a.textContent || a.value || "").trim().slice(0, 30) };
+    });
+    if (onde) fora.push({ tab: i + 1, ...onde });
+  }
+  assert.deepEqual(fora, [], `o Tab saiu do modal: ${JSON.stringify(fora)}`);
+
+  // O irmão do trap (CLAUDE.md §2 — a classe, não a instância): mesmo quem
+  // chegar ao CTA por outro caminho não abre a segunda cobrança.
+  await page.evaluate(() => pixCheckout("pro"));
+  await page.waitForTimeout(400);
+  assert.equal(chamadas.pixCheckout, 1,
+    `com o QR na tela, nasceu um SEGUNDO checkout (${chamadas.pixCheckout} no total)`);
+  assert.equal(await page.$$eval(".pix-ov", (e) => e.length), 1, "ficou um overlay órfão");
+  await page.close();
+});
+
+// ── PT11: campo ausente no corpo do checkout não vira lixo na tela ──────────
+// Fronteira de confiança de VALOR MONETÁRIO: sem `amount_cents` o título dizia
+// "Plus anual · R$ NaN", e sem `qr_image` o `<img>` desenhava um quadrado branco
+// de 230px (o fundo claro que o leitor exige) com cara de QR ilegível.
+test("PT11: sem amount_cents e sem qr_image não sobra R$ NaN nem quadrado branco",
+  async () => {
+    const { page } = await abrirQr({
+      pix: { corpo: { public_token: "tok_x", qr_payload: PAYLOAD, plan: "plus" } },
+    });
+    const titulo = await page.textContent("#pix-modal-titulo");
+    assert.ok(!titulo.includes("NaN"), `valor ilegível no título: "${titulo}"`);
+    assert.match(titulo, /anual/, `o título perdeu o plano: "${titulo}"`);
+    assert.equal(await page.$$eval(".pix-qr", (e) => e.length), 0,
+      "sobrou o <img> do QR sem imagem nenhuma");
+    // O que importa continua na tela: o copia-e-cola é a ação primária.
+    assert.equal(await page.inputValue(".pix-code"), PAYLOAD);
+    await page.close();
+  });
+
+// ── PT7: §13.6 — o QR é instrumento ao portador ─────────────────────────────
+/**
+ * localStorage + sessionStorage + DOM + `<img src="data:...">` + os dois que
+ * faltavam, e sem os quais o grupo era VERDE POR CONSTRUÇÃO:
+ *
+ *  · `valores` — `code.value = payload` escreve a PROPRIEDADE, e o
+ *    `document.body.innerHTML` nunca contém o valor de um `<input>`, nem com o
+ *    modal aberto. A asserção sobre o `dom` passava sem ninguém apagar nada.
+ *  · `retido` — o `pixPoll.code` do nó JÁ DESTACADO. É o único observável que
+ *    separa "o `pixApagarQr` apagou" de "o container foi removido por cima": nos
+ *    três casos do laço abaixo o payload sai da tela junto com o overlay ou com
+ *    o `replaceChildren`, então com `pixApagarQr` virando `{ return; }` os três
+ *    continuavam VERDES (12/12, medido). Depois de EXPIRAR o `pixPoll` continua
+ *    vivo segurando o `<input>` destacado, e é aí que o wipe se mede.
+ *    (`pixPoll` é `let` de topo de script clássico: escopo léxico global, lido
+ *    pelo nome nu — não existe `window.pixPoll`.)
+ */
+function vestigios(page) {
+  return page.evaluate(() => ({
+    local: JSON.stringify({ ...localStorage }),
+    sessao: JSON.stringify({ ...sessionStorage }),
+    dom: document.body.innerHTML,
+    valores: [...document.querySelectorAll("input,textarea")].map((e) => e.value).join("|"),
+    retido: typeof pixPoll !== "undefined" && pixPoll && pixPoll.code
+      ? pixPoll.code.value : "",
+    imgsData: [...document.images].filter((i) => (i.getAttribute("src") || "")
+      .startsWith("data:")).length,
+    campos: document.querySelectorAll(".pix-code").length,
+  }));
+}
+
+for (const [rotulo, encerrar] of [
+  ["fechando o modal", async (page) => {
+    await page.click(".pix-box .pix-ghost");
+    await page.waitForTimeout(200);
+  }],
+  ["deixando expirar", async (page) => { await page.waitForTimeout(8000); }],
+  ["pagando", async (page) => {
+    await page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  }],
+]) {
+  test(`PT7: o copia-e-cola não sobra em lugar nenhum — ${rotulo}`, async () => {
+    const { page } = await abrirQr({
+      pix: { expiresAt: () => new Date(Date.now() + 5000).toISOString() },
+      status: (n) => (rotulo === "pagando" && n >= 2
+        ? { status: "paid" } : { status: "pending" }),
+    });
+    // Âncora do caso: antes de encerrar, o payload ESTÁ na tela. Sem ela o teste
+    // passaria numa página que nunca mostrou QR nenhum.
+    assert.equal(await page.inputValue(".pix-code"), PAYLOAD);
+
+    await encerrar(page);
+    const v = await vestigios(page);
+    for (const [onde, texto] of [["localStorage", v.local], ["sessionStorage", v.sessao],
+                                 ["DOM", v.dom], ["valor dos campos", v.valores],
+                                 ["<input> destacado do pixPoll", v.retido]]) {
+      assert.ok(!texto.includes(PAYLOAD), `o qr_payload sobrou no ${onde}`);
+      assert.ok(!texto.includes("pigbank-teste-qr-payload"),
+        `pedaço do qr_payload sobrou no ${onde}`);
+    }
+    assert.equal(v.imgsData, 0, "sobrou <img src=\"data:...\"> na página");
+    assert.equal(v.campos, 0, "sobrou o <input> do copia-e-cola");
+    // O token pode ficar na URL (é chave pública); o payload, nunca.
+    assert.ok(!page.url().includes(PAYLOAD), "o qr_payload foi parar na URL");
+    await page.close();
+  });
+}
+
+/**
+ * PT10 — o poll morreu, e o §13.6 vale mesmo assim.
+ *
+ * Três falhas de rede seguidas matavam o poll (`pixDesistir`) e com ele a
+ * avaliação do deadline: medido, o payload continuava na tela UMA HORA depois de
+ * vencer, sob a mensagem "o código continua válido". O docstring do arquivo
+ * promete que ele sai ao pagar, EXPIRAR ou fechar.
+ *
+ * É também o caso que DISCRIMINA o `pixApagarQr` (o modal segue aberto, então
+ * nada mais remove o `<input>` por cima) e o que prova a segunda metade do P1-1:
+ * sem confirmação do servidor a tela **não** diz "nada foi cobrado" e **não**
+ * oferece "Gerar novo código", que cancelaria uma cobrança talvez paga.
+ */
+test("PT10: rede fora — no vencimento o payload sai da tela e a mensagem não mente",
+  async () => {
+    const { page } = await abrirQr({
+      pix: { expiresAt: () => new Date(Date.now() + 15000).toISOString() },
+      status: () => null,                    // toda consulta ABORTA
+    });
+    assert.equal(await page.inputValue(".pix-code"), PAYLOAD);
+
+    // 3 falhas em 3 s cada -> desiste. Aqui o código AINDA vale: não some.
+    await page.waitForTimeout(9000);
+    assert.match(await page.textContent(".pix-box"), /não consegui confirmar/i);
+    assert.equal(await page.$$eval(".pix-code", (e) => e.length), 1,
+      "apagou o copia-e-cola de uma cobrança que ainda era pagável");
+
+    // Passado o vencimento, sai — com o modal ainda ABERTO.
+    await page.waitForTimeout(9000);
+    const v = await vestigios(page);
+    assert.equal(v.campos, 0, "o <input> do copia-e-cola ficou na tela depois de vencer");
+    for (const [onde, texto] of [["DOM", v.dom], ["valor dos campos", v.valores],
+                                 ["<input> destacado do pixPoll", v.retido]]) {
+      assert.ok(!texto.includes(PAYLOAD), `o qr_payload sobrou no ${onde}`);
+    }
+    const texto = await page.textContent(".pix-box");
+    assert.match(texto, /venceu/i, `a tela não avisou do vencimento: "${texto}"`);
+    assert.ok(!texto.includes("nada foi cobrado"),
+      `sem resposta do servidor, a tela AFIRMOU que nada foi cobrado: "${texto}"`);
+    const botoes = await page.$$eval(".pix-box button", (e) => e.map((b) => b.textContent.trim()));
+    assert.deepEqual(botoes, ["Fechar"],
+      `ofereceu gerar código novo sem saber se este foi pago: ${JSON.stringify(botoes)}`);
+    await page.close();
+  });
+
+// ── PT12: o CPF/CNPJ — o Asaas exige, e nós não guardamos ───────────────────
+/**
+ * O clique no CTA parou de cobrar: ele abre o ESTADO 1 do modal (o documento) e
+ * o `POST` só sai no submit. Sem isso o cliente clicava em "Pagar no Pix" e
+ * tomava o erro do provedor, que recusa cobrança sem `cpfCnpj`.
+ *
+ * A validação da tela é de FORMA e só (11 ou 14 dígitos). Dígito verificador é
+ * do Asaas: uma segunda cópia da regra aqui recusaria o que ele aceita (§0.7).
+ *
+ * *Negativo do grupo (a/b/c): troque o `pixFormaOk` por `() => true` e o PT12a e
+ * o PT12b ficam vermelhos (o POST passa a sair vazio); troque por `() => false`
+ * e o PT12c fica vermelho (o caminho legítimo para de vender). O par existe
+ * porque este conserto RESTRINGE: sozinho, o "a/b" passaria num código que
+ * recusa todo mundo.*
+ */
+
+/** Abre o modal no estado 1 e devolve o contexto, sem enviar nada. */
+async function abrirForm(ctx = {}) {
+  const r = await abrirPrecos(ctx);
+  await r.page.click("#cycle-annual");
+  await r.page.click('[data-pix-cta="plus"]');
+  await r.page.waitForSelector(".pix-doc");
+  return r;
+}
+
+test("PT12a: sem documento o POST não sai, e o erro diz o que fazer", async () => {
+  const { page, chamadas } = await abrirForm();
+  // O foco inicial do modal é o campo — quem abriu quer digitar.
+  assert.equal(await page.evaluate(() => document.activeElement.className), "pix-doc",
+    "o modal não nasceu com o foco no campo do documento");
+  await enviarDoc(page, "");
+  await page.waitForTimeout(300);
+  assert.equal(chamadas.pixCheckout, 0,
+    `o checkout saiu SEM documento (${chamadas.pixCheckout} chamadas) — o Asaas recusa`);
+  assert.equal(await page.textContent(".pix-erro"),
+    "Informe os 11 dígitos do CPF ou os 14 do CNPJ.");
+  assert.equal(await page.$$eval(".pix-code", (e) => e.length), 0,
+    "apareceu QR sem cobrança nenhuma ter sido pedida");
+  // Erro não tira a pessoa de onde ela conserta.
+  assert.equal(await page.evaluate(() => document.activeElement.className), "pix-doc");
+  await page.close();
+});
+
+for (const [rotulo, valor] of [
+  ["letras", "abcdefghijk"],
+  ["10 dígitos", "1112223334"],
+  ["12 dígitos", "111222333444"],
+  ["15 dígitos", "112223330001812"],
+]) {
+  test(`PT12b: forma errada (${rotulo}) — erro na tela e zero POST`, async () => {
+    const { page, chamadas } = await abrirForm();
+    await enviarDoc(page, valor);
+    await page.waitForTimeout(300);
+    assert.equal(chamadas.pixCheckout, 0,
+      `"${valor}" passou pela validação de forma e virou cobrança`);
+    const erro = (await page.textContent(".pix-erro")).trim();
+    assert.match(erro, /11 dígitos do CPF/, `erro ilegível ou ausente: "${erro}"`);
+    assert.match(erro, /14 do CNPJ/, `o erro não diz a saída do CNPJ: "${erro}"`);
+    // O erro é visível de fato: `.pix-erro:empty` some, e um `display:none` que
+    // sobrasse deixaria a asserção de texto acima verde numa tela muda.
+    assert.ok(await page.isVisible(".pix-erro"), "a mensagem de erro está no DOM e invisível");
+    await page.close();
+  });
+}
+
+for (const [rotulo, digitado, esperado] of [
+  ["CPF de 11 dígitos", CPF, CPF],
+  ["CNPJ de 14 dígitos", CNPJ, CNPJ],
+  ["CPF pontuado — a pontuação é limpa no envio", "111.222.333-44", CPF],
+]) {
+  test(`PT12c: ${rotulo} passa e o QR aparece no MESMO modal`, async () => {
+    const { page, chamadas, corposPix } = await abrirForm();
+    await enviarDoc(page, digitado);
+    await page.waitForSelector(".pix-code");
+    assert.equal(chamadas.pixCheckout, 1);
+    assert.equal(corposPix[0].cpf_cnpj, esperado,
+      `o corpo do POST levou "${corposPix[0].cpf_cnpj}" em vez de "${esperado}"`);
+    assert.equal(await page.inputValue(".pix-code"), PAYLOAD);
+    // MESMO modal, não uma segunda caixa: um overlay só, e o formulário sumiu.
+    assert.equal(await page.$$eval(".pix-ov", (e) => e.length), 1);
+    assert.equal(await page.$$eval(".pix-form", (e) => e.length), 0,
+      "o formulário do documento ficou por baixo do QR");
+    // O foco muda de dono junto com o estado: a ação primária agora é copiar.
+    const foco = (await page.evaluate(() => document.activeElement.textContent)).trim();
+    assert.match(foco, /Copiar código Pix/,
+      `depois do QR o foco ficou em "${foco}" em vez do botão de copiar`);
+    await page.close();
+  });
+}
+
+/**
+ * PT12d — o documento é PII e NÃO é persistido: nem por nós, nem pelo cliente.
+ *
+ * Mede o `value` da PROPRIEDADE e o nó JÁ DESTACADO (`pixDoc`), pelo mesmo
+ * motivo medido no PT7: `document.body.innerHTML` nunca contém o valor de um
+ * `<input>`, então asserção só sobre o DOM serializado é verde por construção —
+ * o overlay/`replaceChildren` removeria o campo por cima e ninguém veria a
+ * diferença entre "apagou" e "sumiu de cena".
+ *
+ * *Negativo: troque o corpo do `pixApagarDoc` por `{ return; }` — medido, os dois
+ * primeiros casos ficam VERMELHOS no `<input> destacado do pixDoc`.* O terceiro
+ * ("indo até o fim da compra") NÃO discrimina o wipe e continua verde: o
+ * `pixPago` navega para a /home e o contexto inteiro morre junto. Ele mede a
+ * outra metade — nada em storage, nada na URL, nada no console e nada no corpo
+ * de requisição nenhuma —, que é onde um `history.state` ou um `sessionStorage`
+ * apareceriam depois da compra.
+ */
+function espiarFugas(page) {
+  const fugas = [];
+  page.on("console", (m) => fugas.push("console: " + m.text()));
+  page.on("pageerror", (e) => fugas.push("pageerror: " + String(e)));
+  // GA4 e Meta CAPI saem como REQUISIÇÃO: se o documento entrasse num deles,
+  // apareceria aqui. O POST do checkout é o único destino legítimo dele.
+  page.on("request", (r) => {
+    if (r.url().endsWith("/billing/pix/checkout")) return;
+    fugas.push(r.url() + " " + (r.postData() || ""));
+  });
+  return fugas;
+}
+
+const vestigiosDoc = (page) => page.evaluate(() => ({
+  local: JSON.stringify({ ...localStorage }),
+  sessao: JSON.stringify({ ...sessionStorage }),
+  dom: document.body.innerHTML,
+  valores: [...document.querySelectorAll("input,textarea")].map((e) => e.value).join("|"),
+  retido: typeof pixDoc !== "undefined" && pixDoc ? pixDoc.value : "",
+  campos: document.querySelectorAll(".pix-doc").length,
+}));
+
+for (const [rotulo, encerrar] of [
+  // Digitou e desistiu ANTES do submit: nenhuma cobrança nasceu, e é o único
+  // caso em que o `pixApagarQr` não passa por perto — quem limpa é o `aoFechar`.
+  ["cancelando antes de enviar", async (page) => {
+    await page.fill(".pix-doc", CPF);
+    await page.click(".pix-box .pix-ghost");
+    await page.waitForTimeout(200);
+  }],
+  ["fechando o modal com o QR na tela", async (page) => {
+    await enviarDoc(page, CPF);
+    await page.waitForSelector(".pix-code");
+    await page.click(".pix-box .pix-ghost");
+    await page.waitForTimeout(200);
+  }],
+  ["indo até o fim da compra", async (page) => {
+    await enviarDoc(page, CPF);
+    await page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  }],
+]) {
+  test(`PT12d: o CPF não sobra em lugar nenhum — ${rotulo}`, async () => {
+    const { page } = await abrirForm({
+      status: (n) => (n >= 2 ? { status: "paid" } : { status: "pending" }),
+    });
+    const fugas = espiarFugas(page);
+    // Âncora do caso: antes de encerrar, o número ESTÁ na tela. Sem ela o teste
+    // passaria numa página que nunca chegou a receber documento nenhum.
+    await page.fill(".pix-doc", CPF);
+    assert.equal(await page.inputValue(".pix-doc"), CPF);
+    await encerrar(page);
+
+    const v = await vestigiosDoc(page);
+    for (const [onde, texto] of [["localStorage", v.local], ["sessionStorage", v.sessao],
+                                 ["DOM", v.dom], ["valor dos campos", v.valores],
+                                 ["<input> destacado do pixDoc", v.retido],
+                                 ["URL", page.url()]]) {
+      assert.ok(!texto.includes(CPF), `o CPF sobrou no ${onde}`);
+    }
+    assert.equal(v.campos, 0, "sobrou o <input> do documento na página");
+    const vazou = fugas.filter((t) => t.includes(CPF) || t.includes("111.222.333-44"));
+    assert.deepEqual(vazou, [],
+      `o CPF saiu por um caminho que não é o POST do checkout: ${JSON.stringify(vazou)}`);
+    await page.close();
+  });
+}
+
+/**
+ * PT12e — o Tab preso vale nos DOIS estados do modal.
+ *
+ * O PT9 mede o estado do QR. Este mede o do formulário, que é o estado NOVO: sem
+ * o trap o foco alcança o CTA atrás do overlay e o Enter ali abriria um segundo
+ * modal por cima de um campo com CPF digitado dentro.
+ *
+ * *Negativo: tire a chamada do `pigTrapTab` do `pixOverlay` — ou o
+ * `<script src="/modals.js">` da precos.html — e o Tab escapa.*
+ */
+test("PT12e: no estado do FORMULÁRIO o Tab não sai do modal", async () => {
+  const { page, chamadas } = await abrirForm();
+  const fora = [];
+  for (let i = 0; i < 10; i++) {
+    await page.keyboard.press("Tab");
+    const onde = await page.evaluate(() => {
+      const a = document.activeElement;
+      const ov = document.querySelector(".pix-ov");
+      return ov && ov.contains(a)
+        ? null
+        : { tag: a.tagName, txt: (a.textContent || a.value || "").trim().slice(0, 30) };
+    });
+    if (onde) fora.push({ tab: i + 1, ...onde });
+  }
+  assert.deepEqual(fora, [], `o Tab saiu do formulário: ${JSON.stringify(fora)}`);
+  // A classe, não a instância (§2): quem chegar ao CTA por outro caminho também
+  // não abre um segundo modal por cima do documento já digitado.
+  await page.evaluate(() => pixCheckout("pro"));
+  assert.equal(await page.$$eval(".pix-ov", (e) => e.length), 1,
+    "nasceu um SEGUNDO modal com o formulário do documento aberto");
+  assert.equal(chamadas.pixCheckout, 0, "o segundo caminho cobrou sem pedir documento");
+  await page.close();
+});

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -73,8 +73,11 @@ async function abrirPrecos({
   status = () => ({ status: "pending" }),
   viewport = { width: 1280, height: 900 },
   relogio = false,
+  atrasos = {},
+  initScript = null,
 } = {}) {
   const page = await browser.newPage({ viewport });
+  if (initScript) await page.addInitScript(initScript);
   // Relógio falso: o teto do CLIENTE é de 15 minutos, e a única forma de medir
   // que ele existe sem esperar 15 minutos é adiantar o relógio da página. Com
   // ele instalado o setTimeout do poll só anda por `fastForward` — nenhuma
@@ -124,10 +127,10 @@ async function abrirPrecos({
   // Depois do `checkout` na ordem de registro: o Playwright usa a ÚLTIMA rota
   // que casa, então o padrão mais amplo tem de vir por último para não engolir
   // o `/billing/pix/checkout`. Este `if` é o que devolve o checkout para ele.
-  await page.route("**/billing/pix/*", (r) => {
+  await page.route("**/billing/pix/*", async (r) => {
     if (r.request().url().endsWith("/checkout")) return r.fallback();
     chamadas.poll += 1;
-    const corpo = status(chamadas.poll);
+    const corpo = await status(chamadas.poll);
     if (!corpo) return r.abort();          // rede fora: o fetch REJEITA
     return r.fulfill({ contentType: "application/json", body: JSON.stringify(corpo) });
   });
@@ -136,6 +139,18 @@ async function abrirPrecos({
   await page.route("**/home*", (r) => r.fulfill({
     contentType: "text/html", body: "<html><body>home</body></html>",
   }));
+
+  // Atraso artificial por pedaço de URL, e por ÚLTIMO de propósito: o Playwright
+  // usa a rota registrada mais tarde, e o `fallback()` devolve o pedido para a
+  // registrada antes (ou para a rede). É o que permite medir corrida de carga —
+  // script que chega depois das requisições, /billing/subscription lento.
+  if (Object.keys(atrasos).length) {
+    await page.route("**/*", async (r) => {
+      const k = Object.keys(atrasos).find((x) => r.request().url().includes(x));
+      if (k) await new Promise((ok) => setTimeout(ok, atrasos[k]));
+      return r.fallback();
+    });
+  }
 
   await page.goto(`${ORIGIN}/precos.html`);
   await page.waitForSelector("#plans-v2 .plan");
@@ -916,5 +931,166 @@ test("PT12e: no estado do FORMULÁRIO o Tab não sai do modal", async () => {
   assert.equal(await page.$$eval(".pix-ov", (e) => e.length), 1,
     "nasceu um SEGUNDO modal com o formulário do documento aberto");
   assert.equal(chamadas.pixCheckout, 0, "o segundo caminho cobrou sem pedir documento");
+  await page.close();
+});
+
+/**
+ * PT13 — A RESPOSTA É DA COBRANÇA QUE A PEDIU, e é a de dinheiro.
+ *
+ * Fechar o modal com o poll no ar e abrir OUTRO checkout deixava `pixPoll`
+ * não-nulo de novo, e a guarda `if (!pixPoll) return` aceitava a resposta da
+ * cobrança VELHA: um `paid` antigo redirecionava para a /home com o `sid` da
+ * cobrança NOVA (atribuição errada no GA4 e no pixel, sobre uma compra que não
+ * aconteceu), e um terminal antigo apagava o QR novo da tela.
+ *
+ * A 1ª pergunta fica PENDURADA no servidor e só responde `paid` quando o teste
+ * solta — que é a cobrança velha liquidando depois de a tela já ser de outra.
+ *
+ * *Negativo: troque os `if (pixPoll !== meu) return;` do `pixBater` de volta por
+ * `if (!pixPoll) return;` → o `waitForTimeout` seguinte encontra a /home.*
+ */
+test("PT13: resposta do poll da cobrança velha não decide sobre o modal novo", async () => {
+  let soltar;
+  const velha = new Promise((ok) => { soltar = ok; });
+  const { page, chamadas } = await abrirQr({
+    status: async (n) => {
+      if (n !== 1) return { status: "pending" };
+      await velha;
+      return { status: "paid" };
+    },
+  });
+  assert.equal(chamadas.poll, 1, "a primeira pergunta não chegou a sair");
+  await page.click(".pix-box .pix-ghost");          // fecha com a requisição no ar
+  await page.waitForTimeout(150);
+  await page.click('[data-pix-cta="pro"]');
+  await page.waitForSelector(".pix-doc");
+  await enviarDoc(page);
+  await page.waitForSelector(".pix-code");
+  const url = page.url();
+
+  soltar();                                          // a cobrança VELHA diz "paid"
+  await page.waitForTimeout(900);
+  assert.equal(page.url(), url,
+    `a resposta da cobrança velha navegou a página: ${page.url()}`);
+  assert.equal(await page.$$eval(".pix-code", (e) => e.length), 1,
+    "a resposta da cobrança velha apagou o QR da cobrança nova");
+  assert.equal(await page.inputValue(".pix-code"), PAYLOAD);
+  await page.close();
+});
+
+/**
+ * PT14 — VITALÍCIO NÃO COMPRA, e o CTA some quando a assinatura chega depois.
+ *
+ * O `refreshPlanButtons` já marca os cards como acesso permanente; o laço do Pix
+ * só olhava `gateway` e `plan`, então o vitalício via os três CTAs, digitava o
+ * CPF e tomava o 409 `lifetime` do backend. Como o CTA agora nasce ANTES do
+ * /billing/subscription (PT15), o caso que importa é o da assinatura ATRASADA:
+ * ele aparece e tem de SAIR.
+ *
+ * Positivo (já no arquivo): o PT4 prova que assinante de Pix não-vitalício
+ * continua vendo os três CTAs, com "Renovar" no plano dele.
+ *
+ * *Negativo: tire o `&& !(pixSub && pixSub.lifetime === true)` do
+ * `pbPixRefresh` → sobram os 3 CTAs depois da assinatura chegar.*
+ */
+test("PT14: vitalício não fica com CTA de Pix nenhum", async () => {
+  const { page } = await abrirPrecos({
+    sub: { active: true, lifetime: true },
+    atrasos: { "/billing/subscription": 1200 },
+  });
+  await page.click("#cycle-annual");
+  assert.equal(await contarCtas(page), 3,
+    "âncora do caso: antes da assinatura chegar os CTAs existem");
+  await page.waitForTimeout(1500);
+  assert.equal(await contarCtas(page), 0,
+    "o vitalício ficou com CTA de compra de Pix depois da assinatura chegar");
+  assert.equal(await page.textContent('[data-plan-btn="plus"]'), "Você tem acesso vitalício");
+  await page.close();
+});
+
+/**
+ * PT15 — O CTA DE PIX NÃO ESPERA O STRIPE.
+ *
+ * Para quem já é cliente do Stripe, o /billing/subscription consulta o Stripe e
+ * pode demorar ou travar. Enquanto ele não voltava, NENHUM CTA de Pix existia —
+ * escondendo a migração cartão → Pix exatamente quando o Stripe está ruim.
+ *
+ * *Negativo: volte o `publicarPix(null)` da precos.html para depois do
+ * `await loadSubscription()` → zero CTA aqui.*
+ */
+test("PT15: com /billing/subscription lento, os CTAs de Pix já estão na tela", async () => {
+  const { page } = await abrirPrecos({
+    sub: { active: true, gateway: "stripe", plan: "plus", interval: "monthly" },
+    atrasos: { "/billing/subscription": 2500 },
+  });
+  await page.click("#cycle-annual");
+  assert.equal(await contarCtas(page), 3,
+    "os CTAs de Pix esperaram o /billing/subscription para nascer");
+  await page.close();
+});
+
+/**
+ * PT16 — O SCRIPT PODE CHEGAR DEPOIS DAS REQUISIÇÕES.
+ *
+ * O `loadPlansState` é inline e começa antes de o parser alcançar os dois
+ * `<script>` do Pix; a única inicialização era guardada por `typeof pbPixInit`.
+ * Com as duas requisições terminando enquanto o script ainda baixa, a guarda
+ * dava falso e ninguém tentava de novo: página sem CTA de Pix, com a flag ligada
+ * no servidor. Agora quem chega por último lê o `window.pbPixState`.
+ *
+ * *Negativo: tire o `if (window.pbPixState) pbPixInit(...)` do fim do
+ * pix-checkout.js → zero CTA aqui, e o `pixCfg` fica nulo (o setCycle também não
+ * salva, porque o `pbPixRefresh` sai na primeira linha sem cfg).*
+ */
+test("PT16: pix-checkout.js chegando depois das requisições ainda cria os CTAs", async () => {
+  const { page } = await abrirPrecos({ atrasos: { "pix-checkout.js": 1500 } });
+  await page.click("#cycle-annual");
+  assert.equal(await contarCtas(page), 3,
+    "o script chegou depois das requisições e a página ficou sem CTA de Pix");
+  await page.close();
+});
+
+/**
+ * PT17 — FECHAR ENTRE OS CABEÇALHOS E O CORPO.
+ *
+ * O `ctx.box.isConnected` era conferido antes do `await r.json()`: dá para
+ * fechar o modal enquanto o corpo ainda baixa, e aí o QR era montado numa caixa
+ * já destacada, com o poll rodando por trás dela — e o `pixPoll` invisível
+ * impedia o próximo checkout até a cobrança vencer.
+ *
+ * O Esc sai de DENTRO do `Response.prototype.json`, que é o único ponto em que a
+ * janela existe: `route.fulfill` não separa cabeçalho de corpo. O evento é o
+ * mesmo que o teclado do usuário dispara.
+ *
+ * *Negativo: mova o `if (!ctx.box.isConnected) return;` do `pixEnviar` para
+ * antes do `const d = await r.json()` → o poll começa e o segundo checkout não
+ * abre.*
+ */
+test("PT17: fechar durante o download do corpo não deixa QR nem poll órfãos", async () => {
+  const { page, chamadas } = await abrirForm({
+    initScript: () => {
+      const orig = Response.prototype.json;
+      Response.prototype.json = function () {
+        return orig.call(this).then((d) => {
+          if (String(this.url).includes("/billing/pix/checkout")) {
+            document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+          }
+          return d;
+        });
+      };
+    },
+  });
+  await enviarDoc(page);
+  await page.waitForTimeout(600);
+  assert.equal(chamadas.pixCheckout, 1, "âncora: o POST do checkout saiu");
+  assert.equal(await page.$$eval(".pix-ov", (e) => e.length), 0,
+    "sobrou modal na tela depois de fechar durante o corpo da resposta");
+  assert.equal(await page.$$eval(".pix-code", (e) => e.length), 0,
+    "o copia-e-cola foi montado numa caixa já destacada");
+  assert.equal(chamadas.poll, 0,
+    "o poll começou contra um modal que o usuário já tinha fechado");
+  // A consequência visível para o usuário: o próximo checkout tem de abrir.
+  await page.click('[data-pix-cta="plus"]');
+  await page.waitForSelector(".pix-doc", { timeout: 3000 });
   await page.close();
 });


### PR DESCRIPTION
O backend sozinho não deixa ninguém pagar — **não existe botão**. Este PR é o que falta.

## Seguro de mergear ANTES do backend, e isso é medido

Sem `pix_annual_available` em `/billing/plans-config`, **nenhum botão nasce** e a página é exatamente a de hoje. Testado contra 6 formas de flag malformada (`"true"`, `1`, `"1"`, `"yes"`, `{}`, `[1]`), com o `plans-config` em 500, com a rede abortada, e chegando 1,5 s **depois** do clique.

## O CPF, e por que ele muda o fluxo

O Asaas exige CPF ou CNPJ para criar a cobrança. O campo vai **dentro do modal**, antes de gerar o QR — sem tela nova.

Isso move o `POST` do clique do CTA para o submit do formulário, o que obriga tratar fechar-no-meio (`box.isConnected`) e estender a guarda de modal duplo, porque `pixPoll` é nulo durante o formulário.

**Validação só de forma** (11 ou 14 dígitos). O dígito verificador é do Asaas — replicá-lo aqui seria segunda fonte da mesma regra, e a divergência apareceria como "CPF válido recusado" no meio da compra.

O CPF é PII com a mesma disciplina do QR: nada de storage, nada de log, apagado do DOM ao fechar e ao gerar o QR, e **não vai para GA4 nem CAPI**.

## Os dois P1 que o ataque achou, e não eram teóricos

**A tela dizia "expirou e nada foi cobrado" sobre cobrança PAGA.** O deadline era testado **antes** de perguntar ao servidor, e nunca havia confirmação final. Na cauda o poll é de 10 s: a liquidação cabe na janela. Medido: **30 polls, nunca redirecionou**.

O agravante é o botão "Gerar novo código" ao lado, que faz **substituição** — cancela a cobrança remota e cria outra. Oferecer isso a quem acabou de pagar é o caminho para **pagamento duplicado**.

E o teto do cliente atropelava o do servidor: `Math.min(expires_at, +15min)`, com o comentário ao lado dizendo que o servidor é a fonte única. O `Math.min` saiu — encurtar a validade no cliente era a tela **mentindo sobre dinheiro**.

**"Copiar código Pix" mentia quando falhava.** `ok()` rodava incondicionalmente e o retorno do `execCommand` era ignorado. Medido: clipboard recusando + `execCommand` false → botão dizendo **"Copiado ✓"**. E não havia **um** teste de cópia, sendo a ação primária — dentro do app o aparelho não se escaneia.

## Os testes do §13.6 não mediam o §13.6

Desligar `pixApagarQr` inteiro deixava **12/12 verdes**. Os três casos passavam por construção: um removia o nó antes de olhar, outro já tinha limpado, e o terceiro media **depois da navegação**, num documento novo.

Agora medem o **valor da propriedade** e o nó já destacado — `innerHTML` nunca contém valor de `<input>`, então asserção sobre ele é verde por construção. Dois casos continuam não discriminando o wipe, e isso está **escrito no arquivo** em vez de omitido.

## Achados que não estavam em plano nenhum

- A mensagem honesta de falha de cópia **vazava 60px para fora do botão** em 390px (`.btn` é `white-space: nowrap`), consertada com o padrão que a própria página já usa 100 linhas abaixo.
- **Escrever o nome de um ícone em COMENTÁRIO já o torna "usado"** para o extrator do subset do Phosphor — o teste ficou vermelho por uma citação em prosa.

**18 mutações** rodadas, cada uma provada vermelha e revertida.

## Medição

- Frontend: **360 passed, 0 failed**
- Python: **6716 passed**, idêntico à baseline
- Nenhum bump de `CACHE_NAME` — o predicado do service worker foi medido: o QR **não** entra no Cache Storage, e o arquivo novo não tem cópia velha a invalidar

Geometria em 390×844 e 1280×900, nos dois estados do modal, com número no corpo do commit.

**NÃO VERIFICADO:** leitura do QR por câmera, pagamento real, `env(safe-area-inset-*)` (vale 0 no headless), pausa do poll por aba escondida, e **a área de transferência no WKWebView do iOS** — onde `select()`+`execCommand` num `<input readonly>` é o caso clássico de falha silenciosa. O que dá para garantir é **não mentir quando falhar**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)