### PR TITLE
Os Termos descreviam um produto que não é mais o único

### DIFF
--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -134,8 +134,13 @@
         </p>
         <p>
           O trial existe no pagamento com <strong>cartão</strong>. O <strong>plano anual pago por
-          Pix</strong> não tem período de teste: o acesso vale a partir da confirmação do pagamento
-          e vai até o fim dos 12 meses contratados.
+          Pix</strong> não tem período de teste, e quando ele começa depende de você já ter ou não
+          um plano pago em vigor. Sem plano ativo, o acesso vale <strong>a partir da confirmação do
+          pagamento</strong>. Com um plano pago ainda em vigor, o período comprado
+          <strong>começa quando o atual termina</strong> — os dois não se sobrepõem, e você não
+          perde o que já pagou; ao subir de plano, o acesso novo pode começar já na confirmação.
+          A tela de pagamento mostra a data de início antes de você pagar, e é ela que vale. Em
+          qualquer um dos casos, o acesso dura <strong>365 dias</strong> contados desse início.
         </p>
       </section>
 
@@ -145,7 +150,7 @@
           <li>Os planos pagos são cobrados em ciclos <strong>mensais</strong> ou <strong>anuais</strong>, conforme o plano escolhido na contratação. O <strong>plano anual pago por Pix</strong> é um pagamento único, e não um ciclo que se repete.</li>
           <li>O processamento de pagamentos é feito pelo <strong>Stripe</strong> (cartão) e pelo <strong>Asaas</strong> (Pix). Não armazenamos dados de cartão de crédito em nossos servidores, nem o CPF/CNPJ informado no pagamento por Pix — ele vai para o Asaas para gerar a cobrança e não fica guardado por nós.</li>
           <li>No <strong>cartão</strong>, a renovação acontece automaticamente no final de cada ciclo. Você recebe um e-mail antes da próxima cobrança quando aplicável.</li>
-          <li>O <strong>anual por Pix não renova sozinho</strong>: não guardamos meio de pagamento e não existe cobrança automática. Quando os 12 meses terminam, o acesso ao plano pago acaba e a conta volta para o plano Grátis. Se quiser continuar, é só contratar um novo período.</li>
+          <li>O <strong>anual por Pix não renova sozinho</strong>: não guardamos meio de pagamento e não existe cobrança automática. Quando os 365 dias terminam, o acesso ao plano pago acaba e a conta volta para o plano Grátis. Se quiser continuar, é só contratar um novo período.</li>
           <li>Em caso de falha de cobrança <strong>no cartão</strong> (cartão recusado, saldo insuficiente, etc.), tentaremos novamente automaticamente nos dias seguintes. Se as tentativas falharem, sua conta retorna ao plano Grátis. No Pix não há retentativa: sem pagamento confirmado, o acesso não começa.</li>
           <li>Preços e formas de cobrança podem mudar a qualquer momento com aviso prévio mínimo de 30 dias para assinantes ativos. Mudanças se aplicam apenas a partir da próxima renovação — ou, no Pix, da próxima compra.</li>
         </ul>
@@ -170,7 +175,7 @@
         <p>
           Quem pagou o <strong>anual por Pix</strong> não tem assinatura para cancelar: como não
           existe cobrança recorrente, não há nada a interromper e não existe Portal de assinatura.
-          O acesso vale até o fim dos 12 meses pagos e termina ali, sem nova cobrança. Pedir o
+          O acesso vale até o fim dos 365 dias pagos e termina ali, sem nova cobrança. Pedir o
           dinheiro de volta é outra coisa — isso é reembolso, e segue a seção 7.
         </p>
       </section>
@@ -194,8 +199,8 @@
         <p>
           Fora dessa janela o reembolso não é garantido, e cancelar não devolve a parte não usada
           do período já pago. <strong>No plano anual isso pesa</strong>: como ele é pago de uma
-          vez, cancelar no segundo mês não devolve os dez meses restantes — você mantém o acesso
-          até o fim dos 12 meses, mas não recebe dinheiro de volta.
+          vez, cancelar no segundo mês não devolve o restante — você mantém o acesso
+          até o fim dos 365 dias, mas não recebe dinheiro de volta.
         </p>
         <p>
           Reembolsos são creditados pelo mesmo meio de pagamento da cobrança original: no cartão,

--- a/frontend/termos.html
+++ b/frontend/termos.html
@@ -39,7 +39,7 @@
     <header class="page-header">
       <div class="breadcrumb">Legal · Termos de Uso</div>
       <h1>Termos de Uso</h1>
-      <p class="updated">Última atualização: 17 de agosto de 2026</p>
+      <p class="updated">Última atualização: 9 de setembro de 2026</p>
     </header>
 
     <article class="privacy-panel">
@@ -64,8 +64,9 @@
           cartões, investimentos e metas em linguagem natural via WhatsApp, Discord e dashboard
           web. O serviço é oferecido em planos pagos (<strong>Essencial</strong>,
           <strong>Plus</strong> e <strong>Pro</strong>), com limites e recursos diferentes em cada
-          um, e todo plano oferece <strong>15 dias de teste gratuito</strong>, limitado a um por
-          número de telefone (seção 4).
+          um. Pagando com <strong>cartão</strong>, todo plano oferece <strong>15 dias de teste
+          gratuito</strong>, limitado a um por número de telefone (seção 4). O <strong>plano anual
+          pago por Pix</strong> não tem teste gratuito (seções 4 e 5).
         </p>
         <p>
           Funcionalidades estão sujeitas a evoluir, ser modificadas ou descontinuadas a qualquer
@@ -131,24 +132,30 @@
           cobrança da mensalidade ou anuidade é feita automaticamente no 16º dia, no mesmo cartão
           informado.
         </p>
+        <p>
+          O trial existe no pagamento com <strong>cartão</strong>. O <strong>plano anual pago por
+          Pix</strong> não tem período de teste: o acesso vale a partir da confirmação do pagamento
+          e vai até o fim dos 12 meses contratados.
+        </p>
       </section>
 
       <section>
         <h2>5. Cobrança e renovação</h2>
         <ul>
-          <li>Os planos pagos são cobrados em ciclos <strong>mensais</strong> ou <strong>anuais</strong>, conforme o plano escolhido na contratação.</li>
-          <li>O processamento de pagamentos é feito pelo <strong>Stripe</strong>. Não armazenamos dados de cartão de crédito em nossos servidores.</li>
-          <li>A renovação acontece automaticamente no final de cada ciclo. Você recebe um e-mail antes da próxima cobrança quando aplicável.</li>
-          <li>Em caso de falha de cobrança (cartão recusado, saldo insuficiente, etc.), tentaremos novamente automaticamente nos dias seguintes. Se as tentativas falharem, sua conta retorna ao plano Grátis.</li>
-          <li>Preços e formas de cobrança podem mudar a qualquer momento com aviso prévio mínimo de 30 dias para assinantes ativos. Mudanças se aplicam apenas a partir da próxima renovação.</li>
+          <li>Os planos pagos são cobrados em ciclos <strong>mensais</strong> ou <strong>anuais</strong>, conforme o plano escolhido na contratação. O <strong>plano anual pago por Pix</strong> é um pagamento único, e não um ciclo que se repete.</li>
+          <li>O processamento de pagamentos é feito pelo <strong>Stripe</strong> (cartão) e pelo <strong>Asaas</strong> (Pix). Não armazenamos dados de cartão de crédito em nossos servidores, nem o CPF/CNPJ informado no pagamento por Pix — ele vai para o Asaas para gerar a cobrança e não fica guardado por nós.</li>
+          <li>No <strong>cartão</strong>, a renovação acontece automaticamente no final de cada ciclo. Você recebe um e-mail antes da próxima cobrança quando aplicável.</li>
+          <li>O <strong>anual por Pix não renova sozinho</strong>: não guardamos meio de pagamento e não existe cobrança automática. Quando os 12 meses terminam, o acesso ao plano pago acaba e a conta volta para o plano Grátis. Se quiser continuar, é só contratar um novo período.</li>
+          <li>Em caso de falha de cobrança <strong>no cartão</strong> (cartão recusado, saldo insuficiente, etc.), tentaremos novamente automaticamente nos dias seguintes. Se as tentativas falharem, sua conta retorna ao plano Grátis. No Pix não há retentativa: sem pagamento confirmado, o acesso não começa.</li>
+          <li>Preços e formas de cobrança podem mudar a qualquer momento com aviso prévio mínimo de 30 dias para assinantes ativos. Mudanças se aplicam apenas a partir da próxima renovação — ou, no Pix, da próxima compra.</li>
         </ul>
       </section>
 
       <section>
         <h2>6. Cancelamento</h2>
         <p>
-          Você pode cancelar sua assinatura a qualquer momento, sem multa nem custo
-          adicional, das seguintes formas:
+          Se você paga com <strong>cartão</strong>, pode cancelar a assinatura a qualquer
+          momento, sem multa nem custo adicional, das seguintes formas:
         </p>
         <ul>
           <li>Pelo <a href="/conta">Portal de assinatura</a> (gerenciado pelo Stripe).</li>
@@ -160,27 +167,40 @@
           esse prazo, a conta volta automaticamente para o plano Grátis. Os dados são preservados (você
           não perde lançamentos, histórico ou conta).
         </p>
+        <p>
+          Quem pagou o <strong>anual por Pix</strong> não tem assinatura para cancelar: como não
+          existe cobrança recorrente, não há nada a interromper e não existe Portal de assinatura.
+          O acesso vale até o fim dos 12 meses pagos e termina ali, sem nova cobrança. Pedir o
+          dinheiro de volta é outra coisa — isso é reembolso, e segue a seção 7.
+        </p>
       </section>
 
       <section>
         <h2>7. Reembolso</h2>
         <p>
-          O período de trial gratuito de 15 dias com cartão funciona como avaliação prática do
-          serviço. Cancelamentos efetuados <strong>durante o trial</strong> não geram cobrança e,
-          portanto, não exigem reembolso.
+          O trial gratuito de 15 dias, que existe no pagamento com <strong>cartão</strong>,
+          funciona como avaliação prática do serviço. Cancelamentos efetuados
+          <strong>durante o trial</strong> não geram cobrança e, portanto, não exigem reembolso.
+          O <strong>anual por Pix</strong> não tem trial: nele a primeira cobrança é a única, e
+          vale o prazo de desistência abaixo.
         </p>
         <p>
-          Após o trial, conforme o Art. 49 do Código de Defesa do Consumidor, o usuário pode
-          solicitar o reembolso integral de uma cobrança feita nas <strong>primeiras 48 horas após
-          o início do primeiro ciclo cobrado</strong>, desde que entre em contato pelo
+          Conforme o <strong>Art. 49 do Código de Defesa do Consumidor</strong>, como a
+          contratação é feita pela internet, você pode desistir e pedir o reembolso integral em
+          até <strong>7 dias</strong> — contados do início do primeiro ciclo cobrado, no cartão,
+          ou da confirmação do pagamento, no Pix —, avisando pelo
           <a href="mailto:suporte@pigbankai.com">suporte@pigbankai.com</a> dentro desse prazo.
-          Reembolsos solicitados fora dessa janela não são garantidos, e cancelamentos não geram
-          reembolso proporcional do ciclo em curso. O acesso permanece ativo até o fim do período
-          já pago.
         </p>
         <p>
-          Reembolsos são creditados pelo mesmo meio de pagamento da cobrança original e podem
-          levar até 7 dias úteis pra aparecer no cartão.
+          Fora dessa janela o reembolso não é garantido, e cancelar não devolve a parte não usada
+          do período já pago. <strong>No plano anual isso pesa</strong>: como ele é pago de uma
+          vez, cancelar no segundo mês não devolve os dez meses restantes — você mantém o acesso
+          até o fim dos 12 meses, mas não recebe dinheiro de volta.
+        </p>
+        <p>
+          Reembolsos são creditados pelo mesmo meio de pagamento da cobrança original: no cartão,
+          podem levar até 7 dias úteis pra aparecer na fatura; no Pix, o valor é devolvido por Pix
+          para a conta que fez o pagamento.
         </p>
       </section>
 


### PR DESCRIPTION
O PigBank vai vender o plano anual **por Pix, via Asaas**. Os Termos falavam só de cartão, Stripe e assinatura recorrente — e cada uma dessas frases fica **falsa** para quem pagar por Pix.

**Só texto: zero linha executável no diff.**

## As três adaptações

| o que os Termos diziam | realidade no Pix anual |
|---|---|
| *"o processamento de pagamentos é feito pelo **Stripe**"* | Stripe para cartão, **Asaas** para Pix — e não guardamos o CPF/CNPJ informado |
| renovação automática, com retentativa se o cartão recusar | **não renova**: pagamento único, sem meio de pagamento guardado |
| cancelamento *"pelo Portal de assinatura (gerenciado pelo Stripe)"* | **não há portal nem assinatura** a cancelar |

## As 48 horas contra os 7 dias do CDC — e isto NÃO é adaptação ao Asaas

O §7 prometia reembolso integral nas primeiras **48 horas**, **citando o Art. 49 do Código de Defesa do Consumidor**.

O artigo dá **sete dias** para contratação fora do estabelecimento comercial — que é o caso de compra pela internet. O texto **citava o artigo e contrariava ele**, e prazo legal não encolhe por contrato.

Corrigido para 7 dias. **O dono foi avisado de que isso amplia a obrigação dele**, e vale também para quem paga no cartão. É um problema que **já existia** e só apareceu porque fomos ler os Termos por outro motivo.

Ainda no §7:
- o trial de 15 dias passa a ser declaradamente **do cartão** — o anual por Pix não tem trial;
- o reembolso **volta por Pix**, em vez de *"aparecer no cartão"*;
- a consequência que estava escondida numa frase escrita para o mensal ficou explícita: **como o anual é pago de uma vez, cancelar no segundo mês não devolve os dez meses restantes**.

## A varredura achou mais quatro

Além das linhas apontadas: *"todo plano oferece 15 dias"* (§1), o ciclo do §5, a retentativa, e *"a partir da próxima renovação"*. Todas corrigidas — a categoria era "frase que vira falsa com pagamento único", não a lista de linhas.

## Medição

- Python **6716 passed, 4 xfailed, 0 failed**; frontend **320 pass, 0 fail**
- Layout medido **antes × depois** nos dois tamanhos (390×844 e 1280×900), servindo o arquivo original na mesma origem — sem isso a medição daria o mesmo número com e sem a mudança. Sem rolagem horizontal, nenhum elemento escapando do `article`.

Erro declarado: a baseline da suíte foi tirada **depois** da edição, não antes. Como ela tem zero falhas, não há regressão possível na coluna de falha — mas a medição correta seria nas duas pontas.

## Fica para o dono — não bloqueia o merge, bloqueia LIGAR

1. **Notificar os usuários.** O §11 promete avisar sobre alterações significativas, e ampliar o prazo de reembolso é significativo. Isso não sai do HTML.
2. **O prazo para o dinheiro voltar no Pix.** No cartão o texto diz "até 7 dias úteis"; para Pix ficou escrito o meio, não o prazo.
3. **Troca de plano no meio do ano pago à vista.** Os Termos não falam de troca em lugar nenhum; agora que há dinheiro pago adiantado, a omissão pesa.
4. **O "plano Grátis"** que o documento ainda descreve, e que o produto não vende mais.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)