### PR TITLE
O dependabot.yml estava inválido, e reprovava todo PR do repositório

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,7 +76,6 @@ updates:
       day: "monday"
     cooldown:
       default-days: 7
-      semver-major-days: 14
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
O GitHub recusa o arquivo inteiro:

```
The property '#/updates/3/cooldown/semver-major-days' is not supported
for the package ecosystem 'github-actions'.
```

O bloco de `cooldown` foi copiado do `pip` para o de `github-actions`, e ali o `semver-major-days` não existe — Actions não versionam por semver da mesma forma.

## Duas consequências

**O check `.github/dependabot.yml` aparece vermelho em TODO pull request do repositório**, inclusive nos que não encostam em dependência nenhuma. Foi assim que ele apareceu nos três PRs do Pix (#330, #331, #332), que não têm nada a ver — e deixou os três em `UNSTABLE` em vez de `CLEAN`.

**E, com o arquivo inválido, a configuração inteira fica em xeque** — o agrupamento `python-minor-patch` pode não estar valendo. É a explicação provável para o #301 ter vindo com o `pydantic_core` sozinho, sem o `pydantic` que o prende numa versão exata. Aquele PR foi fechado como impossível de resolver.

## O conserto — instância, não categoria

Uma linha, só no bloco `github-actions`. Conferi os quatro blocos antes de mexer:

```
0: pip              cooldown=['default-days', 'semver-major-days']
1: npm              cooldown=['default-days', 'semver-major-days']
2: npm              cooldown=['default-days', 'semver-major-days']
3: github-actions   cooldown=['default-days']          ← só este muda
```

Os três de `pip` e `npm` **mantêm** o `semver-major-days`, onde ele é válido. O `default-days: 7` fica nos quatro — a janela contra pacote recém-comprometido continua valendo também para as Actions.

## Verificação

O YAML foi validado depois da edição, e o efeito real só se confirma quando o GitHub reprocessar o arquivo: o check tem de passar a **verde** neste PR e nos três do Pix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)