### PR TITLE
O botão Pix do card Plus não vendia, e o do card Pro cobrava o preço do Plus

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,85 @@
+## O problema, medido em produção
+
+O Pix anual entrou no ar em 2026-09-10 com a venda ligada. Dois vocabulários de plano
+convivem no produto, e `pro` significa **coisas diferentes** nos dois:
+
+| vocabulário | valores | quem fala |
+|---|---|---|
+| **público** | `essencial`, `plus`, `pro` | o frontend inteiro |
+| **legado** | `essencial`, `pro`, `pro_max` | as colunas `plan` / `plan_stored` |
+
+O `POST /billing/pix/checkout` exigia o **legado** — era o único endpoint de cliente
+assim. O gêmeo do Stripe (`/billing/create-checkout`) sempre aceitou o público, e o
+mesmo `frontend/pix-checkout.js` alimenta os dois, mandando público. Efeito:
+
+| card | o botão manda | o que acontecia |
+|---|---|---|
+| Essencial | `essencial` | funcionava, R$ 99 — o único caminho testado na ativação |
+| **Plus** | `plus` | **400 `plan inválido`**, o botão não vendia |
+| **Pro** | `pro` | aceito, mas `pro` é o tier **Plus**: **cobrava R$ 199 e concedia Plus** num card que anuncia R$ 499 |
+
+## A correção
+
+A rota passa a falar **público**, como a irmã, e traduz **uma vez** antes do serviço.
+
+- `core/services/plan_service.py`: `TIER_TO_STORED_PLAN` (3 entradas) nasce colado ao
+  `_STORED_PLAN_TO_TIER`, o mapa canônico. Escrito à mão e não invertido por código
+  porque o canônico **não é injetor** (`pro` e `plus` colidem em `plus`).
+- `frontend/routes/billing_pix.py`: valida contra o mapa novo e traduz na fronteira. A
+  mensagem de erro é a mesma string do gêmeo do Stripe.
+- `tests/test_pix_rotas_billing.py`: o teste de CSRF mandava `pro_max`, que deixou de
+  ser aceito.
+
+**O banco continua guardando legado.** Nada de migração: a tradução mora na fronteira.
+
+## Evidência
+
+**Controle negativo** (`plan_stored=plan_stored` → `plan_stored=plan`) reproduz o bug
+pelo número exato, e **discrimina** — o Essencial fica verde sob a mesma mutação:
+
+```
+FAILED test_cada_card_cobra_o_preco_que_anuncia[pro]
+E   AssertionError: card 'pro' cobrou 19900, anuncia 49900
+FAILED test_cada_card_cobra_o_preco_que_anuncia[plus]
+2 failed, 9 passed
+```
+
+**Controle positivo:** `[essencial]`, o card que já vendia, continua 200 / 9900.
+
+Também provado rodando, contra banco real e Asaas mockado:
+
+- 21 payloads hostis (`free`, `""`, SQLi, 10 mil chars, byte nulo, tipos errados) →
+  todos 400/422 limpos, zero 500, zero linha gravada, zero chamada ao provedor;
+- comprar Plus duas vezes **reaproveita** o mesmo QR; Plus e depois Pro **substitui**,
+  cancelando a cobrança anterior no Asaas — nenhuma cobrança pagável duplicada;
+- uma cobrança `pending` criada com o código **velho** é substituída corretamente
+  depois do deploy, sem deixar nada pagável para trás;
+- CSRF ausente → 403; poll com token de outro usuário → 404.
+
+**Suíte inteira na árvore do branch: `6876 passed, 4 xfailed`**
+(`.venv/bin/python -m pytest -q`, `PYTHONPATH=.`).
+
+Um teste novo amarra a lista de planos aceitos pelas **duas** rotas, e outro amarra as
+**três** cópias da relação legado↔público, para a próxima divergência nascer vermelha.
+
+## Ordem de merge
+
+Este PR deve entrar **antes** do `fix/pix-copy-modal-email`. Sem a tradução, aquele PR
+faz o modal e o e-mail nomearem planos diferentes para a mesma compra (o modal lê o
+slug do frontend, o e-mail lê a coluna). Com esta tradução, os três cards batem nos
+dois canais.
+
+## Fica para issue, fora deste PR
+
+- Vocabulário legado saindo nas **respostas** HTTP: `pix_checkout_resposta.py:55`,
+  `billing_pix.py:107` e `:159`, mais o mock `precos_pix_anual.test.mjs:117`, que já
+  declara `plan: "plus"` e mente sobre o que o servidor devolve. Zero consumidor hoje.
+- `core/services/pix_checkout.py:320` manda o valor legado na `descricao` da cobrança,
+  string que o pagador lê na fatura do Asaas.
+- `finance_bot_websocket_custom.py:4471`: plano vazio vira Plus por default no checkout
+  do Stripe. Pré-existente; o cliente recebe o que paga, então não é descasamento.
+
+## Não verificado
+
+O Asaas é mockado em tudo que foi medido. Que o `pro_max` gere a cobrança de R$ 499 no
+provedor real, e que os botões voltem a vender, só se prova **depois do deploy**.

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -45,6 +45,17 @@ _STORED_PLAN_TO_TIER = {
     "pro_max": "pro",    # tier novo de R$ 39,90 (ainda não vendido)
 }
 
+# O INVERSO do de cima, restrito ao que se VENDE: tier público que o cliente
+# escolhe na /precos → valor legado que a coluna guarda. Não é derivado de
+# `_STORED_PLAN_TO_TIER` porque aquele não é injetor ('pro' e 'plus' dão o mesmo
+# tier); quem ata os dois é `test_vocabulario_de_plano.py`, ida e volta.
+# `free` fica de fora de propósito: não é venda, e `PRECOS_ANUAIS_CENTS` não o tem.
+TIER_TO_STORED_PLAN = {
+    "essencial": "essencial",
+    "plus": "pro",       # legado: o tier Plus grava 'pro'
+    "pro": "pro_max",    # legado: o tier Pro grava 'pro_max'
+}
+
 TRIAL_DAYS_DEFAULT = 15
 
 

--- a/frontend/routes/billing_pix.py
+++ b/frontend/routes/billing_pix.py
@@ -49,13 +49,10 @@ from core.services.pix_checkout import (
     criar_checkout,
 )
 from core.services.pix_pricing import CoberturaJaPaga
+from core.services.plan_service import TIER_TO_STORED_PLAN
 from frontend.routes import shared
 
 router = APIRouter()
-
-# Planos vendáveis no Pix, no valor LEGADO da coluna (`pro` = Plus, `pro_max` =
-# Pro). Mesma lista que `_STORED_PLAN_TO_TIER` conhece; `free` não é venda.
-_PLANOS = ("essencial", "pro", "pro_max")
 
 # CPF tem 11 dígitos, CNPJ tem 14. A validação aqui é de FORMA e só: quem
 # valida de verdade é o Asaas, e replicar o dígito verificador seria uma segunda
@@ -80,9 +77,16 @@ async def billing_pix_checkout(request: Request, payload: PixCheckoutBody):
     primeira. Import tardio para não inverter a direção do import.
     """
     user_id = shared.resolve_dashboard_user_id(request)
+    # O corpo fala o vocabulário PÚBLICO da /precos, o mesmo do gêmeo do Stripe
+    # (`finance_bot_websocket_custom.py:4472`) — o JS que alimenta os dois é UM
+    # só. Aceitar o legado aqui era a armadilha: `plus` levava 400 e o card Pro
+    # mandava `pro`, que no banco é o tier Plus (R$ 199 num card de R$ 499).
     plan = (payload.plan or "").strip().lower()
-    if plan not in _PLANOS:
-        raise HTTPException(status_code=400, detail="plan inválido.")
+    if plan not in TIER_TO_STORED_PLAN:
+        raise HTTPException(
+            status_code=400,
+            detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
+    plan_stored = TIER_TO_STORED_PLAN[plan]
     doc = "".join(c for c in (payload.cpf_cnpj or "") if c.isdigit())
     if len(doc) not in _TAMANHOS_DOC:
         raise HTTPException(status_code=400,
@@ -94,7 +98,7 @@ async def billing_pix_checkout(request: Request, payload: PixCheckoutBody):
     try:
         async with _billing_user_lock(user_id):
             return await asyncio.to_thread(
-                criar_checkout, user_id, plan_stored=plan, cpf_cnpj=doc,
+                criar_checkout, user_id, plan_stored=plan_stored, cpf_cnpj=doc,
                 nome=nome, email=email, rastreio=_rastreio(request),
                 confirm_cancel_stripe=bool(payload.confirm_cancel_stripe))
     except CoberturaJaPaga as exc:

--- a/tests/test_pix_rotas_billing.py
+++ b/tests/test_pix_rotas_billing.py
@@ -172,7 +172,7 @@ def test_webhook_nao_precisa_de_csrf_e_o_checkout_precisa():
     assert sem_csrf.status_code in (401, 503), sem_csrf.status_code
 
     checkout = client.post("/billing/pix/checkout",
-                           json={"plan": "pro_max", "cpf_cnpj": "12345678901"})
+                           json={"plan": "pro", "cpf_cnpj": "12345678901"})
     assert checkout.status_code == 403, "o checkout ganhou isenção de CSRF"
 
 

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -1,0 +1,189 @@
+"""Um vocabulário por FRONTEIRA: o corpo do checkout Pix fala o mesmo que o do
+Stripe, e a tradução para o legado acontece dentro.
+
+O bug que este arquivo prende esteve VIVO em produção com a venda ligada
+(`ASAAS_PIX_ANNUAL_ENABLED=1`, 2026-09-10). O JS é UM só e manda o slug público
+da `/precos` nas duas rotas; a do Pix validava contra o vocabulário LEGADO da
+coluna, e o resultado por card era:
+
+    Essencial → `essencial`  ✔ (o único que alguém tinha testado)
+    Plus      → `plus`       ✘ 400 `plan inválido` — o botão não vendia
+    Pro       → `pro`        ✘ aceito, mas `pro` NO BANCO é o tier Plus:
+                               R$ 199 cobrados num card que anuncia R$ 499
+
+O terceiro é o coração do arquivo, e é por isso que o preço é ASSERÇÃO e não
+comentário: um teste que só conferisse `plan_stored` ficaria verde no dia em que
+`PRECOS_ANUAIS_CENTS` mudasse de chave.
+
+CONTROLES DO GRUPO (medidos, não prometidos):
+
+  * NEGATIVO — desfaça a tradução na rota (troque `plan_stored=plan_stored` por
+    `plan_stored=plan` em `frontend/routes/billing_pix.py`) e
+    `test_cada_card_cobra_o_preco_que_anuncia[pro]` fica VERMELHO cobrando
+    19900 em vez de 49900. É o caso que DISCRIMINA: com `plan="pro"` o valor
+    público e o legado são strings diferentes, então a mutação aparece.
+    Injetada num caso verde de propósito — `essencial` traduz para si mesmo e
+    seguiria passando, e `plus` já falharia por outro motivo.
+  * POSITIVO — `test_cada_card_cobra_o_preco_que_anuncia[essencial]` é o card
+    que JÁ funcionava em produção. Sem ele o grupo passaria numa rota que
+    recusasse tudo, que é pior que o bug.
+
+O que este arquivo NÃO pega: o Asaas é falso aqui (fixture `asaas_falso`), então
+o que o provedor faz com o valor não é medido — só o que sai da nossa rota. O
+banco é de verdade: as linhas de `pix_charges` são lidas do disco.
+"""
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.billing_pix as rotas
+from _billing_grants_helpers import conta
+from _pix_checkout_helpers import asaas_falso, vendavel  # noqa: F401 — fixtures
+from core.services.pix_pricing import PRECOS_ANUAIS_CENTS
+from core.services.plan_service import _STORED_PLAN_TO_TIER, TIER_TO_STORED_PLAN
+from db.pix_charges import buscar_por_public_token
+
+
+@pytest.fixture(autouse=True)
+def _sem_teto_de_taxa():
+    """O checkout é 20/hora por IP e o storage do slowapi é compartilhado entre
+    arquivos: sem zerar, o último teste do grupo cai com 429 e a falha não tem
+    nada a ver com plano."""
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:  # noqa: BLE001 — storage é detalhe do slowapi
+        pass
+    yield
+
+
+@pytest.fixture()
+def logado(monkeypatch, user_id):
+    """Cliente HTTP com as DUAS rotas autenticadas, e o usuário sem cobertura —
+    toda compra aqui é a PRIMEIRA, então `credit_cents` é 0 e `amount_cents` é o
+    preço cheio, que é o que deixa a asserção de dinheiro ser direta.
+
+    `app` é lido AQUI, e não no topo do módulo, de propósito:
+    `tests/test_pix_rota_registrada.py` faz `importlib.reload` do monólito, e um
+    `TestClient(dashboard.app)` de import-time fica preso ao app ANTIGO enquanto
+    o override cai no novo. O sintoma era 401 só quando os dois arquivos rodavam
+    juntos — efeito de ORDEM, invisível no arquivo isolado.
+    """
+    conta(user_id, "free", None)
+    monkeypatch.setattr(rotas.shared, "resolve_dashboard_user_id",
+                        lambda req: user_id)
+    app = dashboard.app
+    # As duas rotas autenticam por caminhos DIFERENTES (o Pix pelo cookie de
+    # dashboard, o Stripe por `Depends(_get_current_user)`), e a comparação entre
+    # elas precisa das duas logadas — senão o teste mede 401, não vocabulário.
+    app.dependency_overrides[dashboard._get_current_user] = lambda: user_id
+    cliente = TestClient(app)
+    cliente.cookies.set(dashboard.CSRF_COOKIE_NAME, _CSRF)
+    yield SimpleNamespace(user_id=user_id, http=cliente)
+    app.dependency_overrides.pop(dashboard._get_current_user, None)
+
+
+_CSRF = "test-csrf-vocabulario"
+
+
+def _cabecalhos() -> dict[str, str]:
+    return {dashboard.CSRF_HEADER_NAME: _CSRF}
+
+
+def _checkout(logado, plan: str):
+    return logado.http.post("/billing/pix/checkout", headers=_cabecalhos(),
+                            json={"plan": plan, "cpf_cnpj": "12345678901"})
+
+
+# ── os três cards da /precos, ponta a ponta pela rota ────────────────────────
+
+@pytest.mark.parametrize("publico,legado", [
+    ("essencial", "essencial"),   # POSITIVO do grupo: o que já vendia
+    ("plus", "pro"),              # dava 400 `plan inválido`
+    ("pro", "pro_max"),           # cobrava 19900 num card de 49900
+], ids=["essencial", "plus", "pro"])
+def test_cada_card_cobra_o_preco_que_anuncia(logado, vendavel, asaas_falso,
+                                             publico, legado):
+    """As três metades de uma vez: aceitou, gravou o LEGADO, cobrou o preço dele.
+
+    O preço esperado é LIDO de `PRECOS_ANUAIS_CENTS` pela chave legada (§0.7) —
+    cravar 49900 aqui criaria uma segunda fonte do número que a `/precos` mostra.
+    """
+    r = _checkout(logado, publico)
+    assert r.status_code == 200, r.text
+
+    esperado = PRECOS_ANUAIS_CENTS[legado]
+    assert r.json()["amount_cents"] == esperado, (
+        f"card '{publico}' cobrou {r.json()['amount_cents']}, anuncia {esperado}")
+
+    linha = buscar_por_public_token(logado.user_id, r.json()["public_token"])
+    assert linha is not None, "a cobrança não foi gravada"
+    # As DUAS colunas continuam no vocabulário legado: grants, projeção e o
+    # `_plan_publico` do /billing/subscription dependem disso.
+    assert linha["plan"] == legado
+    assert linha["plan_stored"] == legado
+    assert int(linha["price_cents"]) == esperado
+
+
+def test_o_vocabulario_legado_nao_entra_mais_pela_rota(logado, vendavel,
+                                                       asaas_falso):
+    """`pro_max` é valor de COLUNA, e o JS nunca o mandou. Aceitá-lo deixaria a
+    rota com dois vocabulários — que é a armadilha inteira, só que armada de
+    novo. 400, e nenhuma cobrança nasce."""
+    r = _checkout(logado, "pro_max")
+    assert r.status_code == 400, r.text
+    assert "essencial" in str(r.json()["detail"])
+    assert asaas_falso["ordem"] == [], "recusa de plano falou com o Asaas"
+
+
+# ── o par de dicionários, e o par de rotas (§0.7) ────────────────────────────
+
+def test_os_dois_mapas_de_plano_sao_inversos():
+    """Ida e volta: público → legado → tier tem de voltar ao público de origem.
+
+    É o que impede os dois dicionários de derivarem em silêncio — mexer num sem
+    o outro nasce vermelho aqui, e não como preço errado numa venda.
+    """
+    for publico, legado in TIER_TO_STORED_PLAN.items():
+        assert _STORED_PLAN_TO_TIER[legado] == publico, (
+            f"'{publico}' → '{legado}' → '{_STORED_PLAN_TO_TIER.get(legado)}'")
+        assert dashboard._plan_publico(legado) == publico
+    # E todo plano vendável tem preço: um valor sem entrada aqui viraria 503
+    # `preco_anual_nao_configurado` só na hora da venda.
+    assert set(TIER_TO_STORED_PLAN.values()) <= set(PRECOS_ANUAIS_CENTS)
+
+
+# `""` está FORA desta tabela, e não por conveniência: as duas rotas de fato
+# divergem nele, por um motivo que não é vocabulário e é ANTERIOR a este PR — o
+# Stripe faz `("" or "plus")` (`finance_bot_websocket_custom.py:4471`), então
+# plano vazio vira Plus em silêncio, enquanto o Pix responde 400. Achado
+# relatado ao Arquiteto; consertar o default de uma rota de dinheiro não estava
+# no plano deste PR, e ampliá-lo por conta própria é o que o §2 proíbe.
+@pytest.mark.parametrize("plan", [
+    "essencial", "plus", "pro",   # públicos: nenhuma das duas rotas recusa
+    "pro_max", "free",            # nenhuma das duas rotas aceita
+    "PLUS",                       # as duas normalizam a caixa antes de validar
+])
+def test_pix_e_stripe_aceitam_a_MESMA_lista_de_planos(logado, vendavel,
+                                                      asaas_falso, plan):
+    """O gêmeo do Stripe (`/billing/create-checkout`) e o do Pix têm de concordar
+    sobre o que é `plan` válido — a próxima divergência entre eles nasce vermelha
+    aqui em vez de virar 400 num botão de venda.
+
+    Mede só o veredito de VOCABULÁRIO (400 `plan inválido` × qualquer outra
+    coisa): o Stripe responde 503 sem os price IDs configurados e o Pix responde
+    200, e essa diferença é de configuração, não de plano.
+    """
+    def _recusa_o_plano(resp) -> bool:
+        return resp.status_code == 400 and "plan inválido" in str(resp.json().get("detail"))
+
+    pix = _checkout(logado, plan)
+    stripe = logado.http.post("/billing/create-checkout", headers=_cabecalhos(),
+                         json={"plan": plan, "interval": "annual"})
+    # 401 significaria que o teste mediu autenticação, não plano.
+    assert stripe.status_code != 401, "o cliente do Stripe não autenticou"
+    assert _recusa_o_plano(pix) == _recusa_o_plano(stripe), (
+        f"'{plan}': Pix {pix.status_code} × Stripe {stripe.status_code}")


### PR DESCRIPTION
## O problema, medido em produção

O Pix anual entrou no ar em 2026-09-10 com a venda ligada. Dois vocabulários de plano
convivem no produto, e `pro` significa **coisas diferentes** nos dois:

| vocabulário | valores | quem fala |
|---|---|---|
| **público** | `essencial`, `plus`, `pro` | o frontend inteiro |
| **legado** | `essencial`, `pro`, `pro_max` | as colunas `plan` / `plan_stored` |

O `POST /billing/pix/checkout` exigia o **legado** — era o único endpoint de cliente
assim. O gêmeo do Stripe (`/billing/create-checkout`) sempre aceitou o público, e o
mesmo `frontend/pix-checkout.js` alimenta os dois, mandando público. Efeito:

| card | o botão manda | o que acontecia |
|---|---|---|
| Essencial | `essencial` | funcionava, R$ 99 — o único caminho testado na ativação |
| **Plus** | `plus` | **400 `plan inválido`**, o botão não vendia |
| **Pro** | `pro` | aceito, mas `pro` é o tier **Plus**: **cobrava R$ 199 e concedia Plus** num card que anuncia R$ 499 |

## A correção

A rota passa a falar **público**, como a irmã, e traduz **uma vez** antes do serviço.

- `core/services/plan_service.py`: `TIER_TO_STORED_PLAN` (3 entradas) nasce colado ao
  `_STORED_PLAN_TO_TIER`, o mapa canônico. Escrito à mão e não invertido por código
  porque o canônico **não é injetor** (`pro` e `plus` colidem em `plus`).
- `frontend/routes/billing_pix.py`: valida contra o mapa novo e traduz na fronteira. A
  mensagem de erro é a mesma string do gêmeo do Stripe.
- `tests/test_pix_rotas_billing.py`: o teste de CSRF mandava `pro_max`, que deixou de
  ser aceito.

**O banco continua guardando legado.** Nada de migração: a tradução mora na fronteira.

## Evidência

**Controle negativo** (`plan_stored=plan_stored` → `plan_stored=plan`) reproduz o bug
pelo número exato, e **discrimina** — o Essencial fica verde sob a mesma mutação:

```
FAILED test_cada_card_cobra_o_preco_que_anuncia[pro]
E   AssertionError: card 'pro' cobrou 19900, anuncia 49900
FAILED test_cada_card_cobra_o_preco_que_anuncia[plus]
2 failed, 9 passed
```

**Controle positivo:** `[essencial]`, o card que já vendia, continua 200 / 9900.

Também provado rodando, contra banco real e Asaas mockado:

- 21 payloads hostis (`free`, `""`, SQLi, 10 mil chars, byte nulo, tipos errados) →
  todos 400/422 limpos, zero 500, zero linha gravada, zero chamada ao provedor;
- comprar Plus duas vezes **reaproveita** o mesmo QR; Plus e depois Pro **substitui**,
  cancelando a cobrança anterior no Asaas — nenhuma cobrança pagável duplicada;
- uma cobrança `pending` criada com o código **velho** é substituída corretamente
  depois do deploy, sem deixar nada pagável para trás;
- CSRF ausente → 403; poll com token de outro usuário → 404.

**Suíte inteira na árvore do branch: `6876 passed, 4 xfailed`**
(`.venv/bin/python -m pytest -q`, `PYTHONPATH=.`).

Um teste novo amarra a lista de planos aceitos pelas **duas** rotas, e outro amarra as
**três** cópias da relação legado↔público, para a próxima divergência nascer vermelha.

## Ordem de merge

Este PR deve entrar **antes** do `fix/pix-copy-modal-email`. Sem a tradução, aquele PR
faz o modal e o e-mail nomearem planos diferentes para a mesma compra (o modal lê o
slug do frontend, o e-mail lê a coluna). Com esta tradução, os três cards batem nos
dois canais.

## Fica para issue, fora deste PR

- Vocabulário legado saindo nas **respostas** HTTP: `pix_checkout_resposta.py:55`,
  `billing_pix.py:107` e `:159`, mais o mock `precos_pix_anual.test.mjs:117`, que já
  declara `plan: "plus"` e mente sobre o que o servidor devolve. Zero consumidor hoje.
- `core/services/pix_checkout.py:320` manda o valor legado na `descricao` da cobrança,
  string que o pagador lê na fatura do Asaas.
- `finance_bot_websocket_custom.py:4471`: plano vazio vira Plus por default no checkout
  do Stripe. Pré-existente; o cliente recebe o que paga, então não é descasamento.

## Não verificado

O Asaas é mockado em tudo que foi medido. Que o `pro_max` gere a cobrança de R$ 499 no
provedor real, e que os botões voltem a vender, só se prova **depois do deploy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
