### PR TITLE
O modal chamava a compra Pix de assinatura, e o e-mail chamava todo plano de PigBank+

### DIFF
--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1105,22 +1105,66 @@ def send_pro_charged_email(to: str, amount_brl: float, next_charge_at, dashboard
     )
 
 
-def send_pix_paid_email(to: str, amount_brl: float, access_expires_at,
-                        dashboard_url: str = "") -> bool:
+# O nome COMERCIAL de cada plano, igual ao que o cliente acabou de ler no modal
+# da /home (`WP_PLANOS` em frontend/home.html). Os mapas de
+# `handlers/billing_commands.py` e do monólito são outra coisa — dizem
+# "Essencial"/"Plus"/"Pro", sem a marca — e por isso não servem aqui.
+#
+# **A chave é o valor LEGADO da coluna `plan` da cobrança, não o slug do
+# frontend.** `pro` é o Plus e `pro_max` é o Pro — a mesma tradução que o
+# frontend já faz em `PLAN_ALIASES = { pro: "plus", pro_max: "pro" }`
+# (frontend/home.html e frontend/nav-auth.js). Chavear em `plus`/`pro` mandava
+# "PigBank Pro" para quem comprou Plus e o fallback genérico para quem comprou
+# Pro: o router só aceita `("essencial", "pro", "pro_max")`
+# (frontend/routes/billing_pix.py) e a coluna guarda exatamente isso.
+PIX_PLAN_NAMES = {
+    "essencial": "PigBank Essencial",
+    "pro": "PigBank+",
+    "pro_max": "PigBank Pro",
+}
+
+
+def send_pix_paid_email(to: str, plan: str, amount_brl: float, access_starts_at,
+                        access_expires_at, dashboard_url: str = "") -> bool:
     """Confirmação da compra Pix ANUAL (§8.2, efeito `email`).
 
     Não reusa `send_pro_charged_email` por causa de duas frases que ficariam
     mentindo para quem pagou por Pix: "próxima cobrança" (não há — o Pix anual
     não renova sozinho) e "portal Stripe" (o cliente não tem um). O que muda é o
     TEXTO; o transporte, o layout e o `send_email` são os mesmos.
+
+    `plan` existe porque o e-mail dizia "PigBank+" para todo mundo — quem pagou
+    Essencial ou Pro recebia o nome de outro plano no assunto e no corpo. Ele é
+    a coluna `plan` da cobrança crua, ou seja o valor LEGADO (`essencial`,
+    `pro` = Plus, `pro_max` = Pro) — ver `PIX_PLAN_NAMES` logo acima.
+    `access_starts_at` no futuro é a compra AGENDADA (quem já tinha plano
+    vigente): o ano só começa quando o período atual terminar, e prometer acesso
+    imediato ali é a mesma mentira de outro jeito.
     """
+    from datetime import datetime as _dt, timezone as _tz
+
+    nome = PIX_PLAN_NAMES.get(plan, "PigBank")
+    # Naive vira UTC antes de comparar, do mesmo jeito que o `_fmt_brl_date`
+    # logo acima faz com ESTE MESMO valor: a coluna é `timestamptz` e hoje só
+    # chega aware, mas comparar aware com naive levanta `TypeError` DENTRO do
+    # efeito `email` — e aí o efeito nunca é registrado, o drain retenta para
+    # sempre e o cliente que pagou fica sem confirmação nenhuma.
+    _inicio = access_starts_at
+    if getattr(_inicio, "tzinfo", "") is None:
+        _inicio = _inicio.replace(tzinfo=_tz.utc)
+    agendado = _inicio is not None and _inicio > _dt.now(_tz.utc)
     valor = f"R$ {amount_brl:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
     ate = _fmt_brl_date(access_expires_at)
+    de = _fmt_brl_date(access_starts_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
+    abertura = (f"Seu {nome} tá garantido — o ano começa quando o plano atual terminar."
+                if agendado else f"Seu {nome} tá liberado.")
+    inicio_li = f"<li><strong>Acesso a partir de:</strong> {de}</li>" if agendado else ""
     content = f"""
-      <p>🐷✨ <strong>Pagamento confirmado!</strong> Seu PigBank+ tá liberado.</p>
+      <p>🐷✨ <strong>Pagamento confirmado!</strong> {abertura}</p>
       <ul>
         <li><strong>Valor pago:</strong> {valor}</li>
+        {inicio_li}
         <li><strong>Acesso até:</strong> {ate}</li>
       </ul>
       <p>É um plano anual pago por Pix: <strong>não tem renovação automática</strong> e não tem cartão
@@ -1128,15 +1172,16 @@ def send_pix_paid_email(to: str, amount_brl: float, access_expires_at,
       <p style="text-align:center;margin:24px 0"><a class="btn" href="{dash}/app">🐷 Abrir meu dashboard</a></p>
       <p>Qualquer dúvida, é só responder este email ou usar <strong>ajuda</strong> no bot.</p>
     """
-    html = _base_html("Pagamento confirmado — PigBank+", content)
+    html = _base_html(f"Pagamento confirmado — {nome}", content)
     text = (
-        f"PigBank+ liberado.\n\n"
+        f"{abertura}\n\n"
         f"Valor pago: {valor}\n"
-        f"Acesso até: {ate}\n\n"
+        + (f"Acesso a partir de: {de}\n" if agendado else "")
+        + f"Acesso até: {ate}\n\n"
         f"Plano anual por Pix, sem renovação automática.\n{dash}/app"
     )
     return send_email(
-        to=to, subject=f"✓ Pagamento confirmado — PigBank+ anual ({valor})",
+        to=to, subject=f"✓ Pagamento confirmado — {nome} anual ({valor})",
         html_body=html, text_body=text,
     )
 

--- a/core/services/pix_checkout_resposta.py
+++ b/core/services/pix_checkout_resposta.py
@@ -33,6 +33,18 @@ def qr_da_linha(linha: dict) -> str | None:
         subject_user_id=linha["user_id"], field="qr_payload"))
 
 
+def agendada(starts_at) -> bool:
+    """"Começa depois" — a conta que separa compra imediata de agendada.
+
+    Mora aqui, e não copiada em cada montagem, porque quem a lê são DOIS
+    contratos: a resposta do checkout (abaixo) e o poll
+    (`frontend/routes/billing_pix.py`). Duas cópias divergiriam (§0.7), e a
+    tela que gatilha pela presença de `starts_at` promete "começa em <hoje>"
+    a quem começa ao pagar.
+    """
+    return bool(starts_at and starts_at > datetime.now(timezone.utc))
+
+
 def resposta(linha: dict, qr_payload: str) -> dict:
     """O contrato que a tela do PR 2 consome. Uma função para os dois caminhos
     (cobrança nova e cobrança reaproveitada) — duas montagens divergiriam.
@@ -63,7 +75,7 @@ def resposta(linha: dict, qr_payload: str) -> dict:
         # Mesma conta do `agendada` que `plano_da_cobranca` devolve em TODOS os
         # ramos (`inicio > agora`) — e não o campo dele, porque o
         # `_reaproveitar` chega aqui só com a data, sem o resto do snapshot.
-        "agendada": bool(starts_at and starts_at > datetime.now(timezone.utc)),
+        "agendada": agendada(starts_at),
         "plan": linha["plan"],
     }
 

--- a/core/services/pix_checkout_resposta.py
+++ b/core/services/pix_checkout_resposta.py
@@ -41,9 +41,17 @@ def resposta(linha: dict, qr_payload: str) -> dict:
     da venda ser paga é o checkout, com o valor que `plano_da_cobranca` calculou:
     a COLUNA só é escrita no pagamento (§7), então ler a linha crua aqui devolvia
     nulo em todo checkout.
+
+    `agendada` existe porque **a data sozinha não separa os dois casos**: na
+    compra IMEDIATA o `access_starts_at` também vem preenchido (com `agora`),
+    então "tem `starts_at`" não quer dizer "começa depois". A tela que gatilhava
+    pela presença da data prometia "começa em <hoje>, assim que o plano atual
+    terminar" para quem tinha acesso naquele instante e não tinha plano nenhum
+    antes.
     """
     from core.services.pix_brcode import qr_svg_data_url
 
+    starts_at = linha["access_starts_at"]
     return {
         "public_token": linha["public_token"],
         "qr_payload": qr_payload,
@@ -51,7 +59,11 @@ def resposta(linha: dict, qr_payload: str) -> dict:
         "expires_at": linha["qr_expires_at"],
         "amount_cents": int(linha["amount_cents"]),
         "credit_cents": int(linha["credit_cents"]),
-        "starts_at": linha["access_starts_at"],
+        "starts_at": starts_at,
+        # Mesma conta do `agendada` que `plano_da_cobranca` devolve em TODOS os
+        # ramos (`inicio > agora`) — e não o campo dele, porque o
+        # `_reaproveitar` chega aqui só com a data, sem o resto do snapshot.
+        "agendada": bool(starts_at and starts_at > datetime.now(timezone.utc)),
         "plan": linha["plan"],
     }
 

--- a/core/services/pix_drain_effects.py
+++ b/core/services/pix_drain_effects.py
@@ -274,7 +274,9 @@ def _email(cobranca, evt) -> None:
     if not destino or recent_event_exists("pix_paid_email_sent",
                                           cobranca["user_id"], 1.0):
         return
-    if not send_pix_paid_email(destino, int(cobranca["amount_cents"]) / 100,
+    if not send_pix_paid_email(destino, cobranca["plan"],
+                               int(cobranca["amount_cents"]) / 100,
+                               cobranca["access_starts_at"],
                                cobranca["access_expires_at"]):
         raise RuntimeError("send_pix_paid_email devolveu False")
     log_system_event_sync("info", "pix_paid_email_sent",

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -2226,18 +2226,47 @@ function wpInicioValido(s) {
         // acabou de pagar olhando para a tela de sempre. Vencido, cai no
         // `catch` e vira o caminho sem valor. `AbortSignal.timeout` é nativo
         // (Safari 16+); em navegador mais velho ele lança e cai no mesmo lugar.
+        // MEDIDO: com o backend a 3 s (rede ruim DENTRO do teto), o modal sobe
+        // em 3905 ms de tela parada para quem acabou de pagar — não empilha com
+        // o overlay `_checkoutSettled` (as duas esperas correm em paralelo; pior
+        // caso com as duas penduradas: 21 s, o mesmo de antes desta busca).
+        // ponytail: sem tela de carregamento nesta rodada; se 4 s incomodar,
+        // o caminho é baixar o teto, não inventar spinner.
         const r = await fetch("/billing/pix/" + encodeURIComponent(sid),
                               { credentials: "same-origin",
                                 signal: AbortSignal.timeout(4000) });
         if (r.ok) cobranca = await r.json();
       } catch { /* sem valor é melhor que valor inventado */ }
     }
-    const cents = cobranca && cobranca.amount_cents;
-    const valorPix = Number.isInteger(cents) && cents > 0 ? cents / 100 : null;
+    /* Dono NÃO é pagamento. O poll responde 200 com `amount_cents` para
+       `pending`, `expired`, `canceled` e `refunded` também — só o `status`
+       separa venda de intenção. Sem esta linha, o próprio dono de uma cobrança
+       PENDENTE abrindo esta URL na mão mandava um Purchase de R$ 499 sem venda
+       nenhuma: número CRÍVEL (mais difícil de achar no relatório que um
+       R$ 999.999) e SEM par na CAPI, porque o evento do servidor só sai no
+       pagamento — não deduplica com nada. E repetível: `criar_cobranca` só
+       barra uma segunda cobrança ATIVA (`ESTADOS_ATIVOS`, no módulo `db/` da
+       cobrança), então cada ciclo expirado ou cancelado dá um `public_token`
+       novo, logo um `eventID` novo e um Purchase fantasma novo.
+
+       O TEXTO cai no mesmo lugar do 404: o modal abre com a cópia do imediato.
+       Quem não pagou não pode ler promessa de data — e não abrir modal nenhum
+       seria tela nova para um caso que ninguém alcança PAGANDO. */
+    const pago = !!cobranca && cobranca.status === "paid";
+    const cents = pago && cobranca.amount_cents;
+    // O teto (R$ 1.000.000 em centavos) sobreviveu à troca de fonte: a coluna é
+    // nossa, mas o plano mais caro custa R$ 499 — acima disso é dado corrompido,
+    // não receita, e receita inventada é o que este commit inteiro existe para
+    // impedir.
+    const valorPix = Number.isInteger(cents) && cents > 0 && cents < 1e8
+      ? cents / 100 : null;
     // `starts_at` vem ISO do servidor; `agendada` é quem separa imediato de
     // agendado (na compra imediata a data também vem preenchida, com `agora`).
-    // O `wpInicioValido` fica: corpo malformado não vira promessa na tela.
-    const inicioPix = cobranca && cobranca.agendada && cobranca.starts_at
+    // `=== true` pela MESMA razão do `Number.isInteger` acima, e não pela metade:
+    // `agendada: 1` e `agendada: "false"` são verdadeiros em JS e prometeriam
+    // "começa em <data>" na tela. O `wpInicioValido` fica: corpo malformado não
+    // vira promessa escrita.
+    const inicioPix = pago && cobranca.agendada === true && cobranca.starts_at
       ? wpInicioValido(String(cobranca.starts_at).slice(0, 10)) : null;
 
     // Conversão pro Meta Ads — só dispara com `sid` (id real da sessão de

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -2054,7 +2054,7 @@ function openWelcomePro({ trial = true, days = 30, plano = "plus", ia = null,
     olho.textContent = "Pagamento confirmado";
     /* O Pix anual é compra À VISTA: não há assinatura para cancelar nem cartão
        para renovar, e quem já tinha plano vigente comprou um ano AGENDADO para
-       o fim dele. `inicio` chega da URL e já veio validado como AAAA-MM-DD;
+       o fim dele. `inicio` chega do servidor, já validado como AAAA-MM-DD;
        aqui ele só vira DD/MM/AAAA, por textContent. */
     chip.hidden = true;
     const quando = inicio
@@ -2148,8 +2148,10 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   if (e.target === e.currentTarget) dismissWelcomePro();
 });
 
-/* Fronteira de confiança: `inicio` é query string, qualquer um digita, e o que
-   sair daqui vira a promessa "seu ano começa em <data>" na tela.
+/* A data que vira a promessa "seu ano começa em <data>" na tela. Ela hoje sai
+   do servidor (`/billing/pix/<token>`), e não mais da query string — este
+   validador ficou porque corpo malformado ou coluna estranha também não podem
+   virar compromisso escrito, e porque ele custa zero linha nova.
 
    A regex sozinha barra markup e formato, e o `Date.parse` NÃO completa o
    serviço: ele normaliza em vez de recusar, então "2027-02-30" virava
@@ -2173,17 +2175,16 @@ function wpInicioValido(s) {
   return bate && a >= 2020 && a <= 2100 ? s : null;
 }
 
-(function handleUpgradeReturn() {
+(async function handleUpgradeReturn() {
   const params = new URLSearchParams(window.location.search);
   const status = params.get("upgrade");
-  const sid = params.get("sid");  // id da sessão Stripe → event_id do evento
+  const sid = params.get("sid");  // sessão Stripe, ou o public_token do Pix →
+                                  // event_id do evento e chave da busca abaixo
   const ev = params.get("ev");    // "trial" | "purchase" (definido pelo success_url)
   const td = params.get("td");    // dias de trial concedidos (0 quando ev=purchase)
   const pl = params.get("pl");    // plano escolhido: essencial | plus | pro
   const ia = params.get("ia");    // cota mensal de mensagens da Piggy nesse plano
   const gw = params.get("gw");    // "pix" quando veio do Pix anual (pix-poll.js)
-  const inicio = params.get("inicio");  // AAAA-MM-DD do começo do ano comprado
-  const vl = params.get("vl");    // valor cobrado em reais (só o Pix manda)
   if (!status) return;
 
   // Limpa os query params da URL pra nao reaparecer em refresh.
@@ -2200,6 +2201,45 @@ function wpInicioValido(s) {
   window.history.replaceState({}, "", cleanUrl.toString());
 
   if (status === "success") {
+    /* No Pix, o VALOR e a DATA saem do servidor — nunca da URL.
+
+       `sid` é o `public_token` da cobrança, e `GET /billing/pix/<token>` é
+       autenticado e filtra por dono (404 para token inexistente OU de outro
+       usuário). Antes daqui a página acreditava na query string, e as duas
+       consequências eram reais: `?vl=999999` mandava um Purchase de
+       R$ 999.999 para a NOSSA conta de anúncios — sem deduplicar com a CAPI,
+       porque o `eventID` carrega o `sid` que o forjador escolheu — e o
+       `inicio=` era um retrato tirado no checkout, que na migração
+       Stripe→Pix o `_stripe_cancel` já tinha adiado (a tela prometia a data
+       velha enquanto o acesso e o e-mail usavam a nova).
+
+       Falhou a busca (404, rede, corpo sem `amount_cents`)? Nada é inventado:
+       o Purchase vai sem `value`, que é o objeto de sempre, e o texto cai no
+       imediato. O `fbq` só dispara DEPOIS — algumas centenas de ms a mais é o
+       preço de mandar número verdadeiro. */
+    const ehPix = String(gw).toLowerCase() === "pix";
+    let cobranca = null;
+    if (ehPix && sid) {
+      try {
+        // O teto de 4 s é o que impede a busca de segurar a CELEBRAÇÃO: o modal
+        // só sobe depois daqui, e sem teto uma conexão pendurada deixava quem
+        // acabou de pagar olhando para a tela de sempre. Vencido, cai no
+        // `catch` e vira o caminho sem valor. `AbortSignal.timeout` é nativo
+        // (Safari 16+); em navegador mais velho ele lança e cai no mesmo lugar.
+        const r = await fetch("/billing/pix/" + encodeURIComponent(sid),
+                              { credentials: "same-origin",
+                                signal: AbortSignal.timeout(4000) });
+        if (r.ok) cobranca = await r.json();
+      } catch { /* sem valor é melhor que valor inventado */ }
+    }
+    const cents = cobranca && cobranca.amount_cents;
+    const valorPix = Number.isInteger(cents) && cents > 0 ? cents / 100 : null;
+    // `starts_at` vem ISO do servidor; `agendada` é quem separa imediato de
+    // agendado (na compra imediata a data também vem preenchida, com `agora`).
+    // O `wpInicioValido` fica: corpo malformado não vira promessa na tela.
+    const inicioPix = cobranca && cobranca.agendada && cobranca.starts_at
+      ? wpInicioValido(String(cobranca.starts_at).slice(0, 10)) : null;
+
     // Conversão pro Meta Ads — só dispara com `sid` (id real da sessão de
     // checkout que a Stripe injeta no success_url). Sem sid = alguém abriu a URL
     // na mão → não conta. `ev` diz se foi início de trial (StartTrial) ou compra
@@ -2209,20 +2249,13 @@ function wpInicioValido(s) {
       if (ev === "trial") {
         fbq("track", "StartTrial", { currency: "BRL" }, { eventID: "trial_" + sid });
       } else {
-        // Fronteira de confiança: `vl` é query string, qualquer um digita. Vira
-        // receita só o que o `Number` converte por INTEIRO — e não o
-        // `parseFloat`, que aceitava "99abc" e "99,00" lendo só o começo. Por
-        // inteiro inclui as notações do próprio JS: `0x63` também vira 99, e
-        // fica, porque o efeito de forjar `vl` é sujar o pixel de quem forjou —
-        // apertar isso custaria uma regex a mais sem nada em troca. Entre
-        // 0 e R$ 1.000.000 — o teto existe porque `&vl=9e99` mandava um
-        // `Purchase` de 9e+99 BRL para a conta de anúncios, e o plano mais caro
-        // custa R$ 499. O resto é ausência, e aí o objeto fica IGUAL ao de antes
-        // deste parâmetro existir (o Stripe não manda `vl`, e o valor dele
-        // continua vindo só da CAPI).
-        const valor = Number(vl);
-        const dados = Number.isFinite(valor) && valor > 0 && valor < 1e6
-          ? { currency: "BRL", value: valor }
+        // A receita vem do `amount_cents` da cobrança do PRÓPRIO dono, lido do
+        // servidor logo acima — não de query string. Não há valor a validar
+        // aqui: URL forjada não chega neste ponto, e sem cobrança lida o objeto
+        // fica IGUAL ao da Stripe (`{ currency: "BRL" }`), cujo valor continua
+        // vindo só da CAPI.
+        const dados = valorPix
+          ? { currency: "BRL", value: valorPix }
           : { currency: "BRL" };
         fbq("track", "Purchase", dados, { eventID: "purchase_" + sid });
       }
@@ -2257,10 +2290,10 @@ function wpInicioValido(s) {
           days: Number.isFinite(dias) && dias > 0 ? dias : 30,
           plano: pl || "plus",
           ia: Number.isFinite(cotaIA) && cotaIA > 0 ? cotaIA : null,
-          // `toLowerCase` porque `pl` já normaliza e este não normalizava:
-          // `?gw=PIX` caía no ramo da Stripe depois de uma compra Pix.
-          pix: String(gw).toLowerCase() === "pix",
-          inicio: wpInicioValido(inicio),
+          // `ehPix` normaliza como o `pl` já fazia: `?gw=PIX` caía no ramo da
+          // Stripe depois de uma compra Pix.
+          pix: ehPix,
+          inicio: inicioPix,
         });
       };
 

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -2224,18 +2224,27 @@ function wpInicioValido(s) {
         // O teto de 4 s é o que impede a busca de segurar a CELEBRAÇÃO: o modal
         // só sobe depois daqui, e sem teto uma conexão pendurada deixava quem
         // acabou de pagar olhando para a tela de sempre. Vencido, cai no
-        // `catch` e vira o caminho sem valor. `AbortSignal.timeout` é nativo
-        // (Safari 16+); em navegador mais velho ele lança e cai no mesmo lugar.
+        // `catch` e vira o caminho sem valor. NÃO use `AbortSignal.timeout`
+        // aqui: ele só existe no Safari/WKWebView 16.4+ e o alvo do app é iOS
+        // 14.0 (IPHONEOS_DEPLOYMENT_TARGET, mobile/ios/App/App.xcodeproj), onde
+        // a expressão lança ANTES de a requisição sair — o `catch` engoliria e
+        // TODA compra Pix perderia o valor do Pixel, e a agendada seria
+        // anunciada como "já começou". `AbortController` + `setTimeout` é o
+        // mesmo teto e roda desde o Safari 12.1 (é o idioma já usado no
+        // `loadAuthMe` e no `_boundedValidate`, acima).
         // MEDIDO: com o backend a 3 s (rede ruim DENTRO do teto), o modal sobe
         // em 3905 ms de tela parada para quem acabou de pagar — não empilha com
         // o overlay `_checkoutSettled` (as duas esperas correm em paralelo; pior
         // caso com as duas penduradas: 21 s, o mesmo de antes desta busca).
         // ponytail: sem tela de carregamento nesta rodada; se 4 s incomodar,
         // o caminho é baixar o teto, não inventar spinner.
-        const r = await fetch("/billing/pix/" + encodeURIComponent(sid),
-                              { credentials: "same-origin",
-                                signal: AbortSignal.timeout(4000) });
-        if (r.ok) cobranca = await r.json();
+        const ctrl = new AbortController();
+        const timer = setTimeout(() => ctrl.abort(), 4000);
+        try {
+          const r = await fetch("/billing/pix/" + encodeURIComponent(sid),
+                                { credentials: "same-origin", signal: ctrl.signal });
+          if (r.ok) cobranca = await r.json();
+        } finally { clearTimeout(timer); }
       } catch { /* sem valor é melhor que valor inventado */ }
     }
     /* Dono NÃO é pagamento. O poll responde 200 com `amount_cents` para

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -1922,7 +1922,10 @@ Object.assign(window, {
     <img class="wp-mark" style="--i:0" src="/brand/icon.png?v=2" alt="" aria-hidden="true"
          width="45" height="48" />
     <p class="wp-eyebrow" style="--i:1">
-      Assinatura confirmada
+      <!-- num <span> próprio porque o chip é irmão dele: `textContent` no <p>
+           levaria o chip junto. O Pix anual troca por "Pagamento confirmado" —
+           não há assinatura nenhuma ali (compra à vista, sem cartão). -->
+      <span id="wp-eyebrow-txt">Assinatura confirmada</span>
       <span class="wp-chip" id="wp-chip" hidden></span>
     </p>
     <h2 id="wp-title" style="--i:2">Tá dentro do PigBank+</h2>
@@ -2007,14 +2010,22 @@ const WP_PLANOS = {
   },
 };
 
-function openWelcomePro({ trial = true, days = 30, plano = "plus", ia = null } = {}) {
+function openWelcomePro({ trial = true, days = 30, plano = "plus", ia = null,
+                         pix = false, inicio = null } = {}) {
   const ov = document.getElementById("welcome-pro-overlay");
   if (!ov) return;
 
   // `plano` vem da URL, então nunca entra em HTML: só serve de chave do mapa, e
   // valor desconhecido cai no Plus, que era o texto único de antes.
   const cfg = WP_PLANOS[String(plano).toLowerCase()] || WP_PLANOS.plus;
-  document.getElementById("wp-title").textContent = `Tá dentro do ${cfg.nome}`;
+  // UMA decisão de ramo, lida pelo título e pelo corpo. Eram duas: o título
+  // olhava `pix && inicio` e o corpo a cadeia `trial → pix → else`, onde o
+  // trial ganha — com `?ev=trial&gw=pix&inicio=…` saía título do Pix com sub
+  // de trial.
+  const modo = trial ? "trial" : (pix ? "pix" : "cartao");
+  document.getElementById("wp-title").textContent = modo === "pix" && inicio
+    ? `Seu ${cfg.nome} tá garantido`
+    : `Tá dentro do ${cfg.nome}`;
   const ul = document.getElementById("wp-feats");
   ul.replaceChildren(...cfg.feats(ia).map((texto) => {
     const li = document.createElement("li");
@@ -2030,11 +2041,30 @@ function openWelcomePro({ trial = true, days = 30, plano = "plus", ia = null } =
   // lia "seus 30 dias grátis começam agora", que é falso pra essa pessoa.
   const chip = document.getElementById("wp-chip");
   const sub = document.getElementById("wp-sub");
-  if (trial) {
+  // O olho é setado em TODOS os ramos, como o título, o sub e o chip: só o Pix
+  // escrevia nele, e o modal é o mesmo elemento reusado — uma vez trocado por
+  // "Pagamento confirmado", nenhum outro ramo o devolvia para o texto do HTML.
+  const olho = document.getElementById("wp-eyebrow-txt");
+  if (modo === "trial") {
+    olho.textContent = "Assinatura confirmada";
     chip.textContent = `${days} dias grátis`;
     chip.hidden = false;
     sub.textContent = `Seus ${days} dias grátis começam agora. A primeira cobrança só vem depois disso, e dá pra cancelar quando quiser.`;
+  } else if (modo === "pix") {
+    olho.textContent = "Pagamento confirmado";
+    /* O Pix anual é compra À VISTA: não há assinatura para cancelar nem cartão
+       para renovar, e quem já tinha plano vigente comprou um ano AGENDADO para
+       o fim dele. `inicio` chega da URL e já veio validado como AAAA-MM-DD;
+       aqui ele só vira DD/MM/AAAA, por textContent. */
+    chip.hidden = true;
+    const quando = inicio
+      ? `começa em ${inicio.split("-").reverse().join("/")}, assim que o plano atual terminar`
+      : "já começou";
+    sub.textContent = `Pagamento confirmado! Seu ano de ${cfg.nome} ${quando}.`
+      + " Foi pago à vista: sem cartão e sem renovação automática — a gente te"
+      + " avisa por e-mail antes de acabar.";
   } else {
+    olho.textContent = "Assinatura confirmada";
     chip.hidden = true;
     sub.textContent = "Sua assinatura já está ativa. Dá pra cancelar quando quiser, direto nas configurações.";
   }
@@ -2118,6 +2148,31 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   if (e.target === e.currentTarget) dismissWelcomePro();
 });
 
+/* Fronteira de confiança: `inicio` é query string, qualquer um digita, e o que
+   sair daqui vira a promessa "seu ano começa em <data>" na tela.
+
+   A regex sozinha barra markup e formato, e o `Date.parse` NÃO completa o
+   serviço: ele normaliza em vez de recusar, então "2027-02-30" virava
+   "30/02/2027" e "2027-11-31" virava "31/11/2027" — datas que não existem,
+   escritas na tela com cara de compromisso nosso. Quem valida de verdade é a
+   ida e volta: reconstrói e exige que os três campos voltem iguais.
+
+   O ano tem uma janela FIXA (2020–2100), e fixa de propósito: uma faixa
+   relativa ao relógio (`anoAtual + 2`) recusava a renovação legítima —
+   `plano_da_cobranca` empilha ano sobre ano sem teto, a 4ª compra Pix seguida
+   já começa em `anoAtual + 3` — e ainda dependia do relógio do aparelho, que
+   num celular com bateria zerada volta para 1970 e reprovaria QUALQUER data.
+   Ela só existe para `9999-12-31`, que passa na ida e volta acima e não é
+   compra, é URL forjada. O que não passa vira null, que é o texto do
+   imediato. */
+function wpInicioValido(s) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s || "")) return null;
+  const [a, m, d] = s.split("-").map(Number);
+  const dt = new Date(a, m - 1, d);
+  const bate = dt.getFullYear() === a && dt.getMonth() === m - 1 && dt.getDate() === d;
+  return bate && a >= 2020 && a <= 2100 ? s : null;
+}
+
 (function handleUpgradeReturn() {
   const params = new URLSearchParams(window.location.search);
   const status = params.get("upgrade");
@@ -2126,6 +2181,9 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   const td = params.get("td");    // dias de trial concedidos (0 quando ev=purchase)
   const pl = params.get("pl");    // plano escolhido: essencial | plus | pro
   const ia = params.get("ia");    // cota mensal de mensagens da Piggy nesse plano
+  const gw = params.get("gw");    // "pix" quando veio do Pix anual (pix-poll.js)
+  const inicio = params.get("inicio");  // AAAA-MM-DD do começo do ano comprado
+  const vl = params.get("vl");    // valor cobrado em reais (só o Pix manda)
   if (!status) return;
 
   // Limpa os query params da URL pra nao reaparecer em refresh.
@@ -2136,6 +2194,9 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
   cleanUrl.searchParams.delete("td");
   cleanUrl.searchParams.delete("pl");
   cleanUrl.searchParams.delete("ia");
+  cleanUrl.searchParams.delete("gw");
+  cleanUrl.searchParams.delete("inicio");
+  cleanUrl.searchParams.delete("vl");
   window.history.replaceState({}, "", cleanUrl.toString());
 
   if (status === "success") {
@@ -2148,7 +2209,22 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
       if (ev === "trial") {
         fbq("track", "StartTrial", { currency: "BRL" }, { eventID: "trial_" + sid });
       } else {
-        fbq("track", "Purchase", { currency: "BRL" }, { eventID: "purchase_" + sid });
+        // Fronteira de confiança: `vl` é query string, qualquer um digita. Vira
+        // receita só o que o `Number` converte por INTEIRO — e não o
+        // `parseFloat`, que aceitava "99abc" e "99,00" lendo só o começo. Por
+        // inteiro inclui as notações do próprio JS: `0x63` também vira 99, e
+        // fica, porque o efeito de forjar `vl` é sujar o pixel de quem forjou —
+        // apertar isso custaria uma regex a mais sem nada em troca. Entre
+        // 0 e R$ 1.000.000 — o teto existe porque `&vl=9e99` mandava um
+        // `Purchase` de 9e+99 BRL para a conta de anúncios, e o plano mais caro
+        // custa R$ 499. O resto é ausência, e aí o objeto fica IGUAL ao de antes
+        // deste parâmetro existir (o Stripe não manda `vl`, e o valor dele
+        // continua vindo só da CAPI).
+        const valor = Number(vl);
+        const dados = Number.isFinite(valor) && valor > 0 && valor < 1e6
+          ? { currency: "BRL", value: valor }
+          : { currency: "BRL" };
+        fbq("track", "Purchase", dados, { eventID: "purchase_" + sid });
       }
     }
     // GA4: só o `start_trial`, e de propósito. O `purchase` sai do SERVIDOR
@@ -2181,6 +2257,10 @@ document.getElementById("welcome-pro-overlay")?.addEventListener("click", (e) =>
           days: Number.isFinite(dias) && dias > 0 ? dias : 30,
           plano: pl || "plus",
           ia: Number.isFinite(cotaIA) && cotaIA > 0 ? cotaIA : null,
+          // `toLowerCase` porque `pl` já normaliza e este não normalizava:
+          // `?gw=PIX` caía no ramo da Stripe depois de uma compra Pix.
+          pix: String(gw).toLowerCase() === "pix",
+          inicio: wpInicioValido(inicio),
         });
       };
 

--- a/frontend/pix-poll.js
+++ b/frontend/pix-poll.js
@@ -47,7 +47,10 @@ function pixModalQr(d, plano, ctx) {
   if (credito && d.credit_cents > 0) {
     vivo.appendChild(pixLinha("Já com " + credito + " de crédito do seu plano atual."));
   }
-  vivo.appendChild(pixLinha(d.starts_at
+  // Mesma regra da l.88: quem separa agendado de imediato é `agendada`, não a
+  // presença de `starts_at` — que na compra imediata vem com `agora` e fazia
+  // esta linha dizer "Seu ano começa em <hoje>" a quem começa ao pagar.
+  vivo.appendChild(pixLinha(d.agendada && d.starts_at
     ? "Seu ano começa em " + fmtBrDate(String(d.starts_at).slice(0, 10)) + "."
     : "Seu ano começa agora, assim que o pagamento cair."));
 
@@ -83,6 +86,19 @@ function pixModalQr(d, plano, ctx) {
   pixPoll = {
     token: d.public_token, plano, vivo, img, code, status, fechar,
     inicio: Date.now(), falhas: 0, timer: null,
+    // A data que a linha acima acabou de mostrar, para a /home repetir a MESMA
+    // promessa no modal de sucesso. Quem gatilha é `agendada`, NUNCA a presença
+    // da data: `starts_at` vem preenchido nos dois casos (na compra imediata,
+    // com `agora`), então gatilhar por ele fazia quem comprou sem ter plano
+    // nenhum ler "começa em <hoje>, assim que o plano atual terminar".
+    comeca: d.agendada && d.starts_at ? String(d.starts_at).slice(0, 10) : null,
+    // O valor COBRADO (o mesmo que a l.34 mostrou no título), para o Purchase do
+    // pixel na /home sair com receita. Sai do checkout e não de tabela de preço:
+    // no upgrade Pix→Pix o cobrado é menor que o de tabela (crédito
+    // proporcional). Formato de máquina, com ponto: quem lê é a Meta, não gente.
+    // Sem inteiro > 0 fica null e o param nem é escrito — mesma regra do `comeca`.
+    vl: Number.isInteger(d.amount_cents) && d.amount_cents > 0
+      ? (d.amount_cents / 100).toFixed(2) : null,
     // `Date.parse(undefined)` é NaN, e NaN é falsy: sem `expires_at` legível
     // sobra o teto do cliente. COM ele, quem manda é o servidor.
     deadline: Date.parse(d.expires_at) || Date.now() + PIX_TETO_MS,
@@ -207,7 +223,7 @@ async function pixBater() {
 }
 
 function pixPago() {
-  const { token, plano, status } = pixPoll;
+  const { token, plano, status, comeca, vl } = pixPoll;
   clearTimeout(pixPoll.timer);
   document.removeEventListener("visibilitychange", pixVisivel);
   pixRotular(status, "ph-check-circle", "Pagamento confirmado! Liberando seu acesso…");
@@ -215,8 +231,15 @@ function pixPago() {
   pixApagarQr();
   // `sid` = public_token (§13.6): vira o eventID do pixel da Meta e o
   // transaction_id do GA4 na /home. Sem `ia=` — a home.html trata a ausência.
+  // `gw=pix` e `inicio=` mudam a CÓPIA da /home: sem eles ela diz "sua
+  // assinatura já está ativa, dá pra cancelar quando quiser" — e o Pix anual não
+  // é assinatura, não tem cartão e pode começar só no fim do plano vigente.
+  // `vl=` leva a RECEITA para o Purchase do pixel: sem ele a venda chega sem
+  // valor quando o evento do servidor (CAPI) falha e só o do navegador sobra.
   window.location.href = "/home?upgrade=success&sid=" + encodeURIComponent(token)
-    + "&ev=purchase&td=0&pl=" + encodeURIComponent(plano);
+    + "&ev=purchase&td=0&pl=" + encodeURIComponent(plano) + "&gw=pix"
+    + (comeca ? "&inicio=" + encodeURIComponent(comeca) : "")
+    + (vl ? "&vl=" + vl : "");
 }
 
 /**

--- a/frontend/pix-poll.js
+++ b/frontend/pix-poll.js
@@ -86,19 +86,11 @@ function pixModalQr(d, plano, ctx) {
   pixPoll = {
     token: d.public_token, plano, vivo, img, code, status, fechar,
     inicio: Date.now(), falhas: 0, timer: null,
-    // A data que a linha acima acabou de mostrar, para a /home repetir a MESMA
-    // promessa no modal de sucesso. Quem gatilha é `agendada`, NUNCA a presença
-    // da data: `starts_at` vem preenchido nos dois casos (na compra imediata,
-    // com `agora`), então gatilhar por ele fazia quem comprou sem ter plano
-    // nenhum ler "começa em <hoje>, assim que o plano atual terminar".
-    comeca: d.agendada && d.starts_at ? String(d.starts_at).slice(0, 10) : null,
-    // O valor COBRADO (o mesmo que a l.34 mostrou no título), para o Purchase do
-    // pixel na /home sair com receita. Sai do checkout e não de tabela de preço:
-    // no upgrade Pix→Pix o cobrado é menor que o de tabela (crédito
-    // proporcional). Formato de máquina, com ponto: quem lê é a Meta, não gente.
-    // Sem inteiro > 0 fica null e o param nem é escrito — mesma regra do `comeca`.
-    vl: Number.isInteger(d.amount_cents) && d.amount_cents > 0
-      ? (d.amount_cents / 100).toFixed(2) : null,
+    // Nem a data nem o valor viajam daqui para a /home: ela busca os dois no
+    // `GET /billing/pix/<token>`, que é autenticado e filtra por dono. Este
+    // objeto é um retrato tirado no checkout, e o retrato ENVELHECE — na
+    // migração Stripe→Pix o `_stripe_cancel` adia o começo do acesso depois
+    // que o QR já está na tela.
     // `Date.parse(undefined)` é NaN, e NaN é falsy: sem `expires_at` legível
     // sobra o teto do cliente. COM ele, quem manda é o servidor.
     deadline: Date.parse(d.expires_at) || Date.now() + PIX_TETO_MS,
@@ -223,7 +215,7 @@ async function pixBater() {
 }
 
 function pixPago() {
-  const { token, plano, status, comeca, vl } = pixPoll;
+  const { token, plano, status } = pixPoll;
   clearTimeout(pixPoll.timer);
   document.removeEventListener("visibilitychange", pixVisivel);
   pixRotular(status, "ph-check-circle", "Pagamento confirmado! Liberando seu acesso…");
@@ -231,15 +223,12 @@ function pixPago() {
   pixApagarQr();
   // `sid` = public_token (§13.6): vira o eventID do pixel da Meta e o
   // transaction_id do GA4 na /home. Sem `ia=` — a home.html trata a ausência.
-  // `gw=pix` e `inicio=` mudam a CÓPIA da /home: sem eles ela diz "sua
-  // assinatura já está ativa, dá pra cancelar quando quiser" — e o Pix anual não
-  // é assinatura, não tem cartão e pode começar só no fim do plano vigente.
-  // `vl=` leva a RECEITA para o Purchase do pixel: sem ele a venda chega sem
-  // valor quando o evento do servidor (CAPI) falha e só o do navegador sobra.
+  // `gw=pix` é só o MARCADOR de gateway: ele manda a /home buscar a cobrança em
+  // `/billing/pix/<sid>` e tirar de lá o valor e a data. Dinheiro não viaja na
+  // query string — `vl=` e `inicio=` saíram daqui porque qualquer um os digita,
+  // e o `vl` forjado virava receita inventada na NOSSA conta de anúncios.
   window.location.href = "/home?upgrade=success&sid=" + encodeURIComponent(token)
-    + "&ev=purchase&td=0&pl=" + encodeURIComponent(plano) + "&gw=pix"
-    + (comeca ? "&inicio=" + encodeURIComponent(comeca) : "")
-    + (vl ? "&vl=" + vl : "");
+    + "&ev=purchase&td=0&pl=" + encodeURIComponent(plano) + "&gw=pix";
 }
 
 /**

--- a/frontend/routes/billing_pix.py
+++ b/frontend/routes/billing_pix.py
@@ -143,6 +143,7 @@ async def billing_pix_status(request: Request, public_token: str):
     compartilham IP, e `shared.limiter` chaveia por endereço remoto, não por
     usuário. Estourar aqui apagaria o QR da tela de quem só esperou.
     """
+    from core.services.pix_checkout_resposta import agendada  # noqa: PLC0415
     from db.pix_charges import buscar_por_public_token  # noqa: PLC0415
 
     user_id = shared.resolve_dashboard_user_id(request)
@@ -158,6 +159,11 @@ async def billing_pix_status(request: Request, public_token: str):
                        if linha["qr_expires_at"] else None),
         "starts_at": (linha["access_starts_at"].isoformat()
                       if linha["access_starts_at"] else None),
+        # A /home lê ESTA resposta (e não mais a query string) para dizer se o
+        # ano começa agora ou no fim do plano vigente: `starts_at` sozinho não
+        # separa os dois casos — na compra imediata ele também vem preenchido,
+        # com `agora`. Mesma função do contrato do checkout (§0.7).
+        "agendada": agendada(linha["access_starts_at"]),
         "expires_access_at": (linha["access_expires_at"].isoformat()
                               if linha["access_expires_at"] else None),
     }

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -476,9 +476,93 @@ test("PT6: pago -> /home?upgrade=success com sid = public_token", async () => {
   assert.equal(url.searchParams.get("ia"), null, `sobrou ia= na URL: ${page.url()}`);
   assert.ok(!page.url().includes("pay_"), `o id do provedor vazou: ${page.url()}`);
   assert.ok(!page.url().includes("9999"), `o id do provedor vazou: ${page.url()}`);
+  // `gw=pix` sempre; `inicio=` só quando o checkout disse `agendada: true`, e
+  // este corpo não diz. Sem o par, a /home inventaria "seu ano começa em
+  // <hoje>" pra quem começou agora.
+  assert.equal(url.searchParams.get("gw"), "pix");
+  assert.equal(url.searchParams.get("inicio"), null,
+    `inventou inicio sem starts_at: ${page.url()}`);
+  // `vl` = os 19900 centavos deste corpo, em reais e com ponto (ver PT6c).
+  assert.equal(url.searchParams.get("vl"), "199.00", `vl errado: ${page.url()}`);
   assert.deepEqual(corposPix[0],
     { plan: "plus", interval: "annual", cpf_cnpj: CPF });
   await page.close();
+});
+
+// ── PT6b: quem separa agendado de imediato é `agendada`, não a data ──────────
+/**
+ * Os DOIS casos no mesmo teste, de propósito: eles só provam alguma coisa
+ * juntos. `access_starts_at` é preenchido nas duas compras — na imediata, com
+ * `agora` —, então "tem `starts_at`" NÃO quer dizer "começa depois". Gatilhar
+ * pela presença da data mandava `&inicio=<hoje>` na compra imediata, e a /home
+ * dizia "começa em 10/09/2026, assim que o plano atual terminar" para quem
+ * tinha acesso naquele segundo e nunca teve plano nenhum.
+ *
+ * E a fonte é o CHECKOUT, não o poll: o `starts_at` de 2026 que o poll devolve
+ * abaixo é o do PAGAMENTO — se ele fosse a fonte, a data agendada sairia 2026.
+ *
+ * Controle negativo: troque o `d.agendada && d.starts_at` do pix-poll.js de
+ * volta por `d.starts_at` e o caso IMEDIATO fica vermelho; apague o `agendada`
+ * da `resposta()` do backend (ou o `&inicio=`) e o AGENDADO fica.
+ */
+test("PT6b: agendada=true manda inicio; agendada=false com starts_at, não", async () => {
+  const base = { public_token: "tok_abc123", qr_payload: PAYLOAD, qr_image: QR_IMG,
+                 amount_cents: 19900, credit_cents: 0, plan: "plus" };
+  const pago = { status: (n) => (n >= 2
+    ? { status: "paid", starts_at: "2026-01-02T12:00:00+00:00" }
+    : { status: "pending" }) };
+
+  const ag = await abrirQr({ ...pago, pix: { corpo: {
+    ...base, agendada: true, starts_at: "2027-08-26T03:00:00+00:00" } } });
+  // A MESMA promessa já na tela do QR, antes de pagar.
+  assert.match(await ag.page.textContent(".pix-box"), /começa em 26\/08\/2027/,
+    "a tela do QR não repetiu a data do agendamento");
+  await ag.page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  const url = new URL(ag.page.url());
+  assert.equal(url.searchParams.get("gw"), "pix");
+  assert.equal(url.searchParams.get("inicio"), "2027-08-26", `URL: ${ag.page.url()}`);
+  await ag.page.close();
+
+  // Compra IMEDIATA: o backend preenche `access_starts_at` com `agora` e diz
+  // `agendada: false`. Nem a tela do QR nem a URL podem falar em data.
+  const hoje = new Date().toISOString();
+  const im = await abrirQr({ ...pago, pix: { corpo: {
+    ...base, agendada: false, starts_at: hoje } } });
+  assert.match(await im.page.textContent(".pix-box"), /começa agora/,
+    "a tela do QR datou uma compra imediata");
+  await im.page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  assert.equal(new URL(im.page.url()).searchParams.get("inicio"), null,
+    `mandou inicio numa compra imediata: ${im.page.url()}`);
+  await im.page.close();
+});
+
+// ── PT6c: o valor COBRADO viaja na URL, para o Purchase do pixel ─────────────
+/**
+ * `vl=` é o `amount_cents` do CHECKOUT em reais, com ponto (formato de máquina:
+ * quem lê é a Meta). Sai daí e não de tabela de preço porque no upgrade Pix→Pix
+ * o cobrado é menor que o de tabela (crédito proporcional). Os dois valores
+ * diferentes — 199,00 no PT6 e 99,00 aqui — são o que separa derivar de chutar.
+ * Sem `amount_cents` inteiro > 0 o param não é escrito, e a /home cai no objeto
+ * de hoje, `{ currency: "BRL" }`.
+ *
+ * Controle negativo: tire o `+ (vl ? "&vl=" + vl : "")` do `pixPago` e PT6, PT6c
+ * e o caso do zero ficam vermelhos.
+ */
+test("PT6c: amount_cents vira vl em reais, e some quando não dá número", async () => {
+  const base = { public_token: "tok_abc123", qr_payload: PAYLOAD, qr_image: QR_IMG,
+                 credit_cents: 0, starts_at: null, plan: "essencial" };
+  const pago = { status: (n) => (n >= 2 ? { status: "paid" } : { status: "pending" }) };
+
+  const a = await abrirQr({ ...pago, pix: { corpo: { ...base, amount_cents: 9900 } } });
+  await a.page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  assert.equal(new URL(a.page.url()).searchParams.get("vl"), "99.00", `URL: ${a.page.url()}`);
+  await a.page.close();
+
+  const b = await abrirQr({ ...pago, pix: { corpo: { ...base, amount_cents: 0 } } });
+  await b.page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  assert.equal(new URL(b.page.url()).searchParams.get("vl"), null,
+    `escreveu vl com amount_cents 0: ${b.page.url()}`);
+  await b.page.close();
 });
 
 // ── PT8: "Copiar código Pix" não pode mentir ────────────────────────────────

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -476,14 +476,9 @@ test("PT6: pago -> /home?upgrade=success com sid = public_token", async () => {
   assert.equal(url.searchParams.get("ia"), null, `sobrou ia= na URL: ${page.url()}`);
   assert.ok(!page.url().includes("pay_"), `o id do provedor vazou: ${page.url()}`);
   assert.ok(!page.url().includes("9999"), `o id do provedor vazou: ${page.url()}`);
-  // `gw=pix` sempre; `inicio=` só quando o checkout disse `agendada: true`, e
-  // este corpo não diz. Sem o par, a /home inventaria "seu ano começa em
-  // <hoje>" pra quem começou agora.
+  // `gw=pix` é o MARCADOR de gateway e viaja sempre; dinheiro e data NÃO
+  // viajam (ver PT6c): a /home busca os dois em `/billing/pix/<sid>`.
   assert.equal(url.searchParams.get("gw"), "pix");
-  assert.equal(url.searchParams.get("inicio"), null,
-    `inventou inicio sem starts_at: ${page.url()}`);
-  // `vl` = os 19900 centavos deste corpo, em reais e com ponto (ver PT6c).
-  assert.equal(url.searchParams.get("vl"), "199.00", `vl errado: ${page.url()}`);
   assert.deepEqual(corposPix[0],
     { plan: "plus", interval: "annual", cpf_cnpj: CPF });
   await page.close();
@@ -494,18 +489,20 @@ test("PT6: pago -> /home?upgrade=success com sid = public_token", async () => {
  * Os DOIS casos no mesmo teste, de propósito: eles só provam alguma coisa
  * juntos. `access_starts_at` é preenchido nas duas compras — na imediata, com
  * `agora` —, então "tem `starts_at`" NÃO quer dizer "começa depois". Gatilhar
- * pela presença da data mandava `&inicio=<hoje>` na compra imediata, e a /home
- * dizia "começa em 10/09/2026, assim que o plano atual terminar" para quem
- * tinha acesso naquele segundo e nunca teve plano nenhum.
+ * pela presença da data fazia a TELA DO QR dizer "seu ano começa em 10/09/2026"
+ * para quem começa ao pagar.
  *
- * E a fonte é o CHECKOUT, não o poll: o `starts_at` de 2026 que o poll devolve
- * abaixo é o do PAGAMENTO — se ele fosse a fonte, a data agendada sairia 2026.
+ * Aqui se mede só a tela do QR: é o único lugar onde a resposta do CHECKOUT é
+ * fonte legítima da data (é a promessa de antes de pagar). A promessa DEPOIS de
+ * pagar é da /home, que busca a cobrança no servidor — por isso a URL de
+ * sucesso não leva `inicio` em nenhum dos dois casos, e os dois casos verificam
+ * isso.
  *
  * Controle negativo: troque o `d.agendada && d.starts_at` do pix-poll.js de
  * volta por `d.starts_at` e o caso IMEDIATO fica vermelho; apague o `agendada`
- * da `resposta()` do backend (ou o `&inicio=`) e o AGENDADO fica.
+ * da `resposta()` do backend e o AGENDADO fica.
  */
-test("PT6b: agendada=true manda inicio; agendada=false com starts_at, não", async () => {
+test("PT6b: agendada=true data na tela do QR; agendada=false com starts_at, não", async () => {
   const base = { public_token: "tok_abc123", qr_payload: PAYLOAD, qr_image: QR_IMG,
                  amount_cents: 19900, credit_cents: 0, plan: "plus" };
   const pago = { status: (n) => (n >= 2
@@ -520,7 +517,8 @@ test("PT6b: agendada=true manda inicio; agendada=false com starts_at, não", asy
   await ag.page.waitForURL(/upgrade=success/, { timeout: 15000 });
   const url = new URL(ag.page.url());
   assert.equal(url.searchParams.get("gw"), "pix");
-  assert.equal(url.searchParams.get("inicio"), "2027-08-26", `URL: ${ag.page.url()}`);
+  assert.equal(url.searchParams.get("inicio"), null,
+    `a data do checkout viajou na URL: ${ag.page.url()}`);
   await ag.page.close();
 
   // Compra IMEDIATA: o backend preenche `access_starts_at` com `agora` e diz
@@ -536,33 +534,34 @@ test("PT6b: agendada=true manda inicio; agendada=false com starts_at, não", asy
   await im.page.close();
 });
 
-// ── PT6c: o valor COBRADO viaja na URL, para o Purchase do pixel ─────────────
+// ── PT6c: a URL de sucesso não carrega dinheiro nem data ────────────────────
 /**
- * `vl=` é o `amount_cents` do CHECKOUT em reais, com ponto (formato de máquina:
- * quem lê é a Meta). Sai daí e não de tabela de preço porque no upgrade Pix→Pix
- * o cobrado é menor que o de tabela (crédito proporcional). Os dois valores
- * diferentes — 199,00 no PT6 e 99,00 aqui — são o que separa derivar de chutar.
- * Sem `amount_cents` inteiro > 0 o param não é escrito, e a /home cai no objeto
- * de hoje, `{ currency: "BRL" }`.
+ * Ela carregava: `vl=` (o valor cobrado) e `inicio=` (a data do começo). Os dois
+ * eram retrato tirado no checkout e query string editável — `?vl=999999` num
+ * link forjado virava um Purchase de R$ 999.999 na NOSSA conta de anúncios, sem
+ * deduplicar com a CAPI, e a data envelhecia quando o `_stripe_cancel` adiava o
+ * acesso depois de o QR já estar na tela. Agora a /home busca a cobrança em
+ * `/billing/pix/<sid>`, e a URL só leva IDENTIFICADORES.
  *
- * Controle negativo: tire o `+ (vl ? "&vl=" + vl : "")` do `pixPago` e PT6, PT6c
- * e o caso do zero ficam vermelhos.
+ * O corpo do checkout aqui traz valor E data agendada de propósito: é o caso em
+ * que o código antigo escrevia os dois. Enumera a lista inteira de params em vez
+ * de checar dois nomes — param novo de dinheiro entra vermelho.
+ *
+ * Controle negativo: reponha `+ (vl ? "&vl=" + vl : "")` (ou o `&inicio=`) no
+ * `pixPago` do pix-poll.js e este caso fica vermelho.
  */
-test("PT6c: amount_cents vira vl em reais, e some quando não dá número", async () => {
-  const base = { public_token: "tok_abc123", qr_payload: PAYLOAD, qr_image: QR_IMG,
-                 credit_cents: 0, starts_at: null, plan: "essencial" };
-  const pago = { status: (n) => (n >= 2 ? { status: "paid" } : { status: "pending" }) };
-
-  const a = await abrirQr({ ...pago, pix: { corpo: { ...base, amount_cents: 9900 } } });
-  await a.page.waitForURL(/upgrade=success/, { timeout: 15000 });
-  assert.equal(new URL(a.page.url()).searchParams.get("vl"), "99.00", `URL: ${a.page.url()}`);
-  await a.page.close();
-
-  const b = await abrirQr({ ...pago, pix: { corpo: { ...base, amount_cents: 0 } } });
-  await b.page.waitForURL(/upgrade=success/, { timeout: 15000 });
-  assert.equal(new URL(b.page.url()).searchParams.get("vl"), null,
-    `escreveu vl com amount_cents 0: ${b.page.url()}`);
-  await b.page.close();
+test("PT6c: a URL de sucesso leva só identificadores, sem vl e sem inicio", async () => {
+  const { page } = await abrirQr({
+    status: (n) => (n >= 2 ? { status: "paid" } : { status: "pending" }),
+    pix: { corpo: { public_token: "tok_abc123", qr_payload: PAYLOAD, qr_image: QR_IMG,
+                    amount_cents: 9900, credit_cents: 0, plan: "essencial",
+                    agendada: true, starts_at: "2027-08-26T03:00:00+00:00" } },
+  });
+  await page.waitForURL(/upgrade=success/, { timeout: 15000 });
+  const params = [...new URL(page.url()).searchParams.keys()].sort();
+  assert.deepEqual(params, ["ev", "gw", "pl", "sid", "td", "upgrade"],
+    `params da URL de sucesso: ${page.url()}`);
+  await page.close();
 });
 
 // ── PT8: "Copiar código Pix" não pode mentir ────────────────────────────────

--- a/tests/frontend/welcome_pro_pix.test.mjs
+++ b/tests/frontend/welcome_pro_pix.test.mjs
@@ -17,15 +17,20 @@
  *
  * Os controles do CLAUDE.md §3, MEDIDOS (rodados, não deduzidos):
  *   · negativo da CÓPIA — troque no `openWelcomePro` o ramo do Pix pelo `else`
- *     da Stripe (`} else if (false && modo === "pix") {`) e ficam vermelhos 13
- *     de 24, por nome: WP1, WP2, os SETE casos do WP4, WP4b, WP8, WP10 e WP13.
- *     **WP5 e WP9 continuam VERDES** — eles só medem `searchParams.delete`,
- *     que a mutação não toca;
+ *     da Stripe (`} else if (false && modo === "pix") {`) e ficam vermelhos 20
+ *     de 33 (remedido depois do WP15/WP16/WP17; era 13 de 24), por nome: WP1,
+ *     WP2, os SETE casos do WP4, WP4b, WP8, WP10, WP13, WP14, os QUATRO do WP15
+ *     e os dois do WP16. **WP5 e WP9 continuam VERDES** — eles só medem
+ *     `searchParams.delete`, que a mutação não toca;
+ *   · negativo do STATUS — `const pago = !!cobranca;` (sem o
+ *     `&& cobranca.status === "paid"`) e ficam vermelhos os QUATRO casos do
+ *     WP15; `WP15 paid` e os outros 28 seguem verdes;
  *   · negativo da FONTE — volte a ler `vl` e `inicio` da URL no `home.html`
  *     (`cents` do `params.get("vl")`, `inicioPix` do `wpInicioValido(inicio)`)
- *     e ficam vermelhos 5: WP1, WP4b, WP6, WP8 e WP13;
+ *     e ficam vermelhos 5: WP1, WP4b, WP6, WP8 e WP13 — número MEDIDO antes de
+ *     WP15/WP16/WP17 existirem, remeça antes de reusar;
  *   · positivo — WP3 e WP7 são o caminho da Stripe SEM `gw`, VERDES nas duas
- *     mutações: cópia igual à de hoje, objeto do pixel sem `value`, e ZERO
+ *     mutações acima: cópia igual à de hoje, objeto do pixel sem `value`, e ZERO
  *     requisição a `/billing/pix/`.
  *
  * O que este arquivo NÃO alcança: a compra de verdade e o e-mail. O e-mail é
@@ -385,5 +390,81 @@ test("WP14: busca pendurada — o modal sobe assim mesmo, sem valor inventado", 
   assert.match(t.sub, /já começou/, `sub: ${t.sub}`);
   assert.ok(decorrido < 12000, `o modal levou ${decorrido}ms para subir`);
   assert.deepEqual(erros, [], `pageerror no timeout: ${erros.join(" | ")}`);
+  await page.close();
+});
+
+/* ── WP15: cobrança NÃO PAGA não vira receita ────────────────────────────────
+ * O buraco que a busca abriu, e que só a validação de DONO não fechava: o poll
+ * responde 200 com `amount_cents` para `pending`, `expired`, `canceled` e
+ * `refunded`. O próprio dono, com o QR na tela e sem ter pago, abrindo
+ * `/home?upgrade=success&sid=<token>&ev=purchase&gw=pix`, mandava um Purchase
+ * de R$ 499 — crível, sem venda e SEM par na CAPI (o evento do servidor só sai
+ * no pagamento), logo sem deduplicar com nada. Repetível: cada ciclo expirado
+ * gera um `public_token` novo, logo um `eventID` novo.
+ *
+ * Controle negativo MEDIDO: tire o `&& cobranca.status === "paid"` do `pago`
+ * (`const pago = !!cobranca;`) e os quatro casos não-pagos ficam VERMELHOS.
+ * Controle positivo: `WP15 paid`, no mesmo grupo — sem ele, um `pago = false`
+ * fixo passaria nos quatro (e mandaria toda venda de verdade sem receita).
+ */
+for (const status of ["pending", "expired", "canceled", "refunded"]) {
+  test(`WP15: status=${status} manda só currency, sem value`, async () => {
+    const { page, erros } = await abrirHome(`${BASE}&pl=pro&gw=pix`,
+      { ...AGENDADA, status });
+    const [, , dados] = await purchase(page);
+    const t = await textos(page);
+    assert.deepEqual(Object.keys(dados), ["currency"],
+      `Purchase com valor numa cobrança ${status}: ${JSON.stringify(dados)}`);
+    // A data também é promessa, e promessa é de quem pagou: o texto cai no
+    // imediato, exatamente como no 404 (WP8).
+    assert.match(t.sub, /já começou/, `cobrança ${status} prometeu data: ${t.sub}`);
+    assert.deepEqual(erros, [], `pageerror com status=${status}: ${erros.join(" | ")}`);
+    await page.close();
+  });
+}
+
+test("WP15 paid: a mesma cobrança, paga, manda os 49900 centavos", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`,
+    { ...AGENDADA, status: "paid" });
+  const [, , dados] = await purchase(page);
+  assert.equal(dados.value, 499, `value: ${JSON.stringify(dados)}`);
+  await page.close();
+});
+
+/* ── WP16: `agendada` fora do booleano não vira promessa de data ─────────────
+ * Par do WP8b, que já blinda `amount_cents` contra lixo: `agendada: 1` e
+ * `agendada: "false"` são verdadeiros em JS e renderizavam "começa em <data>".
+ * Hoje a fonte é o nosso servidor — o caso é TEÓRICO —, mas é a mesma
+ * justificativa que manteve o `wpInicioValido` vivo (corpo malformado não pode
+ * virar compromisso escrito), e ela não pode valer pela metade.
+ *
+ * Controle negativo: troque `cobranca.agendada === true` por `cobranca.agendada`
+ * e o caso da STRING fica vermelho (`1` também). Positivo: WP1, que é
+ * `agendada: true` de verdade e mostra a data.
+ */
+for (const agendada of [1, "false"]) {
+  test(`WP16: agendada=${JSON.stringify(agendada)} cai no texto do imediato`, async () => {
+    const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`,
+      { ...AGENDADA, agendada });
+    const t = await textos(page);
+    assert.match(t.sub, /já começou/, `agendada não-booleano virou data: ${t.sub}`);
+    await page.close();
+  });
+}
+
+/* ── WP17: `amount_cents` absurdo não vira receita ───────────────────────────
+ * O teto de R$ 1.000.000 existia quando o valor vinha da URL e sobreviveu à
+ * troca de fonte: `999999999999` centavos viravam `value: 9999999999.99` num
+ * Purchase da NOSSA conta. A coluna é nossa, mas o plano mais caro custa
+ * R$ 499 — acima do teto é dado corrompido, não venda.
+ *
+ * Controle negativo: tire o `&& cents < 1e8` e este caso fica vermelho (WP6 e
+ * `WP15 paid`, com 49900, seguem verdes).
+ */
+test("WP17: amount_cents=999999999999 cai no caso sem valor", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`,
+    { ...AGENDADA, amount_cents: 999999999999 });
+  const [, , dados] = await purchase(page);
+  assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
   await page.close();
 });

--- a/tests/frontend/welcome_pro_pix.test.mjs
+++ b/tests/frontend/welcome_pro_pix.test.mjs
@@ -15,7 +15,8 @@
  *     Hoje os dois saem de `GET /billing/pix/<sid>`, que é autenticado e filtra
  *     por dono (404 para token de outro usuário).
  *
- * Os controles do CLAUDE.md §3, MEDIDOS (rodados, não deduzidos):
+ * Os controles do CLAUDE.md §3, MEDIDOS (rodados, não deduzidos) — as três
+ * contagens abaixo são ANTERIORES ao WP18, remeça antes de reusar:
  *   · negativo da CÓPIA — troque no `openWelcomePro` o ramo do Pix pelo `else`
  *     da Stripe (`} else if (false && modo === "pix") {`) e ficam vermelhos 20
  *     de 33 (remedido depois do WP15/WP16/WP17; era 13 de 24), por nome: WP1,
@@ -66,11 +67,18 @@ after(async () => { await browser?.close(); server?.kill(); });
  * suja não pode quebrar JS) e `pix.n` conta as requisições a `/billing/pix/`,
  * que no caminho da Stripe têm de ser ZERO.
  */
-async function abrirHome(query, cobranca = null, pendurar = false) {
+async function abrirHome(query, cobranca = null, pendurar = false,
+                         semTimeoutNativo = false) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const erros = [];
   const pix = { n: 0 };
   page.on("pageerror", (e) => erros.push(String(e)));
+  // Safari/WKWebView < 16.4 (o alvo do app é iOS 14.0): `AbortSignal.timeout`
+  // não existe. Apagar a propriedade ANTES do load é o que reproduz esse
+  // navegador aqui — o Chromium do Playwright sempre a tem.
+  if (semTimeoutNativo) {
+    await page.addInitScript(() => { delete AbortSignal.timeout; });
+  }
   // O pixel da Meta vem de CDN, que este arquivo bloqueia — sem stub o
   // `window.fbq` é undefined e o disparo nem acontece (`window.fbq && sid`).
   // Empilha os argumentos crus: o teste mede o objeto que a página MANDOU.
@@ -374,11 +382,12 @@ test("WP13: com inicio antigo na URL, o modal mostra a data que o servidor deu",
 /* ── WP14: a busca não pode segurar a celebração ─────────────────────────────
  * O `fbq` e o modal passaram a esperar a resposta do servidor. Sem teto, uma
  * conexão pendurada deixava quem ACABOU DE PAGAR olhando para a /home de
- * sempre, sem confirmação nenhuma. O `AbortSignal.timeout(4000)` fecha isso, e
- * o caminho vencido é o mesmo do 404: cópia do imediato, Purchase sem `value`.
+ * sempre, sem confirmação nenhuma. O teto de 4 s (`AbortController` +
+ * `setTimeout`) fecha isso, e o caminho vencido é o mesmo do 404: cópia do
+ * imediato, Purchase sem `value`.
  *
- * Controle negativo: tire o `signal: AbortSignal.timeout(4000)` do fetch e este
- * caso estoura no `waitForSelector` (15 s) — os outros 24 seguem verdes.
+ * Controle negativo: tire o `signal: ctrl.signal` do fetch e este caso estoura
+ * no `waitForSelector` (15 s) — os outros seguem verdes.
  */
 test("WP14: busca pendurada — o modal sobe assim mesmo, sem valor inventado", async () => {
   const t0 = Date.now();
@@ -466,5 +475,33 @@ test("WP17: amount_cents=999999999999 cai no caso sem valor", async () => {
     { ...AGENDADA, amount_cents: 999999999999 });
   const [, , dados] = await purchase(page);
   assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
+  await page.close();
+});
+
+/* ── WP18: Safari/WKWebView sem `AbortSignal.timeout` ────────────────────────
+ * O app roda com IPHONEOS_DEPLOYMENT_TARGET 14.0, e `AbortSignal.timeout` só
+ * existe no WKWebView 16.4+. Como ele era avaliado ao MONTAR as opções do
+ * fetch, num aparelho velho o `TypeError` estourava ANTES de a requisição sair:
+ * o `catch` engolia, `cobranca` ficava nula e — com o backend PERFEITAMENTE
+ * saudável — toda compra Pix perdia o `value` do Pixel e a compra AGENDADA era
+ * anunciada como "já começou". `AbortController` + `setTimeout` roda desde o
+ * Safari 12.1 e mantém o mesmo teto.
+ *
+ * Controle negativo MEDIDO: volte o fetch para `signal: AbortSignal.timeout(4000)`
+ * e SÓ este caso fica vermelho (`sub` vira "já começou" e o objeto perde o
+ * `value`). Positivo do grupo: WP1/WP6, os mesmos dados com a propriedade no
+ * lugar — verdes nas duas versões, que é o que prova que a correção não trocou
+ * o comportamento do navegador moderno.
+ */
+test("WP18: sem AbortSignal.timeout (iOS 14), a agendada mantém data e value", async () => {
+  const { page, erros } = await abrirHome(`${BASE}&pl=pro&gw=pix`, AGENDADA, false, true);
+  const semTimeout = await page.evaluate(() => typeof AbortSignal.timeout);
+  assert.equal(semTimeout, "undefined", "o ambiente do teste não foi degradado");
+  const [, , dados] = await purchase(page);
+  const t = await textos(page);
+  assert.equal(dados.value, 499, `Purchase sem value no Safari velho: ${JSON.stringify(dados)}`);
+  assert.match(t.sub, /26\/08\/2027/, `agendada anunciada sem a data: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /já começou/, `agendada virou "já começou": ${t.sub}`);
+  assert.deepEqual(erros, [], `pageerror sem AbortSignal.timeout: ${erros.join(" | ")}`);
   await page.close();
 });

--- a/tests/frontend/welcome_pro_pix.test.mjs
+++ b/tests/frontend/welcome_pro_pix.test.mjs
@@ -1,0 +1,291 @@
+/**
+ * O modal de boas-vindas da /home depois do Pix ANUAL.
+ *
+ * O que estava errado: quem pagava o Pix anual lia "Sua assinatura já está
+ * ativa. Dá pra cancelar quando quiser, direto nas configurações" — e não tem
+ * assinatura nenhuma (compra à vista, sem cartão, sem renovação). Quem comprava
+ * Essencial ou Pro ainda lia o título do plano certo, mas o corpo era o da
+ * Stripe.
+ *
+ * Os dois controles do CLAUDE.md §3, MEDIDOS (rodados, não deduzidos):
+ *   · negativo — troque no `openWelcomePro` o ramo do Pix pelo `else` da
+ *     Stripe e ficam vermelhos, por nome: WP1, WP2, WP10 e os SETE casos do
+ *     WP4 (10 de 22). **WP5 e WP9 continuam VERDES** — eles só medem
+ *     `searchParams.delete`, que a mutação não toca, e uma versão anterior
+ *     deste cabeçalho os listava como cobertura que eles nunca deram;
+ *   · positivo — WP3 é o caminho da Stripe SEM `gw`, provando que a cópia de
+ *     quem assina no cartão continua exatamente a de hoje.
+ *
+ * WP4 e WP8 são a fronteira de confiança: `inicio` e `vl` vêm da URL, que
+ * qualquer um digita. Os controles negativos de cada conserto estão no
+ * comentário do próprio caso.
+ *
+ * O que este arquivo NÃO alcança: a compra de verdade e o e-mail. O e-mail é
+ * `tests/test_pix_paid_email_copy.py`; a compra, só no aparelho.
+ *
+ * Rodar:  npm run test:frontend
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { chromium } from "playwright";
+
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const FRONTEND = join(REPO, "frontend");
+const json = (body) => ({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/**
+ * Abre a /home com o backend inteiro em `{}` e o modal já aberto.
+ * Devolve `{ page, erros }` — `erros` é a lista de `pageerror`, porque o WP4
+ * mede JS quebrado por entrada suja, não só o texto que sobrou na tela.
+ */
+async function abrirHome(query) {
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const erros = [];
+  page.on("pageerror", (e) => erros.push(String(e)));
+  // O pixel da Meta vem de CDN, que este arquivo bloqueia — sem stub o
+  // `window.fbq` é undefined e o disparo nem acontece (`window.fbq && sid`).
+  // Empilha os argumentos crus: o teste mede o objeto que a página MANDOU.
+  await page.addInitScript(() => {
+    window.__fbq = [];
+    window.fbq = (...args) => window.__fbq.push(args);
+  });
+  await page.route("**/*", (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin !== ORIGIN) return route.abort();          // CDN bloqueado
+    if (/\.[a-z0-9]+$/i.test(url.pathname)) return route.continue();
+    return route.fulfill(json({}));
+  });
+  await page.route("**/static/auth-refresh.js", (route) =>
+    route.fulfill({ status: 200, contentType: "application/javascript",
+                    body: readFileSync(join(FRONTEND, "static", "auth-refresh.js"), "utf8") }));
+  await page.route("**/auth/validate", (route) => route.fulfill(json({ user_id: 1 })));
+  // `plan` NÃO pode ser `{}` aqui: com `?upgrade=success` a home levanta o
+  // overlay de "confirmando pagamento" e só o baixa quando o `/auth/me` traz
+  // plano pago (_checkoutSettled) — ou quando o fail-open de 20 s vence. Sem
+  // este corpo o modal só abriria depois dos 20 s, e todo caso deste arquivo
+  // (inclusive o controle positivo da Stripe) morria no timeout.
+  await page.route("**/auth/me", (route) => route.fulfill(
+    json({ user_id: 1, plan: "pro", plan_expires_at: null })));
+  await page.goto(`${ORIGIN}/home.html${query}`);
+  // O modal sobe 450 ms depois do load, e só se a validação de sessão passou.
+  await page.waitForSelector("#welcome-pro-overlay.open", { timeout: 15000 });
+  return { page, erros };
+}
+
+const textos = (page) => page.evaluate(() => ({
+  olho: document.getElementById("wp-eyebrow-txt").textContent.trim(),
+  titulo: document.getElementById("wp-title").textContent,
+  sub: document.getElementById("wp-sub").textContent,
+  subHtml: document.getElementById("wp-sub").innerHTML,
+  chipEscondido: document.getElementById("wp-chip").hidden,
+}));
+
+const BASE = "?upgrade=success&sid=tok_x&ev=purchase&td=0";
+
+// ── WP1: Pix AGENDADO ───────────────────────────────────────────────────────
+test("WP1: Pix agendado diz o plano, a data e que não renova", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=essencial&gw=pix&inicio=2027-08-26`);
+  const t = await textos(page);
+  assert.match(t.titulo, /PigBank Essencial/, `título: ${t.titulo}`);
+  assert.match(t.sub, /26\/08\/2027/, `sub sem a data: ${t.sub}`);
+  assert.match(t.sub, /sem renovação/, `sub: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /cancelar/i, `prometeu cancelamento no Pix: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /assinatura/i, `chamou compra à vista de assinatura: ${t.sub}`);
+  assert.equal(t.chipEscondido, true, "o chip de dias grátis apareceu numa compra");
+  // O olho do card é estático no HTML e dizia "Assinatura confirmada" — a mesma
+  // mentira do sub, num elemento que ninguém tinha olhado.
+  assert.equal(t.olho, "Pagamento confirmado", `olho: ${t.olho}`);
+  await page.close();
+});
+
+// ── WP2: Pix IMEDIATO ───────────────────────────────────────────────────────
+test("WP2: Pix imediato diz que já começou, sem data e sem cancelamento", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`);
+  const t = await textos(page);
+  assert.match(t.titulo, /PigBank Pro/, `título: ${t.titulo}`);
+  assert.match(t.sub, /já começou/, `sub: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /cancelar/i, `prometeu cancelamento no Pix: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /\d{2}\/\d{2}\/\d{4}/, `inventou data no imediato: ${t.sub}`);
+  await page.close();
+});
+
+// ── WP3: CONTROLE POSITIVO — a Stripe não mudou ─────────────────────────────
+test("WP3: compra no cartão (sem gw) mantém a cópia de hoje", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=plus`);
+  const t = await textos(page);
+  assert.equal(t.titulo, "Tá dentro do PigBank+");
+  assert.equal(t.sub,
+    "Sua assinatura já está ativa. Dá pra cancelar quando quiser, direto nas configurações.");
+  assert.equal(t.olho, "Assinatura confirmada", `o olho da Stripe mudou: ${t.olho}`);
+  await page.close();
+});
+
+// ── WP4: `inicio` é entrada de fronteira ────────────────────────────────────
+// "2027-02-30" e "2027-11-31" TÊM o formato e passam no `Date.parse` (que
+// normaliza em vez de recusar) — eram os que chegavam à tela como "30/02/2027".
+// "0000-01-01" também morre na ida e volta, e não na faixa de ano: o `Date` do
+// JS mapeia ano 0 para 1900, então o `getFullYear()` volta diferente. O ÚNICO
+// que depende da faixa é "9999-12-31" — ele passa na ida e volta (medido), e
+// sem a janela fixa viraria "começa em 31/12/9999" na tela.
+for (const sujo of ["<img src=x onerror=alert(1)>", "2027-13-99", "amanhã",
+                    "2027-02-30", "2027-11-31", "0000-01-01", "9999-12-31"]) {
+  test(`WP4: inicio=${sujo} cai no texto imediato, sem markup e sem erro`, async () => {
+    const { page, erros } = await abrirHome(
+      `${BASE}&pl=plus&gw=pix&inicio=${encodeURIComponent(sujo)}`);
+    const t = await textos(page);
+    assert.match(t.sub, /já começou/, `data inválida virou texto de agendado: ${t.sub}`);
+    assert.ok(!t.subHtml.includes("<"), `entrou markup no sub: ${t.subHtml}`);
+    assert.ok(!t.sub.includes(sujo), `a entrada crua foi para a tela: ${t.sub}`);
+    assert.deepEqual(erros, [], `pageerror com inicio sujo: ${erros.join(" | ")}`);
+    await page.close();
+  });
+}
+
+/* ── WP4b: renovação empilhada (3+ anos à frente) é data VÁLIDA ──────────────
+ * `plano_da_cobranca` empilha renovação do mesmo plano sem teto: a 4ª compra
+ * Pix seguida começa no ano corrente + 3. A faixa antiga (`anoAtual`..`+2`)
+ * devolvia null nela, e o card dizia "já começou" para quem só começa em 2029.
+ *
+ * Controle negativo (MEDIDO): reponha a faixa relativa no `wpInicioValido`
+ * (`const anoAtual = new Date().getFullYear();` + `a >= anoAtual && a <=
+ * anoAtual + 2`) e SÓ este caso fica vermelho — os sete do WP4, o WP1 e o WP2
+ * continuam verdes, que é o que o separa de teatro.
+ */
+test("WP4b: inicio 3+ anos à frente sai como agendado, com a data", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&inicio=2029-09-09`);
+  const t = await textos(page);
+  assert.match(t.sub, /09\/09\/2029/, `renovação empilhada virou imediato: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /já começou/, `sub: ${t.sub}`);
+  await page.close();
+});
+
+// ── WP5: a URL não guarda os parâmetros novos ───────────────────────────────
+test("WP5: gw e inicio somem da URL depois do load", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&inicio=2027-08-26`);
+  const busca = await page.evaluate(() => location.search);
+  assert.ok(!busca.includes("gw="), `sobrou gw na URL: ${busca}`);
+  assert.ok(!busca.includes("inicio="), `sobrou inicio na URL: ${busca}`);
+  await page.close();
+});
+
+/* ── Purchase do pixel: o valor ──────────────────────────────────────────────
+ * O `Purchase` do navegador ia sem `value` — só a CAPI (pix_drain_effects.py)
+ * levava receita. Enquanto os dois chegam, deduplicam e ninguém perde nada; no
+ * dia em que o do servidor falhar, a venda entra com R$ 0.
+ *
+ * Controles:
+ *   · negativo — tire o `value` do objeto do fbq no home.html e WP6 fica
+ *     vermelho (WP7, o positivo, continua verde: é o caminho que NÃO muda);
+ *   · positivo — WP7 é a Stripe, que não manda `vl` e cujo objeto tem de
+ *     continuar sendo `{ currency: "BRL" }` e nada mais.
+ *   · WP8 é a fronteira: `vl` vem da URL.
+ */
+const purchase = (page) => page.evaluate(() =>
+  (window.__fbq || []).filter((a) => a[0] === "track" && a[1] === "Purchase")[0]);
+
+// ── WP6: Pix com valor ──────────────────────────────────────────────────────
+test("WP6: vl=99.00 vira value 99 no Purchase, com o eventID de sempre", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=essencial&gw=pix&vl=99.00`);
+  const [, , dados, ids] = await purchase(page);
+  assert.equal(dados.value, 99, `value: ${JSON.stringify(dados)}`);
+  assert.equal(dados.currency, "BRL");
+  assert.equal(ids.eventID, "purchase_tok_x");
+  await page.close();
+});
+
+// ── WP7: CONTROLE POSITIVO — Stripe (sem vl) segue byte a byte ──────────────
+test("WP7: compra sem vl manda só currency, sem a chave value", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=plus`);
+  const [, , dados] = await purchase(page);
+  assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
+  assert.equal(dados.currency, "BRL");
+  await page.close();
+});
+
+// ── WP8: `vl` é entrada de fronteira ────────────────────────────────────────
+// `1e308` e `9e99` são o achado que dói: um link forjado mandava um Purchase
+// de 9e+99 BRL para a conta de anúncios. `99abc` e `99,00` são a leniência do
+// `parseFloat`, que lia o começo e descartava o resto.
+for (const sujo of ["abc", "-5", "1e308", "9e99", "99abc", "99,00"]) {
+  test(`WP8: vl=${sujo} cai no caso sem valor, sem erro de JS`, async () => {
+    const { page, erros } = await abrirHome(
+      `${BASE}&pl=plus&gw=pix&vl=${encodeURIComponent(sujo)}`);
+    const [, , dados] = await purchase(page);
+    assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
+    assert.deepEqual(erros, [], `pageerror com vl sujo: ${erros.join(" | ")}`);
+    await page.close();
+  });
+}
+
+// ── WP9: `vl` também some da URL ────────────────────────────────────────────
+test("WP9: vl some da URL depois do load", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&vl=99.00`);
+  const busca = await page.evaluate(() => location.search);
+  assert.ok(!busca.includes("vl="), `sobrou vl na URL: ${busca}`);
+  await page.close();
+});
+
+// ── WP10: `gw` é comparado normalizado, como o `pl` ─────────────────────────
+/**
+ * `pl` já passava por `toLowerCase` e `gw` era comparado cru: `?gw=PIX` caía no
+ * ramo da Stripe DEPOIS de uma compra Pix — a pessoa que pagou à vista lia
+ * "sua assinatura já está ativa, dá pra cancelar quando quiser".
+ *
+ * Controle negativo: volte o `String(gw).toLowerCase() === "pix"` para
+ * `gw === "pix"` e este caso fica vermelho (WP1 e WP2, minúsculos, seguem
+ * verdes — é o que separa medir do teatro).
+ */
+test("WP10: gw=PIX (maiúsculo) cai no ramo do Pix, não no da Stripe", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=PIX`);
+  const t = await textos(page);
+  assert.match(t.sub, /já começou/, `gw maiúsculo virou cópia da Stripe: ${t.sub}`);
+  assert.equal(t.olho, "Pagamento confirmado", `olho: ${t.olho}`);
+  await page.close();
+});
+
+// ── WP11: título e corpo decidem pelo MESMO ramo ────────────────────────────
+/**
+ * O título olhava `pix && inicio` e o corpo a cadeia `trial → pix → else`, onde
+ * o trial ganha. Com `ev=trial&gw=pix&inicio=…` saía "Seu PigBank+ tá garantido"
+ * (ramo Pix) em cima de "seus 30 dias grátis começam agora" (ramo trial): duas
+ * promessas incompatíveis no mesmo card.
+ *
+ * Qual dos dois ramos vence não é o que se testa aqui — é que os DOIS textos
+ * saiam do mesmo.
+ *
+ * Controle negativo: volte o título para `pix && inicio` e este caso fica
+ * vermelho.
+ */
+test("WP11: ev=trial com gw=pix não mistura título de Pix com sub de trial", async () => {
+  const { page } = await abrirHome(
+    "?upgrade=success&sid=tok_x&ev=trial&td=30&pl=plus&gw=pix&inicio=2027-08-26");
+  const t = await textos(page);
+  assert.match(t.sub, /dias grátis/, `sub: ${t.sub}`);
+  assert.equal(t.titulo, "Tá dentro do PigBank+",
+    `título do ramo Pix com corpo de trial: ${t.titulo}`);
+  assert.equal(t.olho, "Assinatura confirmada", `olho: ${t.olho}`);
+  await page.close();
+});
+
+/* ── WP12 não existe, e o motivo importa ─────────────────────────────────────
+ * O olho (`wp-eyebrow-txt`) passou a ser escrito nos TRÊS ramos, e não só no do
+ * Pix: título, sub e chip já eram, e a troca de mão única deixava o modal preso
+ * em "Pagamento confirmado" depois de um ramo Pix.
+ *
+ * Não há caso aqui porque o defeito é INALCANÇÁVEL por URL: o `openWelcomePro`
+ * roda uma vez por carga, e a carga começa do HTML estático, que já traz
+ * "Assinatura confirmada" — que é o que o WP3 mede. Só uma segunda chamada na
+ * mesma página o expõe, e `openWelcomePro` não é global (mora dentro do
+ * `PBPages.home`); exportá-lo para o `window` só para o teste seria abrir
+ * superfície de produção por causa do teste. O conserto fica pela simetria; a
+ * cobertura, honesta sobre o que não tem.
+ */

--- a/tests/frontend/welcome_pro_pix.test.mjs
+++ b/tests/frontend/welcome_pro_pix.test.mjs
@@ -1,24 +1,32 @@
 /**
- * O modal de boas-vindas da /home depois do Pix ANUAL.
+ * O modal de boas-vindas da /home depois do Pix ANUAL, e o `Purchase` do pixel.
  *
- * O que estava errado: quem pagava o Pix anual lia "Sua assinatura já está
- * ativa. Dá pra cancelar quando quiser, direto nas configurações" — e não tem
- * assinatura nenhuma (compra à vista, sem cartão, sem renovação). Quem comprava
- * Essencial ou Pro ainda lia o título do plano certo, mas o corpo era o da
- * Stripe.
+ * Duas coisas moram aqui, e viraram uma só quando a FONTE mudou:
  *
- * Os dois controles do CLAUDE.md §3, MEDIDOS (rodados, não deduzidos):
- *   · negativo — troque no `openWelcomePro` o ramo do Pix pelo `else` da
- *     Stripe e ficam vermelhos, por nome: WP1, WP2, WP10 e os SETE casos do
- *     WP4 (10 de 22). **WP5 e WP9 continuam VERDES** — eles só medem
- *     `searchParams.delete`, que a mutação não toca, e uma versão anterior
- *     deste cabeçalho os listava como cobertura que eles nunca deram;
- *   · positivo — WP3 é o caminho da Stripe SEM `gw`, provando que a cópia de
- *     quem assina no cartão continua exatamente a de hoje.
+ *   · a CÓPIA — quem pagava o Pix anual lia "Sua assinatura já está ativa. Dá
+ *     pra cancelar quando quiser" e não tem assinatura nenhuma (compra à vista,
+ *     sem cartão, sem renovação);
+ *   · a FONTE — o valor e a data vinham da QUERY STRING (`vl=`, `inicio=`).
+ *     Qualquer visitante abria `/home?upgrade=success&sid=<forjado>&vl=999999`
+ *     e mandava um Purchase de R$ 999.999 para a NOSSA conta de anúncios, sem
+ *     deduplicar com a CAPI (o `eventID` leva o `sid` que ele escolheu). E a
+ *     data era um retrato do checkout, que envelhece: na migração Stripe→Pix o
+ *     `_stripe_cancel` adia o começo do acesso depois de o QR estar na tela.
+ *     Hoje os dois saem de `GET /billing/pix/<sid>`, que é autenticado e filtra
+ *     por dono (404 para token de outro usuário).
  *
- * WP4 e WP8 são a fronteira de confiança: `inicio` e `vl` vêm da URL, que
- * qualquer um digita. Os controles negativos de cada conserto estão no
- * comentário do próprio caso.
+ * Os controles do CLAUDE.md §3, MEDIDOS (rodados, não deduzidos):
+ *   · negativo da CÓPIA — troque no `openWelcomePro` o ramo do Pix pelo `else`
+ *     da Stripe (`} else if (false && modo === "pix") {`) e ficam vermelhos 13
+ *     de 24, por nome: WP1, WP2, os SETE casos do WP4, WP4b, WP8, WP10 e WP13.
+ *     **WP5 e WP9 continuam VERDES** — eles só medem `searchParams.delete`,
+ *     que a mutação não toca;
+ *   · negativo da FONTE — volte a ler `vl` e `inicio` da URL no `home.html`
+ *     (`cents` do `params.get("vl")`, `inicioPix` do `wpInicioValido(inicio)`)
+ *     e ficam vermelhos 5: WP1, WP4b, WP6, WP8 e WP13;
+ *   · positivo — WP3 e WP7 são o caminho da Stripe SEM `gw`, VERDES nas duas
+ *     mutações: cópia igual à de hoje, objeto do pixel sem `value`, e ZERO
+ *     requisição a `/billing/pix/`.
  *
  * O que este arquivo NÃO alcança: a compra de verdade e o e-mail. O e-mail é
  * `tests/test_pix_paid_email_copy.py`; a compra, só no aparelho.
@@ -44,12 +52,19 @@ after(async () => { await browser?.close(); server?.kill(); });
 
 /**
  * Abre a /home com o backend inteiro em `{}` e o modal já aberto.
- * Devolve `{ page, erros }` — `erros` é a lista de `pageerror`, porque o WP4
- * mede JS quebrado por entrada suja, não só o texto que sobrou na tela.
+ *
+ * `cobranca` é o corpo de `GET /billing/pix/<sid>`; `null` (o padrão) responde
+ * **404**, que é o caminho de token forjado — e o que prova que nada é
+ * inventado quando a busca falha.
+ *
+ * Devolve `{ page, erros, pix }` — `erros` é a lista de `pageerror` (entrada
+ * suja não pode quebrar JS) e `pix.n` conta as requisições a `/billing/pix/`,
+ * que no caminho da Stripe têm de ser ZERO.
  */
-async function abrirHome(query) {
+async function abrirHome(query, cobranca = null, pendurar = false) {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const erros = [];
+  const pix = { n: 0 };
   page.on("pageerror", (e) => erros.push(String(e)));
   // O pixel da Meta vem de CDN, que este arquivo bloqueia — sem stub o
   // `window.fbq` é undefined e o disparo nem acontece (`window.fbq && sid`).
@@ -75,10 +90,19 @@ async function abrirHome(query) {
   // (inclusive o controle positivo da Stripe) morria no timeout.
   await page.route("**/auth/me", (route) => route.fulfill(
     json({ user_id: 1, plan: "pro", plan_expires_at: null })));
+  // Depois do `**/*`, de propósito: no Playwright a rota mais recente ganha.
+  await page.route("**/billing/pix/**", (route) => {
+    pix.n += 1;
+    if (pendurar) return;                 // nunca responde: exercita o teto
+    return cobranca
+      ? route.fulfill(json(cobranca))
+      : route.fulfill({ status: 404, contentType: "application/json",
+                        body: JSON.stringify({ detail: "Cobrança não encontrada." }) });
+  });
   await page.goto(`${ORIGIN}/home.html${query}`);
   // O modal sobe 450 ms depois do load, e só se a validação de sessão passou.
   await page.waitForSelector("#welcome-pro-overlay.open", { timeout: 15000 });
-  return { page, erros };
+  return { page, erros, pix };
 }
 
 const textos = (page) => page.evaluate(() => ({
@@ -90,10 +114,18 @@ const textos = (page) => page.evaluate(() => ({
 }));
 
 const BASE = "?upgrade=success&sid=tok_x&ev=purchase&td=0";
+// Cobrança AGENDADA e cobrança IMEDIATA, como o servidor as devolve. Na
+// imediata `starts_at` também vem preenchido (com `agora`) — é por isso que
+// quem separa os dois casos é `agendada`, e não a presença da data.
+const AGENDADA = { status: "paid", plan: "pro_max", amount_cents: 49900,
+                   credit_cents: 0, agendada: true,
+                   starts_at: "2027-08-26T03:00:00+00:00" };
+const IMEDIATA = { ...AGENDADA, agendada: false,
+                   starts_at: new Date().toISOString() };
 
 // ── WP1: Pix AGENDADO ───────────────────────────────────────────────────────
-test("WP1: Pix agendado diz o plano, a data e que não renova", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=essencial&gw=pix&inicio=2027-08-26`);
+test("WP1: Pix agendado diz o plano, a data do servidor e que não renova", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=essencial&gw=pix`, AGENDADA);
   const t = await textos(page);
   assert.match(t.titulo, /PigBank Essencial/, `título: ${t.titulo}`);
   assert.match(t.sub, /26\/08\/2027/, `sub sem a data: ${t.sub}`);
@@ -109,7 +141,7 @@ test("WP1: Pix agendado diz o plano, a data e que não renova", async () => {
 
 // ── WP2: Pix IMEDIATO ───────────────────────────────────────────────────────
 test("WP2: Pix imediato diz que já começou, sem data e sem cancelamento", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`);
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`, IMEDIATA);
   const t = await textos(page);
   assert.match(t.titulo, /PigBank Pro/, `título: ${t.titulo}`);
   assert.match(t.sub, /já começou/, `sub: ${t.sub}`);
@@ -118,34 +150,35 @@ test("WP2: Pix imediato diz que já começou, sem data e sem cancelamento", asyn
   await page.close();
 });
 
-// ── WP3: CONTROLE POSITIVO — a Stripe não mudou ─────────────────────────────
-test("WP3: compra no cartão (sem gw) mantém a cópia de hoje", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=plus`);
+// ── WP3: CONTROLE POSITIVO — a Stripe não mudou e não busca nada ────────────
+test("WP3: compra no cartão (sem gw) mantém a cópia de hoje, sem buscar cobrança", async () => {
+  const { page, pix } = await abrirHome(`${BASE}&pl=plus`, AGENDADA);
   const t = await textos(page);
   assert.equal(t.titulo, "Tá dentro do PigBank+");
   assert.equal(t.sub,
     "Sua assinatura já está ativa. Dá pra cancelar quando quiser, direto nas configurações.");
   assert.equal(t.olho, "Assinatura confirmada", `o olho da Stripe mudou: ${t.olho}`);
+  assert.equal(pix.n, 0, `a Stripe bateu ${pix.n}× em /billing/pix/`);
   await page.close();
 });
 
-// ── WP4: `inicio` é entrada de fronteira ────────────────────────────────────
-// "2027-02-30" e "2027-11-31" TÊM o formato e passam no `Date.parse` (que
-// normaliza em vez de recusar) — eram os que chegavam à tela como "30/02/2027".
-// "0000-01-01" também morre na ida e volta, e não na faixa de ano: o `Date` do
-// JS mapeia ano 0 para 1900, então o `getFullYear()` volta diferente. O ÚNICO
-// que depende da faixa é "9999-12-31" — ele passa na ida e volta (medido), e
-// sem a janela fixa viraria "começa em 31/12/9999" na tela.
+// ── WP4: `starts_at` do servidor também passa pelo validador ────────────────
+// Ele deixou de vir da URL, mas continua virando a promessa "seu ano começa em
+// <data>" na tela — coluna estranha ou corpo malformado não podem escrever
+// compromisso nosso. "2027-02-30" e "2027-11-31" TÊM o formato e passam no
+// `Date.parse` (que normaliza em vez de recusar): eram os que chegavam à tela
+// como "30/02/2027". "0000-01-01" morre na ida e volta (o `Date` do JS mapeia
+// ano 0 para 1900). O ÚNICO que depende da faixa fixa é "9999-12-31".
 for (const sujo of ["<img src=x onerror=alert(1)>", "2027-13-99", "amanhã",
                     "2027-02-30", "2027-11-31", "0000-01-01", "9999-12-31"]) {
-  test(`WP4: inicio=${sujo} cai no texto imediato, sem markup e sem erro`, async () => {
-    const { page, erros } = await abrirHome(
-      `${BASE}&pl=plus&gw=pix&inicio=${encodeURIComponent(sujo)}`);
+  test(`WP4: starts_at=${sujo} cai no texto imediato, sem markup e sem erro`, async () => {
+    const { page, erros } = await abrirHome(`${BASE}&pl=plus&gw=pix`,
+      { ...AGENDADA, starts_at: sujo });
     const t = await textos(page);
     assert.match(t.sub, /já começou/, `data inválida virou texto de agendado: ${t.sub}`);
     assert.ok(!t.subHtml.includes("<"), `entrou markup no sub: ${t.subHtml}`);
     assert.ok(!t.sub.includes(sujo), `a entrada crua foi para a tela: ${t.sub}`);
-    assert.deepEqual(erros, [], `pageerror com inicio sujo: ${erros.join(" | ")}`);
+    assert.deepEqual(erros, [], `pageerror com starts_at sujo: ${erros.join(" | ")}`);
     await page.close();
   });
 }
@@ -161,7 +194,8 @@ for (const sujo of ["<img src=x onerror=alert(1)>", "2027-13-99", "amanhã",
  * continuam verdes, que é o que o separa de teatro.
  */
 test("WP4b: inicio 3+ anos à frente sai como agendado, com a data", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&inicio=2029-09-09`);
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix`,
+    { ...AGENDADA, starts_at: "2029-09-09T03:00:00+00:00" });
   const t = await textos(page);
   assert.match(t.sub, /09\/09\/2029/, `renovação empilhada virou imediato: ${t.sub}`);
   assert.doesNotMatch(t.sub, /já começou/, `sub: ${t.sub}`);
@@ -169,8 +203,10 @@ test("WP4b: inicio 3+ anos à frente sai como agendado, com a data", async () =>
 });
 
 // ── WP5: a URL não guarda os parâmetros novos ───────────────────────────────
+// `inicio` não é mais escrito pelo pix-poll.js, mas continua sendo APAGADO:
+// link antigo, de antes desta mudança, ainda existe em aba e histórico.
 test("WP5: gw e inicio somem da URL depois do load", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&inicio=2027-08-26`);
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&inicio=2027-08-26`, IMEDIATA);
   const busca = await page.evaluate(() => location.search);
   assert.ok(!busca.includes("gw="), `sobrou gw na URL: ${busca}`);
   assert.ok(!busca.includes("inicio="), `sobrou inicio na URL: ${busca}`);
@@ -182,53 +218,71 @@ test("WP5: gw e inicio somem da URL depois do load", async () => {
  * levava receita. Enquanto os dois chegam, deduplicam e ninguém perde nada; no
  * dia em que o do servidor falhar, a venda entra com R$ 0.
  *
+ * A receita sai do `amount_cents` da COBRANÇA DO DONO, lida do servidor: no
+ * upgrade Pix→Pix o cobrado é menor que o de tabela (crédito proporcional), e
+ * a URL não é fonte de dinheiro.
+ *
  * Controles:
- *   · negativo — tire o `value` do objeto do fbq no home.html e WP6 fica
- *     vermelho (WP7, o positivo, continua verde: é o caminho que NÃO muda);
- *   · positivo — WP7 é a Stripe, que não manda `vl` e cujo objeto tem de
- *     continuar sendo `{ currency: "BRL" }` e nada mais.
- *   · WP8 é a fronteira: `vl` vem da URL.
+ *   · negativo — leia o `vl` da URL de novo no home.html e WP6 fica vermelho
+ *     (WP7, o positivo, continua verde: é o caminho que NÃO muda);
+ *   · positivo — WP7 é a Stripe, cujo objeto tem de continuar sendo
+ *     `{ currency: "BRL" }` e nada mais;
+ *   · WP8 e WP8b são a falha da busca: nada é inventado.
  */
 const purchase = (page) => page.evaluate(() =>
   (window.__fbq || []).filter((a) => a[0] === "track" && a[1] === "Purchase")[0]);
 
-// ── WP6: Pix com valor ──────────────────────────────────────────────────────
-test("WP6: vl=99.00 vira value 99 no Purchase, com o eventID de sempre", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=essencial&gw=pix&vl=99.00`);
+// ── WP6: o valor é o do SERVIDOR, mesmo com a URL gritando outro ────────────
+test("WP6: vl=999999 na URL é ignorado; value sai dos 49900 centavos do servidor", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=essencial&gw=pix&vl=999999`, AGENDADA);
   const [, , dados, ids] = await purchase(page);
-  assert.equal(dados.value, 99, `value: ${JSON.stringify(dados)}`);
+  assert.equal(dados.value, 499, `value: ${JSON.stringify(dados)}`);
   assert.equal(dados.currency, "BRL");
   assert.equal(ids.eventID, "purchase_tok_x");
   await page.close();
 });
 
-// ── WP7: CONTROLE POSITIVO — Stripe (sem vl) segue byte a byte ──────────────
-test("WP7: compra sem vl manda só currency, sem a chave value", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=plus`);
+// ── WP7: CONTROLE POSITIVO — Stripe segue byte a byte ───────────────────────
+test("WP7: compra no cartão manda só currency, sem a chave value", async () => {
+  const { page, pix } = await abrirHome(`${BASE}&pl=plus`, AGENDADA);
   const [, , dados] = await purchase(page);
   assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
   assert.equal(dados.currency, "BRL");
+  assert.equal(pix.n, 0, `a Stripe bateu ${pix.n}× em /billing/pix/`);
   await page.close();
 });
 
-// ── WP8: `vl` é entrada de fronteira ────────────────────────────────────────
-// `1e308` e `9e99` são o achado que dói: um link forjado mandava um Purchase
-// de 9e+99 BRL para a conta de anúncios. `99abc` e `99,00` são a leniência do
-// `parseFloat`, que lia o começo e descartava o resto.
-for (const sujo of ["abc", "-5", "1e308", "9e99", "99abc", "99,00"]) {
-  test(`WP8: vl=${sujo} cai no caso sem valor, sem erro de JS`, async () => {
-    const { page, erros } = await abrirHome(
-      `${BASE}&pl=plus&gw=pix&vl=${encodeURIComponent(sujo)}`);
+// ── WP8: token forjado (404) não vira receita ───────────────────────────────
+// É o caso do apontamento: `?sid=<qualquer coisa>&vl=999999` de um visitante
+// que nunca comprou. O 404 do endpoint (token inexistente OU de outro dono) tem
+// de deixar o objeto igual ao da Stripe.
+test("WP8: 404 na busca manda só currency, mesmo com vl na URL", async () => {
+  const { page, erros, pix } = await abrirHome(
+    `${BASE}&pl=plus&gw=pix&vl=999999&inicio=2027-08-26`);
+  const [, , dados] = await purchase(page);
+  const t = await textos(page);
+  assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
+  assert.match(t.sub, /já começou/, `a data da URL virou promessa: ${t.sub}`);
+  assert.equal(pix.n, 1, `buscas: ${pix.n}`);
+  assert.deepEqual(erros, [], `pageerror no 404: ${erros.join(" | ")}`);
+  await page.close();
+});
+
+// ── WP8b: `amount_cents` estranho no corpo não vira valor ───────────────────
+for (const sujo of ["499", null, 0, -5, 49900.5]) {
+  test(`WP8b: amount_cents=${JSON.stringify(sujo)} cai no caso sem valor`, async () => {
+    const { page, erros } = await abrirHome(`${BASE}&pl=plus&gw=pix`,
+      { ...IMEDIATA, amount_cents: sujo });
     const [, , dados] = await purchase(page);
     assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
-    assert.deepEqual(erros, [], `pageerror com vl sujo: ${erros.join(" | ")}`);
+    assert.deepEqual(erros, [], `pageerror com amount_cents sujo: ${erros.join(" | ")}`);
     await page.close();
   });
 }
 
 // ── WP9: `vl` também some da URL ────────────────────────────────────────────
 test("WP9: vl some da URL depois do load", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&vl=99.00`);
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&vl=99.00`, IMEDIATA);
   const busca = await page.evaluate(() => location.search);
   assert.ok(!busca.includes("vl="), `sobrou vl na URL: ${busca}`);
   await page.close();
@@ -238,26 +292,28 @@ test("WP9: vl some da URL depois do load", async () => {
 /**
  * `pl` já passava por `toLowerCase` e `gw` era comparado cru: `?gw=PIX` caía no
  * ramo da Stripe DEPOIS de uma compra Pix — a pessoa que pagou à vista lia
- * "sua assinatura já está ativa, dá pra cancelar quando quiser".
+ * "sua assinatura já está ativa, dá pra cancelar quando quiser". Hoje o mesmo
+ * `ehPix` também decide a BUSCA, então o normalizado vale por dois.
  *
  * Controle negativo: volte o `String(gw).toLowerCase() === "pix"` para
  * `gw === "pix"` e este caso fica vermelho (WP1 e WP2, minúsculos, seguem
  * verdes — é o que separa medir do teatro).
  */
 test("WP10: gw=PIX (maiúsculo) cai no ramo do Pix, não no da Stripe", async () => {
-  const { page } = await abrirHome(`${BASE}&pl=pro&gw=PIX`);
+  const { page, pix } = await abrirHome(`${BASE}&pl=pro&gw=PIX`, IMEDIATA);
   const t = await textos(page);
   assert.match(t.sub, /já começou/, `gw maiúsculo virou cópia da Stripe: ${t.sub}`);
   assert.equal(t.olho, "Pagamento confirmado", `olho: ${t.olho}`);
+  assert.equal(pix.n, 1, `gw maiúsculo não buscou a cobrança: ${pix.n}`);
   await page.close();
 });
 
 // ── WP11: título e corpo decidem pelo MESMO ramo ────────────────────────────
 /**
  * O título olhava `pix && inicio` e o corpo a cadeia `trial → pix → else`, onde
- * o trial ganha. Com `ev=trial&gw=pix&inicio=…` saía "Seu PigBank+ tá garantido"
- * (ramo Pix) em cima de "seus 30 dias grátis começam agora" (ramo trial): duas
- * promessas incompatíveis no mesmo card.
+ * o trial ganha. Com `ev=trial&gw=pix` saía "Seu PigBank+ tá garantido"
+ * (ramo Pix) em cima de "seus 30 dias grátis começam agora": duas promessas
+ * incompatíveis no mesmo card.
  *
  * Qual dos dois ramos vence não é o que se testa aqui — é que os DOIS textos
  * saiam do mesmo.
@@ -267,7 +323,7 @@ test("WP10: gw=PIX (maiúsculo) cai no ramo do Pix, não no da Stripe", async ()
  */
 test("WP11: ev=trial com gw=pix não mistura título de Pix com sub de trial", async () => {
   const { page } = await abrirHome(
-    "?upgrade=success&sid=tok_x&ev=trial&td=30&pl=plus&gw=pix&inicio=2027-08-26");
+    "?upgrade=success&sid=tok_x&ev=trial&td=30&pl=plus&gw=pix", AGENDADA);
   const t = await textos(page);
   assert.match(t.sub, /dias grátis/, `sub: ${t.sub}`);
   assert.equal(t.titulo, "Tá dentro do PigBank+",
@@ -289,3 +345,45 @@ test("WP11: ev=trial com gw=pix não mistura título de Pix com sub de trial", a
  * superfície de produção por causa do teste. O conserto fica pela simetria; a
  * cobertura, honesta sobre o que não tem.
  */
+
+/* ── WP13: a data do servidor GANHA da data que a URL trazia ─────────────────
+ * O caso do apontamento P2, e o motivo de a busca existir: quem cria o QR pouco
+ * antes de a assinatura Stripe renovar tem o `access_starts_at` ADIADO pelo
+ * `_stripe_cancel` no momento do pagamento. O `inicio=` da URL era a estimativa
+ * do checkout, então a /home prometia a data VELHA enquanto o acesso e o e-mail
+ * usavam a nova.
+ *
+ * Controle negativo: volte a passar `wpInicioValido(inicio)` (o da URL) para o
+ * `openWelcomePro` e este caso fica vermelho — WP1 continua verde, porque lá as
+ * duas datas seriam a mesma.
+ */
+test("WP13: com inicio antigo na URL, o modal mostra a data que o servidor deu", async () => {
+  const { page } = await abrirHome(`${BASE}&pl=pro&gw=pix&inicio=2027-08-26`,
+    { ...AGENDADA, starts_at: "2028-01-15T03:00:00+00:00" });
+  const t = await textos(page);
+  assert.match(t.sub, /15\/01\/2028/, `mostrou a data da URL: ${t.sub}`);
+  assert.doesNotMatch(t.sub, /26\/08\/2027/, `a data velha sobreviveu: ${t.sub}`);
+  await page.close();
+});
+
+/* ── WP14: a busca não pode segurar a celebração ─────────────────────────────
+ * O `fbq` e o modal passaram a esperar a resposta do servidor. Sem teto, uma
+ * conexão pendurada deixava quem ACABOU DE PAGAR olhando para a /home de
+ * sempre, sem confirmação nenhuma. O `AbortSignal.timeout(4000)` fecha isso, e
+ * o caminho vencido é o mesmo do 404: cópia do imediato, Purchase sem `value`.
+ *
+ * Controle negativo: tire o `signal: AbortSignal.timeout(4000)` do fetch e este
+ * caso estoura no `waitForSelector` (15 s) — os outros 24 seguem verdes.
+ */
+test("WP14: busca pendurada — o modal sobe assim mesmo, sem valor inventado", async () => {
+  const t0 = Date.now();
+  const { page, erros } = await abrirHome(`${BASE}&pl=plus&gw=pix`, AGENDADA, true);
+  const decorrido = Date.now() - t0;
+  const [, , dados] = await purchase(page);
+  const t = await textos(page);
+  assert.deepEqual(Object.keys(dados), ["currency"], `objeto: ${JSON.stringify(dados)}`);
+  assert.match(t.sub, /já começou/, `sub: ${t.sub}`);
+  assert.ok(decorrido < 12000, `o modal levou ${decorrido}ms para subir`);
+  assert.deepEqual(erros, [], `pageerror no timeout: ${erros.join(" | ")}`);
+  await page.close();
+});

--- a/tests/test_pix_checkout.py
+++ b/tests/test_pix_checkout.py
@@ -71,8 +71,18 @@ def test_venda_nova_emite_pending_com_o_qr_cifrado(user_id, vendavel, asaas_fals
     assert r["qr_image"].startswith("data:image/svg+xml;base64,")
     assert r["public_token"] == linha["public_token"]
     assert set(r) == {"public_token", "qr_payload", "qr_image", "expires_at",
-                      "amount_cents", "credit_cents", "starts_at", "plan"}, (
+                      "amount_cents", "credit_cents", "starts_at", "agendada",
+                      "plan"}, (
         "o contrato que a tela do PR 2 consome mudou de forma"
+    )
+    # O PAR que prova por que `agendada` teve de existir: nesta compra — conta
+    # `free`, sem plano nenhum — o acesso é IMEDIATO e mesmo assim `starts_at`
+    # vem preenchido (com `agora`). A tela gatilhava pela presença da data e
+    # dizia "começa em <hoje>, assim que o plano atual terminar" a quem já tinha
+    # acesso e nunca teve plano.
+    assert r["starts_at"] is not None, "o contrato perdeu a data do começo"
+    assert r["agendada"] is False, (
+        f"compra imediata marcada como agendada: starts_at={r['starts_at']}"
     )
 
 
@@ -241,3 +251,25 @@ def test_rastreio_e_gravado_e_a_exclusao_o_zera(user_id, vendavel, asaas_falso):
     assert (depois["ga_client_id"], depois["fbp"], depois["fbc"]) == (None, None, None)
     assert depois["qr_payload_enc"] is None
     assert depois["amount_cents"] == PRECO, "o valor financeiro não podia sumir"
+
+
+def test_agendada_sai_da_data_e_nao_da_presenca_dela():
+    """O OUTRO lado do par acima, sem banco: a `resposta()` é função pura.
+
+    `test_venda_nova_emite_pending_com_o_qr_cifrado` prova o imediato
+    (`agendada is False` com `starts_at` preenchido). Sem este, `agendada`
+    poderia ser a constante `False` e aquele caso continuaria verde — a compra
+    agendada é a que carrega a promessa de data para a tela.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from core.services.pix_checkout_resposta import resposta
+
+    base = {"public_token": "tok", "qr_expires_at": None, "amount_cents": 19900,
+            "credit_cents": 0, "plan": "pro", "user_id": 1}
+    agora = datetime.now(timezone.utc)
+    futuro = agora + timedelta(days=40)
+
+    assert resposta(dict(base, access_starts_at=futuro), "000201")["agendada"] is True
+    assert resposta(dict(base, access_starts_at=agora), "000201")["agendada"] is False
+    assert resposta(dict(base, access_starts_at=None), "000201")["agendada"] is False

--- a/tests/test_pix_paid_email_copy.py
+++ b/tests/test_pix_paid_email_copy.py
@@ -1,0 +1,167 @@
+"""O e-mail da compra Pix anual chamava TODO MUNDO de "PigBank+".
+
+"PigBank+" é o nome comercial do plano **Plus**. Quem pagava Essencial ou Pro
+recebia no assunto, no título e no corpo o nome de um plano que não comprou — e
+quem comprava com plano vigente (acesso AGENDADO) lia "tá liberado" sobre um
+ano que só começa quando o período atual terminar.
+
+**O vocabulário destes casos é o LEGADO, que é o que a coluna `pix_charges.plan`
+guarda**: `essencial`, `pro` (= Plus) e `pro_max` (= Pro). O router só aceita
+esses três (`frontend/routes/billing_pix.py`) e o checkout grava `plan =
+plan_stored` — `plus` nunca chega ali. Uma versão anterior destes testes usava
+os slugs do frontend, e por isso ficou verde em cima de um mapa que mandava
+"PigBank Pro" para quem comprou Plus e o fallback genérico "PigBank" para quem
+comprou Pro.
+
+Os dois controles do CLAUDE.md §3, para o GRUPO:
+  · negativo — chaveie o `PIX_PLAN_NAMES` no vocabulário do frontend
+    (`plus`/`pro`) e `test_pro_e_o_plus` e `test_pro_max_e_o_pro` ficam
+    vermelhos; volte o `nome` para a constante "PigBank+" (ou apague o
+    `agendado`) e `test_essencial_agendado` fica;
+  · positivo — `test_pro_e_o_plus` é também o controle positivo: o Plus JÁ
+    recebia "PigBank+" antes de tudo isso, e continua recebendo.
+
+O que este arquivo NÃO alcança: o envio de verdade (o `send_email` é
+monkeypatchado) e o modal da /home, que é `tests/frontend/welcome_pro_pix.test.mjs`.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from core.services import email_service as es
+
+
+@pytest.fixture
+def capturado(monkeypatch):
+    """Intercepta o `send_email` e devolve o que a função montou."""
+    caixa = {}
+
+    def _fake(to, subject, html_body, text_body=None, **kw):
+        caixa.update(to=to, subject=subject, html=html_body, text=text_body or "")
+        return True
+
+    monkeypatch.setattr(es, "send_email", _fake)
+    return caixa
+
+
+AGORA = datetime.now(timezone.utc)
+FUTURO = AGORA + timedelta(days=40)
+PASSADO = AGORA - timedelta(minutes=5)
+
+
+def _tudo(caixa):
+    return (caixa["subject"], caixa["html"], caixa["text"])
+
+
+def test_essencial_agendado(capturado):
+    ok = es.send_pix_paid_email("a@b.com", "essencial", 99.0,
+                                FUTURO, FUTURO + timedelta(days=365))
+    assert ok
+    for parte in _tudo(capturado):
+        assert "PigBank Essencial" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano no e-mail: {parte}"
+    assert "a partir de" in capturado["html"].lower()
+    assert "a partir de" in capturado["text"].lower()
+    # A data do começo é a que o cliente precisa: sem ela "agendado" é só adjetivo.
+    assert es._fmt_brl_date(FUTURO) in capturado["html"]
+
+
+def test_pro_e_o_plus(capturado):
+    """`pro` na coluna é o **Plus**, e é o controle positivo do grupo.
+
+    Era o único plano cujo e-mail já estava certo (o texto fixo dizia
+    "PigBank+"), então ele é a prova de que o conserto não trocou o nome de
+    todo mundo por um genérico — e a prova de que o mapa não foi chaveado no
+    vocabulário errado, onde `pro` virava "PigBank Pro".
+    """
+    es.send_pix_paid_email("a@b.com", "pro", 199.0,
+                           PASSADO, AGORA + timedelta(days=365))
+    for parte in _tudo(capturado):
+        assert "PigBank+" in parte, parte
+        assert "PigBank Pro" not in parte, f"nome do plano mais caro: {parte}"
+        assert "a partir de" not in parte.lower(), f"prometeu agendamento: {parte}"
+    assert "liberado" in capturado["text"]
+
+
+def test_pro_max_e_o_pro(capturado):
+    """`pro_max` é o Pro — e é o valor da fixture real (`_dreno_pix_helpers`).
+
+    Nenhum caso o usava, e por isso o fallback genérico "PigBank" passava batido
+    justo no plano de R$ 499.
+    """
+    es.send_pix_paid_email("a@b.com", "pro_max", 499.0,
+                           PASSADO, AGORA + timedelta(days=365))
+    for parte in _tudo(capturado):
+        assert "PigBank Pro" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano no e-mail: {parte}"
+    # O que saía era o fallback genérico, "PigBank anual" — o assunto é onde
+    # ele aparecia inteiro, e é lá que se mede.
+    assert "PigBank Pro anual" in capturado["subject"], capturado["subject"]
+
+
+def test_starts_at_naive_nao_derruba_o_email(capturado):
+    """`access_starts_at` sem fuso não pode levantar `TypeError` aqui.
+
+    O modo de falha é o pior deste PR: a exceção sobe DENTRO do efeito `email`
+    do dreno, o efeito nunca é registrado, o dreno retenta para sempre e quem
+    pagou nunca recebe confirmação. O `_fmt_brl_date`, três linhas abaixo no
+    mesmo arquivo, já tratava naive como UTC — a comparação não tratava.
+
+    Controle negativo (MEDIDO): tire a normalização de `_inicio` em
+    `send_pix_paid_email` e SÓ este caso fica vermelho, com
+    `TypeError: can't compare offset-naive and offset-aware datetimes`.
+
+    Alcançabilidade: a coluna é `timestamptz` e hoje só chega aware — isto é
+    guarda de erro (§0.2), não conserto de bug reproduzido em produção.
+    """
+    naive_futuro = (AGORA + timedelta(days=40)).replace(tzinfo=None)
+    ok = es.send_pix_paid_email("a@b.com", "essencial", 99.0,
+                                naive_futuro, FUTURO + timedelta(days=365))
+    assert ok
+    assert "a partir de" in capturado["html"].lower(), (
+        f"naive no futuro deixou de ser agendado: {capturado['html']}")
+
+    naive_passado = (AGORA - timedelta(days=1)).replace(tzinfo=None)
+    ok = es.send_pix_paid_email("a@b.com", "essencial", 99.0,
+                                naive_passado, FUTURO)
+    assert ok
+    assert "a partir de" not in capturado["html"].lower(), (
+        "naive no passado virou agendado — a normalização inverteu o ramo")
+
+
+def test_plano_desconhecido_nao_inventa_nome(capturado):
+    """Valor fora do mapa (linha antiga, plano descontinuado) cai no genérico —
+    e não pode estourar nem chamar a pessoa de Plus."""
+    es.send_pix_paid_email("a@b.com", "plano_que_nao_existe", 99.0,
+                           PASSADO, AGORA + timedelta(days=365))
+    for parte in _tudo(capturado):
+        assert "PigBank+" not in parte, parte
+        assert "PigBank Pro" not in parte, parte
+        assert "PigBank" in parte, parte
+
+
+def test_o_chamador_manda_o_plano_e_o_comeco(monkeypatch):
+    """O seam entre o dreno e o e-mail — onde a ordem dos argumentos erra calada.
+
+    `cobranca` tem DOIS campos de plano, e na prática eles são IGUAIS (o
+    checkout grava `plan=plan_stored`): o que o dreno não pode fazer é mandar o
+    `amount_cents` no lugar do plano, ou trocar a ordem de
+    `amount_brl`/`access_starts_at`. Nada disso levanta erro — só chega e-mail
+    errado. Este teste chama o efeito real e lê o que saiu do outro lado.
+    """
+    from core.services import pix_drain_effects as pde
+
+    monkeypatch.setattr(pde, "_email_do_titular", lambda uid: "a@b.com")
+    monkeypatch.setattr(pde, "recent_event_exists", lambda *a, **kw: False)
+    monkeypatch.setattr(pde, "log_system_event_sync", lambda *a, **kw: None)
+
+    visto = {}
+    monkeypatch.setattr(es, "send_pix_paid_email",
+                        lambda *a, **kw: visto.update(args=a, kw=kw) or True)
+
+    pde._email({"user_id": 7, "plan": "pro_max", "plan_stored": "pro_max",
+                "amount_cents": 49900, "access_starts_at": FUTURO,
+                "access_expires_at": FUTURO + timedelta(days=365)}, {})
+
+    assert visto["args"] == ("a@b.com", "pro_max", 499.0, FUTURO,
+                             FUTURO + timedelta(days=365)), visto

--- a/tests/test_pix_poll_agendada.py
+++ b/tests/test_pix_poll_agendada.py
@@ -1,0 +1,58 @@
+"""`agendada` no POLL: a mesma fórmula do checkout, medida na mesma linha.
+
+O grupo do Pix era CEGO a `agendada` sempre falso. `test_pix_rotas_billing.py`
+só afirma `False` para `access_starts_at` nulo — e um poll que devolvesse
+`False` SEMPRE passava por ele. Medido: com `"agendada": False` fixo em
+`frontend/routes/billing_pix.py`, `tests/test_pix_*.py` dava 309 passed e
+`tests/frontend/welcome_pro_pix.test.mjs` 25 pass / 0 fail. Zero vermelho —
+enquanto na /home quem comprou agendado leria "seu ano já começou".
+
+A fórmula (`inicio > agora`) está medida em `test_pix_checkout.py`, mas para o
+`resposta()` do CHECKOUT; quem a /home lê desde o modal novo é o POLL. Aqui as
+DUAS montagens são comparadas na MESMA linha, em três datas (§0.7).
+
+CONTROLE NEGATIVO (rodado): `"agendada": False` fixo no poll → este arquivo
+vermelho no caso `+365d`. POSITIVO: os casos `-1s` e nulo, que provam que o
+conserto não é "devolve True".
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.billing_pix as rotas
+from _billing_grants_helpers import conta
+from core.services.pix_checkout_resposta import resposta
+from db.connection import get_conn
+from db.pix_charges import buscar_por_public_token, criar_cobranca
+
+client = TestClient(dashboard.app)
+
+
+def test_poll_e_checkout_dao_o_mesmo_agendada_na_mesma_linha(user_id, monkeypatch):
+    conta(user_id, "free", None)
+    linha = criar_cobranca(user_id, public_token=uuid.uuid4().hex, plan="pro_max",
+                           plan_stored="pro_max", price_cents=49900, credit_cents=0,
+                           amount_cents=49900, duration_days=365)
+    monkeypatch.setattr(rotas.shared, "resolve_dashboard_user_id", lambda req: user_id)
+    agora = datetime.now(timezone.utc)
+
+    for quando, esperado in ((agora + timedelta(days=365), True),
+                             (agora - timedelta(seconds=1), False),
+                             (None, False)):
+        # `access_starts_at` só é escrito no PAGAMENTO (§7) e o que se mede aqui
+        # é a LEITURA: update cru, sem passar pela saga.
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute("update pix_charges set access_starts_at = %s where id = %s",
+                        (quando, linha["id"]))
+            conn.commit()
+        do_poll = client.get(f"/billing/pix/{linha['public_token']}").json()["agendada"]
+        do_checkout = resposta(
+            buscar_por_public_token(user_id, linha["public_token"]), "000201")["agendada"]
+        assert do_poll is esperado and do_poll == do_checkout, (
+            f"starts_at={quando}: poll={do_poll!r} checkout={do_checkout!r}, "
+            f"esperado {esperado!r}"
+        )

--- a/tests/test_pix_rotas_billing.py
+++ b/tests/test_pix_rotas_billing.py
@@ -216,6 +216,41 @@ def test_poll_pelo_id_do_asaas_e_404_e_o_qr_nao_sai(user_id, monkeypatch):
     )
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="DÍVIDA: o poll monta a resposta À MÃO (frontend/routes/billing_pix.py, "
+           "no billing_pix_status) em vez de passar pelo pix_checkout_resposta."
+           "resposta(), e por isso não expõe `agendada` — o campo que existe "
+           "justamente porque `starts_at` SOZINHO não separa compra imediata de "
+           "agendada (na imediata ele também vem preenchido, com `agora`). Hoje "
+           "ninguém consome (pix-poll.js:53,94 leem `starts_at` da resposta do "
+           "POST), então é dívida e não bug. ESTA DÍVIDA NÃO TEM DONO: nenhum PR "
+           "aberto conserta o poll — o `fix/pix-plano-vocabulario` (#347) altera "
+           "só o `billing_pix_checkout` e não encosta no `billing_pix_status`, "
+           "então este teste segue XFAIL depois que ele mergear. Para remover o "
+           "marcador é preciso primeiro consertar o router: fazer o poll montar a "
+           "resposta pelo `resposta()` (hoje `starts_at` é montado à mão em "
+           "frontend/routes/billing_pix.py:159). A issue de rastreio ainda vai ser "
+           "aberta.",
+)
+def test_poll_expoe_agendada_como_a_resposta_do_checkout(user_id, monkeypatch):
+    """§0.7: duas montagens da MESMA resposta, e só uma tem o campo que decide.
+
+    Não compara as chaves inteiras de propósito — os dois contratos divergem
+    legitimamente (o poll não leva QR, o checkout não leva `status`). O que se
+    trava aqui é o campo cuja ausência reproduz o bug original na tela.
+    """
+    conta(user_id, "free", None)
+    linha = _cobranca(user_id)
+    monkeypatch.setattr(rotas.shared, "resolve_dashboard_user_id", lambda req: user_id)
+
+    corpo = client.get(f"/billing/pix/{linha['public_token']}").json()
+    assert "starts_at" in corpo, f"contrato do poll mudou: {sorted(corpo)}"
+    assert "agendada" in corpo, (
+        f"o poll expõe `starts_at` sem `agendada`: {sorted(corpo)}"
+    )
+
+
 def _cobranca(uid: int) -> dict:
     return criar_cobranca(uid, public_token=uuid.uuid4().hex, plan="pro_max",
                           plan_stored="pro_max", price_cents=49900,

--- a/tests/test_pix_rotas_billing.py
+++ b/tests/test_pix_rotas_billing.py
@@ -216,23 +216,6 @@ def test_poll_pelo_id_do_asaas_e_404_e_o_qr_nao_sai(user_id, monkeypatch):
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="DÍVIDA: o poll monta a resposta À MÃO (frontend/routes/billing_pix.py, "
-           "no billing_pix_status) em vez de passar pelo pix_checkout_resposta."
-           "resposta(), e por isso não expõe `agendada` — o campo que existe "
-           "justamente porque `starts_at` SOZINHO não separa compra imediata de "
-           "agendada (na imediata ele também vem preenchido, com `agora`). Hoje "
-           "ninguém consome (pix-poll.js:53,94 leem `starts_at` da resposta do "
-           "POST), então é dívida e não bug. ESTA DÍVIDA NÃO TEM DONO: nenhum PR "
-           "aberto conserta o poll — o `fix/pix-plano-vocabulario` (#347) altera "
-           "só o `billing_pix_checkout` e não encosta no `billing_pix_status`, "
-           "então este teste segue XFAIL depois que ele mergear. Para remover o "
-           "marcador é preciso primeiro consertar o router: fazer o poll montar a "
-           "resposta pelo `resposta()` (hoje `starts_at` é montado à mão em "
-           "frontend/routes/billing_pix.py:159). A issue de rastreio ainda vai ser "
-           "aberta.",
-)
 def test_poll_expoe_agendada_como_a_resposta_do_checkout(user_id, monkeypatch):
     """§0.7: duas montagens da MESMA resposta, e só uma tem o campo que decide.
 
@@ -249,6 +232,11 @@ def test_poll_expoe_agendada_como_a_resposta_do_checkout(user_id, monkeypatch):
     assert "agendada" in corpo, (
         f"o poll expõe `starts_at` sem `agendada`: {sorted(corpo)}"
     )
+    # A FÓRMULA (`inicio > agora`) é medida em
+    # test_pix_checkout.py::test_agendada_sai_da_data_e_nao_da_presenca_dela,
+    # nas três datas. Aqui basta que o poll passe pela mesma função: cobrança
+    # recém-criada tem `access_starts_at` nulo, e nulo não é agendado.
+    assert corpo["agendada"] is False, f"agendada sem data: {corpo['agendada']}"
 
 
 def _cobranca(uid: int) -> dict:

--- a/tests/test_pix_rotas_billing.py
+++ b/tests/test_pix_rotas_billing.py
@@ -232,10 +232,8 @@ def test_poll_expoe_agendada_como_a_resposta_do_checkout(user_id, monkeypatch):
     assert "agendada" in corpo, (
         f"o poll expõe `starts_at` sem `agendada`: {sorted(corpo)}"
     )
-    # A FÓRMULA (`inicio > agora`) é medida em
-    # test_pix_checkout.py::test_agendada_sai_da_data_e_nao_da_presenca_dela,
-    # nas três datas. Aqui basta que o poll passe pela mesma função: cobrança
-    # recém-criada tem `access_starts_at` nulo, e nulo não é agendado.
+    # Só o campo, e nulo: a FÓRMULA (`inicio > agora`) é medida nas três datas
+    # por tests/test_pix_poll_agendada.py, que compara poll × checkout.
     assert corpo["agendada"] is False, f"agendada sem data: {corpo['agendada']}"
 
 


### PR DESCRIPTION
> **Depende do #347. Mergear DEPOIS dele.** O motivo está em "Ordem de merge", no fim.

A ativação do Pix em produção (2026-09-10) mostrou três textos errados na tela e no
e-mail de quem acabou de pagar. Este PR corrige os três.

## 1. O modal de sucesso dizia que a compra era uma assinatura

No ramo de compra sem trial, a `/home` dizia *"Sua assinatura já está ativa. Dá pra
cancelar quando quiser, direto nas configurações."* — falso duas vezes no Pix, que é
compra anual à vista, sem cartão e sem portal, e cujo acesso pode ser **agendado**:
quem já tem plano vigente compra e o ano começa no fim do período atual.

O gatilho não podia ser a presença de `access_starts_at`, que **nunca é nulo** (na
compra imediata ele vem preenchido com o instante da compra). `resposta()` passou a
expor `agendada`, e o `pix-poll.js` manda `gw=pix` e, só quando agendado, `inicio`.

| caso | título | corpo |
|---|---|---|
| Stripe | inalterado | inalterado |
| Pix imediato | Tá dentro do {plano} | "Seu ano de {plano} já começou…" |
| Pix agendado | Seu {plano} tá garantido | "…começa em DD/MM/AAAA, assim que o plano atual terminar." |

A mesma premissa errada estava na tela do QR (`pix-poll.js:53`), que dizia "Seu ano
começa em \<hoje\>" numa compra imediata. Corrigida junto: é a categoria, não a
instância.

## 2. O e-mail chamava todo mundo de "PigBank+"

"PigBank+" é o nome do **Plus**. Quem comprava Essencial ou Pro recebia o nome errado.
`PIX_PLAN_NAMES` é chaveado no vocabulário **legado**, que é o que a coluna guarda — a
primeira versão foi chaveada no slug do frontend e o Tester provou que aquilo era
**regressão** (o Plus passava a receber o nome do Pro). Quando o acesso é agendado, o
e-mail ganha a linha "Acesso a partir de:".

## 3. O `Purchase` do pixel ia sem valor

Só a API de Conversões carregava `value`. Enquanto os dois lados chegam não se perde
receita, mas se o servidor falhar a venda entra sem valor. O evento do navegador passa
a levar `value`, com o número que o servidor cobrou — não o preço de tabela, porque o
upgrade Pix→Pix cobra menos por causa do crédito proporcional.

**Ressalva pedida pela revisão:** o *objeto do pixel* no caminho Stripe é idêntico ao
da `main`, medido por mutação (WP7 fica verde com e sem `value`). O *DOM* do olho mudou
(o texto virou um `<span>` para poder ser trocado no ramo Pix), com efeito nulo medido
pelo WP3.

## O que a revisão derrubou pelo caminho

Duas rodadas de Tester e um Manager, com tudo provado rodando:

- a compra **imediata** caía no ramo agendado — o bug do item 1 de volta, invertido;
- o e-mail nomeava errado 2 dos 3 planos, **piorando** o Plus;
- os testes do e-mail mediam um vocabulário que a coluna nunca contém;
- `vl=9e99` entrava como receita no pixel; `vl=99abc` virava 99;
- `30/02/2027` chegava na tela como data de início;
- a **4ª compra** do mesmo plano começa em `ano+3` e era recusada pela validação, caindo
  no texto "já começou";
- a faixa de ano dependia do **relógio do aparelho** — celular em 1970 lia "já começou".

Os dois últimos foram fechados com uma janela fixa, e não removendo a faixa: medido que
a ida-e-volta do `Date` sozinha **não** barra `9999-12-31` (o `Date` do JS vai ao ano
275760).

## Medições

```
.venv/bin/python -m pytest -q            → 6872 passed, 5 xfailed
.venv/bin/python -m pytest -q tests/test_pix_*.py → 308 passed, 1 xfailed
npm run test:frontend                    → 408 tests / 400 pass / 0 fail / 8 skip
```

Navegador (Chromium), caso agendado de 3+ anos, `pageerror: []` e `scrollTop 0` nos dois:
1440×900 card 440×658, 390×844 card 350×726. Texto: "Seu ano de PigBank Pro **começa em
09/09/2029**". Sem o conserto, a mesma URL dizia "já começou".

Cada conserto tem controle negativo **rodado**, com o nome do teste que fica vermelho, e
controle positivo que não se move.

## Ordem de merge

Sem o #347, o router recusa `plus` com 400 e lê `pro` como o tier Plus — o card de R$ 499
cobra R$ 199. Mergear este PR primeiro faria o e-mail **nomear corretamente o plano
errado que foi cobrado**. Com o #347 dentro, os dois canais batem nos três cards:

| card | modal | e-mail |
|---|---|---|
| Essencial | PigBank Essencial | PigBank Essencial |
| Plus | PigBank+ | PigBank+ |
| Pro | PigBank Pro | PigBank Pro |

## Fica para issue, fora deste PR

- **A mesma classe, no gêmeo do Stripe:** `send_pro_charged_email` diz "Seu PigBank+ tá
  renovado" para **todo** assinante, inclusive Essencial e Pro. É o defeito do item 2 no
  canal antigo, com volume provavelmente maior. Fora do escopo por decisão do dono.
  Parentes menores: `billing_commands.py:279,307` e `statement_service.py:32`.
- **Dívida sem dono:** o poll (`billing_pix.py:159`) monta `starts_at` à mão, fora do
  `resposta()`, e não expõe `agendada`. Sem consumidor hoje. Travada por
  `xfail(strict=True)` cujo `reason` diz que nenhum PR aberto conserta isso.

## Não verificado

Compra real pelo Asaas, envio real do e-mail (`send_email` é monkeypatchado em todos os
casos), o `Purchase` chegando na conta de anúncios, e o modal no aparelho — o app carrega
o site ao vivo, então nada disso existe antes do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
