### PR TITLE
CPF inválido ia parar no Asaas e voltava como falha nossa

### DIFF
--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -184,8 +184,9 @@ function pixApagarDoc() {
 /**
  * Só a FORMA: 11 dígitos (CPF) ou 14 (CNPJ), depois de tirar a pontuação.
  *
- * O dígito verificador NÃO se confere aqui: quem valida documento é o Asaas, e
- * uma segunda cópia da regra recusaria na tela o que o provedor aceita (§0.7).
+ * O dígito verificador NÃO se confere aqui: quem confere o mod-11 é o SERVIDOR,
+ * e uma cópia só da regra é a do §0.7. O Asaas segue sendo a autoridade final —
+ * ele recusa por regras próprias documento estruturalmente válido.
  */
 const pixDigitos = (v) => String(v || "").replace(/\D/g, "");
 const pixFormaOk = (d) => d.length === 11 || d.length === 14;
@@ -293,7 +294,12 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     if (r.status === 409 && det.error === "stripe_active") {
       return pixModalMigracao(plano, det, documento, ctx);
     }
-    if (!r.ok) return showToast(det.message || "Não consegui gerar o código Pix agora.", "err");
+    // `detail` do FastAPI é STRING quando o raise passa texto (400 do documento) e
+    // OBJETO nos 409 — sem esta linha a mensagem específica virava o genérico.
+    if (!r.ok) {
+      const msg = (typeof det === "string" ? det : det.message);
+      return showToast(msg || "Não consegui gerar o código Pix agora.", "err");
+    }
     pixApagarDoc();          // o QR vai entrar: o documento sai da tela antes
     pixModalQr(d, plano, ctx);
   } catch {

--- a/frontend/routes/billing_pix.py
+++ b/frontend/routes/billing_pix.py
@@ -54,10 +54,21 @@ from frontend.routes import shared
 
 router = APIRouter()
 
-# CPF tem 11 dígitos, CNPJ tem 14. A validação aqui é de FORMA e só: quem
-# valida de verdade é o Asaas, e replicar o dígito verificador seria uma segunda
-# fonte da mesma regra (§0.7).
-_TAMANHOS_DOC = (11, 14)
+# Os pesos do mod-11, por tamanho de documento — CPF tem 11 dígitos, CNPJ tem 14,
+# e esta tabela é a fonte única dos tamanhos aceitos NO SERVIDOR. A mesma regra
+# 11/14 vive também no cliente, porque o JS não importa Python: `pix-checkout.js`
+# em `pixFormaOk`, no texto de erro do submit e no `campo.maxLength = 18` (14
+# dígitos + os 4 separadores do CNPJ) — são TRÊS sites derivados deste 11/14.
+# Não há teste comparando as duas fontes — quem mudar um lado muda os outros na
+# mão (`grep -n 'pixFormaOk\|maxLength\|14 do CNPJ' frontend/pix-checkout.js`).
+# O que se confere aqui é ESTRUTURA: dígito verificador que fecha. A autoridade
+# final continua sendo o Asaas, que recusa por regras próprias documento
+# estruturalmente válido.
+_PESOS_DOC = {
+    11: ((10, 9, 8, 7, 6, 5, 4, 3, 2), (11, 10, 9, 8, 7, 6, 5, 4, 3, 2)),
+    14: ((5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2),
+         (6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2)),
+}
 
 
 class PixCheckoutBody(BaseModel):
@@ -87,8 +98,8 @@ async def billing_pix_checkout(request: Request, payload: PixCheckoutBody):
             status_code=400,
             detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
     plan_stored = TIER_TO_STORED_PLAN[plan]
-    doc = "".join(c for c in (payload.cpf_cnpj or "") if c.isdigit())
-    if len(doc) not in _TAMANHOS_DOC:
+    doc = "".join(c for c in (payload.cpf_cnpj or "") if c in "0123456789")
+    if not _documento_valido(doc):
         raise HTTPException(status_code=400,
                             detail="Informe um CPF ou CNPJ válido.")
 
@@ -233,6 +244,27 @@ async def asaas_webhook(request: Request, background_tasks: BackgroundTasks):
         # levanta — falha vira `attempts` e o laço de 60 s retoma.
         background_tasks.add_task(drenar_evento, event_id)
     return {"ok": True}
+
+
+def _documento_valido(doc: str) -> bool:
+    """Só dígitos. Confere o mod-11 de CPF (11) ou CNPJ (14) — ESTRUTURA, não
+    existência: quem sabe se o documento existe é o Asaas, e ele pode recusar
+    depois um número que fecha aqui. Uma implementação para os dois documentos:
+    a diferença é a lista de pesos, e ela tem de existir de qualquer jeito."""
+    pesos = _PESOS_DOC.get(len(doc))
+    if pesos is None:          # tamanho errado (ou string vazia), da mesma tabela
+        return False
+    # Caso especial EXPLÍCITO, e não consequência do algoritmo: `11111111111`,
+    # `00000000000`, `99999999999` e `00000000000000` PASSAM no mod-11 puro
+    # (medido). Sem esta linha, o CPF que mais chega errado é aceito.
+    if len(set(doc)) == 1:
+        return False
+    n = [int(c) for c in doc]
+    for p in pesos:
+        r = sum(a * b for a, b in zip(n, p)) % 11
+        if n[len(p)] != (0 if r < 2 else 11 - r):
+            return False
+    return True
 
 
 def _titular(user_id: int) -> tuple[str, str | None]:

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -48,7 +48,8 @@ const PAYLOAD = "00020126580014BR.GOV.BCB.PIX0136pigbank-teste-qr-payload-520400
 // atributo SOME, não o desenho.
 const QR_IMG = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
 // O documento do pagador. Dígito verificador NÃO é conferido na tela (quem
-// valida é o Asaas, §0.7), então o que importa aqui é a FORMA: 11 e 14 dígitos.
+// confere o mod-11 é o servidor, uma cópia só, §0.7; e o Asaas ainda pode
+// recusar depois), então o que importa aqui é a FORMA: 11 e 14 dígitos.
 // São strings improváveis de aparecer por acaso — o PT12d procura por elas no
 // storage, no DOM, no console e no corpo de TODA requisição da página.
 const CPF = "11122233344";
@@ -1175,5 +1176,46 @@ test("PT17: fechar durante o download do corpo não deixa QR nem poll órfãos",
   // A consequência visível para o usuário: o próximo checkout tem de abrir.
   await page.click('[data-pix-cta="plus"]');
   await page.waitForSelector(".pix-doc", { timeout: 3000 });
+  await page.close();
+});
+
+/**
+ * PT18 — A MENSAGEM DA RECUSA CHEGA À TELA, NOS DOIS FORMATOS DE `detail`.
+ *
+ * O `detail` do FastAPI é STRING quando o `raise` passa texto (o 400 do CPF
+ * inválido) e OBJETO nos 409. O ramo do `!r.ok` lia só `det.message`: com
+ * string, `det.message` é `undefined` e a pessoa recebia o genérico "não
+ * consegui gerar o código Pix agora" — que sugere problema nosso, quando o
+ * conserto é digitar o documento certo.
+ *
+ * *Negativo (rodado): volte o `!r.ok` para `det.message || …` → PT18a vermelho.*
+ * O PT18b é o par que uma correção do tipo `String(d.detail)` destruiria: o
+ * objeto tem de continuar sendo lido pela `message`.
+ */
+test("PT18a: o 400 com detail string mostra a mensagem do servidor no toast", async () => {
+  const { page } = await abrirForm({
+    pix: { httpStatus: 400, corpo: { detail: "Informe um CPF ou CNPJ válido." } },
+  });
+  await enviarDoc(page);
+  await page.waitForTimeout(300);
+  const toast = await page.textContent("#toast");
+  assert.equal(toast, "Informe um CPF ou CNPJ válido.",
+    `a recusa do documento virou outra coisa na tela: "${toast}"`);
+  assert.ok(await page.$eval("#toast", (e) => e.classList.contains("err")),
+    "a recusa apareceu sem a classe de erro");
+  await page.close();
+});
+
+test("PT18b: o 409 com detail objeto continua mostrando a `message`", async () => {
+  const { page } = await abrirForm({
+    pix: { httpStatus: 409,
+           corpo: { detail: { error: "lifetime",
+                              message: "Você já tem acesso vitalício de brinde." } } },
+  });
+  await enviarDoc(page);
+  await page.waitForTimeout(300);
+  const toast = await page.textContent("#toast");
+  assert.equal(toast, "Você já tem acesso vitalício de brinde.",
+    `o detail objeto parou de ser lido pela message: "${toast}"`);
   await page.close();
 });

--- a/tests/test_pix_documento_invalido.py
+++ b/tests/test_pix_documento_invalido.py
@@ -1,0 +1,127 @@
+"""CPF/CNPJ estruturalmente inválido é recusado ANTES de `pix_charges` e do Asaas.
+
+O 400 do documento é a fronteira de confiança do checkout Pix: até 2026-09-10 ele
+media só o TAMANHO, então `11111111111` e um CPF com o DV trocado abriam linha em
+`pix_charges`, chegavam ao Asaas e só lá caíam. Aqui as duas provas moram
+juntas — o status 400 **e** o banco vazio (`_linhas`) **e** o Asaas intocado
+(`asaas_falso["ordem"]`), porque recusar com a saga já rodada não é recusar.
+
+`11111111111`, `00000000000`, `99999999999` e `00000000000000` PASSAM no mod-11
+puro (medido): por isso a sequência repetida é caso à parte e tem caso próprio.
+
+CONTROLES NEGATIVOS MEDIDOS (um a um, em `frontend/routes/billing_pix.py`):
+
+  * apague `if len(set(doc)) == 1: return False` →
+    `test_documento_invalido_nao_toca_o_banco_nem_o_asaas` vermelho nos casos
+    `11111111111`, `00000000000` e `00000000000000` (viram 200);
+  * troque o corpo de `_documento_valido` por `return len(doc) in (11, 14)` (o
+    comportamento anterior) → o mesmo teste vermelho em `52998224724` e
+    `11222333000182`, e os positivos seguem verdes;
+  * troque o filtro ASCII do começo de `billing_pix_checkout` (o
+    `c in "0123456789"` que monta `doc`) de volta para `c.isdigit()` → o mesmo
+    teste vermelho em `1234567890²` (500, `int("²")` estoura) e em
+    `٥٢٩٩٨٢٢٤٧٢٥` (200, dígito não-ASCII fecha o mod-11 e vai ao Asaas), e o
+    positivo `52998224725５` vermelho junto (400: o `５` sobrevive e viram 12
+    dígitos). Os demais positivos seguem verdes.
+
+POSITIVOS do grupo (`..._cpf_valido_...` e `..._cnpj_valido_...`): sem eles, um
+`_documento_valido` que devolvesse `False` para tudo passaria em todos os
+negativos e mataria a venda inteira.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.billing_pix as rotas
+from _billing_grants_helpers import conta
+from _pix_checkout_helpers import (  # noqa: F401 - `asaas_falso`/`vendavel` são fixtures
+    _linhas,
+    asaas_falso,
+    vendavel,
+)
+
+client = TestClient(dashboard.app)
+
+
+@pytest.fixture(autouse=True)
+def _zera_rate_limit():
+    """`/billing/pix/checkout` é 20/hour POR IP e todo teste daqui usa o mesmo
+    TestClient — sem zerar, os últimos POSTs do arquivo levariam 429 no lugar do
+    status medido."""
+    from frontend.routes import shared as routes_shared
+
+    routes_shared.limiter.reset()
+    yield
+
+
+def _checkout(user_id, monkeypatch, doc: str, plan: str = "pro"):
+    monkeypatch.setattr(rotas.shared, "resolve_dashboard_user_id", lambda req: user_id)
+    token = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, token)
+    return client.post("/billing/pix/checkout",
+                       headers={dashboard.CSRF_HEADER_NAME: token},
+                       json={"plan": plan, "cpf_cnpj": doc})
+
+
+@pytest.mark.parametrize("doc", [
+    "11111111111",       # passa no mod-11 puro; recusado pelo caso especial
+    "00000000000",       # idem
+    "52998224724",       # CPF com o dígito verificador trocado
+    "11222333000182",    # CNPJ com o dígito verificador trocado
+    "00000000000000",    # CNPJ de sequência repetida, que também passa no mod-11
+    "123456789",         # tamanho que não é nem 11 nem 14
+    "1234567890²",       # `str.isdigit()` é True para `²` e o `int()` estourava (500)
+    "٥٢٩٩٨٢٢٤٧٢٥",       # `52998224725` em árabe-indiano: fechava o mod-11 (200)
+])
+def test_documento_invalido_nao_toca_o_banco_nem_o_asaas(user_id, vendavel,
+                                                         asaas_falso, monkeypatch,
+                                                         doc):
+    conta(user_id, "free", None)
+    r = _checkout(user_id, monkeypatch, doc)
+
+    assert r.status_code == 400, f"{doc}: {r.status_code} {r.text}"
+    assert r.json()["detail"] == "Informe um CPF ou CNPJ válido."
+    assert _linhas(user_id) == [], f"{doc} abriu linha em pix_charges"
+    assert asaas_falso["ordem"] == [], f"{doc} chegou ao Asaas: {asaas_falso['ordem']}"
+
+
+def test_cpf_valido_emite_a_cobranca(user_id, vendavel, asaas_falso, monkeypatch):
+    """POSITIVO: a venda legítima continua saindo, pelo HTTP inteiro."""
+    conta(user_id, "free", None)
+    r = _checkout(user_id, monkeypatch, "52998224725")
+
+    assert r.status_code == 200, r.text
+    assert asaas_falso["ordem"] == ["customer", "create", "qr"]
+    linhas = _linhas(user_id)
+    assert len(linhas) == 1 and linhas[0]["status"] == "pending"
+
+
+def test_cnpj_valido_emite_a_cobranca(user_id, vendavel, asaas_falso, monkeypatch):
+    """POSITIVO do ramo de 14 dígitos: o CNPJ não foi fechado junto com a recusa."""
+    conta(user_id, "free", None)
+    r = _checkout(user_id, monkeypatch, "11222333000181")
+
+    assert r.status_code == 200, r.text
+    assert asaas_falso["ordem"] == ["customer", "create", "qr"]
+    linhas = _linhas(user_id)
+    assert len(linhas) == 1 and linhas[0]["status"] == "pending"
+
+
+@pytest.mark.parametrize("doc", [
+    "529.982.247-25",    # a máscara que o campo da /precos manda
+    "52998224725５",      # `５` fullwidth no fim: o filtro ASCII descarta e sobra
+                         # o CPF válido — antes de 2026-09-10 dava 400 (12 dígitos
+                         # sobreviviam ao `isdigit()`). O cliente normaliza igual
+                         # (`\D` em JS é ASCII-only), então não há divergência.
+])
+def test_cpf_com_lixo_ao_redor_dos_digitos_passa(user_id, vendavel, asaas_falso,
+                                                 monkeypatch, doc):
+    """Sem este caso, a validação podia estar recusando exatamente o que o
+    usuário digita."""
+    conta(user_id, "free", None)
+    r = _checkout(user_id, monkeypatch, doc)
+
+    assert r.status_code == 200, r.text
+    assert len(_linhas(user_id)) == 1

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -94,8 +94,12 @@ def _cabecalhos() -> dict[str, str]:
 
 
 def _checkout(logado, plan: str):
+    # CPF com o mod-11 fechando: o que este arquivo mede é o VOCABULÁRIO de plano,
+    # e desde 2026-09-10 o router recusa documento estruturalmente inválido antes
+    # de chegar ao preço. `12345678901` levava 400 aqui e o teste media a recusa
+    # do documento achando que media a do plano.
     return logado.http.post("/billing/pix/checkout", headers=_cabecalhos(),
-                            json={"plan": plan, "cpf_cnpj": "12345678901"})
+                            json={"plan": plan, "cpf_cnpj": "52998224725"})
 
 
 # ── os três cards da /precos, ponta a ponta pela rota ────────────────────────


### PR DESCRIPTION
## O problema

O checkout do Pix anual só conferia o **tamanho** do documento, nas duas camadas
(`pix-checkout.js` e `billing_pix.py`). `111.111.111-11`, `000.000.000-00` e
qualquer sequência de 11 dígitos passavam, chegavam ao Asaas, ele recusava a
criação do cliente, e a linha ficava presa em `status='creating'` — a tentativa
seguinte tinha de cancelar a anterior lá antes de emitir outra.

Na tela isso virava `"Não consegui gerar o código Pix agora."` — a **mesma frase**
que apareceu em 10/09 quando o `ASAAS_BASE_URL` estava errado e o sistema estava
de fato quebrado. Erro de digitação do cliente e indisponibilidade real produziam
a mesma mensagem.

E havia um segundo defeito por trás: mesmo o 400 que já existia nunca chegava à
tela. `const det = (d && d.detail) || {}` seguido de `det.message` — quando o
FastAPI manda `detail` como **string**, `det.message` é `undefined` e o toast caía
no genérico.

## O que muda

**1. `_documento_valido` (mod-11) no servidor**, antes de inserir em `pix_charges`
e antes de qualquer chamada ao Asaas. Uma cópia só — o navegador continua
conferindo apenas a forma. A tabela de pesos substituiu `_TAMANHOS_DOC`, então o
tamanho aceito tem uma fonte só no Python.

Sequência repetida é **caso especial explícito**, não consequência: `11111111111`,
`00000000000`, `99999999999` e `00000000000000` **passam** no mod-11 puro (medido).

**2. O toast mostra `detail` quando ele é string.** O tratamento do `detail`
**objeto** (409 `stripe_active`, `lifetime`) fica idêntico — PT18b existe para
travar isso.

**3. Filtro de dígitos ASCII estrito.** `str.isdigit()` é `True` para **1912
caracteres não-ASCII**: **1242** derrubavam a rota com **HTTP 500** no `int()`
(`"1234567890²"`) e **670** fechavam o mod-11 e iam ao Asaas com o documento
errado (`"٥٢٩٩٨٢٢٤٧٢٥"`). O JS já normalizava só ASCII (`\D` sem flag `u`), então
o buraco era exatamente a divergência cliente×servidor que a validação de servidor
existe para cobrir.

## Como foi medido

| verificação | resultado |
|---|---|
| suíte Python | `6897 passed, 4 xfailed`; lista de nomes falhando **vazia** (baseline pós-rebase idem, sem o caso novo) |
| mod-11 correto | fuzz de 400k CPFs + 400k CNPJs e varredura **exaustiva dos 100 DVs** sobre 2000 bases de cada, contra duas implementações de referência escritas em separado → **0 divergências** |
| categoria não-ASCII fechada | enumeração dos **1.114.112 code points**: nenhum caractere não-ASCII escapa do filtro. 35 casos HTTP em 17 scripts (árabe, devanágari, tailandês, fullwidth, matemático fora do BMP, `Nl`/`No`/`Lo`) → todos 400, banco e Asaas intocados |
| nada legítimo passou a ser recusado | NBSP, ZWSP, BOM, marcas RTL, `\t`, `\n`, máscara, `"CPF: 529.982.247-25"` → 11/11 dão 200 com `cpf_visto='52998224725'` |
| divergência cliente×servidor | 9665 entradas pelo `replace(/\D/g,"")` real do Node × o filtro Python → **0 divergências** |
| `npm run lint` | 0 errors (223 warnings, todos pré-existentes) |
| PT3 + PT18a + PT18b | 3 pass, 0 fail |

**Controles negativos, rodados um a um:**

| mutação | fica vermelho |
|---|---|
| apagar `if len(set(doc)) == 1` | `[11111111111]`, `[00000000000]`, `[00000000000000]` |
| corpo → `return len(doc) in (11, 14)` (o de hoje) | + `[52998224724]`, `[11222333000182]` |
| filtro → `c.isdigit()` | `[1234567890²]` com **500**, `[٥٢٩٩٨٢٢٤٧٢٥]` com **200**, `[52998224725５]` com 400 |
| `_documento_valido` → `return True` | 8 dos casos |
| JS → `det.message \|\| …` | só **PT18a** |
| JS → `String(det)` | só **PT18b** |

Os 3 positivos (CPF, CNPJ, lixo em volta dos dígitos) ficam **verdes em todas** —
é o que impede um validador que recuse tudo de passar no grupo.

## Escopo

`tests/test_vocabulario_de_plano.py` teve **um literal** de CPF trocado: ele posta
na rota que passou a validar. Não é melhoria — é consequência. Verificado nas 4
combinações que aquele arquivo **não mede documento** e que o controle negativo
declarado na docstring dele continua discriminando.

**Deliberadamente fora deste PR:** separar o `except` genérico do `_emitir`,
mapear códigos de erro do Asaas, e o texto do 503.

## O que este PR NÃO entrega

**Erros específicos do Asaas continuam não chegando ao cliente.** Todo erro do
provedor — inclusive `invalid_cpfCnpj` — é engolido por
`core/services/pix_checkout.py:322` e sai como o 503 fixo de `billing_pix.py:144`.
O fix do `detail` string trocou uma frase genérica por outra nesse caminho, e a
nova (`"Tenta de novo em instantes."`) sugere retentativa para um erro que não
resolve com retentativa. Fechar isso exige mexer no `pix_checkout.py`, que está
fora do escopo deste PR.

## Não verificado

- **Nada foi verificado no aparelho nem em produção.** Mudança de frontend só
  aparece depois do deploy.
- **O Asaas real nunca foi chamado** (`asaas_falso` é mock). Que ele aceite
  `52998224725`/`11222333000181` não foi provado — o que se provou é que passam
  pela validação estrutural.
- `npm run test:frontend` **inteiro nunca saiu verde neste branch**: 24 falhas de
  `ERR_CONNECTION_REFUSED`. Medido em duas colunas — `origin/main` dá **29** pela
  mesma causa, sob `load average` 7,7–10,4. É flake de ambiente, não do branch,
  mas PT18a/PT18b foram provados **isoladamente**, não dentro de suíte verde.
- **CNPJ alfanumérico** (letras nas 12 primeiras posições) leva 400 permanente.
  Não é regressão — `len in (11,14)` recusava igual — mas este é o commit que
  escreve a regra do documento.

## Achados fora de escopo, registrados

1. `core/services/pix_checkout.py:215` (`bruto.isdigit() or int(bruto) <= 0`) tem
   **a mesma forma do bug de `int()`** consertado aqui. Alcance:
   `os.getenv("ASAAS_MIN_CHARGE_CENTS")` — operador, não usuário. Varredura da
   classe inteira (24 sites de `isdigit()` alimentando `int()`): é o **único**
   irmão. O idioma correto já existe em `db/accounts.py:1229`.
2. **Acessibilidade:** a recusa do servidor sobre o campo do documento vai só para
   o `#toast` (`role="status"`, some em 3800 ms, foco não volta), enquanto o
   `<p id="pix-doc-erro" role="alert">` — alvo do `aria-describedby` do próprio
   campo — fica vazio. Pré-existente, mas este PR torna o 400 a recusa **comum**.
3. `precos.html:1022` tem uma **terceira** cópia da normalização do `detail` (o
   checkout do Stripe, na mesma página). Concordam hoje.
4. 403 CSRF passou a mostrar `"Token CSRF inválido ou ausente."` no toast.
5. `frontend/pix-checkout.js` está em **343/350** com `quality/max-lines` em
   `error` — 7 linhas de folga.
6. Não existe teste comparando `pixFormaOk` (11/14 no JS) com `_PESOS_DOC` (11/14
   no Python), como o §0.7 pediria. Dívida **pré-existente** — `_TAMANHOS_DOC` ×
   `pixFormaOk` já divergiam sem guarda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
