### PR TITLE
Os e-mails do Stripe chamavam Essencial e Pro de PigBank+

### DIFF
--- a/core/services/billing_commands.py
+++ b/core/services/billing_commands.py
@@ -98,16 +98,19 @@ def _format_plan_expires(expires_at) -> str:
 
 
 def _handle_assinar(user_id: int, platform: str) -> str:
+    from core.services.email_service import plan_display_name
     from core.services.plan_service import is_pro
     from db import get_auth_user
 
     if is_pro(user_id):
         user = get_auth_user(user_id)
         expires = _format_plan_expires((user or {}).get("plan_expires_at"))
+        # #351 no bot: `pro_max` (PigBank Pro) lia "PigBank+" aqui, sem gate de v2.
+        nome = plan_display_name((user or {}).get("plan"))
         link = build_dashboard_link(user_id, hours=1.0, next_path="/conta") or "https://pigbankai.com/conta"
         b = lambda s: _bold(s, platform)
         return (
-            f"🐷 Você já tá no {b('PigBank+')}!\n\n"
+            f"🐷 Você já tá no {b(nome)}!\n\n"
             f"Próxima renovação: {b(expires)}\n\n"
             f"Pra ver detalhes ou cancelar:\n{link}"
         )

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1040,11 +1040,23 @@ PLAN_DISPLAY_NAMES = {
 
 
 def _plan_name(plan: str | None) -> str:
-    """Nome comercial do plano; valor fora do mapa cai no genérico.
+    """Nome comercial do plano; valor fora do mapa cai na marca sem sufixo.
 
-    O fallback é a marca sem sufixo de propósito: linha antiga, plano
-    descontinuado ou dado corrompido não podem chamar a pessoa de assinante de
-    um plano que ela não comprou — nem derrubar o envio.
+    **Quem chega pelo Stripe NUNCA cai no genérico**, e a versão anterior desta
+    docstring afirmava o contrário ("linha antiga, plano descontinuado ou dado
+    corrompido"). Não é o que acontece: naqueles ramos o `plan` sai de
+    `_stored_plan_for_price` (`frontend/finance_bot_websocket_custom.py:293`),
+    que devolve `'pro'` para price desconhecido, price nulo E assinatura sem
+    item — as três formas de "dado ruim" viram Plus, e o e-mail sai "PigBank+".
+    O genérico é alcançável por UM caminho só: `plan=None` explícito, que é o
+    que a fatura AVULSA (`invoice.payment_failed` sem assinatura) manda, por não
+    ter plano nenhum para nomear.
+
+    O atenuante de o Stripe errar sempre para `'pro'`: esse MESMO valor é o que
+    grava a coluna `plan` da conta (`_stored_plan_for_price` alimenta os dois),
+    então o nome do e-mail erra JUNTO com o entitlement, nunca sozinho — quem
+    receber "PigBank+" indevidamente está, no banco, com o Plus que o e-mail
+    nomeia. Consertar isso é consertar o mapa de prices, não este fallback.
     """
     return PLAN_DISPLAY_NAMES.get(plan, "PigBank")
 
@@ -1218,12 +1230,26 @@ def send_pix_paid_email(to: str, plan: str, amount_brl: float, access_starts_at,
         html_body=html, text_body=text,
     )
 
-def send_payment_failed_email(to: str, dashboard_url: str = "") -> bool:
-    """E-mail quando pagamento falha — Stripe vai retentar (item 40)."""
+def send_payment_failed_email(to: str, plan: str | None, dashboard_url: str = "") -> bool:
+    """E-mail quando pagamento falha — Stripe vai retentar (item 40).
+
+    `plan` é o valor LEGADO da coluna `plan` — ver `PLAN_DISPLAY_NAMES`. Vem do
+    price da assinatura que o ramo do webhook JÁ tinha em mão (o
+    `Subscription.retrieve` que decide se o evento é obsoleto), e é `None` na
+    fatura AVULSA, que não tem assinatura de onde tirar plano: ali sai o
+    genérico "PigBank", como no `send_payment_reminder_email` logo abaixo.
+
+    DÍVIDA DE COPY, deliberadamente não tocada aqui: o texto promete que o
+    plano "volta pra Free", e plano Free não existe mais no produto. É decisão
+    de produto (o que acontece hoje com quem não paga), não erro de nome — quem
+    trouxer a regra reescreve as duas copies, esta e a do
+    `send_subscription_canceled_email`.
+    """
+    nome = _plan_name(plan)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
       <p>🐷 Opa, tivemos um problema.</p>
-      <p>A cobrança do seu PigBank+ <strong>não passou</strong>. Pode ser cartão expirado, saldo insuficiente,
+      <p>A cobrança do seu {nome} <strong>não passou</strong>. Pode ser cartão expirado, saldo insuficiente,
       ou banco recusando a transação.</p>
       <p>Não se preocupa — a gente vai tentar de novo automaticamente nos próximos dias. Mas pra evitar perder o
       acesso aos recursos Pro, vale dar uma olhada agora:</p>
@@ -1235,13 +1261,13 @@ def send_payment_failed_email(to: str, dashboard_url: str = "") -> bool:
     """
     html = _base_html("Pagamento falhou — atualize seu cartão", content)
     text = (
-        f"PigBank+ — pagamento falhou.\n\n"
+        f"{nome} — pagamento falhou.\n\n"
         f"Vamos tentar de novo automaticamente, mas pra evitar perder acesso:\n"
         f"Atualize o cartão em {dash}/conta\n\n"
         f"Se as tentativas falharem, o plano volta pra Free."
     )
     return send_email(
-        to=to, subject="⚠️ PigBank+ — pagamento falhou, atualize seu cartão",
+        to=to, subject=f"⚠️ {nome} — pagamento falhou, atualize seu cartão",
         html_body=html, text_body=text,
     )
 
@@ -1282,8 +1308,19 @@ def send_payment_reminder_email(to: str, dashboard_url: str = "") -> bool:
     )
 
 
-def send_subscription_canceled_email(to: str, expires_at, dashboard_url: str = "") -> bool:
-    """E-mail de confirmação de cancelamento (item 41)."""
+def send_subscription_canceled_email(to: str, plan: str | None, expires_at,
+                                     dashboard_url: str = "") -> bool:
+    """E-mail de confirmação de cancelamento (item 41).
+
+    `plan` é o valor LEGADO da coluna `plan` — ver `PLAN_DISPLAY_NAMES`. Sai do
+    price da própria Subscription que o `customer.subscription.deleted` entrega,
+    e NÃO da conta: o `update_user_plan(user_id, "free", None)` do ramo roda
+    antes deste e-mail, então ler a conta devolveria "free" para todo mundo.
+
+    DÍVIDA DE COPY, deliberadamente não tocada aqui: a mesma promessa de volta
+    ao "Free" do `send_payment_failed_email` — ver a docstring de lá.
+    """
+    nome = _plan_name(plan)
     has_grace = expires_at is not None
     fim = _fmt_brl_date(expires_at) if has_grace else None
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
@@ -1307,7 +1344,7 @@ def send_subscription_canceled_email(to: str, expires_at, dashboard_url: str = "
         access_text = "Sua conta voltou pro plano Free a partir de agora. Os limites Pro foram desativados."
 
     content = f"""
-      <p>🐷 Sua assinatura PigBank+ foi cancelada.</p>
+      <p>🐷 Sua assinatura {nome} foi cancelada.</p>
       {access_html}
       <p>Valeu por ter dado uma chance pra gente. Se quiser contar o que faltou ou poderia melhorar,
       responde este email ou escreve pra <a href="mailto:{support_email}">{support_email}</a> — leitura garantida.</p>
@@ -1315,14 +1352,14 @@ def send_subscription_canceled_email(to: str, expires_at, dashboard_url: str = "
         <a class="btn" href="{dash}/app">Abrir o dashboard</a>
       </p>
     """
-    html = _base_html("Assinatura cancelada — PigBank+", content)
+    html = _base_html(f"Assinatura cancelada — {nome}", content)
     text = (
-        f"PigBank+ cancelado.\n\n"
+        f"{nome} cancelado.\n\n"
         f"{access_text}\n\n"
         f"Mudou de ideia? Mande 'assinar plano' no bot.\n\n"
         f"Dúvidas ou feedback? Responde este email ou escreve pra {support_email} — leitura garantida."
     )
     return send_email(
-        to=to, subject="PigBank+ — assinatura cancelada",
+        to=to, subject=f"{nome} — assinatura cancelada",
         html_body=html, text_body=text,
     )

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1016,13 +1016,53 @@ def _fmt_brl_date(value) -> str:
     return str(value)
 
 
-def send_pro_welcome_email(to: str, trial_end_at, dashboard_url: str = "") -> bool:
-    """E-mail pós-checkout — usuário acabou de assinar (item 37)."""
+# O nome COMERCIAL de cada plano, igual ao que o cliente acabou de ler no modal
+# da /home (`WP_PLANOS` em frontend/home.html). Os mapas de
+# `handlers/billing_commands.py` e do monólito são outra coisa — dizem
+# "Essencial"/"Plus"/"Pro", sem a marca — e por isso não servem aqui.
+#
+# **A chave é o valor LEGADO do plano na cobrança, não o slug do frontend.**
+# `pro` é o Plus e `pro_max` é o Pro — a mesma tradução que o frontend já faz em
+# `PLAN_ALIASES = { pro: "plus", pro_max: "pro" }` (frontend/home.html e
+# frontend/nav-auth.js). Chavear em `plus`/`pro` mandava "PigBank Pro" para quem
+# comprou Plus e o fallback genérico para quem comprou Pro.
+#
+# O mapa deixou de ser só do Pix porque os DOIS gateways chegam com ESSE mesmo
+# vocabulário: o router do Pix só aceita `("essencial", "pro", "pro_max")`
+# (frontend/routes/billing_pix.py), e no Stripe o `plan_value` do webhook sai de
+# `_stored_plan_for_price` (frontend/finance_bot_websocket_custom.py:293), que
+# devolve exatamente os mesmos três.
+PLAN_DISPLAY_NAMES = {
+    "essencial": "PigBank Essencial",
+    "pro": "PigBank+",
+    "pro_max": "PigBank Pro",
+}
+
+
+def _plan_name(plan: str | None) -> str:
+    """Nome comercial do plano; valor fora do mapa cai no genérico.
+
+    O fallback é a marca sem sufixo de propósito: linha antiga, plano
+    descontinuado ou dado corrompido não podem chamar a pessoa de assinante de
+    um plano que ela não comprou — nem derrubar o envio.
+    """
+    return PLAN_DISPLAY_NAMES.get(plan, "PigBank")
+
+
+def send_pro_welcome_email(to: str, plan: str, trial_end_at, dashboard_url: str = "") -> bool:
+    """E-mail pós-checkout — usuário acabou de assinar (item 37).
+
+    `plan` é o valor LEGADO da coluna `plan` (`essencial`, `pro` = Plus,
+    `pro_max` = Pro) — ver `PLAN_DISPLAY_NAMES` logo acima. Existe porque os
+    três e-mails desta família diziam "PigBank+" para todo mundo, e quem
+    assinava Essencial ou Pro lia o nome de outro plano.
+    """
+    nome = _plan_name(plan)
     trial_end = _fmt_brl_date(trial_end_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     cta = f'<p style="text-align:center;margin:24px 0"><a class="btn" href="{dash}/app">🐷 Abrir meu dashboard</a></p>'
     content = f"""
-      <p>🐷✨ <strong>Tá dentro do PigBank+!</strong></p>
+      <p>🐷✨ <strong>Tá dentro do {nome}!</strong></p>
       <p>Sua assinatura começou agora. Os <strong>15 dias grátis</strong> vão até <strong>{trial_end}</strong> —
       só tem cobrança depois disso, e você pode cancelar quando quiser sem ser cobrado.</p>
       <p>Agora você desbloqueou:</p>
@@ -1036,26 +1076,30 @@ def send_pro_welcome_email(to: str, trial_end_at, dashboard_url: str = "") -> bo
       {cta}
       <p style="font-size:13px;color:rgba(255,255,255,.55)">Pra cancelar antes do fim do trial, é só mandar <strong>cancelar plano</strong> no bot ou acessar <a href="{dash}/conta">{dash}/conta</a>.</p>
     """
-    html = _base_html("Bem-vindo ao PigBank+", content)
+    html = _base_html(f"Bem-vindo ao {nome}", content)
     text = (
-        f"PigBank+ ativado!\n\n"
+        f"{nome} ativado!\n\n"
         f"Sua assinatura começou. 15 dias grátis até {trial_end} — só tem cobrança depois.\n\n"
         f"Abra o dashboard: {dash}/app\n"
         f"Pra cancelar antes: mande 'cancelar plano' no bot ou acesse {dash}/conta"
     )
     return send_email(
-        to=to, subject="🐷 Tá dentro do PigBank+!",
+        to=to, subject=f"🐷 Tá dentro do {nome}!",
         html_body=html, text_body=text,
     )
 
 
-def send_trial_ending_email(to: str, trial_end_at, dashboard_url: str = "") -> bool:
-    """E-mail 3 dias antes do trial acabar (item 38)."""
+def send_trial_ending_email(to: str, plan: str, trial_end_at, dashboard_url: str = "") -> bool:
+    """E-mail 3 dias antes do trial acabar (item 38).
+
+    `plan` é o valor LEGADO da coluna `plan` — ver `PLAN_DISPLAY_NAMES`.
+    """
+    nome = _plan_name(plan)
     trial_end = _fmt_brl_date(trial_end_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
       <p>🐷 Oi, parceiro.</p>
-      <p>Seu trial do PigBank+ termina em <strong>3 dias</strong> ({trial_end}).
+      <p>Seu trial do {nome} termina em <strong>3 dias</strong> ({trial_end}).
       Na sequência, a primeira cobrança vai entrar automaticamente no cartão que você cadastrou.</p>
       <p>Se tá curtindo, não precisa fazer nada — só relaxar e seguir usando.</p>
       <p>Se mudou de ideia, sem stress: manda <strong>cancelar plano</strong> no bot até {trial_end} e
@@ -1066,25 +1110,32 @@ def send_trial_ending_email(to: str, trial_end_at, dashboard_url: str = "") -> b
     """
     html = _base_html("Seu trial termina em 3 dias", content)
     text = (
-        f"PigBank+ — trial termina em 3 dias ({trial_end}).\n\n"
+        f"{nome} — trial termina em 3 dias ({trial_end}).\n\n"
         f"Pra continuar: não precisa fazer nada, a cobrança entra automaticamente.\n"
         f"Pra cancelar sem ser cobrado: mande 'cancelar plano' no bot até {trial_end}.\n\n"
         f"Gerenciar: {dash}/conta"
     )
     return send_email(
-        to=to, subject="🐷 Seu trial PigBank+ termina em 3 dias",
+        to=to, subject=f"🐷 Seu trial {nome} termina em 3 dias",
         html_body=html, text_body=text,
     )
 
 
-def send_pro_charged_email(to: str, amount_brl: float, next_charge_at, dashboard_url: str = "") -> bool:
-    """E-mail de confirmação de cobrança após o trial (item 39)."""
+def send_pro_charged_email(to: str, plan: str, amount_brl: float, next_charge_at,
+                           dashboard_url: str = "") -> bool:
+    """E-mail de confirmação de cobrança após o trial (item 39).
+
+    `plan` é o valor LEGADO da coluna `plan` — ver `PLAN_DISPLAY_NAMES`. É o
+    e-mail de maior volume da família: dizia "Seu PigBank+ tá renovado" em toda
+    cobrança, inclusive nas de Essencial e de Pro.
+    """
+    nome = _plan_name(plan)
     valor = f"R$ {amount_brl:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
     proxima = _fmt_brl_date(next_charge_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
       <p>🐷 Cobrança confirmada — valeu por continuar com a gente!</p>
-      <p>Seu PigBank+ tá renovado. Detalhes da cobrança:</p>
+      <p>Seu {nome} tá renovado. Detalhes da cobrança:</p>
       <ul>
         <li><strong>Valor:</strong> {valor}</li>
         <li><strong>Próxima cobrança:</strong> {proxima}</li>
@@ -1092,36 +1143,17 @@ def send_pro_charged_email(to: str, amount_brl: float, next_charge_at, dashboard
       <p>Sua nota fiscal e histórico de pagamentos ficam no portal Stripe — abra em <a href="{dash}/conta">{dash}/conta</a>.</p>
       <p>Qualquer dúvida, é só responder este email ou usar <strong>ajuda</strong> no bot.</p>
     """
-    html = _base_html("Pagamento confirmado — PigBank+", content)
+    html = _base_html(f"Pagamento confirmado — {nome}", content)
     text = (
-        f"PigBank+ renovado.\n\n"
+        f"{nome} renovado.\n\n"
         f"Valor: {valor}\n"
         f"Próxima cobrança: {proxima}\n\n"
         f"Histórico de pagamentos: {dash}/conta"
     )
     return send_email(
-        to=to, subject=f"✓ Pagamento confirmado — PigBank+ ({valor})",
+        to=to, subject=f"✓ Pagamento confirmado — {nome} ({valor})",
         html_body=html, text_body=text,
     )
-
-
-# O nome COMERCIAL de cada plano, igual ao que o cliente acabou de ler no modal
-# da /home (`WP_PLANOS` em frontend/home.html). Os mapas de
-# `handlers/billing_commands.py` e do monólito são outra coisa — dizem
-# "Essencial"/"Plus"/"Pro", sem a marca — e por isso não servem aqui.
-#
-# **A chave é o valor LEGADO da coluna `plan` da cobrança, não o slug do
-# frontend.** `pro` é o Plus e `pro_max` é o Pro — a mesma tradução que o
-# frontend já faz em `PLAN_ALIASES = { pro: "plus", pro_max: "pro" }`
-# (frontend/home.html e frontend/nav-auth.js). Chavear em `plus`/`pro` mandava
-# "PigBank Pro" para quem comprou Plus e o fallback genérico para quem comprou
-# Pro: o router só aceita `("essencial", "pro", "pro_max")`
-# (frontend/routes/billing_pix.py) e a coluna guarda exatamente isso.
-PIX_PLAN_NAMES = {
-    "essencial": "PigBank Essencial",
-    "pro": "PigBank+",
-    "pro_max": "PigBank Pro",
-}
 
 
 def send_pix_paid_email(to: str, plan: str, amount_brl: float, access_starts_at,
@@ -1136,14 +1168,15 @@ def send_pix_paid_email(to: str, plan: str, amount_brl: float, access_starts_at,
     `plan` existe porque o e-mail dizia "PigBank+" para todo mundo — quem pagou
     Essencial ou Pro recebia o nome de outro plano no assunto e no corpo. Ele é
     a coluna `plan` da cobrança crua, ou seja o valor LEGADO (`essencial`,
-    `pro` = Plus, `pro_max` = Pro) — ver `PIX_PLAN_NAMES` logo acima.
+    `pro` = Plus, `pro_max` = Pro) — ver `PLAN_DISPLAY_NAMES`, que desde a #351
+    serve também os e-mails do Stripe.
     `access_starts_at` no futuro é a compra AGENDADA (quem já tinha plano
     vigente): o ano só começa quando o período atual terminar, e prometer acesso
     imediato ali é a mesma mentira de outro jeito.
     """
     from datetime import datetime as _dt, timezone as _tz
 
-    nome = PIX_PLAN_NAMES.get(plan, "PigBank")
+    nome = _plan_name(plan)
     # Naive vira UTC antes de comparar, do mesmo jeito que o `_fmt_brl_date`
     # logo acima faz com ESTE MESMO valor: a coluna é `timestamptz` e hoje só
     # chega aware, mas comparar aware com naive levanta `TypeError` DENTRO do

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1032,9 +1032,20 @@ def _fmt_brl_date(value) -> str:
 # (frontend/routes/billing_pix.py), e no Stripe o `plan_value` do webhook sai de
 # `_stored_plan_for_price` (frontend/finance_bot_websocket_custom.py:293), que
 # devolve exatamente os mesmos três.
+#
+# `plus` é o QUARTO, e entra por ser valor de COLUNA aceito, não por ser escrito
+# hoje: `_STORED_PLAN_TO_TIER` (core/services/plan_service.py:44) o mapeia para o
+# mesmo tier de `pro`, e `frontend/admin-dashboard.html:2192` já o trata como
+# "valor antigo em algumas contas". Sem a entrada, tal conta lê o genérico
+# "PigBank" — em `billing_commands.py:109`, entre outros. Nenhum escritor atual o
+# produz e a produção tinha ZERO linhas com ele (medido 2026-09-10 por
+# `SELECT plan, count(*) FROM auth_accounts GROUP BY 1`; remeça antes de reusar):
+# é defesa contra valor que o repositório declara ter existido, não regressão
+# viva. Quem amarra este mapa ao dos tiers é `tests/test_vocabulario_de_plano.py`.
 PLAN_DISPLAY_NAMES = {
     "essencial": "PigBank Essencial",
     "pro": "PigBank+",
+    "plus": "PigBank+",
     "pro_max": "PigBank Pro",
 }
 

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1039,11 +1039,11 @@ PLAN_DISPLAY_NAMES = {
 }
 
 
-def _plan_name(plan: str | None) -> str:
+def plan_display_name(plan: str | None) -> str:
     """Nome comercial do plano; valor fora do mapa cai na marca sem sufixo.
 
-    **Quem chega pelo Stripe NUNCA cai no genérico**, e a versão anterior desta
-    docstring afirmava o contrário ("linha antiga, plano descontinuado ou dado
+    **Nenhum e-mail COM ASSINATURA cai no genérico**, e a versão anterior desta
+    docstring afirmava outra coisa ("linha antiga, plano descontinuado ou dado
     corrompido"). Não é o que acontece: naqueles ramos o `plan` sai de
     `_stored_plan_for_price` (`frontend/finance_bot_websocket_custom.py:293`),
     que devolve `'pro'` para price desconhecido, price nulo E assinatura sem
@@ -1069,7 +1069,7 @@ def send_pro_welcome_email(to: str, plan: str, trial_end_at, dashboard_url: str 
     três e-mails desta família diziam "PigBank+" para todo mundo, e quem
     assinava Essencial ou Pro lia o nome de outro plano.
     """
-    nome = _plan_name(plan)
+    nome = plan_display_name(plan)
     trial_end = _fmt_brl_date(trial_end_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     cta = f'<p style="text-align:center;margin:24px 0"><a class="btn" href="{dash}/app">🐷 Abrir meu dashboard</a></p>'
@@ -1106,7 +1106,7 @@ def send_trial_ending_email(to: str, plan: str, trial_end_at, dashboard_url: str
 
     `plan` é o valor LEGADO da coluna `plan` — ver `PLAN_DISPLAY_NAMES`.
     """
-    nome = _plan_name(plan)
+    nome = plan_display_name(plan)
     trial_end = _fmt_brl_date(trial_end_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
@@ -1141,7 +1141,7 @@ def send_pro_charged_email(to: str, plan: str, amount_brl: float, next_charge_at
     e-mail de maior volume da família: dizia "Seu PigBank+ tá renovado" em toda
     cobrança, inclusive nas de Essencial e de Pro.
     """
-    nome = _plan_name(plan)
+    nome = plan_display_name(plan)
     valor = f"R$ {amount_brl:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
     proxima = _fmt_brl_date(next_charge_at)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
@@ -1188,7 +1188,7 @@ def send_pix_paid_email(to: str, plan: str, amount_brl: float, access_starts_at,
     """
     from datetime import datetime as _dt, timezone as _tz
 
-    nome = _plan_name(plan)
+    nome = plan_display_name(plan)
     # Naive vira UTC antes de comparar, do mesmo jeito que o `_fmt_brl_date`
     # logo acima faz com ESTE MESMO valor: a coluna é `timestamptz` e hoje só
     # chega aware, mas comparar aware com naive levanta `TypeError` DENTRO do
@@ -1245,19 +1245,19 @@ def send_payment_failed_email(to: str, plan: str | None, dashboard_url: str = ""
     trouxer a regra reescreve as duas copies, esta e a do
     `send_subscription_canceled_email`.
     """
-    nome = _plan_name(plan)
+    nome = plan_display_name(plan)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
     content = f"""
       <p>🐷 Opa, tivemos um problema.</p>
       <p>A cobrança do seu {nome} <strong>não passou</strong>. Pode ser cartão expirado, saldo insuficiente,
       ou banco recusando a transação.</p>
       <p>Não se preocupa — a gente vai tentar de novo automaticamente nos próximos dias. Mas pra evitar perder o
-      acesso aos recursos Pro, vale dar uma olhada agora:</p>
+      acesso aos recursos do seu plano, vale dar uma olhada agora:</p>
       <p style="text-align:center;margin:24px 0">
         <a class="btn" href="{dash}/conta">Atualizar cartão</a>
       </p>
       <p style="font-size:13px;color:rgba(255,255,255,.55)">Enquanto isso, seu plano fica como <strong>past_due</strong>.
-      Se as tentativas falharem, ele volta pra Free e os recursos Pro são bloqueados.</p>
+      Se as tentativas falharem, ele volta pra Free e os recursos do plano são bloqueados.</p>
     """
     html = _base_html("Pagamento falhou — atualize seu cartão", content)
     text = (
@@ -1320,7 +1320,7 @@ def send_subscription_canceled_email(to: str, plan: str | None, expires_at,
     DÍVIDA DE COPY, deliberadamente não tocada aqui: a mesma promessa de volta
     ao "Free" do `send_payment_failed_email` — ver a docstring de lá.
     """
-    nome = _plan_name(plan)
+    nome = plan_display_name(plan)
     has_grace = expires_at is not None
     fim = _fmt_brl_date(expires_at) if has_grace else None
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
@@ -1328,20 +1328,20 @@ def send_subscription_canceled_email(to: str, plan: str | None, expires_at,
 
     if has_grace:
         access_html = (
-            f"<p>Tudo certo — você continua com acesso aos recursos Pro <strong>até {fim}</strong>. "
-            f"Depois disso, sua conta volta automaticamente pro plano Free e os limites Pro são desativados.</p>"
+            f"<p>Tudo certo — você continua com acesso aos recursos do seu plano <strong>até {fim}</strong>. "
+            f"Depois disso, sua conta volta automaticamente pro plano Free e os limites do plano são desativados.</p>"
             f"<p>Se mudar de ideia antes dessa data, é só mandar <strong>assinar plano</strong> no bot.</p>"
         )
         access_text = (
-            f"Você mantém acesso aos recursos Pro até {fim}. Depois disso, a conta volta pra Free."
+            f"Você mantém acesso aos recursos do seu plano até {fim}. Depois disso, a conta volta pra Free."
         )
     else:
         access_html = (
             "<p>Tudo certo — sua conta voltou pro plano <strong>Free</strong> a partir de agora. "
-            "Os limites Pro foram desativados.</p>"
+            "Os limites do plano foram desativados.</p>"
             "<p>Se mudar de ideia, é só mandar <strong>assinar plano</strong> no bot.</p>"
         )
-        access_text = "Sua conta voltou pro plano Free a partir de agora. Os limites Pro foram desativados."
+        access_text = "Sua conta voltou pro plano Free a partir de agora. Os limites do plano foram desativados."
 
     content = f"""
       <p>🐷 Sua assinatura {nome} foi cancelada.</p>

--- a/core/services/engagement_scheduler.py
+++ b/core/services/engagement_scheduler.py
@@ -234,7 +234,7 @@ async def _check_trial_ending() -> None:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    select user_id, email, email_enc, plan_expires_at
+                    select user_id, email, email_enc, plan, plan_expires_at
                     from auth_accounts
                     where plan = 'pro'
                       and last_payment_status = 'trialing'
@@ -276,7 +276,10 @@ async def _check_trial_ending() -> None:
         ):
             continue
         try:
-            ok = await loop.run_in_executor(None, send_trial_ending_email, email, expires_at, dashboard_url)
+            # `row["plan"]`, não o literal 'pro' do WHERE (§0.7): o dia em que
+            # o filtro deixar de ser só Plus, a cópia mentiria (#351).
+            ok = await loop.run_in_executor(
+                None, send_trial_ending_email, email, row["plan"], expires_at, dashboard_url)
             if ok:
                 logger.info("[trial-ending] enviado → user_id=%s (%s)", user_id, _mask_email(email))
                 log_system_event_sync(

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -5095,14 +5095,32 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
         indistinguíveis: o segundo é suprimido pela chave que o primeiro gravou
         e o cliente fica com "PigBank Essencial" para uma cobrança de Pro. Antes
         do #351 os dois e-mails eram idênticos e suprimir era de graça.
-        ponytail: teto conhecido e não fechado. O custo de fechar é maior que o
-        do caso: `chave` é TAMBÉM o `event_type` gravado em
-        `system_event_logs`, lido de fora daqui por nome literal (o
-        `recent_event_exists("trial_ending_email_sent", ...)` do ramo
-        `trial_will_end`, :5547) e pelos painéis — pendurar o plano nela
-        fragmenta a série histórica e quebra aquele leitor. Se o upgrade
-        no mesmo dia virar volume, o conserto é `chave` com sufixo do plano
-        MAIS o leitor de fora migrado junto, num commit só.
+        ponytail: teto conhecido, deixado aberto DE PROPÓSITO — e o custo é
+        menor do que uma versão anterior deste comentário dizia. Ela alegava
+        que `chave` era lida de fora por
+        `recent_event_exists("trial_ending_email_sent", ...)` e pelos painéis.
+        Medido, é falso nas duas pontas, e quem for mexer aqui precisa saber:
+
+          · **não há leitor externo.** `chave` é `f"{fn.__name__}_sent"`, ou
+            seja `send_trial_ending_email_sent`. O `recent_event_exists` de
+            :5555 lê `trial_ending_email_sent` — outra string, gravada por
+            outro escritor (o `log_system_event` de :5566 e o
+            `engagement_scheduler.py:287`). Busca literal pelas quatro chaves
+            desta família em `*.py`/`*.js`/`*.sql`/`*.html`: zero ocorrências
+            fora de uma menção em docstring de teste.
+          · **nenhum painel usa.** `core/admin_dashboard.py:742-755` filtra
+            `event_type IN ('email_sent','email_failed')`, que saem do
+            `email_service.py:95` — outro evento; e os rótulos de
+            `frontend/admin-dashboard.html` não citam chave desta família.
+
+        Sobra de custo real: (a) a série histórica em `system_event_logs`
+        fragmenta — série que hoje nenhum consumidor consulta; e (b) a dedupe
+        deixa de significar "um e-mail desta função por janela" e passa a ser
+        "um por função E plano", o que solta um segundo e-mail quando o plano
+        muda dentro da janela longa do `send_payment_failed_email`. Fica como
+        está porque o caso é raro e o conserto não é de graça, não porque algo
+        quebre. Se o upgrade no mesmo dia virar volume: sufixo do plano na
+        `chave`, sem leitor nenhum para migrar junto.
 
         Dedup por (função, usuário, `dedup_days`) porque o handler agora devolve 5xx
         de propósito quando a materialização falha, e a Stripe reentrega o
@@ -5132,16 +5150,6 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
         cada retry não é; e ZERO e-mail na janela inteira — o que uma dedupe
         gravada sem olhar o retorno produz — é o pior dos três.
         """
-        # `fn.__name__` FORA do try, e isto é uma mina, não um estilo: um
-        # `functools.partial` ou qualquer wrapper sem `__name__` levanta
-        # `AttributeError` AQUI, onde nada captura — e o webhook devolve 5xx
-        # para a Stripe por causa de um e-mail. Passe funções nomeadas (todos
-        # os call sites de hoje passam); se algum dia precisar de argumentos
-        # pré-ligados, use `*args` desta função, não `partial`.
-        #
-        # ponytail: mina pré-existente e não alcançável hoje — não mexi. Quem
-        # precisar mesmo de wrapper: `getattr(fn, "__name__", ...)` resolve, ou
-        # mover a linha para dentro do try.
         chave = f"{fn.__name__}_sent"
         try:
             from core.observability import recent_event_exists  # noqa: PLC0415
@@ -5695,7 +5703,7 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
             # "⚠️ PigBank+ — pagamento falhou". `None` quando `_sub_agora` é
             # None, que é a fatura AVULSA (sem `subscription` em nenhuma das
             # duas formas da API): ali não há assinatura de onde tirar plano, e
-            # `_plan_name` devolve o genérico "PigBank".
+            # `plan_display_name` devolve o genérico "PigBank".
             _plano_falha = (_stored_plan_for_price(_subscription_price_id(_sub_agora))
                             if _sub_agora is not None else None)
             from core.services.email_service import send_payment_failed_email
@@ -5806,6 +5814,12 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
             except Exception as exc:
                 print(f"[billing] email canceled falhou user={user_id}: {exc}")
             # Notificação admin
+            # DÍVIDA PRÉ-EXISTENTE, não deste PR: `email` só nasce se o
+            # `_user_email` acima RETORNAR. Se ele levantar, o except de cima
+            # engole e o `email=email` daqui vira `NameError` — engolido pelo
+            # except deste try, com a notificação admin sumindo calada. Mesma
+            # classe do `_sub_agora` que o #351 fechou dez linhas acima; fica
+            # anotado para não ser "descoberto" depois como defeito novo.
             try:
                 from core.services.admin_notify import notify_subscription_canceled
                 await asyncio.to_thread(

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -5088,6 +5088,22 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
     async def _fire_email(uid: int, fn, *args, dedup_days: float = 1.0):
         """Envia email transacional em background — falha silenciosa pra nao quebrar webhook.
 
+        **A chave NÃO inclui os argumentos, e desde a #351 isso custa um caso.**
+        Os e-mails desta família passaram a carregar o NOME DO PLANO, então dois
+        `invoice.paid` de planos diferentes no MESMO dia (upgrade
+        Essencial→Pro, que gera fatura proporcional na hora) deixam de ser
+        indistinguíveis: o segundo é suprimido pela chave que o primeiro gravou
+        e o cliente fica com "PigBank Essencial" para uma cobrança de Pro. Antes
+        do #351 os dois e-mails eram idênticos e suprimir era de graça.
+        ponytail: teto conhecido e não fechado. O custo de fechar é maior que o
+        do caso: `chave` é TAMBÉM o `event_type` gravado em
+        `system_event_logs`, lido de fora daqui por nome literal (o
+        `recent_event_exists("trial_ending_email_sent", ...)` do ramo
+        `trial_will_end`, :5547) e pelos painéis — pendurar o plano nela
+        fragmenta a série histórica e quebra aquele leitor. Se o upgrade
+        no mesmo dia virar volume, o conserto é `chave` com sufixo do plano
+        MAIS o leitor de fora migrado junto, num commit só.
+
         Dedup por (função, usuário, `dedup_days`) porque o handler agora devolve 5xx
         de propósito quando a materialização falha, e a Stripe reentrega o
         evento INTEIRO: sem isto, cada retry mandaria um e-mail de compra novo.
@@ -5116,6 +5132,16 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
         cada retry não é; e ZERO e-mail na janela inteira — o que uma dedupe
         gravada sem olhar o retorno produz — é o pior dos três.
         """
+        # `fn.__name__` FORA do try, e isto é uma mina, não um estilo: um
+        # `functools.partial` ou qualquer wrapper sem `__name__` levanta
+        # `AttributeError` AQUI, onde nada captura — e o webhook devolve 5xx
+        # para a Stripe por causa de um e-mail. Passe funções nomeadas (todos
+        # os call sites de hoje passam); se algum dia precisar de argumentos
+        # pré-ligados, use `*args` desta função, não `partial`.
+        #
+        # ponytail: mina pré-existente e não alcançável hoje — não mexi. Quem
+        # precisar mesmo de wrapper: `getattr(fn, "__name__", ...)` resolve, ou
+        # mover a linha para dentro do try.
         chave = f"{fn.__name__}_sent"
         try:
             from core.observability import recent_event_exists  # noqa: PLC0415
@@ -5573,6 +5599,7 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
         )
         _sub_id = _invoice_subscription_id(invoice)
         _status_agora = ""
+        _sub_agora = None
         if user_id and _sub_id:
             # `to_thread` porque este handler é `async` e roda no event loop
             # ÚNICO do Uvicorn: um `retrieve` síncrono aqui congela o processo
@@ -5661,9 +5688,19 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
             # deixavam o segundo mudo. Fora do ciclo novo vale
             # `DUNNING_GRACE_DAYS`: cada smart retry do MESMO ciclo cai na
             # janela e não vira um e-mail a mais.
+            #
+            # O PLANO vem do `retrieve` que este ramo JÁ fez para decidir se o
+            # evento é obsoleto — mesma fonte dos outros e-mails da família
+            # (#351). Sem ele, o assinante Essencial cujo cartão falha recebia
+            # "⚠️ PigBank+ — pagamento falhou". `None` quando `_sub_agora` é
+            # None, que é a fatura AVULSA (sem `subscription` em nenhuma das
+            # duas formas da API): ali não há assinatura de onde tirar plano, e
+            # `_plan_name` devolve o genérico "PigBank".
+            _plano_falha = (_stored_plan_for_price(_subscription_price_id(_sub_agora))
+                            if _sub_agora is not None else None)
             from core.services.email_service import send_payment_failed_email
             await _fire_email(
-                user_id, send_payment_failed_email,
+                user_id, send_payment_failed_email, _plano_falha,
                 dedup_days=0.0 if _abriu_ciclo else float(DUNNING_GRACE_DAYS))
             # Notificação admin
             try:
@@ -5753,11 +5790,19 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                 user_id=user_id,
             )
             # Email de confirmacao de cancelamento (item 41)
+            # O plano sai do PRICE do `obj`, que é a própria Subscription do
+            # evento (#351) — e não da conta, porque o `update_user_plan(...,
+            # "free", None)` lá em cima já rodou e a conta diria "free" para
+            # todo mundo. Sem isto, quem cancelava Essencial lia "PigBank+ —
+            # assinatura cancelada".
+            _plano_cancelado = _stored_plan_for_price(_subscription_price_id(obj))
             from core.services.email_service import send_subscription_canceled_email
             try:
                 email = await _user_email(user_id)
                 if email:
-                    await asyncio.to_thread(send_subscription_canceled_email, email, expires_for_email, DASHBOARD_URL)
+                    await asyncio.to_thread(send_subscription_canceled_email, email,
+                                            _plano_cancelado, expires_for_email,
+                                            DASHBOARD_URL)
             except Exception as exc:
                 print(f"[billing] email canceled falhou user={user_id}: {exc}")
             # Notificação admin

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -5218,9 +5218,12 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
                     "status": sub_status,
                 },
             )
-            # Email de boas-vindas Pro (item 37)
+            # Email de boas-vindas Pro (item 37) — `plan_value` é o MESMO que
+            # acabou de ser gravado e logado acima (vocabulário legado, de
+            # `_stored_plan_for_price`): sem ele o e-mail chamava todo
+            # assinante de PigBank+, que é só o Plus (#351).
             from core.services.email_service import send_pro_welcome_email
-            await _fire_email(user_id, send_pro_welcome_email, expires_dt)
+            await _fire_email(user_id, send_pro_welcome_email, plan_value, expires_dt)
             # Notificação admin (Slack/Discord webhook)
             try:
                 from core.services.admin_notify import notify_new_pro
@@ -5407,7 +5410,8 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
             if amount_cents and amount_cents > 0:
                 amount_brl = float(amount_cents) / 100.0
                 from core.services.email_service import send_pro_charged_email
-                await _fire_email(user_id, send_pro_charged_email, amount_brl, expires_dt)
+                await _fire_email(user_id, send_pro_charged_email,
+                                  plan_value, amount_brl, expires_dt)
 
                 # Comissão de afiliado: se o pagante foi indicado por um afiliado
                 # ativo, credita a % da fatura. Idempotente por invoice id (retry
@@ -5516,8 +5520,13 @@ async def billing_webhook(request: Request, background_tasks: BackgroundTasks):
             from core.observability import recent_event_exists
             if not recent_event_exists("trial_ending_email_sent", user_id, within_days=6):
                 expires_dt = _subscription_period_end(sub)
+                # Mesma fonte do plano dos outros ramos (#351): o PRICE da
+                # assinatura, não o texto do e-mail. Quem está em trial de
+                # Essencial ou de Pro lia "seu trial do PigBank+".
+                plan_value = _stored_plan_for_price(_subscription_price_id(sub))
                 from core.services.email_service import send_trial_ending_email
-                await _fire_email(user_id, send_trial_ending_email, expires_dt)
+                await _fire_email(user_id, send_trial_ending_email,
+                                  plan_value, expires_dt)
                 await log_system_event(
                     "info",
                     "trial_ending_email_sent",

--- a/tests/_billing_grants_helpers.py
+++ b/tests/_billing_grants_helpers.py
@@ -121,6 +121,22 @@ def evt_checkout(uid: int, subscription, created: int, session_id: str) -> dict:
             "created": created, "data": {"object": objeto}}
 
 
+def espiao_email(vistos: dict, nome: str):
+    """Substitui um remetente de e-mail e GRAVA a tupla de argumentos.
+
+    Duas coisas não são detalhe. `__name__` é a CHAVE da dedupe do `_fire_email`
+    (`finance_bot_websocket_custom.py`): três espiões com o mesmo nome viram um
+    balde só e os e-mails 2 e 3 saem DEDUPADOS, com o teste acusando "não
+    chamou". E o `return True` é o que faz o envio contar como confirmado —
+    `_fire_email` trata falsy como falha, não grava a chave e não segue.
+    """
+    def _fn(*a, **kw):
+        vistos[nome] = a
+        return True
+    _fn.__name__ = nome
+    return _fn
+
+
 class FakeStripeSubs:
     """Só o `Subscription.list` que o `_find_active_subscription` usa.
 

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -300,14 +300,19 @@ def test_assinar_de_quem_tem_pro_max_nao_diz_pigbank_mais(patches):
     assert "PigBank+" not in out, f"nome de outro plano pra quem paga Pro: {out}"
 
 
-def test_assinar_de_quem_tem_plus_continua_pigbank_mais(patches):
+@pytest.mark.parametrize("plano", ["pro", "plus"])
+def test_assinar_de_quem_tem_plus_continua_pigbank_mais(patches, plano):
     """CONTROLE POSITIVO do par: `pro` já lia o nome certo e continua lendo.
 
     Sem ele o conserto poderia trocar todo mundo pelo genérico "PigBank" e o
     teste de cima ficaria verde do mesmo jeito.
+
+    `plus` é o mesmo tier gravado com o valor ANTIGO da coluna (achado do Codex
+    no #358): `is_pro` o aceita, então esta linha é alcançável, e sem a entrada
+    em `PLAN_DISPLAY_NAMES` ele lê "PigBank" seco.
     """
     patches["is_pro"] = True
-    patches["auth_user"] = {"plan": "pro", "last_payment_status": "active",
+    patches["auth_user"] = {"plan": plano, "last_payment_status": "active",
                             "plan_expires_at": None}
 
     out = mod.handle_billing_command(99, "assinar plano", platform="whatsapp")

--- a/tests/test_billing_commands.py
+++ b/tests/test_billing_commands.py
@@ -277,3 +277,39 @@ def test_assinar_v2_com_consulta_indisponivel_delega_confirmacao_ao_checkout(pat
 
     assert "15 dias grátis" not in out
     assert "checkout confirma" in out
+
+
+# ─── #351: o nome do plano de quem JÁ assina ────────────────────────────────
+
+
+def test_assinar_de_quem_tem_pro_max_nao_diz_pigbank_mais(patches):
+    """`pro_max` (PigBank Pro) lia "🐷 Você já tá no PigBank+!".
+
+    Quem chega nesta linha é só `pro` (Plus) e `pro_max` (Pro): `is_pro` exige
+    tier >= plus, então Essencial NÃO passa por aqui — ao contrário do que a
+    revisão supôs. E a linha não tem gate de `PLANS_V2_ENABLED`: ela sai com a
+    flag ligada ou desligada, porque o nome vem da coluna `plan`, não do tier.
+    """
+    patches["is_pro"] = True
+    patches["auth_user"] = {"plan": "pro_max", "last_payment_status": "active",
+                            "plan_expires_at": None}
+
+    out = mod.handle_billing_command(99, "assinar plano", platform="whatsapp")
+
+    assert "PigBank Pro" in out, out
+    assert "PigBank+" not in out, f"nome de outro plano pra quem paga Pro: {out}"
+
+
+def test_assinar_de_quem_tem_plus_continua_pigbank_mais(patches):
+    """CONTROLE POSITIVO do par: `pro` já lia o nome certo e continua lendo.
+
+    Sem ele o conserto poderia trocar todo mundo pelo genérico "PigBank" e o
+    teste de cima ficaria verde do mesmo jeito.
+    """
+    patches["is_pro"] = True
+    patches["auth_user"] = {"plan": "pro", "last_payment_status": "active",
+                            "plan_expires_at": None}
+
+    out = mod.handle_billing_command(99, "assinar plano", platform="whatsapp")
+
+    assert "já tá no *PigBank+*" in out, out

--- a/tests/test_billing_email_nome_do_plano.py
+++ b/tests/test_billing_email_nome_do_plano.py
@@ -125,8 +125,9 @@ def test_a_conversa_do_webhook_manda_o_plano_nos_tres_emails(user_id, monkeypatc
 
     Aqui é onde a ordem dos argumentos erra CALADA: `_fire_email` chama
     `fn(email, *args, DASHBOARD_URL)` posicionalmente e engole toda exceção
-    (`finance_bot_websocket_custom.py:5137`) — trocar `plan` com `amount_brl`
-    não levanta nada visível, só manda e-mail errado (ou nenhum). Por isso o
+    (`finance_bot_websocket_custom.py:5164`, `except` em `:5171`) — trocar
+    `plan` com `amount_brl` não levanta nada visível, só manda e-mail errado
+    (ou nenhum). Por isso o
     teste posta o evento inteiro no `/billing/webhook` e lê a tupla que chegou
     do outro lado, em vez de chamar a função de e-mail direto.
 

--- a/tests/test_billing_email_nome_do_plano.py
+++ b/tests/test_billing_email_nome_do_plano.py
@@ -1,0 +1,180 @@
+"""Os e-mails de billing do Stripe chamavam TODO assinante de "PigBank+" (#351).
+
+Mesmo defeito que o #348 corrigiu no Pix, no canal mais antigo e de mais volume.
+"PigBank+" é o nome comercial do **Plus**: quem assinava Essencial ou Pro lia o
+nome de outro plano nas boas-vindas, no aviso de fim de trial e — pior — na
+confirmação de cobrança, que sai em toda renovação.
+
+**O vocabulário aqui é o LEGADO**, e isso não é escolha de estilo: o `plan_value`
+do webhook sai de `_stored_plan_for_price`
+(`frontend/finance_bot_websocket_custom.py:293`), que devolve `essencial`, `pro`
+(= Plus) ou `pro_max` (= Pro) a partir do price da assinatura. `plus` nunca
+chega. Chavear no vocabulário público mandaria "PigBank Pro" para quem assinou
+Plus — foi a primeira versão do #348, e é regressão, não conserto.
+
+Os dois controles do CLAUDE.md §3, para o GRUPO. As três mutações abaixo foram
+RODADAS, não previstas — cada uma com o vermelho que produziu:
+
+  · **negativo, a copy** — volte `nome` para a constante `"PigBank+"` em
+    `send_pro_charged_email` e ficam vermelhos `test_essencial_cobrado...` e
+    `test_pro_max_cobrado...`, que estavam VERDES.
+  · **negativo, o vocabulário** — chaveie `PLAN_DISPLAY_NAMES` em
+    `plus`/`pro` (os slugs do frontend) e ficam vermelhos
+    `test_pro_max_cobrado...`, `test_boas_vindas...` e — a regressão que o #348
+    quase mandou para produção — o CONTROLE POSITIVO
+    `test_plus_cobrado_continua_pigbank_mais`, além de dois casos do arquivo do
+    Pix, que compartilham o mesmo mapa.
+  · **negativo, o seam** — tire `plan_value` da chamada de
+    `_fire_email(user_id, send_pro_charged_email, ...)`
+    (`finance_bot_websocket_custom.py:5410`): só
+    `test_a_conversa_do_webhook...` fica vermelho, com
+    `send_pro_charged_email recebeu 9.9`. Esta mutação não levanta erro nenhum
+    em produção — manda o VALOR no lugar do plano e o cliente recebe
+    "PigBank" genérico. É a única das três que a copy não alcança, e por isso
+    este teste existe.
+  · **positivo** — `test_plus_cobrado_continua_pigbank_mais` é o plano que já
+    estava CERTO com o texto fixo, e continua verde na 1ª mutação. Sem ele, o
+    grupo passaria num conserto que trocasse todo mundo por um genérico — que
+    é pior que o bug.
+
+O que este arquivo NÃO alcança: o envio de verdade (`send_email` é
+monkeypatchado), o `_check_trial_ending` do scheduler (nenhum teste do repo
+exercita aquele laço) e os dois irmãos que ficaram de fora do escopo da #351 —
+`send_payment_failed_email` (`email_service.py:1193`) e
+`send_subscription_canceled_email` (`:1277`) continuam com "PigBank+" fixo.
+"""
+from datetime import datetime, timedelta, timezone
+
+from _billing_grants_helpers import (
+    conta as _conta, evt_checkout as _evt_checkout, evt_paid as _evt_paid,
+    garantir_system_event_logs, sub_stripe as _sub,
+)
+import frontend.finance_bot_websocket_custom as dashboard
+from core.services import email_service as es
+# A fixture `capturado` (intercepta o `send_email` e devolve o que a função
+# montou) é a MESMA do arquivo do Pix — importar em vez de copiar (§0.1): duas
+# cópias é como dois testes passam a medir coisas diferentes achando que medem
+# a mesma.
+from test_pix_paid_email_copy import capturado  # noqa: F401
+from test_billing_webhook_lifecycle import _post, _setup
+
+PROXIMA = datetime.now(timezone.utc) + timedelta(days=30)
+
+
+def _tudo(caixa):
+    return (caixa["subject"], caixa["html"], caixa["text"])
+
+
+# ── a copy, por plano ────────────────────────────────────────────────────────
+
+def test_essencial_cobrado_nao_vira_plus(capturado):  # noqa: F811
+    """R$ 9,90 cobrados e o e-mail dizia "Seu PigBank+ tá renovado"."""
+    assert es.send_pro_charged_email("a@b.com", "essencial", 9.9, PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank Essencial" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano na cobrança: {parte}"
+
+
+def test_pro_max_cobrado_e_o_pro(capturado):  # noqa: F811
+    """`pro_max` é o Pro — o plano mais caro, e o que o mapa erra se for
+    chaveado no vocabulário público (lá `pro` já é o Plus)."""
+    assert es.send_pro_charged_email("a@b.com", "pro_max", 49.9, PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank Pro" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano na cobrança: {parte}"
+
+
+def test_plus_cobrado_continua_pigbank_mais(capturado):  # noqa: F811
+    """CONTROLE POSITIVO: o Plus já recebia o nome certo e continua recebendo.
+
+    `pro` na coluna é o Plus. Se o conserto tivesse trocado todo mundo por um
+    genérico ("PigBank"), ou chaveado no vocabulário do frontend (onde `pro` é
+    o Pro), este é o caso que reprova.
+    """
+    assert es.send_pro_charged_email("a@b.com", "pro", 19.9, PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank+" in parte, parte
+        assert "PigBank Pro" not in parte, f"nome do plano mais caro: {parte}"
+
+
+def test_boas_vindas_e_fim_de_trial_tambem(capturado):  # noqa: F811
+    """As outras duas da família — consertar só a cobrança é achar um caso e
+    chamar de categoria resolvida (§2)."""
+    assert es.send_pro_welcome_email("a@b.com", "pro_max", PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank Pro" in parte, parte
+        assert "PigBank+" not in parte, parte
+
+    assert es.send_trial_ending_email("a@b.com", "essencial", PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank Essencial" in parte, parte
+        assert "PigBank+" not in parte, parte
+
+
+# ── o seam: o webhook de verdade, três eventos no mesmo usuário ──────────────
+
+def test_a_conversa_do_webhook_manda_o_plano_nos_tres_emails(user_id, monkeypatch):
+    """Três eventos da Stripe, um usuário de Essencial, os três e-mails.
+
+    Aqui é onde a ordem dos argumentos erra CALADA: `_fire_email` chama
+    `fn(email, *args, DASHBOARD_URL)` posicionalmente e engole toda exceção
+    (`finance_bot_websocket_custom.py:5137`) — trocar `plan` com `amount_brl`
+    não levanta nada visível, só manda e-mail errado (ou nenhum). Por isso o
+    teste posta o evento inteiro no `/billing/webhook` e lê a tupla que chegou
+    do outro lado, em vez de chamar a função de e-mail direto.
+
+    O `price_ess` é o que amarra o vocabulário: ele entra como PRICE do Stripe e
+    tem de sair como `"essencial"` — o valor da coluna, não o slug do frontend.
+    """
+    uid, client, fake = _setup(monkeypatch, f"nome-{user_id}")
+    _conta(uid, "free", None, "inactive")
+    # Sem a tabela, o `recent_event_exists` do ramo trial_will_end estoura fora
+    # do try do `_fire_email` e o webhook devolve 500.
+    garantir_system_event_logs()
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_ESSENCIAL_MENSAL", "price_ess")
+
+    vistos: dict[str, tuple] = {}
+
+    def _espiao(nome):
+        def _fn(*a, **kw):
+            vistos[nome] = a
+            return True                      # confirma o envio: senão o
+                                             # `_fire_email` trata como falha
+        # `__name__` é a CHAVE da dedup do `_fire_email`. Três espiões com o
+        # mesmo nome viram um só balde: medido — o 1º e-mail gravava a chave e
+        # os outros dois saíam DEDUPADOS, com o teste acusando "não chamou".
+        _fn.__name__ = nome
+        return _fn
+
+    for nome in ("send_pro_welcome_email", "send_pro_charged_email",
+                 "send_trial_ending_email"):
+        monkeypatch.setattr(es, nome, _espiao(nome), raising=False)
+
+    subs = {"sub_nome": _sub("active", "price_ess", 30)}
+
+    r = _post(client, fake, _evt_checkout(uid, "sub_nome", 1_800_000_000, "cs_nome"),
+              subs=subs)
+    assert r.status_code == 200, r.text
+
+    trial_end = _sub("trialing", "price_ess", 3)
+    trial_end["id"] = "sub_nome"
+    trial_end["metadata"] = {"finbot_user_id": str(uid)}
+    r = _post(client, fake,
+              {"type": "customer.subscription.trial_will_end",
+               "id": "evt_nome_twe", "created": 1_800_000_050,
+               "data": {"object": trial_end}}, subs=subs)
+    assert r.status_code == 200, r.text
+
+    cobranca = _evt_paid(uid, "sub_nome", 1_800_000_100)
+    cobranca["data"]["object"]["amount_paid"] = 990
+    r = _post(client, fake, cobranca, subs=subs)
+    assert r.status_code == 200, r.text
+
+    assert set(vistos) == {"send_pro_welcome_email", "send_trial_ending_email",
+                           "send_pro_charged_email"}, vistos
+    # O plano é o 2º argumento posicional nas três, logo depois do e-mail.
+    for nome, args in vistos.items():
+        assert args[1] == "essencial", f"{nome} recebeu {args[1]!r}: {args}"
+    # E na cobrança o valor continua no lugar dele — o erro que a troca de
+    # ordem produziria sem levantar nada.
+    assert vistos["send_pro_charged_email"][2] == 9.90, vistos

--- a/tests/test_billing_email_nome_do_plano.py
+++ b/tests/test_billing_email_nome_do_plano.py
@@ -25,29 +25,36 @@ RODADAS, não previstas — cada uma com o vermelho que produziu:
     `test_plus_cobrado_continua_pigbank_mais`, além de dois casos do arquivo do
     Pix, que compartilham o mesmo mapa.
   · **negativo, o seam** — tire `plan_value` da chamada de
-    `_fire_email(user_id, send_pro_charged_email, ...)`
-    (`finance_bot_websocket_custom.py:5410`): só
+    `_fire_email(user_id, send_pro_charged_email, ...)`: só
     `test_a_conversa_do_webhook...` fica vermelho, com
-    `send_pro_charged_email recebeu 9.9`. Esta mutação não levanta erro nenhum
-    em produção — manda o VALOR no lugar do plano e o cliente recebe
-    "PigBank" genérico. É a única das três que a copy não alcança, e por isso
-    este teste existe.
+    `send_pro_charged_email recebeu 9.9`. **Em produção esta mutação não
+    levanta nada**, e o que ela produz foi RODADO, não deduzido: os argumentos
+    andam uma casa, `amount_brl` recebe o `datetime` do vencimento e o
+    `f"R$ {amount_brl:,.2f}"` cai no `__format__` do `datetime` — que é o
+    `strftime` e devolve a própria string de formato. O e-mail sai
+    `✓ Pagamento confirmado — PigBank (R$ .,2f)`: nome genérico, valor
+    destruído, zero exceção. É a única das três que a copy não alcança, e por
+    isso este teste existe.
   · **positivo** — `test_plus_cobrado_continua_pigbank_mais` é o plano que já
     estava CERTO com o texto fixo, e continua verde na 1ª mutação. Sem ele, o
     grupo passaria num conserto que trocasse todo mundo por um genérico — que
     é pior que o bug.
 
+Os outros DOIS e-mails da mesma família — `send_payment_failed_email` e
+`send_subscription_canceled_email` — moram em
+`tests/test_billing_email_nome_do_plano_irmaos.py`, e o motivo de estarem lá é
+o teto de 350 linhas por arquivo (§0.5): são outro assunto (o que acontece
+quando a cobrança FALHA), com seams em outros dois ramos do webhook.
+
 O que este arquivo NÃO alcança: o envio de verdade (`send_email` é
-monkeypatchado), o `_check_trial_ending` do scheduler (nenhum teste do repo
-exercita aquele laço) e os dois irmãos que ficaram de fora do escopo da #351 —
-`send_payment_failed_email` (`email_service.py:1193`) e
-`send_subscription_canceled_email` (`:1277`) continuam com "PigBank+" fixo.
+monkeypatchado) e o `_check_trial_ending` do scheduler (nenhum teste do repo
+exercita aquele laço).
 """
 from datetime import datetime, timedelta, timezone
 
 from _billing_grants_helpers import (
-    conta as _conta, evt_checkout as _evt_checkout, evt_paid as _evt_paid,
-    garantir_system_event_logs, sub_stripe as _sub,
+    conta as _conta, espiao_email as _espiao, evt_checkout as _evt_checkout,
+    evt_paid as _evt_paid, garantir_system_event_logs, sub_stripe as _sub,
 )
 import frontend.finance_bot_websocket_custom as dashboard
 from core.services import email_service as es
@@ -134,21 +141,9 @@ def test_a_conversa_do_webhook_manda_o_plano_nos_tres_emails(user_id, monkeypatc
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_ESSENCIAL_MENSAL", "price_ess")
 
     vistos: dict[str, tuple] = {}
-
-    def _espiao(nome):
-        def _fn(*a, **kw):
-            vistos[nome] = a
-            return True                      # confirma o envio: senão o
-                                             # `_fire_email` trata como falha
-        # `__name__` é a CHAVE da dedup do `_fire_email`. Três espiões com o
-        # mesmo nome viram um só balde: medido — o 1º e-mail gravava a chave e
-        # os outros dois saíam DEDUPADOS, com o teste acusando "não chamou".
-        _fn.__name__ = nome
-        return _fn
-
     for nome in ("send_pro_welcome_email", "send_pro_charged_email",
                  "send_trial_ending_email"):
-        monkeypatch.setattr(es, nome, _espiao(nome), raising=False)
+        monkeypatch.setattr(es, nome, _espiao(vistos, nome), raising=False)
 
     subs = {"sub_nome": _sub("active", "price_ess", 30)}
 

--- a/tests/test_billing_email_nome_do_plano_irmaos.py
+++ b/tests/test_billing_email_nome_do_plano_irmaos.py
@@ -4,14 +4,14 @@ Separado de `test_billing_email_nome_do_plano.py` pelo teto de 350 linhas
 (§0.5). Lá estão os três e-mails do caminho FELIZ (boas-vindas, fim de trial,
 cobrança confirmada); aqui os dois do caminho em que a cobrança falha ou a
 assinatura morre. Os dois grupos compartilham o mapa `PLAN_DISPLAY_NAMES` e o
-`_plan_name`, e isso foi MEDIDO: chavear o mapa no vocabulário público
+`plan_display_name`, e isso foi MEDIDO: chavear o mapa no vocabulário público
 (`plus`/`pro`) derruba 9 casos nos três arquivos do assunto — 3 lá, 4 aqui e 2
 no do Pix.
 
 Uma versão anterior do commit dizia que estes dois ficavam de fora porque
 "nenhum dos dois tem o plano em escopo no chamador". **Era falso, e o Tester
 provou:** o ramo `invoice.payment_failed` já faz um `Subscription.retrieve`
-para decidir se o evento é obsoleto (`finance_bot_websocket_custom.py:5666`), e
+para decidir se o evento é obsoleto (`finance_bot_websocket_custom.py:5626`), e
 no `customer.subscription.deleted` o próprio `event.data.object` É a
 Subscription. Medido antes do conserto: assinante Essencial cujo cartão falha
 recebia `⚠️ PigBank+ — pagamento falhou, atualize seu cartão`, e quem cancelava
@@ -45,6 +45,7 @@ O que este arquivo NÃO alcança: o envio de verdade (`send_email` é
 monkeypatchado) e o e-mail de fatura AVULSA em produção — aqui ele é provado
 só até o argumento (`None`) e a copy genérica.
 """
+import re
 from datetime import datetime, timedelta, timezone
 
 from _billing_grants_helpers import (
@@ -62,6 +63,16 @@ from test_billing_webhook_lifecycle import _post, _setup
 PROXIMA = datetime.now(timezone.utc) + timedelta(days=30)
 
 
+def _sem_tier_solto(parte: str, nome: str) -> None:
+    """Nenhum tier SOLTO no corpo, sem a marca — "os recursos Pro", "os limites
+    Pro". `assert "PigBank Pro" not in parte` NÃO pega essa forma, e foi assim
+    que o assunto passou a dizer "PigBank Essencial" com o corpo ainda dizendo
+    o nome de outro tier. Tira o nome legítimo primeiro; o que sobrar é leak.
+    """
+    resto = parte.replace(nome, "")
+    assert not re.search(r"\b(Pro|Plus)\b", resto), f"tier solto no corpo: {parte}"
+
+
 # ── a copy, por plano ────────────────────────────────────────────────────────
 # A copy destes dois NÃO foi tocada além do nome: continua prometendo volta ao
 # "Free". Os asserts abaixo afirmam só o NOME de propósito — o dia em que o
@@ -73,6 +84,7 @@ def test_falha_de_pagamento_do_essencial_nao_vira_plus(capturado):  # noqa: F811
     for parte in _tudo(capturado):
         assert "PigBank Essencial" in parte, parte
         assert "PigBank+" not in parte, f"nome de outro plano na falha: {parte}"
+        _sem_tier_solto(parte, "PigBank Essencial")
 
 
 def test_falha_de_pagamento_do_pro_max_e_o_pro(capturado):  # noqa: F811
@@ -80,6 +92,7 @@ def test_falha_de_pagamento_do_pro_max_e_o_pro(capturado):  # noqa: F811
     for parte in _tudo(capturado):
         assert "PigBank Pro" in parte, parte
         assert "PigBank+" not in parte, f"nome de outro plano na falha: {parte}"
+        _sem_tier_solto(parte, "PigBank Pro")
 
 
 def test_falha_de_pagamento_do_plus_continua_pigbank_mais(capturado):  # noqa: F811
@@ -88,13 +101,15 @@ def test_falha_de_pagamento_do_plus_continua_pigbank_mais(capturado):  # noqa: F
     for parte in _tudo(capturado):
         assert "PigBank+" in parte, parte
         assert "PigBank Pro" not in parte, f"nome do plano mais caro: {parte}"
+        _sem_tier_solto(parte, "PigBank+")
 
 
 def test_fatura_avulsa_sem_assinatura_usa_o_generico(capturado):  # noqa: F811
     """`plan=None` é a fatura AVULSA — sem assinatura, não há plano a nomear.
 
-    É o ÚNICO caminho que alcança o fallback genérico (ver `_plan_name`): pelo
-    Stripe o plano sai de `_stored_plan_for_price`, que nunca devolve nada fora
+    É o ÚNICO caminho que alcança o fallback genérico (ver
+    `plan_display_name`): pelo Stripe o plano sai de `_stored_plan_for_price`,
+    que nunca devolve nada fora
     do mapa. O precedente da copy neutra é o `send_payment_reminder_email`, que
     já diz "PigBank" sem sufixo.
     """
@@ -103,6 +118,7 @@ def test_fatura_avulsa_sem_assinatura_usa_o_generico(capturado):  # noqa: F811
         assert "PigBank" in parte, parte
         for outro in ("PigBank+", "PigBank Essencial", "PigBank Pro"):
             assert outro not in parte, f"nomeou plano numa fatura avulsa: {parte}"
+        _sem_tier_solto(parte, "PigBank")
 
 
 def test_cancelamento_do_essencial_nao_vira_plus(capturado):  # noqa: F811
@@ -111,6 +127,7 @@ def test_cancelamento_do_essencial_nao_vira_plus(capturado):  # noqa: F811
     for parte in _tudo(capturado):
         assert "PigBank Essencial" in parte, parte
         assert "PigBank+" not in parte, f"nome de outro plano no cancelamento: {parte}"
+        _sem_tier_solto(parte, "PigBank Essencial")
 
 
 def test_cancelamento_do_pro_max_e_o_pro(capturado):  # noqa: F811
@@ -119,6 +136,7 @@ def test_cancelamento_do_pro_max_e_o_pro(capturado):  # noqa: F811
     for parte in _tudo(capturado):
         assert "PigBank Pro" in parte, parte
         assert "PigBank+" not in parte, f"nome de outro plano no cancelamento: {parte}"
+        _sem_tier_solto(parte, "PigBank Pro")
 
 
 def test_cancelamento_do_plus_continua_pigbank_mais(capturado):  # noqa: F811
@@ -127,6 +145,7 @@ def test_cancelamento_do_plus_continua_pigbank_mais(capturado):  # noqa: F811
     for parte in _tudo(capturado):
         assert "PigBank+" in parte, parte
         assert "PigBank Pro" not in parte, f"nome do plano mais caro: {parte}"
+        _sem_tier_solto(parte, "PigBank+")
 
 
 # ── os seams dos dois irmãos ────────────────────────────────────────────────

--- a/tests/test_billing_email_nome_do_plano_irmaos.py
+++ b/tests/test_billing_email_nome_do_plano_irmaos.py
@@ -1,0 +1,208 @@
+"""Os DOIS irmãos do #351: falha de cobrança e cancelamento (`email_service`).
+
+Separado de `test_billing_email_nome_do_plano.py` pelo teto de 350 linhas
+(§0.5). Lá estão os três e-mails do caminho FELIZ (boas-vindas, fim de trial,
+cobrança confirmada); aqui os dois do caminho em que a cobrança falha ou a
+assinatura morre. Os dois grupos compartilham o mapa `PLAN_DISPLAY_NAMES` e o
+`_plan_name`, e isso foi MEDIDO: chavear o mapa no vocabulário público
+(`plus`/`pro`) derruba 9 casos nos três arquivos do assunto — 3 lá, 4 aqui e 2
+no do Pix.
+
+Uma versão anterior do commit dizia que estes dois ficavam de fora porque
+"nenhum dos dois tem o plano em escopo no chamador". **Era falso, e o Tester
+provou:** o ramo `invoice.payment_failed` já faz um `Subscription.retrieve`
+para decidir se o evento é obsoleto (`finance_bot_websocket_custom.py:5666`), e
+no `customer.subscription.deleted` o próprio `event.data.object` É a
+Subscription. Medido antes do conserto: assinante Essencial cujo cartão falha
+recebia `⚠️ PigBank+ — pagamento falhou, atualize seu cartão`, e quem cancelava
+recebia `PigBank+ — assinatura cancelada`.
+
+Os controles do §3, para o GRUPO — RODADOS, com o vermelho que produziram:
+
+  · **negativo, a copy da falha** — volte `nome` para a constante `"PigBank+"`
+    em `send_payment_failed_email` → vermelhos `test_falha_..._essencial...`,
+    `test_falha_..._pro_max...` e `test_fatura_avulsa...`.
+  · **negativo, a copy do cancelamento** — o mesmo em
+    `send_subscription_canceled_email` → vermelhos
+    `test_cancelamento_..._essencial...` e `test_cancelamento_..._pro_max...`.
+  · **negativo, o seam da falha** — tire `_plano_falha` da chamada de
+    `_fire_email` → vermelho `test_o_webhook_manda_o_plano_na_falha_e_na_avulsa`
+    com `plano inventado numa fatura avulsa: (..., 'http://localhost:8000')` —
+    a `DASHBOARD_URL` andando uma casa, que é o que a troca de ordem faz sem
+    levantar nada.
+  · **negativo, o seam do cancelamento** — tire `_plano_cancelado` → vermelho
+    `test_o_webhook_manda_o_plano_no_cancelamento` com um `datetime` no lugar
+    do plano.
+  · **negativo, a guarda da avulsa** — tire `_sub_agora = None` de antes do
+    `if` → vermelho `..._na_falha_e_na_avulsa` com **500** no webhook
+    (`UnboundLocalError`), que é a Stripe reentregando por 3 dias.
+  · **positivo** — `test_falha_..._plus_continua_pigbank_mais` e
+    `test_cancelamento_..._plus_continua_pigbank_mais`: o Plus já lia o nome
+    certo com o texto fixo e continua lendo. Sem eles o grupo passaria num
+    conserto que trocasse todo mundo pelo genérico.
+
+O que este arquivo NÃO alcança: o envio de verdade (`send_email` é
+monkeypatchado) e o e-mail de fatura AVULSA em produção — aqui ele é provado
+só até o argumento (`None`) e a copy genérica.
+"""
+from datetime import datetime, timedelta, timezone
+
+from _billing_grants_helpers import (
+    conta as _conta, espiao_email as _espiao, garantir_system_event_logs,
+    sub_stripe as _sub,
+)
+import frontend.finance_bot_websocket_custom as dashboard
+from core.services import email_service as es
+# A fixture `capturado` e o `_tudo` são os MESMOS dos arquivos irmãos —
+# importar em vez de copiar (§0.1).
+from test_pix_paid_email_copy import capturado  # noqa: F401
+from test_billing_email_nome_do_plano import _tudo
+from test_billing_webhook_lifecycle import _post, _setup
+
+PROXIMA = datetime.now(timezone.utc) + timedelta(days=30)
+
+
+# ── a copy, por plano ────────────────────────────────────────────────────────
+# A copy destes dois NÃO foi tocada além do nome: continua prometendo volta ao
+# "Free". Os asserts abaixo afirmam só o NOME de propósito — o dia em que o
+# produto decidir o que acontece com quem não paga, a copy muda sem mexer aqui.
+
+def test_falha_de_pagamento_do_essencial_nao_vira_plus(capturado):  # noqa: F811
+    """Cartão do Essencial recusado e o assunto dizia "⚠️ PigBank+"."""
+    assert es.send_payment_failed_email("a@b.com", "essencial")
+    for parte in _tudo(capturado):
+        assert "PigBank Essencial" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano na falha: {parte}"
+
+
+def test_falha_de_pagamento_do_pro_max_e_o_pro(capturado):  # noqa: F811
+    assert es.send_payment_failed_email("a@b.com", "pro_max")
+    for parte in _tudo(capturado):
+        assert "PigBank Pro" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano na falha: {parte}"
+
+
+def test_falha_de_pagamento_do_plus_continua_pigbank_mais(capturado):  # noqa: F811
+    """CONTROLE POSITIVO do par: o Plus já lia o nome certo e continua lendo."""
+    assert es.send_payment_failed_email("a@b.com", "pro")
+    for parte in _tudo(capturado):
+        assert "PigBank+" in parte, parte
+        assert "PigBank Pro" not in parte, f"nome do plano mais caro: {parte}"
+
+
+def test_fatura_avulsa_sem_assinatura_usa_o_generico(capturado):  # noqa: F811
+    """`plan=None` é a fatura AVULSA — sem assinatura, não há plano a nomear.
+
+    É o ÚNICO caminho que alcança o fallback genérico (ver `_plan_name`): pelo
+    Stripe o plano sai de `_stored_plan_for_price`, que nunca devolve nada fora
+    do mapa. O precedente da copy neutra é o `send_payment_reminder_email`, que
+    já diz "PigBank" sem sufixo.
+    """
+    assert es.send_payment_failed_email("a@b.com", None)
+    for parte in _tudo(capturado):
+        assert "PigBank" in parte, parte
+        for outro in ("PigBank+", "PigBank Essencial", "PigBank Pro"):
+            assert outro not in parte, f"nomeou plano numa fatura avulsa: {parte}"
+
+
+def test_cancelamento_do_essencial_nao_vira_plus(capturado):  # noqa: F811
+    """Cancelou Essencial e recebia "PigBank+ — assinatura cancelada"."""
+    assert es.send_subscription_canceled_email("a@b.com", "essencial", PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank Essencial" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano no cancelamento: {parte}"
+
+
+def test_cancelamento_do_pro_max_e_o_pro(capturado):  # noqa: F811
+    """Sem grace (`expires_at=None`): o outro ramo da função, mesmo nome."""
+    assert es.send_subscription_canceled_email("a@b.com", "pro_max", None)
+    for parte in _tudo(capturado):
+        assert "PigBank Pro" in parte, parte
+        assert "PigBank+" not in parte, f"nome de outro plano no cancelamento: {parte}"
+
+
+def test_cancelamento_do_plus_continua_pigbank_mais(capturado):  # noqa: F811
+    """CONTROLE POSITIVO do par."""
+    assert es.send_subscription_canceled_email("a@b.com", "pro", PROXIMA)
+    for parte in _tudo(capturado):
+        assert "PigBank+" in parte, parte
+        assert "PigBank Pro" not in parte, f"nome do plano mais caro: {parte}"
+
+
+# ── os seams dos dois irmãos ────────────────────────────────────────────────
+
+def test_o_webhook_manda_o_plano_na_falha_e_na_avulsa(user_id, monkeypatch):
+    """`invoice.payment_failed` de Essencial → `"essencial"`; avulsa → `None`.
+
+    O plano sai do `Subscription.retrieve` que o ramo JÁ fazia para decidir se o
+    evento é obsoleto — o mesmo objeto, sem uma chamada de API a mais.
+
+    A metade AVULSA é o caminho que ESTOURA se `_sub_agora` não for inicializado
+    antes do `if`: `UnboundLocalError` dentro do handler, 500 no webhook e a
+    Stripe reentregando por 3 dias. Tire o `_sub_agora = None` e esta metade
+    fica vermelha em `status_code == 200`.
+    """
+    uid, client, fake = _setup(monkeypatch, f"pf-{user_id}")
+    _conta(uid, "essencial", None, "active")
+    garantir_system_event_logs()
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_ESSENCIAL_MENSAL", "price_ess")
+
+    vistos: dict[str, tuple] = {}
+    monkeypatch.setattr(es, "send_payment_failed_email",
+                        _espiao(vistos, "send_payment_failed_email"))
+
+    # A AVULSA vem PRIMEIRO, e a ordem é obrigatória, não estética: ela não
+    # abre ciclo (`_abriu_ciclo` depende de `_sub_id`), então cai na dedupe de
+    # `DUNNING_GRACE_DAYS` e ficaria MUDA depois da fatura de assinatura —
+    # medido, o teste acusava "a avulsa não mandou e-mail nenhum". A de
+    # assinatura abre ciclo e manda com `dedup_days=0.0`, que é "não suprima",
+    # então nesta ordem as duas saem.
+    avulsa = {"type": "invoice.payment_failed", "id": "evt_nome_pf_avulsa",
+              "created": 1_800_000_200,
+              "data": {"object": {"metadata": {"finbot_user_id": str(uid)},
+                                  "attempt_count": 1}}}
+    r = _post(client, fake, avulsa)
+    assert r.status_code == 200, r.text
+    args = vistos.get("send_payment_failed_email")
+    assert args is not None, "a avulsa não mandou e-mail nenhum"
+    assert args[1] is None, f"plano inventado numa fatura avulsa: {args}"
+
+    vistos.clear()
+    falha = {"type": "invoice.payment_failed", "id": "evt_nome_pf",
+             "created": 1_800_000_300,
+             "data": {"object": {"metadata": {"finbot_user_id": str(uid)},
+                                 "subscription": "sub_pf", "attempt_count": 1}}}
+    r = _post(client, fake, falha, subs={"sub_pf": _sub("past_due", "price_ess", 5)})
+    assert r.status_code == 200, r.text
+    args = vistos.get("send_payment_failed_email")
+    assert args is not None, "o e-mail de falha não saiu"
+    assert args[1] == "essencial", f"send_payment_failed_email recebeu {args[1]!r}: {args}"
+
+
+def test_o_webhook_manda_o_plano_no_cancelamento(user_id, monkeypatch):
+    """`customer.subscription.deleted` de Essencial → `"essencial"`.
+
+    O `obj` do evento É a Subscription, então o price está ali — e tem de ser
+    ele, não a conta: o `update_user_plan(..., "free", None)` do mesmo ramo roda
+    ANTES do e-mail, e ler a conta devolveria "free" para todo mundo.
+    """
+    uid, client, fake = _setup(monkeypatch, f"cx-{user_id}")
+    _conta(uid, "essencial", PROXIMA, "active")
+    garantir_system_event_logs()
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_ESSENCIAL_MENSAL", "price_ess")
+
+    vistos: dict[str, tuple] = {}
+    monkeypatch.setattr(es, "send_subscription_canceled_email",
+                        _espiao(vistos, "send_subscription_canceled_email"))
+
+    morta = _sub("canceled", "price_ess", 5)
+    morta["id"] = "sub_cx"
+    morta["metadata"] = {"finbot_user_id": str(uid)}
+    r = _post(client, fake, {"type": "customer.subscription.deleted",
+                             "id": "evt_nome_del", "created": 1_800_000_400,
+                             "data": {"object": morta}})
+    assert r.status_code == 200, r.text
+    args = vistos.get("send_subscription_canceled_email")
+    assert args is not None, "o e-mail de cancelamento não saiu"
+    assert args[1] == "essencial", (
+        f"send_subscription_canceled_email recebeu {args[1]!r}: {args}")

--- a/tests/test_pix_paid_email_copy.py
+++ b/tests/test_pix_paid_email_copy.py
@@ -14,7 +14,7 @@ os slugs do frontend, e por isso ficou verde em cima de um mapa que mandava
 comprou Pro.
 
 Os dois controles do CLAUDE.md §3, para o GRUPO:
-  · negativo — chaveie o `PIX_PLAN_NAMES` no vocabulário do frontend
+  · negativo — chaveie o `PLAN_DISPLAY_NAMES` no vocabulário do frontend
     (`plus`/`pro`) e `test_pro_e_o_plus` e `test_pro_max_e_o_pro` ficam
     vermelhos; volte o `nome` para a constante "PigBank+" (ou apague o
     `agendado`) e `test_essencial_agendado` fica;

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -43,6 +43,7 @@ import frontend.finance_bot_websocket_custom as dashboard
 import frontend.routes.billing_pix as rotas
 from _billing_grants_helpers import conta
 from _pix_checkout_helpers import asaas_falso, vendavel  # noqa: F401 — fixtures
+from core.services.email_service import PLAN_DISPLAY_NAMES
 from core.services.pix_pricing import PRECOS_ANUAIS_CENTS
 from core.services.plan_service import _STORED_PLAN_TO_TIER, TIER_TO_STORED_PLAN
 from db.pix_charges import buscar_por_public_token
@@ -158,6 +159,39 @@ def test_os_dois_mapas_de_plano_sao_inversos():
     # E todo plano vendável tem preço: um valor sem entrada aqui viraria 503
     # `preco_anual_nao_configurado` só na hora da venda.
     assert set(TIER_TO_STORED_PLAN.values()) <= set(PRECOS_ANUAIS_CENTS)
+
+
+def test_todo_plano_pago_da_coluna_tem_nome_comercial():
+    """O terceiro mapa entra no amarre: valor de coluna → nome que o cliente lê.
+
+    Fecha a CLASSE do achado do Codex no #358, em vez da instância. `plus` era a
+    instância: `_STORED_PLAN_TO_TIER` o aceita (mesmo tier de `pro`) e
+    `frontend/admin-dashboard.html:2192` afirma que há contas com ele, mas
+    `PLAN_DISPLAY_NAMES` não o tinha — e essas contas liam o genérico "PigBank"
+    no e-mail e em `billing_commands.py:109`. Um SEXTO valor futuro nasce
+    vermelho aqui em vez de virar genérico numa cobrança.
+
+    `free` fica de fora, e não por conveniência: é o estado de plano INATIVO, não
+    um plano comprado. `_stored_plan_for_price` nunca o devolve (nenhum e-mail
+    desta família o nomeia) e `billing_commands.py:109` é inalcançável para ele,
+    porque `is_pro` é falso. Dar-lhe nome comercial seria escrever copy de
+    assinatura para quem não assinou.
+
+    NEGATIVO deste teste: tire `"plus"` de `PLAN_DISPLAY_NAMES` e ele fica
+    vermelho por NOME, citando `['plus']`.
+    """
+    nomes_por_tier: dict[str, set[str]] = {}
+    for plano, tier in _STORED_PLAN_TO_TIER.items():
+        if plano == "free":
+            continue
+        assert plano in PLAN_DISPLAY_NAMES, (
+            f"'{plano}' vale um plano pago na coluna e não tem nome comercial: "
+            "e-mail e bot chamariam a conta de 'PigBank' genérico")
+        nomes_por_tier.setdefault(tier, set()).add(PLAN_DISPLAY_NAMES[plano])
+    # Ter entrada não basta: dois valores do MESMO tier têm de nomear o MESMO
+    # plano, senão `plus` diria "PigBank Pro" e o teste acima ficaria verde.
+    for tier, nomes in nomes_por_tier.items():
+        assert len(nomes) == 1, f"tier '{tier}' com dois nomes: {sorted(nomes)}"
 
 
 # `""` está FORA desta tabela, e não por conveniência: as duas rotas de fato


### PR DESCRIPTION
Fecha a issue #351. **Mergear este ANTES do PR do vocabulário nas saídas** — o motivo está no fim.

## O que estava errado

Os e-mails do Stripe diziam "PigBank+" para **todo** assinante, inclusive quem paga
Essencial ou Pro. É o mesmo defeito que o #348 corrigiu no Pix, no canal mais antigo e
com mais volume.

Não era uma função, era uma **família de cinco**, e o plano estava na mão do chamador
sendo jogado fora.

## O que mudou

`PIX_PLAN_NAMES` virou `PLAN_DISPLAY_NAMES` (serve os dois gateways agora) e ganhou
`plan_display_name()`, que centraliza o fallback. As cinco funções recebem o plano.

Dois chamadores **não tinham** o plano em escopo e foram resolvidos: o aviso de fim de
teste, e uma varredura do agendador onde o filtro era um valor cravado na consulta.

## A armadilha que quase virou regressão

O #348 quase mandou "PigBank Pro" para quem comprou Plus, por chavear o mapa no
vocabulário errado. Aqui o vocabulário foi **rastreado até a origem** antes de escrever:
`_stored_plan_for_price` devolve só `essencial`, `pro_max` e `pro` (fallback), e a
docstring dela diz que `pro` é o valor legado do Plus. `plus` não chega por caminho nenhum.

## O irmão que sai em produção

`core/services/billing_commands.py:110` dizia "🐷 Você já tá no PigBank+!" para qualquer
assinante, **sem gate de flag** — esse sai. As duas linhas vizinhas que pareciam ser o
problema estão no ramo legado, que só roda com o freio de emergência acionado.

Medido: quem lia o nome errado ali era **só o Pro**; o Essencial nem alcança o ramo.

## Dentro dos próprios e-mails corrigidos

O assunto passou a dizer o plano certo e o corpo continuava falando em "recursos Pro" e
"limites Pro" para quem é Essencial. Sete ocorrências, corrigidas. Os testes passavam
porque procuravam a expressão exata do nome do plano, e essa forma não casava — a
asserção nova recusa qualquer tier solto que sobre.

## Evidência

Seis mutações rodadas, cada uma com o nome do teste que fica vermelho. O controle
positivo é o Plus, que já lia certo e continua lendo — sem ele o grupo passaria num
código que troca todo mundo por um genérico.

Uma delas merece nota: tirar o plano da chamada **não levanta erro** em produção. O
valor em reais vai para a posição do plano, a formatação de moeda recebe uma data, e o
cliente recebe o nome genérico. Só o teste que roda a conversa inteira do webhook pega.

```
pytest -q  →  6901 passed, 4 xfailed
```

## Uma decisão de desenho, com o custo medido

A deduplicação de e-mails usa o nome da função como chave. Num upgrade de plano no mesmo
dia, o segundo e-mail é suprimido e o cliente lê o nome do plano antigo.

**Não foi mexido**, e a razão está escrita no código com o acoplamento **medido**: a
chave gerada e a chave lida por outro ponto do sistema são strings **diferentes**, não há
leitor externo e nenhum painel usa. Sobra a série de log fragmentar, e essa série não tem
consumidor. O caso é raro, o conserto não é de graça, e o teto está nomeado.

## Ordem de merge

O PR `fix/plano-publico-nas-saidas` importa o mapa **pelo nome antigo**. Os dois tocam
arquivos disjuntos, então **o git mescla limpo e produz `ImportError`** — 500 nos três
cards do Pix, cobrança nenhuma emitida. Nada no ferramental acusa: `merge-tree` sai
`rc=0` e o CI fica verde nos dois isolados.

Este PR entra primeiro; o outro rebasa e troca o nome.

## Fica para issue

A copy dos e-mails de falha e de cancelamento promete volta ao plano **Free**, que não
existe mais. É decisão de produto e depende da issue #274. Registrado na issue #354.

## Não verificado

Nenhum e-mail real foi enviado — o envio é substituído em todos os testes. O texto no
cliente de e-mail e o comportamento contra o Stripe real não foram medidos aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
