### PR TITLE
O vocabulário do banco vazava pelas saídas do Pix, inclusive para o GA4 e para a fatura

### DIFF
--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -306,7 +306,7 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
     (b) do §10.1 acharia seguro apagar.
     """
     from core.services.asaas_customers import criar_cliente
-    from core.services.email_service import PIX_PLAN_NAMES
+    from core.services.email_service import plan_display_name
     from db.pix_charges import transicionar
     from db.pix_charges_saga import attach_pagamento
 
@@ -321,14 +321,14 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
             # NOME COMERCIAL, não o slug: esta linha é a descrição da FATURA que
             # o pagador lê no app do banco, e ela vinha saindo "PigBank anual
             # (pro_max)". Nome, e não o tier público (`pro`), porque ali não há
-            # legenda nenhuma para traduzir um slug. `PIX_PLAN_NAMES` é a fonte
-            # que o e-mail de confirmação já usa, chaveada pelo MESMO valor
-            # legado da coluna (§0.7) — o cliente lê o mesmo nome nos dois.
+            # legenda nenhuma para traduzir um slug. `plan_display_name` é a
+            # fonte que o e-mail de confirmação já usa, chaveada pelo MESMO
+            # valor legado da coluna (§0.7) — o cliente lê o mesmo nome nos
+            # dois, e o fallback genérico mora lá dentro em vez de aqui.
             # Separador ASCII de propósito: como cada app de banco renderiza um
             # travessão (U+2014) na descrição do Pix não dá para verificar aqui,
             # e o hífen não perde nada. O texto era ASCII puro antes do #350.
-            descricao=f"{PIX_PLAN_NAMES.get(linha['plan'], 'PigBank')} - "
-                      f"plano anual")
+            descricao=f"{plan_display_name(linha['plan'])} - plano anual")
         qr = asaas.obter_qr_pix(str(pagamento.get("id") or ""))
     except Exception as exc:  # noqa: BLE001 — a linha fica `creating` de propósito
         raise CheckoutIndisponivel("asaas_emissao_falhou") from exc

--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -324,7 +324,10 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
             # legenda nenhuma para traduzir um slug. `PIX_PLAN_NAMES` é a fonte
             # que o e-mail de confirmação já usa, chaveada pelo MESMO valor
             # legado da coluna (§0.7) — o cliente lê o mesmo nome nos dois.
-            descricao=f"{PIX_PLAN_NAMES.get(linha['plan'], 'PigBank')} — "
+            # Separador ASCII de propósito: como cada app de banco renderiza um
+            # travessão (U+2014) na descrição do Pix não dá para verificar aqui,
+            # e o hífen não perde nada. O texto era ASCII puro antes do #350.
+            descricao=f"{PIX_PLAN_NAMES.get(linha['plan'], 'PigBank')} - "
                       f"plano anual")
         qr = asaas.obter_qr_pix(str(pagamento.get("id") or ""))
     except Exception as exc:  # noqa: BLE001 — a linha fica `creating` de propósito

--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -306,6 +306,7 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
     (b) do §10.1 acharia seguro apagar.
     """
     from core.services.asaas_customers import criar_cliente
+    from core.services.email_service import PIX_PLAN_NAMES
     from db.pix_charges import transicionar
     from db.pix_charges_saga import attach_pagamento
 
@@ -317,7 +318,14 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
             customer_id=cliente, valor_cents=int(linha["amount_cents"]),
             due_date=vence.isoformat(),
             external_reference=linha["external_reference"],
-            descricao=f"PigBank anual ({linha['plan']})")
+            # NOME COMERCIAL, não o slug: esta linha é a descrição da FATURA que
+            # o pagador lê no app do banco, e ela vinha saindo "PigBank anual
+            # (pro_max)". Nome, e não o tier público (`pro`), porque ali não há
+            # legenda nenhuma para traduzir um slug. `PIX_PLAN_NAMES` é a fonte
+            # que o e-mail de confirmação já usa, chaveada pelo MESMO valor
+            # legado da coluna (§0.7) — o cliente lê o mesmo nome nos dois.
+            descricao=f"{PIX_PLAN_NAMES.get(linha['plan'], 'PigBank')} — "
+                      f"plano anual")
         qr = asaas.obter_qr_pix(str(pagamento.get("id") or ""))
     except Exception as exc:  # noqa: BLE001 — a linha fica `creating` de propósito
         raise CheckoutIndisponivel("asaas_emissao_falhou") from exc

--- a/core/services/pix_checkout_resposta.py
+++ b/core/services/pix_checkout_resposta.py
@@ -62,6 +62,7 @@ def resposta(linha: dict, qr_payload: str) -> dict:
     antes.
     """
     from core.services.pix_brcode import qr_svg_data_url
+    from core.services.plan_service import tier_publico
 
     starts_at = linha["access_starts_at"]
     return {
@@ -76,7 +77,11 @@ def resposta(linha: dict, qr_payload: str) -> dict:
         # ramos (`inicio > agora`) — e não o campo dele, porque o
         # `_reaproveitar` chega aqui só com a data, sem o resto do snapshot.
         "agendada": agendada(starts_at),
-        "plan": linha["plan"],
+        # PÚBLICO, e a coluna continua legada: quem pediu `plus` tem de ler
+        # `plus` de volta, não o `pro` que a coluna guarda. Sai daqui como entrou
+        # no corpo do POST — é o mesmo vocabulário do `/billing/subscription`,
+        # que é quem a tela compara (`pixSub.plan === plano`).
+        "plan": tier_publico(linha["plan"]),
     }
 
 

--- a/core/services/pix_drain_effects.py
+++ b/core/services/pix_drain_effects.py
@@ -220,6 +220,7 @@ def _ga4(cobranca, evt) -> None:
     """`purchase` com `transaction_id = public_token` — a chave de dedupe do
     GA4, e o único identificador da cobrança que sai do servidor (§13.6)."""
     from core.services.ga4_mp import fallback_client_id, mp_configured, send_purchase
+    from core.services.plan_service import tier_publico
 
     if not mp_configured():
         return
@@ -227,7 +228,13 @@ def _ga4(cobranca, evt) -> None:
         transaction_id=cobranca["public_token"],
         value=int(cobranca["amount_cents"]) / 100,
         currency=cobranca["currency"] or "BRL",
-        plan=cobranca["plan"],
+        # PÚBLICO, e esta é a linha de RECEITA: `send_purchase` usa este valor
+        # como `item_id` E `item_name` do evento `purchase`. O Stripe já manda o
+        # público no mesmo campo (`_ga_plano_publico`), então o legado da coluna
+        # fazia o Pro virar dois produtos no relatório — e, pior, o Plus do Pix
+        # (`pro`, R$ 199) caía na MESMA linha do Pro do Stripe (`pro`, R$ 39,90).
+        # É o achado do Codex no #244, do lado do Pix.
+        plan=tier_publico(cobranca["plan"]),
         client_id=cobranca["ga_client_id"] or fallback_client_id(cobranca["user_id"]),
         user_id=cobranca["user_id"],
     )

--- a/core/services/pix_pricing.py
+++ b/core/services/pix_pricing.py
@@ -54,7 +54,7 @@ class CoberturaJaPaga(RuntimeError):
 
         except CoberturaJaPaga as exc:
             raise HTTPException(409, detail={"error": exc.ERRO,
-                                             "plan": exc.plano,
+                                             "plan": tier_publico(exc.plano),
                                              "covered_until": exc.cobertura_ate})
 
     Exceção e não campo `recusada` num dict: campo pode ser ignorado em

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -58,6 +58,9 @@ TIER_TO_STORED_PLAN = {
 }
 
 
+TRIAL_DAYS_DEFAULT = 15
+
+
 def tier_publico(plan_stored: str) -> str:
     """Valor legado da coluna → o tier PÚBLICO, sem tocar no banco.
 
@@ -72,9 +75,6 @@ def tier_publico(plan_stored: str) -> str:
     monólito, a cópia local que esta função substituiu.
     """
     return _STORED_PLAN_TO_TIER.get(plan_stored, plan_stored)
-
-
-TRIAL_DAYS_DEFAULT = 15
 
 
 def plans_v2_enabled() -> bool:

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -62,12 +62,14 @@ def tier_publico(plan_stored: str) -> str:
     """Valor legado da coluna → o tier PÚBLICO, sem tocar no banco.
 
     O irmão sem-banco de `get_plan_tier`, para quem já tem a string na mão e não
-    o `user_id`: as respostas HTTP do checkout Pix e do poll dele. Mora aqui
-    porque quem é dono do vocabulário é `_STORED_PLAN_TO_TIER` — uma quarta
-    cópia do `{"pro": "plus", "pro_max": "pro"}` é o §0.7 ao contrário.
+    o `user_id`: as respostas HTTP do Pix (checkout, poll e o 409), o `plan` do
+    `purchase` do GA4 e o `/billing/subscription`. Mora aqui porque quem é dono
+    do vocabulário é `_STORED_PLAN_TO_TIER` — outra cópia do
+    `{"pro": "plus", "pro_max": "pro"}` é o §0.7 ao contrário.
 
-    Desconhecido volta como veio, igual ao `_plan_publico` do monólito: numa
-    resposta de venda, apagar o plano é pior que devolver um nome estranho.
+    Desconhecido volta como veio: numa resposta de venda, apagar o plano é pior
+    que devolver um nome estranho. Era o comportamento do `_plan_publico` do
+    monólito, a cópia local que esta função substituiu.
     """
     return _STORED_PLAN_TO_TIER.get(plan_stored, plan_stored)
 

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -57,6 +57,21 @@ TIER_TO_STORED_PLAN = {
     "pro": "pro_max",    # legado: o tier Pro grava 'pro_max'
 }
 
+
+def tier_publico(plan_stored: str) -> str:
+    """Valor legado da coluna → o tier PÚBLICO, sem tocar no banco.
+
+    O irmão sem-banco de `get_plan_tier`, para quem já tem a string na mão e não
+    o `user_id`: as respostas HTTP do checkout Pix e do poll dele. Mora aqui
+    porque quem é dono do vocabulário é `_STORED_PLAN_TO_TIER` — uma quarta
+    cópia do `{"pro": "plus", "pro_max": "pro"}` é o §0.7 ao contrário.
+
+    Desconhecido volta como veio, igual ao `_plan_publico` do monólito: numa
+    resposta de venda, apagar o plano é pior que devolver um nome estranho.
+    """
+    return _STORED_PLAN_TO_TIER.get(plan_stored, plan_stored)
+
+
 TRIAL_DAYS_DEFAULT = 15
 
 

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4598,10 +4598,14 @@ async def billing_subscription(user_id: int = Depends(_get_current_user)):
     # e chamaria `/billing/change-plan`, que não tem assinatura para trocar.
     # Grant Pix vigente é a resposta autoritativa: ele foi criado pelo dinheiro
     # que entrou, e não depende de o Stripe estar de pé.
+    # `tier_publico` e não uma cópia local do `{"pro": "plus", ...}`: quem é dono
+    # do vocabulário é o `_STORED_PLAN_TO_TIER` do `plan_service` (§0.1/§0.7).
+    from core.services.plan_service import tier_publico
+
     pix = await asyncio.to_thread(_grant_pix_vigente, user_id)
     if pix is not None:
         return {"active": True, "lifetime": False, "gateway": "pix",
-                "plan": _plan_publico(pix["plan_stored"]), "interval": "annual",
+                "plan": tier_publico(pix["plan_stored"]), "interval": "annual",
                 "current_period_end": pix["ends_at"].date().isoformat(),
                 "scheduled_change": None}
 
@@ -4674,12 +4678,6 @@ def _grant_pix_vigente(user_id: int) -> dict | None:
     if not grant_vigente(pix, agora):
         return None
     return max(pix, key=lambda g: g["ends_at"])
-
-
-def _plan_publico(plan_stored: str) -> str:
-    """Valor LEGADO da coluna → o nome que a /precos usa. Uma tradução, um
-    lugar: `_plan_interval_for_price` já devolve `plus`/`pro` para o Stripe."""
-    return {"pro": "plus", "pro_max": "pro"}.get(plan_stored, plan_stored)
 
 
 @app.post("/billing/change-plan")

--- a/frontend/routes/billing_pix.py
+++ b/frontend/routes/billing_pix.py
@@ -49,7 +49,7 @@ from core.services.pix_checkout import (
     criar_checkout,
 )
 from core.services.pix_pricing import CoberturaJaPaga
-from core.services.plan_service import TIER_TO_STORED_PLAN
+from core.services.plan_service import TIER_TO_STORED_PLAN, tier_publico
 from frontend.routes import shared
 
 router = APIRouter()
@@ -115,8 +115,10 @@ async def billing_pix_checkout(request: Request, payload: PixCheckoutBody):
     except CoberturaJaPaga as exc:
         # `plano` e `cobertura_ate` vêm da PRÓPRIA exceção: reconsultar o banco
         # aqui poderia devolver um estado diferente do que motivou a recusa.
+        # `exc.plano` é o valor LEGADO (a exceção nasce depois da tradução da
+        # linha 89), e a fronteira fala público nos dois sentidos.
         raise HTTPException(status_code=409, detail={
-            "error": exc.ERRO, "plan": exc.plano,
+            "error": exc.ERRO, "plan": tier_publico(exc.plano),
             "covered_until": exc.cobertura_ate.isoformat()}) from exc
     except Vitalicio as exc:
         # Sem consultar nada de novo: quem decidiu foi o `criar_checkout`. A
@@ -167,7 +169,9 @@ async def billing_pix_status(request: Request, public_token: str):
         raise HTTPException(status_code=404, detail="Cobrança não encontrada.")
     return {
         "status": linha["status"],
-        "plan": linha["plan"],
+        # Público, como no contrato do checkout (§0.7): a mesma tela lê as duas
+        # respostas, e um `pro` aqui e um `plus` lá seriam dois vocabulários.
+        "plan": tier_publico(linha["plan"]),
         "amount_cents": int(linha["amount_cents"]),
         "credit_cents": int(linha["credit_cents"]),
         "expires_at": (linha["qr_expires_at"].isoformat()

--- a/tests/_dreno_pix_helpers.py
+++ b/tests/_dreno_pix_helpers.py
@@ -112,6 +112,10 @@ def mundo_externo(monkeypatch) -> dict:
     zero em qualquer versão do código — a tautologia clássica.
     """
     contas = {"ga4": 0, "capi": 0, "email": 0, "alerta": [], "grant": 0,
+              # Os kwargs de CADA `send_purchase`, na ordem. Contar chamadas e
+              # jogar o conteúdo fora deixa cego para o que VAI no evento — e o
+              # `plan` do GA4 é `item_id`/`item_name`, a linha de receita.
+              "ga4_kw": [],
               # `send_email` NUNCA levanta: Resend fora do ar e Resend sem chave
               # saem os dois por `return False`. O falso devolve o mesmo `bool`
               # que a produção, senão o efeito `email` seria medido contra uma
@@ -127,9 +131,13 @@ def mundo_externo(monkeypatch) -> dict:
         contas["email"] += 1
         return contas["email_ok"]
 
+    def _purchase(**kw):
+        contas["ga4"] += 1
+        contas["ga4_kw"].append(kw)
+        return True
+
     monkeypatch.setattr(ga4, "mp_configured", lambda: True)
-    monkeypatch.setattr(ga4, "send_purchase",
-                        lambda **kw: contas.__setitem__("ga4", contas["ga4"] + 1))
+    monkeypatch.setattr(ga4, "send_purchase", _purchase)
     monkeypatch.setattr(capi, "capi_configured", lambda: True)
     monkeypatch.setattr(capi, "send_event",
                         lambda **kw: contas.__setitem__("capi", contas["capi"] + 1))

--- a/tests/_pix_checkout_helpers.py
+++ b/tests/_pix_checkout_helpers.py
@@ -47,8 +47,11 @@ def asaas_falso(monkeypatch):
     # (linha `creating` sem `asaas_payment_id`): sem o stub o teste sairia para a
     # rede, e com `[]` o comportamento é o de antes — nada remoto para deletar.
     # Uma exceção aqui simula o provedor fora do ar.
+    # `descricoes` guarda o que foi para o campo que o PAGADOR lê na fatura —
+    # a única saída deste PR visível para cliente hoje. Lista, e não o último
+    # valor: um teste que compra duas vezes tem de conseguir ver as duas.
     estado = {"ordem": [], "delete_falha": False, "n": 0, "marca": marca,
-              "remotas": [], "qr_falha": False}
+              "remotas": [], "qr_falha": False, "descricoes": []}
 
     def _cliente(**kw):
         estado["ordem"].append("customer")
@@ -58,6 +61,7 @@ def asaas_falso(monkeypatch):
     def _pagamento(**kw):
         estado["n"] += 1
         estado["ordem"].append("create")
+        estado["descricoes"].append(kw.get("descricao"))
         return {"id": f"pay_{marca}_{estado['n']}"}
 
     def _qr(pid):

--- a/tests/test_pix_checkout_ambiguo.py
+++ b/tests/test_pix_checkout_ambiguo.py
@@ -131,7 +131,11 @@ def test_creating_sem_cobranca_remota_substitui_sem_delete(
     r = _comprar(user_id, "pro")
 
     assert not [p for p in asaas_falso["ordem"] if p.startswith("delete:")]
-    assert r["plan"] == "pro"
+    # `plus` para um `plan_stored="pro"`: a RESPOSTA fala o público da /precos
+    # desde o #350, e `pro` é o valor legado do tier Plus. O que a coluna guarda
+    # continua legado — quem prende os dois lados é
+    # `tests/test_vocabulario_de_plano_nas_saidas.py`.
+    assert r["plan"] == "plus"
     assert [l["status"] for l in _linhas(user_id)] == ["canceled", "pending"]
 
 

--- a/tests/test_pix_checkout_substituicao.py
+++ b/tests/test_pix_checkout_substituicao.py
@@ -79,7 +79,10 @@ def test_substituicao_deleta_no_asaas_antes_de_criar(user_id, vendavel, asaas_fa
     linhas = _linhas(user_id)
     assert [l["status"] for l in linhas] == ["canceled", "pending"]
     assert linhas[0]["qr_payload_enc"] is None, "o QR da cancelada não foi apagado"
-    assert r["plan"] == "pro"
+    # `plus` para um `plan_stored="pro"`: a RESPOSTA fala o público da /precos
+    # desde o #350, e `pro` é o valor legado do tier Plus. A coluna continua
+    # legada — ver `tests/test_vocabulario_de_plano_nas_saidas.py`.
+    assert r["plan"] == "plus"
     assert buscar_ativa(user_id)["id"] == linhas[1]["id"]
 
 

--- a/tests/test_pix_rotas_billing.py
+++ b/tests/test_pix_rotas_billing.py
@@ -210,7 +210,10 @@ def test_poll_pelo_id_do_asaas_e_404_e_o_qr_nao_sai(user_id, monkeypatch):
     ok = client.get(f"/billing/pix/{linha['public_token']}")
     assert ok.status_code == 200
     corpo = ok.json()
-    assert corpo["status"] == "pending" and corpo["plan"] == "pro_max"
+    # `pro`, não `pro_max`: a linha guarda o legado e a RESPOSTA fala o público
+    # da /precos (#350). Quem prende esse contrato, com os dois controles, é
+    # `tests/test_vocabulario_de_plano_nas_saidas.py` — aqui é só de passagem.
+    assert corpo["status"] == "pending" and corpo["plan"] == "pro"
     assert not [c for c in corpo if "qr" in c.lower()], (
         f"o poll devolveu o instrumento de pagamento: {sorted(corpo)}"
     )

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -45,7 +45,8 @@ from _billing_grants_helpers import conta
 from _pix_checkout_helpers import asaas_falso, vendavel  # noqa: F401 — fixtures
 from core.services.email_service import PLAN_DISPLAY_NAMES
 from core.services.pix_pricing import PRECOS_ANUAIS_CENTS
-from core.services.plan_service import _STORED_PLAN_TO_TIER, TIER_TO_STORED_PLAN
+from core.services.plan_service import (
+    _STORED_PLAN_TO_TIER, TIER_TO_STORED_PLAN, tier_publico)
 from db.pix_charges import buscar_por_public_token
 
 
@@ -126,8 +127,8 @@ def test_cada_card_cobra_o_preco_que_anuncia(logado, vendavel, asaas_falso,
 
     linha = buscar_por_public_token(logado.user_id, r.json()["public_token"])
     assert linha is not None, "a cobrança não foi gravada"
-    # As DUAS colunas continuam no vocabulário legado: grants, projeção e o
-    # `_plan_publico` do /billing/subscription dependem disso.
+    # As DUAS colunas continuam no vocabulário legado: grants, projeção e a
+    # tradução do /billing/subscription dependem disso.
     assert linha["plan"] == legado
     assert linha["plan_stored"] == legado
     assert int(linha["price_cents"]) == esperado
@@ -155,7 +156,12 @@ def test_os_dois_mapas_de_plano_sao_inversos():
     for publico, legado in TIER_TO_STORED_PLAN.items():
         assert _STORED_PLAN_TO_TIER[legado] == publico, (
             f"'{publico}' → '{legado}' → '{_STORED_PLAN_TO_TIER.get(legado)}'")
-        assert dashboard._plan_publico(legado) == publico
+        # `tier_publico` é a FUNÇÃO do mesmo mapa, e o que ela prendia era a
+        # cópia local do monólito (`_plan_publico`), que deixou de existir: hoje
+        # o /billing/subscription chama esta mesma função. Quem cobre a rota,
+        # pela rota, é `test_o_consumidor_real_continua_casando` em
+        # `tests/test_vocabulario_de_plano_nas_saidas.py`.
+        assert tier_publico(legado) == publico
     # E todo plano vendável tem preço: um valor sem entrada aqui viraria 503
     # `preco_anual_nao_configurado` só na hora da venda.
     assert set(TIER_TO_STORED_PLAN.values()) <= set(PRECOS_ANUAIS_CENTS)

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -156,10 +156,12 @@ def test_os_dois_mapas_de_plano_sao_inversos():
     for publico, legado in TIER_TO_STORED_PLAN.items():
         assert _STORED_PLAN_TO_TIER[legado] == publico, (
             f"'{publico}' → '{legado}' → '{_STORED_PLAN_TO_TIER.get(legado)}'")
-        # `tier_publico` é a FUNÇÃO do mesmo mapa, e o que ela prendia era a
-        # cópia local do monólito (`_plan_publico`), que deixou de existir: hoje
-        # o /billing/subscription chama esta mesma função. Quem cobre a rota,
-        # pela rota, é `test_o_consumidor_real_continua_casando` em
+        # NÃO é a repetição da linha acima: aquela prende o DICIONÁRIO, esta
+        # prende a FUNÇÃO. Trocar `tier_publico` pela identidade deixa vermelha
+        # só a segunda — medido. Ela substituiu a asserção sobre a cópia local
+        # do monólito (`_plan_publico`), que deixou de existir: hoje o
+        # /billing/subscription chama esta mesma função. Quem cobre a rota, pela
+        # rota, é `test_o_consumidor_real_continua_casando` em
         # `tests/test_vocabulario_de_plano_nas_saidas.py`.
         assert tier_publico(legado) == publico
     # E todo plano vendável tem preço: um valor sem entrada aqui viraria 503

--- a/tests/test_vocabulario_de_plano_nas_saidas.py
+++ b/tests/test_vocabulario_de_plano_nas_saidas.py
@@ -6,8 +6,12 @@ entra). Arquivo separado, e não mais uma seção lá, porque o teto de 350 linh
 caiu bem: entra × sai são as duas metades da mesma fronteira, e cada uma tem os
 seus controles.
 
-CINCO saídas carregavam o valor LEGADO da coluna, medidas na `main` em
-`b71de69`:
+CINCO saídas DO PIX carregavam o valor LEGADO da coluna, medidas na `main` em
+`b71de69`. **Cinco do Pix, e não cinco no produto**: fora daqui a categoria
+segue ABERTA — `/auth/login`, `/auth/dashboard-profile`, `/auth/mfa/verify-login`
+e `/settings/{id}/security` devolvem `plan` cru, e os `PLAN_ALIASES` de
+`frontend/home.html` e `frontend/nav-auth.js` são o tradutor copiado em JS, sem
+teste ligando-os a `_STORED_PLAN_TO_TIER` (§0.7). Fora do escopo deste PR (§2).
 
     resposta do checkout   `core/services/pix_checkout_resposta.py`
     resposta do poll       `frontend/routes/billing_pix.py`
@@ -45,12 +49,15 @@ CONTROLES DESTE GRUPO (medidos, não prometidos):
     `[essencial]` continua VERDE em todas de propósito: ali o legado e o público
     são a MESMA string, e é `[plus]`/`[pro]` que discriminam.
 
-    O PORTÃO tem mutação própria, porque a primeira versão dele não media o que
-    prometia: um campo novo vazando SÓ o legado do Plus
-    (`"tier_atual": linha["plan"] if linha["plan"] == "pro" else None`, em
-    `pix_checkout_resposta.py`) passava com o grupo inteiro verde. Parametrizado,
-    ele fica VERMELHO em `PORTAO[plus]` — e só nele, que é o caso que a versão
-    anterior nunca chegava a rodar.
+    O PORTÃO tem DUAS mutações próprias, uma por versão dele, e cada uma pega o
+    que a versão anterior deixava passar (as duas em `pix_checkout_resposta.py`):
+
+      * legado SÓ do Plus (`"tier_atual": linha["plan"] if linha["plan"] ==
+        "pro" else None`): a 1ª versão comprava só Pro e ficava VERDE com o
+        grupo inteiro. Parametrizada → VERMELHO em `PORTAO[plus]`, e só nele.
+      * legado EMBUTIDO NUMA FRASE (`"resumo": f"plano {linha['plan']} anual"`):
+        a 2ª versão comparava VALOR e ficava VERDE nos dois cards (13 passed).
+        Por substring → VERMELHO em `PORTAO[plus]` E `PORTAO[pro]`.
   * POSITIVO — `test_o_consumidor_real_continua_casando`. O único consumidor de
     `plan` que existe hoje é `pixSub.plan === plano`
     (`frontend/pix-checkout.js:101`), e ele lê o `/billing/subscription`, que
@@ -145,17 +152,30 @@ _DISCRIMINAM = [(p, l) for p, l in _CARDS if p != l]
 _IDS_DISCRIMINAM = [publico for publico, _ in _DISCRIMINAM]
 
 
-def _valores(corpo):
-    """Todo escalar de um corpo JSON, em profundidade — inclusive o do campo que
-    ainda não existe, que é o ponto do portão."""
+# Campos OPACOS: string que a MÁQUINA gera e ninguém lê como plano. Ficam fora
+# da busca por substring porque o acaso os faz conter `pro` — `public_token` é
+# `secrets.token_urlsafe(16)` (alfabeto de 64, ~20 posições: ~7,6e-5 por token) e
+# `qr_image` é base64 de milhares de caracteres. Nenhum dos dois abre buraco: o
+# `qr_image` é só o DESENHO do `qr_payload`, que CONTINUA sendo varrido, e num
+# token aleatório plano nenhum tem como cair.
+_OPACOS = {"qr_image", "public_token"}
+
+
+def _valores(corpo, chave=None):
+    """Todo escalar de um corpo JSON, em profundidade, COM a chave que o carrega
+    — inclusive o do campo que ainda não existe, que é o ponto do portão.
+
+    A chave sai junto por causa do `_OPACOS`: sem ela a exclusão teria de ser
+    por conteúdo, que é adivinhação. Item de lista herda a chave da lista.
+    """
     if isinstance(corpo, dict):
-        for valor in corpo.values():
-            yield from _valores(valor)
+        for k, valor in corpo.items():
+            yield from _valores(valor, k)
     elif isinstance(corpo, list):
         for valor in corpo:
-            yield from _valores(valor)
+            yield from _valores(valor, chave)
     else:
-        yield corpo
+        yield chave, corpo
 
 
 @pytest.mark.parametrize("publico,legado", _CARDS, ids=_IDS)
@@ -246,11 +266,14 @@ def test_nenhuma_saida_do_pix_deixa_o_valor_de_coluna_escapar(
     inteiro verde — medido pelo Tester. Um consumidor futuro desse campo marcaria
     "Renovar" no card Pro (R$ 499) para quem comprou Plus (R$ 199).
 
-    Compara VALOR, não substring, e é por isso que dá para procurar `pro`: o
-    `qr_image` é um data URL de milhares de caracteres, e `"pro" in corpo`
-    acusaria o ruído do base64 — falha intermitente com cara de vazamento. O que
-    a comparação por valor não pega é o legado EMBUTIDO numa frase maior; contra
-    isso vale a `descricao` da fatura, que é texto curto e determinístico.
+    **SUBSTRING, não igualdade de valor.** A versão anterior comparava valor e
+    se justificava com um ruído de base64 no `qr_image` que NÃO existe: 500 data
+    URLs de `qr_svg_data_url` sobre BR Codes aleatórios (média de 17.321 chars)
+    deram `"pro" in url` ZERO vezes. E igualdade é cega ao modo que ESTE PR
+    nomeou — `PigBank anual (pro_max)`, o legado EMBUTIDO numa frase —, que só a
+    `descricao` cobria, campo a campo: o jeito de errar que o portão existe para
+    não deixar errar. Substring cobre igualdade também: `legado` é sempre string,
+    e escalar não-string nunca a igualaria.
     """
     r = _checkout(logado, publico)
     assert r.status_code == 200, r.text
@@ -259,9 +282,11 @@ def test_nenhuma_saida_do_pix_deixa_o_valor_de_coluna_escapar(
 
     assert legado == TIER_TO_STORED_PLAN[publico]   # o que se procura, da fonte
     for onde, corpo in (("checkout", r.json()), ("poll", poll.json())):
-        assert legado not in list(_valores(corpo)), (
-            f"o {onde} do card '{publico}' devolveu o valor de coluna "
-            f"'{legado}' em algum campo: {corpo}")
+        vazou = [(c, v) for c, v in _valores(corpo)
+                 if c not in _OPACOS and isinstance(v, str) and legado in v]
+        assert not vazou, (
+            f"o {onde} do card '{publico}' carrega o valor de coluna "
+            f"'{legado}' em {vazou}")
     assert legado not in asaas_falso["descricoes"][0], (
         f"a fatura do card '{publico}' carrega o valor de coluna '{legado}': "
         f"{asaas_falso['descricoes'][0]}")

--- a/tests/test_vocabulario_de_plano_nas_saidas.py
+++ b/tests/test_vocabulario_de_plano_nas_saidas.py
@@ -1,0 +1,238 @@
+"""A VOLTA da fronteira: o que sai das rotas do Pix também é público (#350).
+
+O gêmeo de `tests/test_vocabulario_de_plano.py`, que prende a IDA (o corpo que
+entra). Arquivo separado, e não mais uma seção lá, porque o teto de 350 linhas
+(`tests/test_max_lines_python.py`) reprovou a soma — e a divisão por ASSUNTO
+caiu bem: entra × sai são as duas metades da mesma fronteira, e cada uma tem os
+seus controles.
+
+Quatro saídas carregavam o valor LEGADO da coluna, medidas na `main` em
+`b71de69`:
+
+    resposta do checkout   `core/services/pix_checkout_resposta.py`
+    resposta do poll       `frontend/routes/billing_pix.py`
+    corpo do 409           `frontend/routes/billing_pix.py`
+    `descricao` da fatura  `core/services/pix_checkout.py`
+
+As três primeiras não têm consumidor nenhum hoje — é por isso que ninguém viu.
+A quarta o cliente lê: saía `PigBank anual (pro_max)` no app do banco de quem
+paga.
+
+CONTROLES DESTE GRUPO (medidos, não prometidos):
+
+  * NEGATIVO — uma mutação por saída, RODADAS, com os nomes que caem:
+
+      resposta do checkout   `tier_publico(linha["plan"])` → `linha["plan"]`
+        em `pix_checkout_resposta.py`  → 4 vermelhos:
+        `..._falam_publico[plus]`, `[pro]`, `..._pro_max_escapar`,
+        `..._consumidor_real_continua_casando`
+      resposta do poll       idem em `frontend/routes/billing_pix.py`
+        → `..._falam_publico[plus]`, `[pro]`, `..._pro_max_escapar`
+      corpo do 409           `tier_publico(exc.plano)` → `exc.plano`
+        → `test_o_409_de_cobertura_ja_paga_fala_publico`
+      `descricao` da fatura  volta a `f"PigBank anual ({linha['plan']})"`
+        → os 3 `..._nome_comercial[*]` e `..._pro_max_escapar`
+
+    `[essencial]` continua VERDE nas três primeiras de propósito: ali o legado e
+    o público são a MESMA string, e é `[plus]`/`[pro]` que discriminam.
+  * POSITIVO — `test_o_consumidor_real_continua_casando`. O único consumidor de
+    `plan` que existe hoje é `pixSub.plan === plano`
+    (`frontend/pix-checkout.js:101`), e ele lê o `/billing/subscription`, que
+    JÁ falava público. Que ele MEDE está provado por uma quinta mutação:
+    `tier_publico` devolvendo um vocabulário TERCEIRO
+    (`{"pro": "PLUS", "pro_max": "PRO"}`) o deixa vermelho junto com
+    `..._falam_publico[plus]`, `[pro]` e o 409 — e o portão do `pro_max` fica
+    VERDE, porque legado nenhum vazou. Sem este caso o grupo aprovaria a
+    tradução que quebra o botão "Renovar" de quem já é assinante.
+
+O que este arquivo NÃO pega: o provedor é falso (`asaas_falso`), então o que ele
+faz com a `descricao` não é medido — só o texto que sai daqui. E o JS não roda:
+a ponta do `pixSub.plan === plano` é verificada comparando as respostas das duas
+rotas, não clicando no botão.
+"""
+from __future__ import annotations
+
+import pytest
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.billing_pix as rotas
+from _billing_grants_helpers import conta
+from _pix_checkout_helpers import (  # noqa: F401 — fixtures
+    _marcar_paga, asaas_falso, vendavel)
+from core.services.email_service import PIX_PLAN_NAMES
+from core.services.plan_service import TIER_TO_STORED_PLAN
+
+_CSRF = "test-csrf-saidas"
+
+# O molde da `descricao`, para o assert não repetir o literal três vezes. O NOME
+# vem de `PIX_PLAN_NAMES` (§0.7) — cravá-lo aqui criaria a segunda fonte do nome
+# que o e-mail de confirmação já usa.
+_FATURA = "{} — plano anual"
+
+
+@pytest.fixture(autouse=True)
+def _sem_teto_de_taxa():
+    """20/hora por IP, e o storage do slowapi é compartilhado entre arquivos:
+    sem zerar, o último teste cai com 429 por causa do vizinho."""
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:  # noqa: BLE001 — storage é detalhe do slowapi
+        pass
+    yield
+
+
+@pytest.fixture()
+def logado(monkeypatch, user_id):
+    """Cliente HTTP com as rotas do Pix e a `/billing/subscription` autenticadas.
+
+    As duas autenticam por caminhos DIFERENTES (o Pix pelo cookie de dashboard,
+    o monólito por `Depends(_get_current_user)`), e o POSITIVO deste arquivo
+    compara as duas — com uma só logada ele mediria 401.
+
+    `app` é lido AQUI e não no topo do módulo: `tests/test_pix_rota_registrada.py`
+    faz `importlib.reload` do monólito, e um `TestClient` de import-time fica
+    preso ao app ANTIGO enquanto o override cai no novo (efeito de ORDEM).
+    """
+    conta(user_id, "free", None)
+    monkeypatch.setattr(rotas.shared, "resolve_dashboard_user_id",
+                        lambda req: user_id)
+    app = dashboard.app
+    app.dependency_overrides[dashboard._get_current_user] = lambda: user_id
+    cliente = TestClient(app)
+    cliente.cookies.set(dashboard.CSRF_COOKIE_NAME, _CSRF)
+    yield SimpleNamespace(user_id=user_id, http=cliente)
+    app.dependency_overrides.pop(dashboard._get_current_user, None)
+
+
+def _checkout(logado, plan: str):
+    return logado.http.post(
+        "/billing/pix/checkout", headers={dashboard.CSRF_HEADER_NAME: _CSRF},
+        json={"plan": plan, "cpf_cnpj": "12345678901"})
+
+
+_CARDS = [("essencial", "essencial"), ("plus", "pro"), ("pro", "pro_max")]
+_IDS = ["essencial", "plus", "pro"]
+
+
+@pytest.mark.parametrize("publico,legado", _CARDS, ids=_IDS)
+def test_as_saidas_do_pix_falam_publico(logado, vendavel, asaas_falso,
+                                        publico, legado):
+    """As DUAS respostas HTTP da compra, num fluxo só: quem pediu `plus` lê
+    `plus` de volta no checkout e no poll, e a COLUNA continua legada.
+
+    As duas juntas de propósito: a mesma tela lê as duas, e traduzir uma só
+    trocaria o vazamento por uma DIVERGÊNCIA — pior, porque some num teste que
+    olha uma resposta de cada vez.
+    """
+    from db.pix_charges import buscar_por_public_token
+
+    r = _checkout(logado, publico)
+    assert r.status_code == 200, r.text
+    assert r.json()["plan"] == publico, (
+        f"checkout devolveu '{r.json()['plan']}' para o card '{publico}'")
+
+    token = r.json()["public_token"]
+    poll = logado.http.get(f"/billing/pix/{token}")
+    assert poll.status_code == 200, poll.text
+    assert poll.json()["plan"] == publico, (
+        f"poll devolveu '{poll.json()['plan']}' para o card '{publico}'")
+
+    linha = buscar_por_public_token(logado.user_id, token)
+    assert linha["plan"] == legado, "a coluna deixou de guardar o legado"
+
+
+@pytest.mark.parametrize("publico,legado", _CARDS, ids=_IDS)
+def test_a_fatura_do_pagador_traz_o_nome_comercial(logado, vendavel,
+                                                   asaas_falso, publico, legado):
+    """A ÚNICA das quatro saídas que o cliente já lê hoje: a `descricao` da
+    cobrança, que aparece no app do banco de quem paga.
+
+    Nome comercial e não o tier público (`pro`): numa fatura não há legenda para
+    traduzir slug.
+    """
+    assert _checkout(logado, publico).status_code == 200
+    assert asaas_falso["descricoes"] == [_FATURA.format(PIX_PLAN_NAMES[legado])]
+    assert legado not in asaas_falso["descricoes"][0], (
+        f"o valor de coluna '{legado}' foi para a fatura do pagador")
+
+
+def test_o_409_de_cobertura_ja_paga_fala_publico(logado, vendavel, asaas_falso):
+    """A saída que não tinha teste nenhum: o corpo da recusa.
+
+    `exc.plano` é o `plan_stored` (provado em `tests/test_pix_recompra.py`:
+    `capturado.value.plano == "pro_max"`), então o 409 devolvia `pro_max` ao
+    mesmo JS que tinha mandado `pro`.
+
+    O estado é montado COMPRANDO, não com `upsert_grant` de mentira: a recusa só
+    nasce com um vigente de tier menor MAIS um grant Pix futuro já pago
+    (`core/services/pix_pricing.py`), e grant sem cobrança por trás derruba a
+    guarda do `amount_cents` antes de chegar à recusa — medido.
+    """
+    primeira = _checkout(logado, "essencial")
+    assert primeira.status_code == 200, primeira.text
+    _marcar_paga(logado.user_id, primeira.json()["public_token"], dias=-10)
+
+    renovacao = _checkout(logado, "essencial")   # agendada: cobre o ano seguinte
+    assert renovacao.status_code == 200, renovacao.text
+    _marcar_paga(logado.user_id, renovacao.json()["public_token"], dias=355)
+
+    r = _checkout(logado, "pro")
+    assert r.status_code == 409, r.text
+    detalhe = r.json()["detail"]
+    assert detalhe["error"] == "pix_future_purchase_conflict"
+    assert detalhe["plan"] == "pro", (
+        f"o 409 devolveu '{detalhe['plan']}' para quem pediu 'pro'")
+    assert asaas_falso["ordem"][-1] != "create", "a recusa emitiu cobrança"
+
+
+def test_nenhuma_saida_do_pix_deixa_o_pro_max_escapar(logado, vendavel,
+                                                      asaas_falso):
+    """O PORTÃO DA CATEGORIA: a próxima saída nova nasce vermelha aqui.
+
+    Os asserts acima olham o campo `plan` POR NOME, e por isso são cegos a um
+    campo que ainda não existe — foi assim que quatro saídas passaram
+    despercebidas. Este olha o corpo INTEIRO, serializado: qualquer chave que
+    venha a carregar o valor da coluna cai aqui sem ninguém ter de se lembrar de
+    escrever o assert.
+
+    **O que ele NÃO pega, de propósito:** o legado do tier Plus é `pro`, que
+    também é valor PÚBLICO válido (o tier Pro) — procurá-lo daria falso positivo
+    em toda compra de Pro. `pro_max` é o único token puramente legado, e é por
+    isso que a compra medida aqui é a de Pro. Contra o vazamento de `pro` valem
+    os casos por campo acima, um por card.
+    """
+    r = _checkout(logado, "pro")
+    assert r.status_code == 200, r.text
+    poll = logado.http.get(f"/billing/pix/{r.json()['public_token']}")
+
+    for onde, corpo in (("checkout", r.text), ("poll", poll.text),
+                        ("fatura", asaas_falso["descricoes"][0])):
+        assert "pro_max" not in corpo, (
+            f"a resposta do {onde} carrega o valor de coluna 'pro_max': {corpo}")
+
+
+def test_o_consumidor_real_continua_casando(logado, vendavel, asaas_falso):
+    """POSITIVO do grupo. `pixSub.plan === plano` (`pix-checkout.js:101`) compara
+    o `/billing/subscription` com o slug do card. Traduzir as saídas do Pix não
+    pode desalinhar essa comparação — se desalinhar, o assinante Pix vê "Pagar"
+    no lugar de "Renovar" e paga um ano que já tem.
+
+    As três pontas na MESMA asserção de propósito: o slug que o JS itera, o que
+    o `/billing/subscription` devolve, e o que o checkout do Pix passou a
+    devolver.
+    """
+    r = _checkout(logado, "pro")
+    _marcar_paga(logado.user_id, r.json()["public_token"])
+
+    sub = logado.http.get("/billing/subscription")
+    assert sub.status_code == 200, sub.text
+    assert sub.json()["gateway"] == "pix", sub.text
+    # `TIER_TO_STORED_PLAN` são os slugs dos cards — a mesma lista que o
+    # `PIX_PLANOS` do JS percorre.
+    assert sub.json()["plan"] in TIER_TO_STORED_PLAN
+    assert sub.json()["plan"] == "pro" == r.json()["plan"], (
+        "o /billing/subscription e o checkout do Pix divergiram: "
+        f"{sub.json()['plan']} x {r.json()['plan']}")

--- a/tests/test_vocabulario_de_plano_nas_saidas.py
+++ b/tests/test_vocabulario_de_plano_nas_saidas.py
@@ -136,9 +136,10 @@ def logado(monkeypatch, user_id):
 
 
 def _checkout(logado, plan: str):
+    # CPF que fecha o mod-11 (#355): documento inválido leva 400 antes do plano.
     return logado.http.post(
         "/billing/pix/checkout", headers={dashboard.CSRF_HEADER_NAME: _CSRF},
-        json={"plan": plan, "cpf_cnpj": "12345678901"})
+        json={"plan": plan, "cpf_cnpj": "52998224725"})
 
 
 # Os cards da /precos, na ordem da escada e LIDOS da fonte (§0.7): plano vendável

--- a/tests/test_vocabulario_de_plano_nas_saidas.py
+++ b/tests/test_vocabulario_de_plano_nas_saidas.py
@@ -89,14 +89,14 @@ from _billing_grants_helpers import conta, garantir_system_event_logs
 from _dreno_pix_helpers import entregar, mundo_externo, nova_cobranca
 from _pix_checkout_helpers import (  # noqa: F401 — fixtures
     _marcar_paga, asaas_falso, vendavel)
-from core.services.email_service import PIX_PLAN_NAMES
+from core.services.email_service import PLAN_DISPLAY_NAMES
 from core.services.pix_pricing import PRECOS_ANUAIS_CENTS
 from core.services.plan_service import TIER_TO_STORED_PLAN
 
 _CSRF = "test-csrf-saidas"
 
 # O molde da `descricao`, para o assert não repetir o literal três vezes. O NOME
-# vem de `PIX_PLAN_NAMES` (§0.7) — cravá-lo aqui criaria a segunda fonte do nome
+# vem de `PLAN_DISPLAY_NAMES` (§0.7) — cravá-lo aqui criaria a segunda fonte do nome
 # que o e-mail de confirmação já usa.
 _FATURA = "{} - plano anual"
 
@@ -216,7 +216,7 @@ def test_a_fatura_do_pagador_traz_o_nome_comercial(logado, vendavel,
     traduzir slug.
     """
     assert _checkout(logado, publico).status_code == 200
-    assert asaas_falso["descricoes"] == [_FATURA.format(PIX_PLAN_NAMES[legado])]
+    assert asaas_falso["descricoes"] == [_FATURA.format(PLAN_DISPLAY_NAMES[legado])]
     assert legado not in asaas_falso["descricoes"][0], (
         f"o valor de coluna '{legado}' foi para a fatura do pagador")
 

--- a/tests/test_vocabulario_de_plano_nas_saidas.py
+++ b/tests/test_vocabulario_de_plano_nas_saidas.py
@@ -6,49 +6,68 @@ entra). Arquivo separado, e não mais uma seção lá, porque o teto de 350 linh
 caiu bem: entra × sai são as duas metades da mesma fronteira, e cada uma tem os
 seus controles.
 
-Quatro saídas carregavam o valor LEGADO da coluna, medidas na `main` em
+CINCO saídas carregavam o valor LEGADO da coluna, medidas na `main` em
 `b71de69`:
 
     resposta do checkout   `core/services/pix_checkout_resposta.py`
     resposta do poll       `frontend/routes/billing_pix.py`
     corpo do 409           `frontend/routes/billing_pix.py`
     `descricao` da fatura  `core/services/pix_checkout.py`
+    `purchase` do GA4      `core/services/pix_drain_effects.py`
 
 As três primeiras não têm consumidor nenhum hoje — é por isso que ninguém viu.
 A quarta o cliente lê: saía `PigBank anual (pro_max)` no app do banco de quem
-paga.
+paga. A QUINTA saiu da primeira varredura deste arquivo (achado do Tester) e é a
+que vira dinheiro em relatório: o `plan` do `purchase` é `item_id` e `item_name`
+no GA4, e o Stripe já mandava o público no mesmo campo — o legado daqui colidia
+o Pro consigo mesmo e o Plus do Pix (R$ 199) com o Pro do Stripe.
 
 CONTROLES DESTE GRUPO (medidos, não prometidos):
 
-  * NEGATIVO — uma mutação por saída, RODADAS, com os nomes que caem:
+  * NEGATIVO — uma mutação por saída, RODADAS (as cinco de novo depois de o
+    portão ser parametrizado, porque o nome dele mudou), com os nomes que caem.
+    `PORTAO` abaixo é `..._deixa_o_valor_de_coluna_escapar`:
 
       resposta do checkout   `tier_publico(linha["plan"])` → `linha["plan"]`
-        em `pix_checkout_resposta.py`  → 4 vermelhos:
-        `..._falam_publico[plus]`, `[pro]`, `..._pro_max_escapar`,
+        em `pix_checkout_resposta.py`  → 5 vermelhos:
+        `..._falam_publico[plus]`, `[pro]`, `PORTAO[plus]`, `PORTAO[pro]`,
         `..._consumidor_real_continua_casando`
       resposta do poll       idem em `frontend/routes/billing_pix.py`
-        → `..._falam_publico[plus]`, `[pro]`, `..._pro_max_escapar`
+        → 4: `..._falam_publico[plus]`, `[pro]`, `PORTAO[plus]`, `PORTAO[pro]`
       corpo do 409           `tier_publico(exc.plano)` → `exc.plano`
-        → `test_o_409_de_cobertura_ja_paga_fala_publico`
+        → 1: `test_o_409_de_cobertura_ja_paga_fala_publico`
       `descricao` da fatura  volta a `f"PigBank anual ({linha['plan']})"`
-        → os 3 `..._nome_comercial[*]` e `..._pro_max_escapar`
+        → 5: os 3 `..._nome_comercial[*]`, `PORTAO[plus]` e `PORTAO[pro]`
+      `purchase` do GA4      `tier_publico(cobranca["plan"])` → `cobranca["plan"]`
+        em `pix_drain_effects.py`
+        → 2: `..._purchase_do_ga4_leva_o_plano_publico[plus]` e `[pro]`
 
-    `[essencial]` continua VERDE nas três primeiras de propósito: ali o legado e
-    o público são a MESMA string, e é `[plus]`/`[pro]` que discriminam.
+    `[essencial]` continua VERDE em todas de propósito: ali o legado e o público
+    são a MESMA string, e é `[plus]`/`[pro]` que discriminam.
+
+    O PORTÃO tem mutação própria, porque a primeira versão dele não media o que
+    prometia: um campo novo vazando SÓ o legado do Plus
+    (`"tier_atual": linha["plan"] if linha["plan"] == "pro" else None`, em
+    `pix_checkout_resposta.py`) passava com o grupo inteiro verde. Parametrizado,
+    ele fica VERMELHO em `PORTAO[plus]` — e só nele, que é o caso que a versão
+    anterior nunca chegava a rodar.
   * POSITIVO — `test_o_consumidor_real_continua_casando`. O único consumidor de
     `plan` que existe hoje é `pixSub.plan === plano`
     (`frontend/pix-checkout.js:101`), e ele lê o `/billing/subscription`, que
-    JÁ falava público. Que ele MEDE está provado por uma quinta mutação:
+    JÁ falava público. Que ele MEDE está provado por mais uma mutação:
     `tier_publico` devolvendo um vocabulário TERCEIRO
     (`{"pro": "PLUS", "pro_max": "PRO"}`) o deixa vermelho junto com
-    `..._falam_publico[plus]`, `[pro]` e o 409 — e o portão do `pro_max` fica
-    VERDE, porque legado nenhum vazou. Sem este caso o grupo aprovaria a
-    tradução que quebra o botão "Renovar" de quem já é assinante.
+    `..._falam_publico[plus]`, `[pro]`, o 409 e os dois do GA4 — e o `PORTAO`
+    fica VERDE nos dois cards, porque legado nenhum vazou. Sem este caso o
+    grupo aprovaria a tradução que quebra o botão "Renovar" de quem já é
+    assinante.
 
 O que este arquivo NÃO pega: o provedor é falso (`asaas_falso`), então o que ele
-faz com a `descricao` não é medido — só o texto que sai daqui. E o JS não roda:
-a ponta do `pixSub.plan === plano` é verificada comparando as respostas das duas
-rotas, não clicando no botão.
+faz com a `descricao` não é medido — só o texto que sai daqui; e o GA4 também é
+falso (`mundo_externo`), então o que se afirma é o valor que chega ao
+`send_purchase`, não o que o relatório do Google mostra. E o JS não roda: a ponta
+do `pixSub.plan === plano` é verificada comparando as respostas das duas rotas,
+não clicando no botão.
 """
 from __future__ import annotations
 
@@ -59,10 +78,12 @@ from fastapi.testclient import TestClient
 
 import frontend.finance_bot_websocket_custom as dashboard
 import frontend.routes.billing_pix as rotas
-from _billing_grants_helpers import conta
+from _billing_grants_helpers import conta, garantir_system_event_logs
+from _dreno_pix_helpers import entregar, mundo_externo, nova_cobranca
 from _pix_checkout_helpers import (  # noqa: F401 — fixtures
     _marcar_paga, asaas_falso, vendavel)
 from core.services.email_service import PIX_PLAN_NAMES
+from core.services.pix_pricing import PRECOS_ANUAIS_CENTS
 from core.services.plan_service import TIER_TO_STORED_PLAN
 
 _CSRF = "test-csrf-saidas"
@@ -70,7 +91,7 @@ _CSRF = "test-csrf-saidas"
 # O molde da `descricao`, para o assert não repetir o literal três vezes. O NOME
 # vem de `PIX_PLAN_NAMES` (§0.7) — cravá-lo aqui criaria a segunda fonte do nome
 # que o e-mail de confirmação já usa.
-_FATURA = "{} — plano anual"
+_FATURA = "{} - plano anual"
 
 
 @pytest.fixture(autouse=True)
@@ -113,8 +134,28 @@ def _checkout(logado, plan: str):
         json={"plan": plan, "cpf_cnpj": "12345678901"})
 
 
-_CARDS = [("essencial", "essencial"), ("plus", "pro"), ("pro", "pro_max")]
-_IDS = ["essencial", "plus", "pro"]
+# Os cards da /precos, na ordem da escada e LIDOS da fonte (§0.7): plano vendável
+# novo entra sozinho em todo `parametrize` daqui, o portão de categoria incluído.
+_CARDS = list(TIER_TO_STORED_PLAN.items())
+_IDS = [publico for publico, _ in _CARDS]
+
+# O portão de categoria só DISCRIMINA onde as duas strings diferem: em
+# `essencial` o legado É o público, e procurá-lo acusaria o próprio campo `plan`.
+_DISCRIMINAM = [(p, l) for p, l in _CARDS if p != l]
+_IDS_DISCRIMINAM = [publico for publico, _ in _DISCRIMINAM]
+
+
+def _valores(corpo):
+    """Todo escalar de um corpo JSON, em profundidade — inclusive o do campo que
+    ainda não existe, que é o ponto do portão."""
+    if isinstance(corpo, dict):
+        for valor in corpo.values():
+            yield from _valores(valor)
+    elif isinstance(corpo, list):
+        for valor in corpo:
+            yield from _valores(valor)
+    else:
+        yield corpo
 
 
 @pytest.mark.parametrize("publico,legado", _CARDS, ids=_IDS)
@@ -188,30 +229,74 @@ def test_o_409_de_cobertura_ja_paga_fala_publico(logado, vendavel, asaas_falso):
     assert asaas_falso["ordem"][-1] != "create", "a recusa emitiu cobrança"
 
 
-def test_nenhuma_saida_do_pix_deixa_o_pro_max_escapar(logado, vendavel,
-                                                      asaas_falso):
+@pytest.mark.parametrize("publico,legado", _DISCRIMINAM, ids=_IDS_DISCRIMINAM)
+def test_nenhuma_saida_do_pix_deixa_o_valor_de_coluna_escapar(
+        logado, vendavel, asaas_falso, publico, legado):
     """O PORTÃO DA CATEGORIA: a próxima saída nova nasce vermelha aqui.
 
     Os asserts acima olham o campo `plan` POR NOME, e por isso são cegos a um
     campo que ainda não existe — foi assim que quatro saídas passaram
-    despercebidas. Este olha o corpo INTEIRO, serializado: qualquer chave que
-    venha a carregar o valor da coluna cai aqui sem ninguém ter de se lembrar de
-    escrever o assert.
+    despercebidas. Este olha o corpo INTEIRO: qualquer chave, em qualquer
+    profundidade, que venha a carregar `TIER_TO_STORED_PLAN[publico]` cai aqui
+    sem ninguém ter de se lembrar de escrever o assert.
 
-    **O que ele NÃO pega, de propósito:** o legado do tier Plus é `pro`, que
-    também é valor PÚBLICO válido (o tier Pro) — procurá-lo daria falso positivo
-    em toda compra de Pro. `pro_max` é o único token puramente legado, e é por
-    isso que a compra medida aqui é a de Pro. Contra o vazamento de `pro` valem
-    os casos por campo acima, um por card.
+    **Roda nos DOIS cards que discriminam, e a primeira versão não rodava.** Ela
+    comprava só Pro e procurava o literal `pro_max`, então um campo novo que
+    vazasse só o legado do Plus (`"tier_atual": "pro"`) passava com o grupo
+    inteiro verde — medido pelo Tester. Um consumidor futuro desse campo marcaria
+    "Renovar" no card Pro (R$ 499) para quem comprou Plus (R$ 199).
+
+    Compara VALOR, não substring, e é por isso que dá para procurar `pro`: o
+    `qr_image` é um data URL de milhares de caracteres, e `"pro" in corpo`
+    acusaria o ruído do base64 — falha intermitente com cara de vazamento. O que
+    a comparação por valor não pega é o legado EMBUTIDO numa frase maior; contra
+    isso vale a `descricao` da fatura, que é texto curto e determinístico.
     """
-    r = _checkout(logado, "pro")
+    r = _checkout(logado, publico)
     assert r.status_code == 200, r.text
     poll = logado.http.get(f"/billing/pix/{r.json()['public_token']}")
+    assert poll.status_code == 200, poll.text
 
-    for onde, corpo in (("checkout", r.text), ("poll", poll.text),
-                        ("fatura", asaas_falso["descricoes"][0])):
-        assert "pro_max" not in corpo, (
-            f"a resposta do {onde} carrega o valor de coluna 'pro_max': {corpo}")
+    assert legado == TIER_TO_STORED_PLAN[publico]   # o que se procura, da fonte
+    for onde, corpo in (("checkout", r.json()), ("poll", poll.json())):
+        assert legado not in list(_valores(corpo)), (
+            f"o {onde} do card '{publico}' devolveu o valor de coluna "
+            f"'{legado}' em algum campo: {corpo}")
+    assert legado not in asaas_falso["descricoes"][0], (
+        f"a fatura do card '{publico}' carrega o valor de coluna '{legado}': "
+        f"{asaas_falso['descricoes'][0]}")
+
+
+@pytest.mark.parametrize("publico,legado", _CARDS, ids=_IDS)
+def test_o_purchase_do_ga4_leva_o_plano_publico(user_id, monkeypatch,
+                                                publico, legado):
+    """A QUINTA saída, e a única que vira DINHEIRO em relatório: o `plan` do
+    `purchase` do GA4 (`core/services/pix_drain_effects.py`), que
+    `core/services/ga4_mp.py` usa como `item_id` E `item_name`.
+
+    O Stripe já traduz no mesmo destino (`_ga_plano_publico`), então o legado
+    daqui colidia DUAS linhas de receita: o Pro virava dois produtos (`pro` pelo
+    Stripe, `pro_max` pelo Pix) e o Plus do Pix (`pro`, R$ 199) caía na mesma
+    linha do Pro do Stripe (R$ 39,90/mês). É o achado do Codex no #244.
+
+    Pelo DRENO, não chamando `_ga4` na mão: o que se afirma é que o valor
+    traduzido chega ao seam, e o `cobranca` que o efeito lê é montado pelo
+    caminho real.
+    """
+    garantir_system_event_logs()
+    conta(user_id, "free", None)
+    externo = mundo_externo(monkeypatch)
+    cobranca = nova_cobranca(user_id, plan=legado, plan_stored=legado,
+                             price_cents=PRECOS_ANUAIS_CENTS[legado],
+                             amount_cents=PRECOS_ANUAIS_CENTS[legado])
+
+    entregar("PAYMENT_RECEIVED", cobranca)
+
+    assert externo["ga4"] == 1, "o efeito ga4 não rodou — o assert abaixo mediria zero"
+    enviado = externo["ga4_kw"][0]
+    assert enviado["plan"] == publico, (
+        f"o purchase do card '{publico}' foi para o GA4 como '{enviado['plan']}'")
+    assert enviado["value"] == PRECOS_ANUAIS_CENTS[legado] / 100
 
 
 def test_o_consumidor_real_continua_casando(logado, vendavel, asaas_falso):


### PR DESCRIPTION
> ⚠️ **NÃO MERGEAR ANTES DO #358.** Sem ele, este PR quebra 100% das vendas de Pix com
> HTTP 500. O git mescla limpo e o CI fica verde nos dois — nada acusa. Detalhe no fim.

Fecha a issue #350.

## O que estava errado

O banco guarda o vocabulário legado (`pro` = tier Plus, `pro_max` = tier Pro). Isso é
interno e está certo. O problema era esse valor **atravessar a fronteira**.

Cinco saídas do Pix carregavam o valor de coluna: a resposta do checkout, a do poll, o
corpo do 409, a **descrição da cobrança que o pagador lê na fatura do Asaas**, e o evento
`purchase` mandado ao GA4.

## A quinta era a pior

`core/services/pix_drain_effects.py` mandava o valor legado como `item_id` **e**
`item_name` do evento de compra. Resultado medido:

| venda | `item_id` no GA4 | valor |
|---|---|---|
| Pro por Stripe | `pro` | R$ 39,90/mês |
| **Plus por Pix** | **`pro`** | **R$ 199** |
| Pro por Pix | `pro_max` | R$ 499 |

Duas colisões: o Pro vira dois produtos, e o **Plus do Pix cai na mesma linha do Pro do
Stripe**. Receita de um plano atribuída ao identificador de outro, no dado que decide
gasto de anúncio.

O lado do Stripe **já traduzia** nesse mesmo destino, e a docstring dele diz por quê,
citando um apontamento anterior do Codex. O problema tinha sido resolvido uma vez, de um
lado só.

Nenhum teste pegava: o dublê de teste contava quantas vezes o evento saía e **descartava
os argumentos**. Corrigido.

## O que mudou

`tier_publico()` em `core/services/plan_service.py`, uma linha sobre o mapa canônico.
As cinco saídas traduzem na fronteira. **O banco continua guardando legado** — nenhuma
migração.

A `descricao` do Asaas passou a usar o **nome comercial** (`PigBank Pro - plano anual`),
o mesmo que o cliente lê no e-mail de confirmação. Isso é decisão de copy num texto que
o pagador vê na fatura do banco: **vetável**.

E a terceira cópia do tradutor, `_plan_publico` no monólito, foi **deletada** em vez de
documentada. Diff negativo.

## Um quinto ponto que era prosa

Um exemplo de código dentro da docstring de uma exceção **ensinava o padrão errado**.
Quem copiasse dali reintroduzia o vazamento.

## O portão, e por que ele mudou de forma

A primeira versão comparava valor a valor, justificada com a alegação de que buscar
substring daria falso positivo no data URL do QR. **Medido: 0 em 500.** O SVG é
estruturado demais para colidir.

A justificativa era falsa e descartava a única forma que pega a classe que esta issue
nomeou — `"PigBank anual (pro_max)"` é legado **embutido numa frase**, e comparação por
valor é cega para isso. Provado:

| portão | mutação "legado embutido em frase" |
|---|---|
| por valor | `13 passed` — mede **zero** |
| por substring | `2 failed` |

Dois campos opacos ficam de fora **por nome**, e o segundo foi excluído aplicando o mesmo
critério de forma consistente: o token público tem ~7,6e-5 de chance de conter `pro` por
acaso, que é exatamente o defeito de que o data URL foi falsamente acusado.

## Evidência

Oito mutações rodadas, cada uma com o nome do teste vermelho. O controle positivo é o
consumidor real da tela, provado por mutação que ele mede.

```
pytest -q              →  6898 passed, 4 xfailed
npm run test:frontend  →  419 pass, 0 fail      (nenhum .js/.mjs tocado)
```

## A categoria fechou no Pix, e NÃO fechou fora dele

Seis sites continuam devolvendo o valor de coluna, fora do escopo deste PR:

```
frontend/finance_bot_websocket_custom.py:3020  POST /auth/login
frontend/finance_bot_websocket_custom.py:2759  GET  /auth/dashboard-profile
frontend/finance_bot_websocket_custom.py:3595  POST /auth/mfa/verify-login
frontend/routes/settings.py:115                _get_security_settings
frontend/home.html:724                         PLAN_ALIASES — 3ª cópia do tradutor
frontend/nav-auth.js:135                       PLAN_ALIASES — 4ª cópia, literal idêntico
```

Nenhum teste liga as duas cópias em JavaScript à fonte única. É o teste que o §0.7 exige.

## Por que a ordem de merge importa

`core/services/pix_checkout.py:309` e um teste importam `PIX_PLAN_NAMES`, e o #358
renomeia esse mapa sem alias. Os dois PRs tocam arquivos **disjuntos**: `merge-tree` sai
`rc=0`, sem conflito, e produz `ImportError`.

O import está **fora** do `try` que vira 503, e a rota só captura quatro exceções
nomeadas. Efeito: **500 nos três cards**. A linha fica em `draft`, que a varredura
reconcilia em 15 minutos.

Depois do #358, rebasar e trocar os dois imports por `plan_display_name`, junto com os
dois comentários que citam o nome antigo.

## Não verificado

O que o app de banco do pagador renderiza na descrição, e o que o relatório do GA4
exibe. Os dois só depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
