### PR TITLE
Checkout sem plano comprava Plus em silêncio

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4150,8 +4150,11 @@ class CreateCheckoutBody(BaseModel):
     interval: str = "monthly"  # "monthly" | "annual"
     # `plan` NÃO tem default de plano: ausente ou vazio é 400 na rota, nunca uma
     # compra de Plus em silêncio (o default histórico era `"plus"`). O `""` aqui
-    # existe só pra o caso ausente cair no MESMO 400 `plan inválido` do gêmeo do
-    # Pix, em vez de num 422 com outro formato de corpo.
+    # faz a chave AUSENTE cair no mesmo 400 `plan inválido` da chave vazia, em
+    # vez de num 422 `Field required` que a /precos só sabe mostrar como erro
+    # genérico. Por que 400 e não corpo obrigatório: docstring de
+    # `billing_create_checkout`. O Pix, com `plan: str`, dá 422 na chave ausente
+    # — divergência anotada em `tests/test_vocabulario_de_plano.py`.
     plan: str = ""             # "essencial" | "plus" | "pro"
 
 
@@ -4464,19 +4467,56 @@ async def billing_create_checkout(
     payload: CreateCheckoutBody | None = None,
     user_id: int = Depends(_get_current_user),
 ):
-    """
-    Cria uma sessão de checkout no Stripe para o plano escolhido.
+    """Cria a sessão de checkout no Stripe para o plano escolhido.
+
     Body: {"plan": "essencial" | "plus" | "pro" (obrigatório),
            "interval": "monthly" | "annual" (default monthly)}.
     Requer: STRIPE_SECRET_KEY + price ID do interval escolhido.
+
+    `plan` é obrigatório NA ROTA e opcional no modelo. A terceira opção (§1) —
+    corpo obrigatório, `payload: CreateCheckoutBody` sem `| None` — foi
+    enumerada antes de ser descartada, e são duas coisas diferentes:
+
+      * campo obrigatório no modelo (`plan: str` sem default) NÃO fecha o caso
+        do relato. Com `| None = None` na assinatura, um POST sem body nenhum
+        não chega a instanciar o modelo: o FastAPI entrega `payload is None` e
+        a rota respondia 200 sem plano nenhum. Nenhum 422 sairia daí — é esta
+        a razão que sustenta a guarda ser aqui, na rota;
+      * corpo obrigatório fecharia OS DOIS casos na camada do Pydantic, e é uma
+        alternativa legítima. Fica de fora porque troca o 400 `plan inválido
+        (use 'essencial', 'plus' ou 'pro')` por um 422 cujo `detail` é uma
+        LISTA: a /precos (`precos.html:1018-1023`) lê `detail` como string ou
+        `detail.message`, uma lista não casa com nenhum dos dois e o clique cai
+        no fallback "Não foi possível iniciar o checkout." — genérico, porém
+        CORRETO (não é JSON cru na tela nem mensagem errada). O 400 daqui ganha
+        por ser específico, não por evitar um estrago.
+
+    Cliente antigo: `startCheckout('monthly', this)`, SEM plano, existiu em 30
+    das 60 revisões da precos.html, a última em `0a37439` (2026-08-06); esse JS
+    manda `{"interval":"monthly"}` e a partir daqui leva 400. Sobra UM chamador
+    real, o mesmo vetor da `/billing/select-free` logo abaixo: a aba com a
+    /precos ANTIGA já carregada no instante do deploy — ali o 400 vira o texto
+    de erro do próprio `startCheckout`, e um reload traz a página nova. Os
+    outros vetores estão fechados: o HTML sai `no-store`
+    (`frontend/routes/shared.py:266`) e o service worker não intercepta
+    navegação (`frontend/service-worker.js:103`), então não existe /precos
+    velha servida por cache HTTP nem por PWA.
     """
-    interval = (payload.interval if payload else "monthly")
+    # Sem body, `payload` chega None (o modelo nem é instanciado) — um default
+    # aqui evita repetir `if payload else` em cada campo. Não é caminho de
+    # sucesso: sem `plan` a validação abaixo recusa com 400.
+    payload = payload if payload is not None else CreateCheckoutBody()
+    # Expressão IDÊNTICA à da `/billing/change-plan`, a única outra rota que
+    # recebe `interval` (o Pix é anual e só): sem o `.lower()`, `"ANNUAL"` era
+    # 400 aqui e 409 lá. `.strip()` não entra — `plan` precisa dele porque
+    # divergia de verdade entre as rotas, `interval` não (§0.2).
+    interval = (payload.interval or "monthly").lower()
     if interval not in ("monthly", "annual"):
         raise HTTPException(status_code=400, detail="interval inválido (use 'monthly' ou 'annual').")
     # Mesma normalização do gêmeo do Pix (`frontend/routes/billing_pix.py`): sem o
     # `.strip()` aqui, `" plus "` era 200 lá e 400 aqui, com UM só JS alimentando
     # as duas. Sem plano é 400, não Plus (issue #352).
-    plan = (payload.plan if payload else "").strip().lower()
+    plan = (payload.plan or "").strip().lower()
     if plan not in ("essencial", "plus", "pro"):
         raise HTTPException(status_code=400, detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
 
@@ -4699,12 +4739,14 @@ async def billing_change_plan(
 ):
     """Agenda a troca de plano pro fim do período já pago. Sem cobrança agora;
     a primeira fatura do plano novo sai na data da virada (cartão em arquivo)."""
+    # Expressão IDÊNTICA à da `/billing/create-checkout` (§0.7): são as duas
+    # únicas rotas que recebem `interval`, e o `.lower()` faltava LÁ, não aqui.
     interval = (payload.interval or "monthly").lower()
     if interval not in ("monthly", "annual"):
         raise HTTPException(status_code=400, detail="interval inválido (use 'monthly' ou 'annual').")
-    # Terceira rota que recebe plano, mesma normalização das duas de checkout
-    # (§2: um caso corrigido não é a categoria resolvida). Sem plano continua
-    # 400 aqui — nunca houve `or "plus"` nesta rota (issue #352).
+    # Terceira rota que recebe plano, mesma normalização de `plan` das duas de
+    # checkout (§2: um caso corrigido não é a categoria resolvida). Sem plano
+    # continua 400 aqui — nunca houve `or "plus"` nesta rota (issue #352).
     plan = (payload.plan or "").strip().lower()
     if plan not in ("essencial", "plus", "pro"):
         raise HTTPException(status_code=400, detail="plan inválido (use 'essencial', 'plus' ou 'pro').")

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4148,13 +4148,12 @@ async def auth_google_complete_signup(
 
 class CreateCheckoutBody(BaseModel):
     interval: str = "monthly"  # "monthly" | "annual"
-    # `plan` NÃO tem default de plano: ausente ou vazio é 400 na rota, nunca uma
-    # compra de Plus em silêncio (o default histórico era `"plus"`). O `""` aqui
-    # faz a chave AUSENTE cair no mesmo 400 `plan inválido` da chave vazia, em
-    # vez de num 422 `Field required` que a /precos só sabe mostrar como erro
-    # genérico. Por que 400 e não corpo obrigatório: docstring de
-    # `billing_create_checkout`. O Pix, com `plan: str`, dá 422 na chave ausente
-    # — divergência anotada em `tests/test_vocabulario_de_plano.py`.
+    # Sem default de plano: ausente ou vazio é 400 na rota, nunca uma compra de
+    # Plus em silêncio (o default histórico era `"plus"`, issue #352). O `""`
+    # faz a chave AUSENTE cair no mesmo 400 `plan inválido` da vazia, em vez de
+    # num 422 cujo `detail` é lista — o porquê está na docstring da rota. O Pix,
+    # com `plan: str`, dá 422 na ausente: anotado em
+    # `tests/test_vocabulario_de_plano.py`.
     plan: str = ""             # "essencial" | "plus" | "pro"
 
 
@@ -4473,51 +4472,38 @@ async def billing_create_checkout(
            "interval": "monthly" | "annual" (default monthly)}.
     Requer: STRIPE_SECRET_KEY + price ID do interval escolhido.
 
-    `plan` é obrigatório NA ROTA e opcional no modelo. A terceira opção (§1) —
-    corpo obrigatório, `payload: CreateCheckoutBody` sem `| None` — foi
-    enumerada antes de ser descartada, e são duas coisas diferentes:
+    `plan` é obrigatório NA ROTA e opcional no modelo. Corpo obrigatório
+    (sem `| None`) fecharia no Pydantic e foi descartado por UM motivo: troca o
+    400 específico por um 422 cujo `detail` é LISTA, e a /precos
+    (`precos.html:1019-1024`) só lê `detail` string ou `detail.message` — cai no
+    fallback genérico. Campo obrigatório só no modelo não fecharia nada: com
+    `| None = None` o POST sem body nenhum nem instancia o modelo.
 
-      * campo obrigatório no modelo (`plan: str` sem default) NÃO fecha o caso
-        do relato. Com `| None = None` na assinatura, um POST sem body nenhum
-        não chega a instanciar o modelo: o FastAPI entrega `payload is None` e
-        a rota respondia 200 sem plano nenhum. Nenhum 422 sairia daí — é esta
-        a razão que sustenta a guarda ser aqui, na rota;
-      * corpo obrigatório fecharia OS DOIS casos na camada do Pydantic, e é uma
-        alternativa legítima. Fica de fora porque troca o 400 `plan inválido
-        (use 'essencial', 'plus' ou 'pro')` por um 422 cujo `detail` é uma
-        LISTA: a /precos (`precos.html:1018-1023`) lê `detail` como string ou
-        `detail.message`, uma lista não casa com nenhum dos dois e o clique cai
-        no fallback "Não foi possível iniciar o checkout." — genérico, porém
-        CORRETO (não é JSON cru na tela nem mensagem errada). O 400 daqui ganha
-        por ser específico, não por evitar um estrago.
-
-    Cliente antigo: `startCheckout('monthly', this)`, SEM plano, existiu em 30
-    das 60 revisões da precos.html, a última em `0a37439` (2026-08-06); esse JS
-    manda `{"interval":"monthly"}` e a partir daqui leva 400. Sobra UM chamador
-    real, o mesmo vetor da `/billing/select-free` logo abaixo: a aba com a
-    /precos ANTIGA já carregada no instante do deploy — ali o 400 vira o texto
-    de erro do próprio `startCheckout`, e um reload traz a página nova. Os
-    outros vetores estão fechados: o HTML sai `no-store`
-    (`frontend/routes/shared.py:266`) e o service worker não intercepta
-    navegação (`frontend/service-worker.js:103`), então não existe /precos
-    velha servida por cache HTTP nem por PWA.
+    Cliente antigo (`startCheckout('monthly', this)`, sem plano) morreu em
+    `0a37439` e a partir daqui leva 400. Sobra a aba com a /precos ANTIGA aberta
+    no instante do deploy — o 400 vira o erro do próprio `startCheckout` e um
+    reload resolve; não há /precos velha em cache (`no-store` em
+    `frontend/routes/shared.py:266`, e o SW não intercepta navegação).
     """
-    # Sem body, `payload` chega None (o modelo nem é instanciado) — um default
-    # aqui evita repetir `if payload else` em cada campo. Não é caminho de
-    # sucesso: sem `plan` a validação abaixo recusa com 400.
+    from core.services.plan_service import TIER_TO_STORED_PLAN  # noqa: PLC0415
+
+    # Sem body, `payload` chega None (o modelo nem é instanciado). Não é caminho
+    # de sucesso: sem `plan` a validação abaixo recusa com 400.
     payload = payload if payload is not None else CreateCheckoutBody()
     # Expressão IDÊNTICA à da `/billing/change-plan`, a única outra rota que
     # recebe `interval` (o Pix é anual e só): sem o `.lower()`, `"ANNUAL"` era
-    # 400 aqui e 409 lá. `.strip()` não entra — `plan` precisa dele porque
-    # divergia de verdade entre as rotas, `interval` não (§0.2).
-    interval = (payload.interval or "monthly").lower()
+    # 400 aqui e 409 lá. Sem `or "monthly"` nas duas: valor VAZIO é 400, e não
+    # uma venda mensal em silêncio — é a #352 com `interval` no lugar de `plan`.
+    interval = payload.interval.lower()
     if interval not in ("monthly", "annual"):
         raise HTTPException(status_code=400, detail="interval inválido (use 'monthly' ou 'annual').")
-    # Mesma normalização do gêmeo do Pix (`frontend/routes/billing_pix.py`): sem o
-    # `.strip()` aqui, `" plus "` era 200 lá e 400 aqui, com UM só JS alimentando
-    # as duas. Sem plano é 400, não Plus (issue #352).
+    # Vocabulário público em UMA fonte (§0.7): as três rotas de plano validam
+    # contra o MESMO dicionário, e não contra uma tupla literal por rota. O
+    # `.strip().lower()` é o do gêmeo do Pix (`frontend/routes/billing_pix.py`) —
+    # sem ele `" plus "` era 200 lá e 400 aqui, com UM só JS alimentando as duas.
+    # Sem plano é 400, não Plus (issue #352).
     plan = (payload.plan or "").strip().lower()
-    if plan not in ("essencial", "plus", "pro"):
+    if plan not in TIER_TO_STORED_PLAN:
         raise HTTPException(status_code=400, detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
 
     price_id = _resolve_price_id(plan, interval)
@@ -4739,16 +4725,19 @@ async def billing_change_plan(
 ):
     """Agenda a troca de plano pro fim do período já pago. Sem cobrança agora;
     a primeira fatura do plano novo sai na data da virada (cartão em arquivo)."""
+    from core.services.plan_service import TIER_TO_STORED_PLAN  # noqa: PLC0415
+
     # Expressão IDÊNTICA à da `/billing/create-checkout` (§0.7): são as duas
-    # únicas rotas que recebem `interval`, e o `.lower()` faltava LÁ, não aqui.
-    interval = (payload.interval or "monthly").lower()
+    # únicas rotas que recebem `interval`, o `.lower()` faltava LÁ e o
+    # `or "monthly"` saiu daqui — `""` é 400 nas duas, não mensal em silêncio.
+    interval = payload.interval.lower()
     if interval not in ("monthly", "annual"):
         raise HTTPException(status_code=400, detail="interval inválido (use 'monthly' ou 'annual').")
-    # Terceira rota que recebe plano, mesma normalização de `plan` das duas de
-    # checkout (§2: um caso corrigido não é a categoria resolvida). Sem plano
-    # continua 400 aqui — nunca houve `or "plus"` nesta rota (issue #352).
+    # Terceira rota que recebe plano: mesma normalização e o MESMO dicionário
+    # das duas de checkout (§2: um caso corrigido não é a categoria resolvida).
+    # Sem plano continua 400 — nunca houve `or "plus"` aqui (issue #352).
     plan = (payload.plan or "").strip().lower()
-    if plan not in ("essencial", "plus", "pro"):
+    if plan not in TIER_TO_STORED_PLAN:
         raise HTTPException(status_code=400, detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
     target_price = _resolve_price_id(plan, interval)
     if not STRIPE_SECRET_KEY or not target_price:

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4148,7 +4148,11 @@ async def auth_google_complete_signup(
 
 class CreateCheckoutBody(BaseModel):
     interval: str = "monthly"  # "monthly" | "annual"
-    plan: str = "plus"         # "essencial" | "plus" | "pro" (default = Plus, o plano histórico)
+    # `plan` NÃO tem default de plano: ausente ou vazio é 400 na rota, nunca uma
+    # compra de Plus em silêncio (o default histórico era `"plus"`). O `""` aqui
+    # existe só pra o caso ausente cair no MESMO 400 `plan inválido` do gêmeo do
+    # Pix, em vez de num 422 com outro formato de corpo.
+    plan: str = ""             # "essencial" | "plus" | "pro"
 
 
 def _resolve_price_id(plan: str, interval: str) -> str:
@@ -4461,14 +4465,18 @@ async def billing_create_checkout(
     user_id: int = Depends(_get_current_user),
 ):
     """
-    Cria uma sessão de checkout no Stripe para upgrade para o plano Pro.
-    Body opcional: {"interval": "monthly" | "annual"} (default monthly).
+    Cria uma sessão de checkout no Stripe para o plano escolhido.
+    Body: {"plan": "essencial" | "plus" | "pro" (obrigatório),
+           "interval": "monthly" | "annual" (default monthly)}.
     Requer: STRIPE_SECRET_KEY + price ID do interval escolhido.
     """
     interval = (payload.interval if payload else "monthly")
     if interval not in ("monthly", "annual"):
         raise HTTPException(status_code=400, detail="interval inválido (use 'monthly' ou 'annual').")
-    plan = ((payload.plan if payload else "plus") or "plus").lower()
+    # Mesma normalização do gêmeo do Pix (`frontend/routes/billing_pix.py`): sem o
+    # `.strip()` aqui, `" plus "` era 200 lá e 400 aqui, com UM só JS alimentando
+    # as duas. Sem plano é 400, não Plus (issue #352).
+    plan = (payload.plan if payload else "").strip().lower()
     if plan not in ("essencial", "plus", "pro"):
         raise HTTPException(status_code=400, detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
 

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -4702,7 +4702,10 @@ async def billing_change_plan(
     interval = (payload.interval or "monthly").lower()
     if interval not in ("monthly", "annual"):
         raise HTTPException(status_code=400, detail="interval inválido (use 'monthly' ou 'annual').")
-    plan = (payload.plan or "").lower()
+    # Terceira rota que recebe plano, mesma normalização das duas de checkout
+    # (§2: um caso corrigido não é a categoria resolvida). Sem plano continua
+    # 400 aqui — nunca houve `or "plus"` nesta rota (issue #352).
+    plan = (payload.plan or "").strip().lower()
     if plan not in ("essencial", "plus", "pro"):
         raise HTTPException(status_code=400, detail="plan inválido (use 'essencial', 'plus' ou 'pro').")
     target_price = _resolve_price_id(plan, interval)

--- a/tests/test_admin_users_panel.py
+++ b/tests/test_admin_users_panel.py
@@ -1052,7 +1052,7 @@ def test_reset_faz_o_checkout_voltar_a_mandar_trial(panel_accounts, monkeypatch)
             dashboard.limiter._storage.reset()
         except Exception:
             pass
-        r1 = user_client.post("/billing/create-checkout", headers=headers)
+        r1 = user_client.post("/billing/create-checkout", json={"plan": "plus"}, headers=headers)
         assert r1.status_code == 200, r1.text
         assert "trial_period_days" not in fake.last_session_kwargs["subscription_data"]
 
@@ -1070,7 +1070,7 @@ def test_reset_faz_o_checkout_voltar_a_mandar_trial(panel_accounts, monkeypatch)
             dashboard.limiter._storage.reset()
         except Exception:
             pass
-        r2 = user_client.post("/billing/create-checkout", headers=headers)
+        r2 = user_client.post("/billing/create-checkout", json={"plan": "plus"}, headers=headers)
         assert r2.status_code == 200, r2.text
         assert fake.last_session_kwargs["subscription_data"]["trial_period_days"] == 15
     finally:

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -6,7 +6,8 @@ Cobre:
   desde #352: sem ele é 400, não uma compra de Plus em silêncio)
 - interval=annual usa STRIPE_PRICE_ID_PRO_ANUAL
 - interval=monthly cai no fallback STRIPE_PRICE_ID_PRO se MENSAL nao setado
-- interval invalido retorna 400
+- interval invalido retorna 400, e `"ANNUAL"` NÃO é inválido (mesma
+  normalização da /billing/change-plan)
 - 503 se Stripe nao configurado para o interval pedido
 - reaproveita stripe_customer_id existente
 """
@@ -250,7 +251,10 @@ def _stripe_pronto(monkeypatch):
     {},                        # body vazio
     {"interval": "annual"},    # o caso do relato: interval sem plan
     {"plan": ""},
-    {"plan": "   "},           # só espaços — o `.strip()` não pode ressuscitar o default
+    # `"   "` NÃO discrimina: sob a mutação do bug (`or "plus"`), `"   " or
+    # "plus"` devolve `"   "`, que já era 400 antes do conserto. Fica como
+    # companhia do grupo, e não pode ser citado como prova de nada (§7).
+    {"plan": "   "},
 ], ids=["sem-body", "body-vazio", "so-interval", "plan-vazio", "plan-so-espacos"])
 def test_checkout_sem_plano_e_400_e_nao_vende_plus(request, user_id, monkeypatch, corpo):
     """Sem plano no corpo, a rota RECUSA — não vende Plus em silêncio (#352).
@@ -303,6 +307,33 @@ def test_checkout_aceita_plano_com_espacos_como_o_pix(user_id, monkeypatch):
     assert resp.status_code == 200, resp.text
     assert resp.json()["plan"] == "plus"
     assert fake.session_create_calls == 1
+
+
+def test_checkout_aceita_interval_em_caixa_alta_como_a_troca(user_id, monkeypatch):
+    """`interval` normaliza IGUAL à `/billing/change-plan` (§0.7): `"ANNUAL"`
+    era 400 aqui e 409 lá, com UM só JS alimentando as duas.
+
+    A asserção é o PRICE ID, não só o status: um `annual` mal normalizado que
+    caísse em `monthly` sairia 200 e venderia o plano mensal com cara de acerto.
+
+    CONTROLE NEGATIVO deste caso: troque a linha do `interval` na rota
+    (`frontend/finance_bot_websocket_custom.py`, `billing_create_checkout`) de
+    `(payload.interval or "monthly").lower()` por `(payload.interval or
+    "monthly")` e este teste fica VERMELHO em 400
+    `interval inválido`. Injetado num caso VERDE — `annual` sem espaços passa
+    com e sem o conserto (`test_checkout_annual_uses_annual_price` é ele).
+    """
+    _, _, client = _auth_user_setup(f"interval-{user_id}")
+    fake = _stripe_pronto(monkeypatch)
+
+    resp = client.post("/billing/create-checkout",
+                       json={"plan": "plus", "interval": "ANNUAL"},
+                       headers=_CSRF_HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["interval"] == "annual"
+    assert fake.last_session_kwargs["line_items"] == [
+        {"price": "price_anual_xyz", "quantity": 1}
+    ]
 
 
 def test_checkout_returns_503_when_annual_price_missing(user_id, monkeypatch):

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -157,7 +157,10 @@ def _patch_stripe(monkeypatch) -> _FakeStripe:
     return fake
 
 
-def test_checkout_default_uses_monthly_price(user_id, monkeypatch):
+def test_checkout_omitted_interval_uses_monthly_price(user_id, monkeypatch):
+    """`interval` ausente cai no default do modelo (`monthly`). O nome já disse
+    só `default`, quando `plan` também tinha um; hoje `plan` é obrigatório
+    (#352) e o único default que sobrou é este."""
     _, _, client = _auth_user_setup(f"def-{user_id}")
     monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
@@ -223,14 +226,28 @@ def test_checkout_monthly_falls_back_to_legacy_price(user_id, monkeypatch):
     ]
 
 
-def test_checkout_invalid_interval_returns_400(user_id, monkeypatch):
-    _, _, client = _auth_user_setup(f"inv-{user_id}")
-    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
-    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+@pytest.mark.parametrize("interval", ["weekly", ""], ids=["weekly", "vazio"])
+def test_checkout_invalid_interval_returns_400(request, user_id, monkeypatch, interval):
+    """`""` entra aqui pelo mesmo motivo de `plan` (#352): um `or "monthly"`
+    nesta rota transformava valor VAZIO em venda MENSAL silenciosa — 200 com
+    `interval: "monthly"` num corpo que não escolheu ciclo nenhum.
 
-    resp = client.post("/billing/create-checkout", json={"plan": "plus", "interval": "weekly"}, headers=_CSRF_HEADERS)
-    assert resp.status_code == 400
+    CONTROLE NEGATIVO do caso `vazio`: em `billing_create_checkout`
+    (`frontend/finance_bot_websocket_custom.py`) troque `payload.interval.lower()`
+    por `(payload.interval or "monthly").lower()` e
+    `test_checkout_invalid_interval_returns_400[vazio]` fica VERMELHO em 200.
+    Injetado num caso VERDE — `weekly` é 400 com e sem o `or`.
+
+    A sessão zero é o que dá dinheiro à medição: 400 sozinho também sairia de
+    uma validação depois de a cobrança nascer.
+    """
+    _, _, client = _auth_user_setup(f"inv-{request.node.callspec.id}-{user_id}")
+    fake = _stripe_pronto(monkeypatch)
+
+    resp = client.post("/billing/create-checkout", json={"plan": "plus", "interval": interval}, headers=_CSRF_HEADERS)
+    assert resp.status_code == 400, resp.text
     assert "interval" in resp.json()["detail"].lower()
+    assert fake.session_create_calls == 0, "recusa de interval abriu checkout no Stripe"
 
 
 def _stripe_pronto(monkeypatch):
@@ -318,10 +335,9 @@ def test_checkout_aceita_interval_em_caixa_alta_como_a_troca(user_id, monkeypatc
 
     CONTROLE NEGATIVO deste caso: troque a linha do `interval` na rota
     (`frontend/finance_bot_websocket_custom.py`, `billing_create_checkout`) de
-    `(payload.interval or "monthly").lower()` por `(payload.interval or
-    "monthly")` e este teste fica VERMELHO em 400
-    `interval inválido`. Injetado num caso VERDE — `annual` sem espaços passa
-    com e sem o conserto (`test_checkout_annual_uses_annual_price` é ele).
+    `payload.interval.lower()` por `payload.interval` e este teste fica VERMELHO
+    em 400 `interval inválido`. Injetado num caso VERDE — `annual` sem espaços
+    passa com e sem o conserto (`test_checkout_annual_uses_annual_price` é ele).
     """
     _, _, client = _auth_user_setup(f"interval-{user_id}")
     fake = _stripe_pronto(monkeypatch)

--- a/tests/test_billing_checkout.py
+++ b/tests/test_billing_checkout.py
@@ -2,7 +2,8 @@
 tests/test_billing_checkout.py — POST /billing/create-checkout.
 
 Cobre:
-- default sem body == monthly e usa STRIPE_PRICE_ID_PRO_MENSAL
+- interval ausente == monthly e usa STRIPE_PRICE_ID_PRO_MENSAL (`plan` é obrigatório
+  desde #352: sem ele é 400, não uma compra de Plus em silêncio)
 - interval=annual usa STRIPE_PRICE_ID_PRO_ANUAL
 - interval=monthly cai no fallback STRIPE_PRICE_ID_PRO se MENSAL nao setado
 - interval invalido retorna 400
@@ -166,7 +167,7 @@ def test_checkout_default_uses_monthly_price(user_id, monkeypatch):
     monkeypatch.setenv("PRO_TRIAL_DAYS", "7")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["interval"] == "monthly"
@@ -195,7 +196,7 @@ def test_checkout_annual_uses_annual_price(user_id, monkeypatch):
     monkeypatch.setenv("PRO_TRIAL_DAYS", "7")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", json={"interval": "annual"}, headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus", "interval": "annual"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["interval"] == "annual"
@@ -214,7 +215,7 @@ def test_checkout_monthly_falls_back_to_legacy_price(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", "price_legacy_pro")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", json={"interval": "monthly"}, headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus", "interval": "monthly"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     assert fake.last_session_kwargs["line_items"] == [
         {"price": "price_legacy_pro", "quantity": 1}
@@ -226,9 +227,82 @@ def test_checkout_invalid_interval_returns_400(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
 
-    resp = client.post("/billing/create-checkout", json={"interval": "weekly"}, headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus", "interval": "weekly"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 400
     assert "interval" in resp.json()["detail"].lower()
+
+
+def _stripe_pronto(monkeypatch):
+    """Stripe inteiramente configurado: mensal, anual e legado com price ID.
+
+    É o que impede um 400 de plano de ser confundido com o 503 de "pagamentos
+    não configurados" — com todos os preços no lugar, 503 aqui seria bug.
+    """
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_xxx")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "price_anual_xyz")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", "price_legacy_pro")
+    return _patch_stripe(monkeypatch)
+
+
+@pytest.mark.parametrize("corpo", [
+    None,                      # POST sem body nenhum
+    {},                        # body vazio
+    {"interval": "annual"},    # o caso do relato: interval sem plan
+    {"plan": ""},
+    {"plan": "   "},           # só espaços — o `.strip()` não pode ressuscitar o default
+], ids=["sem-body", "body-vazio", "so-interval", "plan-vazio", "plan-so-espacos"])
+def test_checkout_sem_plano_e_400_e_nao_vende_plus(request, user_id, monkeypatch, corpo):
+    """Sem plano no corpo, a rota RECUSA — não vende Plus em silêncio (#352).
+
+    O default histórico era `("" or "plus")`: um bug no JS que parasse de mandar
+    o campo faria todo mundo comprar Plus sem escolher, e o sintoma ("as vendas
+    migraram pro Plus") não aponta pra cá.
+
+    A asserção de sessão zero é o que dá dinheiro à medição: 400 sozinho também
+    sairia de um erro de validação depois da cobrança nascer.
+    """
+    _, _, client = _auth_user_setup(f"{request.node.callspec.id}-{user_id}")
+    fake = _stripe_pronto(monkeypatch)
+
+    kwargs = {"headers": _CSRF_HEADERS}
+    if corpo is not None:
+        kwargs["json"] = corpo
+    resp = client.post("/billing/create-checkout", **kwargs)
+
+    assert resp.status_code == 400, resp.text
+    assert "plan" in str(resp.json()["detail"]).lower()
+    assert fake.session_create_calls == 0, "recusa de plano abriu checkout no Stripe"
+
+
+def test_checkout_com_plano_explicito_continua_vendendo(user_id, monkeypatch):
+    """POSITIVO do grupo: `plan` explícito segue abrindo o checkout.
+
+    Sem ele o grupo passaria numa rota que recusasse tudo — pior que o bug.
+    """
+    _, _, client = _auth_user_setup(f"complan-{user_id}")
+    fake = _stripe_pronto(monkeypatch)
+
+    resp = client.post("/billing/create-checkout",
+                       json={"plan": "plus", "interval": "annual"},
+                       headers=_CSRF_HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["plan"] == "plus"
+    assert fake.session_create_calls == 1
+
+
+def test_checkout_aceita_plano_com_espacos_como_o_pix(user_id, monkeypatch):
+    """`" plus "` era 200 no Pix (`.strip().lower()`) e 400 aqui (só `.lower()`),
+    com UM só JS alimentando as duas rotas. As gêmeas normalizam igual."""
+    _, _, client = _auth_user_setup(f"espacos-{user_id}")
+    fake = _stripe_pronto(monkeypatch)
+
+    resp = client.post("/billing/create-checkout",
+                       json={"plan": " plus ", "interval": "annual"},
+                       headers=_CSRF_HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["plan"] == "plus"
+    assert fake.session_create_calls == 1
 
 
 def test_checkout_returns_503_when_annual_price_missing(user_id, monkeypatch):
@@ -239,7 +313,7 @@ def test_checkout_returns_503_when_annual_price_missing(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "")
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO", "price_legacy_pro")
 
-    resp = client.post("/billing/create-checkout", json={"interval": "annual"}, headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus", "interval": "annual"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 503
 
 
@@ -254,7 +328,7 @@ def test_checkout_creates_new_customer_with_brazil_country_and_locale(user_id, m
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
 
     assert fake.customer_create_calls == 1
@@ -272,7 +346,7 @@ def test_checkout_reuses_existing_stripe_customer(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200
     assert fake.customer_create_calls == 0
     assert fake.last_session_kwargs["customer"] == "cus_existing_999"
@@ -295,7 +369,7 @@ def test_checkout_bloqueia_quem_ja_assina(user_id, monkeypatch):
 
     fake.Subscription = _Subscription
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 409, resp.text
     assert resp.json()["detail"]["error"] == "already_subscribed"
     assert fake.last_session_kwargs is None  # checkout NUNCA foi criado
@@ -317,7 +391,7 @@ def test_checkout_fail_closed_com_stripe_fora(user_id, monkeypatch):
 
     fake.Subscription = _SubscriptionBoom
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 503, resp.text
     assert fake.last_session_kwargs is None  # nada de checkout no escuro
 
@@ -339,7 +413,7 @@ def test_checkout_recupera_customer_apagado_no_stripe(user_id, monkeypatch):
 
     fake.Subscription = _MissingCustomerSubscription
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     assert fake.customer_create_calls == 1
     assert fake.session_create_calls == 1
@@ -355,7 +429,7 @@ def test_checkout_sem_customer_segue_normal(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     assert fake.last_session_kwargs is not None
 
@@ -374,7 +448,7 @@ def test_checkout_v2_elegivel_manda_trial_de_30(user_id, monkeypatch):
     monkeypatch.setattr("db.plans.is_trial_eligible_for_user", lambda uid: True)
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     assert fake.last_session_kwargs["subscription_data"]["trial_period_days"] == 30
 
@@ -390,7 +464,7 @@ def test_checkout_v2_inelegivel_cobra_na_hora(user_id, monkeypatch):
     monkeypatch.setattr("db.plans.is_trial_eligible_for_user", lambda uid: False)
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
     assert "trial_period_days" not in fake.last_session_kwargs["subscription_data"]
 
@@ -442,7 +516,7 @@ def test_checkout_v2_falha_fechada_se_elegibilidade_indisponivel(user_id, monkey
     monkeypatch.setattr("db.plans.is_trial_eligible_for_user", fail)
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
 
     assert resp.status_code == 503
     assert fake.session_create_calls == 0
@@ -460,7 +534,7 @@ def test_checkout_concorrente_reutiliza_uma_unica_sessao(user_id, monkeypatch):
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         responses = list(executor.map(
-            lambda client: client.post("/billing/create-checkout", headers=_CSRF_HEADERS),
+            lambda client: client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS),
             (client_a, client_b),
         ))
 
@@ -477,10 +551,10 @@ def test_checkout_novo_plano_expira_sessao_aberta_incompativel(user_id, monkeypa
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_ANUAL", "price_anual_xyz")
     fake = _patch_stripe(monkeypatch)
 
-    first = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    first = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     second = client.post(
         "/billing/create-checkout",
-        json={"interval": "annual"},
+        json={"plan": "plus", "interval": "annual"},
         headers=_CSRF_HEADERS,
     )
 
@@ -504,7 +578,7 @@ def test_checkout_grava_started_no_funil_com_session_id(user_id, monkeypatch):
     _patch_stripe(monkeypatch)
 
     resp = client.post(
-        "/billing/create-checkout", json={"interval": "monthly"}, headers=_CSRF_HEADERS
+        "/billing/create-checkout", json={"plan": "plus", "interval": "monthly"}, headers=_CSRF_HEADERS
     )
     assert resp.status_code == 200, resp.text
     assert "session_id" not in resp.json(), "session_id não pode vazar pro cliente"
@@ -529,7 +603,7 @@ def test_checkout_falho_nao_grava_started(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "")  # 503: pagamentos off
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 503
 
     with get_conn() as conn:
@@ -554,8 +628,8 @@ def test_checkout_reaproveitado_propaga_session_id_no_funil(user_id, monkeypatch
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     fake = _patch_stripe(monkeypatch)
 
-    r1 = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
-    r2 = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    r1 = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
+    r2 = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert r1.status_code == 200 and r2.status_code == 200
     # 2ª chamada reaproveitou a sessão da 1ª (não criou nova)
     assert fake.session_create_calls == 1
@@ -586,7 +660,7 @@ def test_checkout_nao_fecha_gate_da_precos_na_abertura(user_id, monkeypatch):
     monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_mensal_abc")
     fake = _patch_stripe(monkeypatch)
 
-    resp = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    resp = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert resp.status_code == 200, resp.text
 
     # plan_selected_at continua NULL — o gate NÃO foi fechado na abertura

--- a/tests/test_ga4_measurement_protocol.py
+++ b/tests/test_ga4_measurement_protocol.py
@@ -340,7 +340,7 @@ def test_cookie_ga_vira_metadata_do_checkout(user_id, monkeypatch):
     fake = _patch_stripe(monkeypatch)
     client.cookies.set("_ga", f"GA1.1.{_CID_REAL}")
 
-    r = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    r = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert r.status_code == 200, r.text
 
     kwargs = fake.last_session_kwargs
@@ -366,7 +366,7 @@ def test_sem_cookie_ga_o_checkout_nasce_sem_o_campo(user_id, monkeypatch):
     fake = _patch_stripe(monkeypatch)
     client.cookies.set("_ga", "lixo-que-nao-e-cookie-do-ga")
 
-    r = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    r = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert r.status_code == 200, r.text
     assert "ga_client_id" not in fake.last_session_kwargs["metadata"]
 

--- a/tests/test_meta_capi_cookies.py
+++ b/tests/test_meta_capi_cookies.py
@@ -153,7 +153,7 @@ def test_cookies_do_pixel_viram_metadata_do_checkout(user_id, monkeypatch):
     client.cookies.set("_fbp", _FBP)
     client.cookies.set("_fbc", _FBC)
 
-    r = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    r = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert r.status_code == 200, r.text
 
     kwargs = fake.last_session_kwargs
@@ -180,7 +180,7 @@ def test_cookie_forjado_nao_vira_metadata(user_id, monkeypatch):
     fake = _patch_stripe(monkeypatch)
     client.cookies.set("_fbp", "sou-um-cookie-inventado")
 
-    r = client.post("/billing/create-checkout", headers=_CSRF_HEADERS)
+    r = client.post("/billing/create-checkout", json={"plan": "plus"}, headers=_CSRF_HEADERS)
     assert r.status_code == 200, r.text
     assert "fbp" not in fake.last_session_kwargs["metadata"]
 

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -212,13 +212,18 @@ def test_pix_e_stripe_aceitam_a_MESMA_lista_de_planos(logado, vendavel,
 # (`essencial/plus/pro/PLUS/" plus "` → pix 200, stripe 503, change 503, os três
 # `recusa=False`; `pro_max/free/""` → 400 nos três), sem monkeypatch nenhum.
 #
-# O que a coluna não saberia dizer é o que este grupo mede a mais:
+# Ela fica de fora porque a duplicação que vigiaria FOI REMOVIDA em vez de
+# vigiada (§0.7 é sobre UMA fonte; o teste comparador é o que se faz quando a
+# cópia é inevitável, e aqui não era): as três rotas de plano não têm mais tupla
+# literal — todas validam contra `TIER_TO_STORED_PLAN`
+# (`core/services/plan_service.py`), e um quarto tier entra num lugar só. Nenhum
+# comentário guarda isso; o `not in` guarda.
+#
+# O que sobra medir é COMPORTAMENTO, e a coluna não saberia dizer:
 #   * a ACEITAÇÃO aqui é o 409 `no_subscription` ESPECÍFICO, não "qualquer
 #     coisa que não seja 400 `plan inválido`";
 #   * a RECUSA é medida pelo TRABALHO — `chamadas == []`, a rota nem leu a
 #     conta. O predicado da tabela só enxerga status.
-# Pôr a coluna e ainda manter isto deixaria a metade do vocabulário em dois
-# lugares (§0.7); fica o teste, que mede as duas coisas.
 #
 # CONTROLES DO GRUPO:
 #   * NEGATIVO — tire o `.strip()` de `plan = (payload.plan or "").strip().lower()`
@@ -266,3 +271,26 @@ def test_change_plan_normaliza_como_o_checkout(logado, monkeypatch, plan, veredi
         assert r.json()["detail"]["error"] == "no_subscription", r.text
         assert chamadas == [logado.user_id], (
             f"'{plan}' foi aceito mas a rota não chegou a ler a conta")
+
+
+@pytest.mark.parametrize("rota", ["/billing/create-checkout", "/billing/change-plan"],
+                         ids=["stripe", "change-plan"])
+def test_interval_vazio_e_400_nas_duas_rotas(logado, rota):
+    """`interval: ""` é recusado nas duas — é a #352 com `interval` no lugar de
+    `plan`. As duas tinham `(payload.interval or "monthly")`, que vendia o ciclo
+    MENSAL para um corpo que não escolheu ciclo nenhum, em silêncio e com 200.
+
+    CONTROLE NEGATIVO: reponha o `or "monthly"` em qualquer uma das duas
+    (`frontend/finance_bot_websocket_custom.py`) e a linha correspondente fica
+    VERMELHA — 503 `Pagamentos ainda não configurados` no `stripe`, 503 `Esse
+    plano ainda não está configurado` no `change-plan`, porque sem price ID a
+    rota segue adiante em vez de recusar. Injetado nos dois casos VERDES.
+    CONTROLE POSITIVO: `interval` legítimo continua atravessando —
+    `test_pix_e_stripe_aceitam_a_MESMA_lista_de_planos` manda `"annual"` no
+    Stripe e `test_change_plan_normaliza_como_o_checkout[plus]` omite o campo
+    (default `monthly`); os dois passam da validação de `interval`.
+    """
+    r = logado.http.post(rota, headers=_cabecalhos(),
+                         json={"plan": "plus", "interval": ""})
+    assert r.status_code == 400, r.text
+    assert "interval inválido" in str(r.json()["detail"]), r.text

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -156,17 +156,13 @@ def test_os_dois_mapas_de_plano_sao_inversos():
     assert set(TIER_TO_STORED_PLAN.values()) <= set(PRECOS_ANUAIS_CENTS)
 
 
-# `""` está FORA desta tabela, e não por conveniência: as duas rotas de fato
-# divergem nele, por um motivo que não é vocabulário e é ANTERIOR a este PR — o
-# Stripe faz `("" or "plus")` (`finance_bot_websocket_custom.py:4471`), então
-# plano vazio vira Plus em silêncio, enquanto o Pix responde 400. Achado
-# relatado ao Arquiteto; consertar o default de uma rota de dinheiro não estava
-# no plano deste PR, e ampliá-lo por conta própria é o que o §2 proíbe.
 @pytest.mark.parametrize("plan", [
     "essencial", "plus", "pro",   # públicos: nenhuma das duas rotas recusa
     "pro_max", "free",            # nenhuma das duas rotas aceita
     "PLUS",                       # as duas normalizam a caixa antes de validar
-])
+    "",                           # vazio: 400 nas duas (o Stripe fazia Plus, #352)
+    " plus ",                     # espaços: as duas dão `.strip()` antes de validar
+], ids=["essencial", "plus", "pro", "pro_max", "free", "PLUS", "vazio", "com-espacos"])
 def test_pix_e_stripe_aceitam_a_MESMA_lista_de_planos(logado, vendavel,
                                                       asaas_falso, plan):
     """O gêmeo do Stripe (`/billing/create-checkout`) e o do Pix têm de concordar

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -183,3 +183,60 @@ def test_pix_e_stripe_aceitam_a_MESMA_lista_de_planos(logado, vendavel,
     assert stripe.status_code != 401, "o cliente do Stripe não autenticou"
     assert _recusa_o_plano(pix) == _recusa_o_plano(stripe), (
         f"'{plan}': Pix {pix.status_code} × Stripe {stripe.status_code}")
+
+
+# ── /billing/change-plan: a mesma normalização, com semântica própria ────────
+#
+# Esta rota fica FORA da tabela de duas colunas acima de propósito: ela não é
+# checkout — não cobra nada, e o veredito dela para um plano válido é 409
+# `no_subscription` (estado da assinatura), não 200/503 (estado da venda).
+# Comparar os dois vereditos na mesma parametrização forçaria semântica
+# diferente para dentro da mesma tabela; o que se compartilha é o vocabulário,
+# que é o assunto do arquivo.
+#
+# CONTROLES DO GRUPO:
+#   * NEGATIVO — tire o `.strip()` de `plan = (payload.plan or "").strip().lower()`
+#     em `frontend/finance_bot_websocket_custom.py` (rota `/billing/change-plan`)
+#     e `test_change_plan_normaliza_como_o_checkout[com-espacos]` fica VERMELHO
+#     (400 `plan inválido` onde se espera 409 `no_subscription`). Injetado num
+#     caso que estava VERDE — `plus` sem espaços passa com e sem o conserto.
+#   * POSITIVO — o caso `plus` prova que o plano legítimo continua atravessando
+#     a validação e chegando a LER a conta; sem ele o grupo passaria numa rota
+#     que recusasse tudo.
+
+_ACEITA, _RECUSA = "aceita", "recusa"
+
+
+@pytest.mark.parametrize("plan,veredito", [
+    ("plus", _ACEITA),      # positivo: o plano correto continua funcionando
+    (" plus ", _ACEITA),    # o conserto desta rodada
+    ("pro_max", _RECUSA),   # o vocabulário da COLUNA continua fora da fronteira
+    ("", _RECUSA),          # vazio nunca vira Plus (esta rota nunca teve default)
+], ids=["plus", "com-espacos", "pro_max", "vazio"])
+def test_change_plan_normaliza_como_o_checkout(logado, monkeypatch, plan, veredito):
+    """Aceitar/recusar é medido pelo TRABALHO, não só pelo status: quando a rota
+    recusa o plano ela não pode ter lido a conta, e quando aceita ela tem de ter
+    lido — senão o teste ficaria verde numa rota que recusa tudo cedo demais."""
+    import db as db_mod
+
+    chamadas: list[int] = []
+    real = db_mod.get_auth_user
+    monkeypatch.setattr(db_mod, "get_auth_user",
+                        lambda uid: (chamadas.append(uid), real(uid))[1])
+    # Sem price ID configurado, TODO plano válido morre em 503 antes de a rota
+    # fazer qualquer coisa — e aí o teste mediria configuração, não plano.
+    monkeypatch.setattr(dashboard, "STRIPE_SECRET_KEY", "sk_test_vocabulario")
+    monkeypatch.setattr(dashboard, "STRIPE_PRICE_ID_PRO_MENSAL", "price_test_plus_mensal")
+
+    r = logado.http.post("/billing/change-plan", headers=_cabecalhos(),
+                         json={"plan": plan})
+
+    if veredito == _RECUSA:
+        assert r.status_code == 400, r.text
+        assert "plan inválido" in str(r.json()["detail"])
+        assert chamadas == [], f"'{plan}' foi recusado mas a rota leu a conta"
+    else:
+        assert r.status_code == 409, r.text
+        assert r.json()["detail"]["error"] == "no_subscription", r.text
+        assert chamadas == [logado.user_id], (
+            f"'{plan}' foi aceito mas a rota não chegou a ler a conta")

--- a/tests/test_vocabulario_de_plano.py
+++ b/tests/test_vocabulario_de_plano.py
@@ -185,14 +185,40 @@ def test_pix_e_stripe_aceitam_a_MESMA_lista_de_planos(logado, vendavel,
         f"'{plan}': Pix {pix.status_code} × Stripe {stripe.status_code}")
 
 
+# CEGUEIRA CONHECIDA da tabela acima: ela sempre manda a chave `plan` (nem que
+# seja `""`), então nunca vê um corpo SEM a chave — e é exatamente aí que as
+# três rotas divergem (medido em 2026-09-10; comando: POST com
+# `{"interval":"annual"}` em cada uma):
+#
+#   /billing/create-checkout → 400 `plan inválido ...`   (detail STRING)
+#   /billing/pix/checkout    → 422 `Field required`      (detail LISTA)
+#   /billing/change-plan     → 422 `Field required`      (detail LISTA)
+#
+# Só o Stripe dá 400 porque só ele tem `plan: str = ""` no modelo, e só ele tem
+# porque só ele aceita POST sem body nenhum (`payload: ... | None = None`) —
+# a razão inteira está na docstring de `billing_create_checkout`. Não entra na
+# tabela: a asserção dela é de IGUALDADE entre as colunas, e aqui a diferença é
+# intencional. Fica ANOTADO porque `frontend/pix-checkout.js:269` tem a mesma
+# forma de `JSON.stringify` que apagou a chave e gerou a #352: se um dia ela
+# apagar `plan`, o Pix responde 422 e a /precos mostra o fallback genérico.
+
+
 # ── /billing/change-plan: a mesma normalização, com semântica própria ────────
 #
-# Esta rota fica FORA da tabela de duas colunas acima de propósito: ela não é
-# checkout — não cobra nada, e o veredito dela para um plano válido é 409
-# `no_subscription` (estado da assinatura), não 200/503 (estado da venda).
-# Comparar os dois vereditos na mesma parametrização forçaria semântica
-# diferente para dentro da mesma tabela; o que se compartilha é o vocabulário,
-# que é o assunto do arquivo.
+# Esta rota fica FORA da tabela de duas colunas acima, e a razão NÃO é
+# incompatibilidade de status — essa foi medida e é FALSA: `_recusa_o_plano` já
+# colapsa 200 e 503 em "não é recusa de plano", e colapsaria 409 igual. Uma
+# terceira coluna PASSA: medido em 2026-09-10, as 8 linhas concordaram
+# (`essencial/plus/pro/PLUS/" plus "` → pix 200, stripe 503, change 503, os três
+# `recusa=False`; `pro_max/free/""` → 400 nos três), sem monkeypatch nenhum.
+#
+# O que a coluna não saberia dizer é o que este grupo mede a mais:
+#   * a ACEITAÇÃO aqui é o 409 `no_subscription` ESPECÍFICO, não "qualquer
+#     coisa que não seja 400 `plan inválido`";
+#   * a RECUSA é medida pelo TRABALHO — `chamadas == []`, a rota nem leu a
+#     conta. O predicado da tabela só enxerga status.
+# Pôr a coluna e ainda manter isto deixaria a metade do vocabulário em dois
+# lugares (§0.7); fica o teste, que mede as duas coisas.
 #
 # CONTROLES DO GRUPO:
 #   * NEGATIVO — tire o `.strip()` de `plan = (payload.plan or "").strip().lower()`


### PR DESCRIPTION
Fecha a issue #352. Independente dos outros três PRs desta leva.

## O que estava errado

`/billing/create-checkout` fazia:

```python
plan = ((payload.plan if payload else "plus") or "plus").lower()
```

Requisição **sem plano**, ou com plano vazio, virava **Plus em silêncio**, numa rota que
move dinheiro.

## Não era risco futuro, era caminho vivo

A issue dizia "se um dia o frontend parar de mandar o campo". O frontend **já faz isso**:
`frontend/precos.html:992` monta o corpo com `if (plan) payload.plan = plan;` — a chave
**some** quando o valor é falsy.

## O que mudou

O campo nasce vazio no modelo e a rota faz `(payload.plan if payload else "").strip().lower()`,
caindo no 400 que já existia. E a rota de **troca de plano**, que era a terceira a receber
plano e a única sem limpeza de espaços, foi alinhada.

Vinte e sete pontos de teste dependiam do default e passaram a mandar o plano. Nenhum era
produção.

## A terceira opção, que faltava enumerar

Tornar o **campo** obrigatório não fecha o caso: o corpo inteiro é opcional, então uma
requisição sem corpo não instancia o modelo e o default continuaria valendo. Tornar o
**corpo** obrigatório fecharia — e essa não tinha sido considerada. Ficou registrada e
não foi adotada: 400 com mensagem específica é contrato melhor que a validação automática,
que devolve uma lista e cai no texto genérico da tela.

## O erro que a própria correção introduziu

Ao alinhar o campo de **periodicidade** entre as gêmeas, entrou junto um operador que não
existia:

```
antes:  {"plan":"plus","interval":""}  ->  400 interval inválido
depois: {"plan":"plus","interval":""}  ->  200, vendido como mensal
```

É a frase desta issue com o outro campo. As três mensagens de commit descreviam a mudança
como sendo só a conversão para minúsculas, e o caso medido (caixa alta passando a ser
aceita) era verdade e serviu de cobertura para o que não foi medido.

**Corrigido nas duas rotas**, e o critério ficou escrito:

> Quando as gêmeas divergem, alinha-se pelo lado **restritivo**, o que recusa mais.
> Alargar contrato de rota de dinheiro exige pedido explícito; estreitar exige só provar
> que nenhum chamador legítimo cai.

## Duplicação removida em vez de comparada

A lista de planos aceitos estava em **três** cópias literais. A tabela que compara as
rotas amarrava duas delas; a terceira não estava presa em nada.

As duas tuplas viraram `if plan not in TIER_TO_STORED_PLAN:`, como a rota do Pix já fazia.
Diff negativo, e o portão extra deixou de ser necessário.

## Retratações

O primeiro commit afirmava que chave ausente e chave vazia caem no mesmo 400 do gêmeo do
Pix. Vale para a **vazia**; para a **ausente** o Pix devolve 422. Mensagem de commit é
imutável, então fica retratado aqui.

Também: `precos.html:991` é 992, e a faixa de linhas citada numa docstring excluía
justamente a linha que a frase afirmava existir.

## Evidência

```
pytest -q  →  6902 passed, 4 xfailed
```

Quatro mutações, cada uma com o nome do teste vermelho, injetadas em casos que estavam
**verdes**. Uma das linhas parametrizadas **não discrimina** e isso está dito no código,
para ninguém citá-la como prova.

Entrada hostil: 41 corpos nas duas rotas, zero 500, e **zero sessão criada no Stripe**
em qualquer caminho que devia recusar.

## Cobertura que já existia e ninguém tinha citado

`tests/frontend/precos_sem_plano_gratis.test.mjs:314` já assevera o corpo do POST — mas
só para **1 dos 6** botões. Ficam de fora os cards Essencial e Pro e os três da tabela
comparativa.

## Não verificado

Nada foi exercitado contra o Stripe real. O que se prova é a rota, com o provedor
substituído e o banco real. Nenhuma linha de frontend mudou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
