### PR TITLE
Quem já pagou o período lia a frase da indisponibilidade

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,12 @@ export default defineConfig([
         pixCheckout: "readonly",
         pixModalQr: "readonly",
         pixEncerrar: "readonly",
+        // Declaradas no pix-poll.js e chamadas pelo `pixEnviar` do
+        // pix-checkout.js — e o `pixModalMigracao` chama o `pixEnviar` de volta.
+        // As caixas foram para lá pelo teto de 350 linhas, não por assunto.
+        pixModalMigracao: "readonly",
+        pixModalJaPago: "readonly",
+        pixEnviar: "readonly",
         // Declarado no pix-checkout.js e chamado pelo `pixApagarQr` do
         // pix-poll.js: o documento e o payload saem do DOM na mesma hora.
         pixApagarDoc: "readonly",

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -294,6 +294,9 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     if (r.status === 409 && det.error === "stripe_active") {
       return pixModalMigracao(plano, det, documento, ctx);
     }
+    const pago = det.error === "pix_future_purchase_conflict"
+      && /^\d{4}-\d{2}-\d{2}/.exec(det.covered_until || "");
+    if (r.status === 409 && pago) return pixModalJaPago(pago[0], ctx);
     // `detail` do FastAPI é STRING quando o raise passa texto (400 do documento) e
     // OBJETO nos 409 — sem esta linha a mensagem específica virava o genérico.
     if (!r.ok) {
@@ -332,6 +335,16 @@ function pixModalMigracao(plano, det, documento, ctx) {
   const nao = pixBotao("pix-ghost", "Manter o cartão");
   nao.addEventListener("click", () => fechar());
   box.append(ok, nao);
+  ok.focus();
+}
+
+// 409 pix_future_purchase_conflict: caixa e não toast — reenviar dá o mesmo 409.
+function pixModalJaPago(dia, ctx) {
+  pixApagarDoc();                       // o formulário sai, e o CPF com ele
+  ctx.titulo.textContent = "Esse ano já é seu";
+  const ok = pixBotao("btn-primary", "Entendi");
+  ok.addEventListener("click", () => ctx.fechar());
+  ctx.box.replaceChildren(ctx.titulo, pixLinha("Você já pagou esse plano até " + fmtBrDate(dia) + ". Não cobramos nada agora."), ok);
   ok.focus();
 }
 

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -298,7 +298,9 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     // indisponibilidade e o 403 do CSRF, de que o checkout não tem isenção.
     // Mesma forma do `apiError` do comecar.js:175 — o 500 real não tem `detail`
     // nenhum (`{"error": …}`, finance_bot_websocket_custom.py:2415), então segue
-    // no genérico.
+    // no genérico. O #355 consertou o mesmo defeito só no toast; normalizar aqui
+    // em cima cobre o toast E as duas caixas do 409 de uma vez — por isso o
+    // rebase deixou UMA das duas versões, não as duas.
     const det = (d && (typeof d.detail === "string" ? { message: d.detail } : d.detail)) || {};
     if (r.status === 409 && det.error === "stripe_active") {
       return pixModalMigracao(plano, det, documento, ctx);
@@ -314,12 +316,7 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     const pago = det.error === "pix_future_purchase_conflict"
       && /^\d{4}-\d{2}-\d{2}/.exec(det.covered_until || "");
     if (r.status === 409 && pago) return pixModalJaPago(pago[0], ctx);
-    // `detail` do FastAPI é STRING quando o raise passa texto (400 do documento) e
-    // OBJETO nos 409 — sem esta linha a mensagem específica virava o genérico.
-    if (!r.ok) {
-      const msg = (typeof det === "string" ? det : det.message);
-      return showToast(msg || "Não consegui gerar o código Pix agora.", "err");
-    }
+    if (!r.ok) return showToast(det.message || "Não consegui gerar o código Pix agora.", "err");
     pixApagarDoc();          // o QR vai entrar: o documento sai da tela antes
     pixModalQr(d, plano, ctx);
   } catch {

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -1,9 +1,9 @@
 /**
  * Pix anual na /precos — o CTA nos cards, o overlay e o checkout.
  *
- * O QR, a cópia e o poll moram no pix-poll.js (par deste arquivo; os dois
- * dividem o escopo global e a divisão é do teto de 350 linhas do
- * `quality/max-lines`).
+ * O QR, a cópia, o poll e as duas caixas de recusa do 409 moram no pix-poll.js
+ * (par deste arquivo; os dois dividem o escopo global e a divisão é do teto de
+ * 350 linhas do `quality/max-lines` — foi ele que mandou as caixas para lá).
  *
  * Script CLÁSSICO (sem módulo ES) de propósito: a precos.html chama
  * `pbPixInit`/`pbPixRefresh` do escopo global e este arquivo lê de lá o que ela já
@@ -290,10 +290,27 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
       }, 900);
       return;
     }
-    const det = (d && d.detail) || {};
+    // `detail` STRING é a metade que faltava: o FastAPI manda `{"detail": "<frase>"}`
+    // em todo `HTTPException(detail="…")`, e aqui isso caía num `det.message`
+    // undefined — a frase que o servidor escreveu era descartada e o cliente lia o
+    // genérico. São cinco: os dois 400 (plano, documento), o 429 do limitador (por
+    // IP — routes/shared.py:98, então não é só quem digitou que o toma), o 503 da
+    // indisponibilidade e o 403 do CSRF, de que o checkout não tem isenção.
+    // Mesma forma do `apiError` do comecar.js:171 — o 500 real não tem `detail`
+    // nenhum (`{"error": …}`, finance_bot_websocket_custom.py:2416), então segue
+    // no genérico.
+    const det = (d && (typeof d.detail === "string" ? { message: d.detail } : d.detail)) || {};
     if (r.status === 409 && det.error === "stripe_active") {
       return pixModalMigracao(plano, det, documento, ctx);
     }
+    // Guarda de FORMA, não de data: "2028-13-45" passa e a tela escreve
+    // "45/13/2028" (medido). Não se aperta porque não é alcançável — o
+    // `covered_until` é o `isoformat()` de um timestamptz (billing_pix.py:107). O
+    // que ela barra é o que já chegava: ausente, ou texto livre virando "undefined".
+    // ponytail: e o dia recortado é o do calendário UTC, não o de Brasília — compra
+    // entre 21h e 24h (3 das 24 horas) nomeia o dia seguinte. Categoria, não caso:
+    // o `pixModalMigracao` e o pix-poll.js:54 recortam igual. Fechar é converter o
+    // fuso nos três, não recortar string.
     const pago = det.error === "pix_future_purchase_conflict"
       && /^\d{4}-\d{2}-\d{2}/.exec(det.covered_until || "");
     if (r.status === 409 && pago) return pixModalJaPago(pago[0], ctx);
@@ -312,40 +329,6 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     // formulário e reanimá-lo seria escrever num nó que ninguém vê.
     if (botao.isConnected) { botao.disabled = false; botao.textContent = rotulo; }
   }
-}
-
-/** 409 stripe_active: a migração cartão → Pix (§9 do plano). Mesmo modal. */
-function pixModalMigracao(plano, det, documento, ctx) {
-  const { box, fechar, titulo } = ctx;
-  // O documento sai da tela agora — esta caixa decide sobre o Stripe, e o número
-  // segue vivo só na closure do botão abaixo.
-  pixApagarDoc();
-  titulo.textContent = "Trocar o cartão pelo Pix?";
-  box.replaceChildren(titulo);
-  const data = fmtBrDate(String(det.current_period_end || "").slice(0, 10));
-  box.append(
-    pixLinha("Sua assinatura no cartão é cancelada no fim do período que você já"
-      + " pagou (" + data + "). Não existe cobrança dupla."),
-    pixLinha("Não cancele pelo painel do Stripe: quem cancela somos nós, na data"
-      + " certa. Cancelando por lá você perde o acesso antes."),
-    pixLinha("Seu ano de Pix começa em " + data + ", quando o cartão termina."),
-  );
-  const ok = pixBotao("btn-primary", "Continuar no Pix");
-  ok.addEventListener("click", () => pixEnviar(plano, documento, true, ctx, ok));
-  const nao = pixBotao("pix-ghost", "Manter o cartão");
-  nao.addEventListener("click", () => fechar());
-  box.append(ok, nao);
-  ok.focus();
-}
-
-// 409 pix_future_purchase_conflict: caixa e não toast — reenviar dá o mesmo 409.
-function pixModalJaPago(dia, ctx) {
-  pixApagarDoc();                       // o formulário sai, e o CPF com ele
-  ctx.titulo.textContent = "Esse ano já é seu";
-  const ok = pixBotao("btn-primary", "Entendi");
-  ok.addEventListener("click", () => ctx.fechar());
-  ctx.box.replaceChildren(ctx.titulo, pixLinha("Você já pagou esse plano até " + fmtBrDate(dia) + ". Não cobramos nada agora."), ok);
-  ok.focus();
 }
 
 // A precos.html chama o `pbPixInit` depois de duas requisições, guardada por

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -296,8 +296,8 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     // genérico. São cinco: os dois 400 (plano, documento), o 429 do limitador (por
     // IP — routes/shared.py:98, então não é só quem digitou que o toma), o 503 da
     // indisponibilidade e o 403 do CSRF, de que o checkout não tem isenção.
-    // Mesma forma do `apiError` do comecar.js:171 — o 500 real não tem `detail`
-    // nenhum (`{"error": …}`, finance_bot_websocket_custom.py:2416), então segue
+    // Mesma forma do `apiError` do comecar.js:175 — o 500 real não tem `detail`
+    // nenhum (`{"error": …}`, finance_bot_websocket_custom.py:2415), então segue
     // no genérico.
     const det = (d && (typeof d.detail === "string" ? { message: d.detail } : d.detail)) || {};
     if (r.status === 409 && det.error === "stripe_active") {

--- a/frontend/pix-poll.js
+++ b/frontend/pix-poll.js
@@ -1,12 +1,14 @@
 /**
- * O QR do Pix anual da /precos: o modal, a cópia, o poll e o §13.6.
+ * O QR do Pix anual da /precos: o modal, a cópia, o poll, o §13.6 e as duas
+ * caixas de recusa do 409.
  *
  * Metade de trás do pix-checkout.js, e não um arquivo por gosto: juntos os dois
  * passam das 350 linhas do `quality/max-lines`. Os dois são script CLÁSSICO e
- * dividem o mesmo escopo global — daqui saem `pixModalQr` e `pixEncerrar`, e de
- * lá vêm `pixLinha`, `pixBotao`, `pixRotular`, `pixBrl`, `pixApagarDoc` e
- * `pixCheckout`. O `pixPoll` (estado do modal aberto) mora SÓ aqui; o `pixDoc`
- * mora SÓ lá: nenhum dos dois arquivos escreve variável do outro.
+ * dividem o mesmo escopo global — daqui saem `pixModalQr`, `pixEncerrar` e as
+ * duas caixas de recusa, e de lá vêm `pixLinha`, `pixBotao`, `pixRotular`,
+ * `pixBrl`, `pixApagarDoc`, `pixCheckout` e `pixEnviar`. O `pixPoll` (estado do
+ * modal aberto) mora SÓ aqui; o `pixDoc` mora SÓ lá: nenhum dos dois arquivos
+ * escreve variável do outro.
  *
  * O modal é UM só, com dois estados: o pix-checkout.js abre a caixa pedindo o
  * CPF/CNPJ (o Asaas exige o documento do pagador) e o `pixModalQr` daqui troca o
@@ -267,4 +269,44 @@ function pixDesistir() {
   pixRotular(pixPoll.status, "ph-clock", "Não consegui confirmar por aqui — o"
     + " código continua válido. Entre de novo e a gente confirma.");
   pixAgendar(Math.max(0, pixPoll.deadline - Date.now()));
+}
+
+// ── As duas caixas de recusa do 409 ─────────────────────────────────────────
+//
+// Aqui e não no pix-checkout.js por TETO: aquele bateu nas 350 linhas do
+// `quality/max-lines`, e este é a metade de trás dele. Quem chama as duas é o
+// `pixEnviar` de lá, e as duas tiram o formulário — com o CPF digitado dentro
+// dele — da tela antes de escrever.
+/** 409 stripe_active: a migração cartão → Pix (§9 do plano). Mesmo modal. */
+function pixModalMigracao(plano, det, documento, ctx) {
+  const { box, fechar, titulo } = ctx;
+  // O documento sai da tela agora — esta caixa decide sobre o Stripe, e o número
+  // segue vivo só na closure do botão abaixo.
+  pixApagarDoc();
+  titulo.textContent = "Trocar o cartão pelo Pix?";
+  box.replaceChildren(titulo);
+  const data = fmtBrDate(String(det.current_period_end || "").slice(0, 10));
+  box.append(
+    pixLinha("Sua assinatura no cartão é cancelada no fim do período que você já"
+      + " pagou (" + data + "). Não existe cobrança dupla."),
+    pixLinha("Não cancele pelo painel do Stripe: quem cancela somos nós, na data"
+      + " certa. Cancelando por lá você perde o acesso antes."),
+    pixLinha("Seu ano de Pix começa em " + data + ", quando o cartão termina."),
+  );
+  const ok = pixBotao("btn-primary", "Continuar no Pix");
+  ok.addEventListener("click", () => pixEnviar(plano, documento, true, ctx, ok));
+  const nao = pixBotao("pix-ghost", "Manter o cartão");
+  nao.addEventListener("click", () => fechar());
+  box.append(ok, nao);
+  ok.focus();
+}
+
+// 409 pix_future_purchase_conflict: caixa e não toast — reenviar dá o mesmo 409.
+function pixModalJaPago(dia, ctx) {
+  pixApagarDoc();                       // o formulário sai, e o CPF com ele
+  ctx.titulo.textContent = "Esse ano já é seu";
+  const ok = pixBotao("btn-primary", "Entendi");
+  ok.addEventListener("click", () => ctx.fechar());
+  ctx.box.replaceChildren(ctx.titulo, pixLinha("Você já pagou esse plano até " + fmtBrDate(dia) + ". Não cobramos nada agora."), ok);
+  ok.focus();
 }

--- a/frontend/pix-poll.js
+++ b/frontend/pix-poll.js
@@ -302,11 +302,21 @@ function pixModalMigracao(plano, det, documento, ctx) {
 }
 
 // 409 pix_future_purchase_conflict: caixa e não toast — reenviar dá o mesmo 409.
+//
+// A frase NÃO nomeia plano, de propósito: quem bloqueia pode ser um grant de
+// OUTRO tier. O `plano_da_cobranca` junta `pix_futuro_pago` (qualquer Pix futuro,
+// de qualquer tier) com `cobre_o_tier` e levanta `CoberturaJaPaga(plano_novo, …)`
+// — o `plan` que volta no corpo do 409 é o PEDIDO, não o pago
+// (core/services/pix_pricing.py:230-240; o caso Plus futuro → Pro está em
+// tests/test_pix_recompra.py:109). "Você já pagou esse plano" era falso ali, numa
+// tela de dinheiro. O que é verdade nos dois caminhos: existe período pago até
+// tal dia, e por isso não há cobrança agora.
 function pixModalJaPago(dia, ctx) {
   pixApagarDoc();                       // o formulário sai, e o CPF com ele
-  ctx.titulo.textContent = "Esse ano já é seu";
+  ctx.titulo.textContent = "Você já tem tempo pago";
   const ok = pixBotao("btn-primary", "Entendi");
   ok.addEventListener("click", () => ctx.fechar());
-  ctx.box.replaceChildren(ctx.titulo, pixLinha("Você já pagou esse plano até " + fmtBrDate(dia) + ". Não cobramos nada agora."), ok);
+  ctx.box.replaceChildren(ctx.titulo, pixLinha("Seu período pago vai até "
+    + fmtBrDate(dia) + ". Por isso não cobramos nada agora."), ok);
   ok.focus();
 }

--- a/tests/frontend/precos_pix_ja_pago.test.mjs
+++ b/tests/frontend/precos_pix_ja_pago.test.mjs
@@ -99,7 +99,7 @@ test("conflito: a caixa nomeia a data já paga, e não o genérico", async () =>
   const page = await tentarComprar({ httpStatus: 409, corpo: CONFLITO });
   const t = await tela(page);
   assert.match(t.caixa, /06\/07\/2028/, "a data de covered_until não apareceu na tela");
-  assert.match(t.caixa, /Esse ano já é seu/);
+  assert.match(t.caixa, /Você já tem tempo pago/);
   assert.equal(t.toastVisivel, false, "o aviso genérico apareceu junto da caixa");
   assert.ok(!t.corpo.includes(GENERICO), "a tela ainda mostra a frase genérica");
   // PII: o formulário sai da tela junto com o documento digitado.
@@ -119,6 +119,44 @@ test("conflito em 390x844: a caixa cabe na tela do celular", async () => {
   assert.match(await page.$eval(".pix-box", (e) => e.textContent), /06\/07\/2028/);
   await page.close();
 });
+
+// ── O tier que bloqueia não é o tier pedido (P2 do Codex no #361) ───────────
+//
+// `plano_da_cobranca` junta `pix_futuro_pago` — QUALQUER Pix futuro, de qualquer
+// tier — com `cobre_o_tier`, e levanta `CoberturaJaPaga(plano_novo, …)`: o `plan`
+// do corpo é o PEDIDO, não o pago (core/services/pix_pricing.py:230-240, caso em
+// tests/test_pix_recompra.py:109 — grant Plus futuro, compra de Pro, recusada com
+// a data do PLUS). Aqui o clique é no Plus e o 409 volta com "pro_max": a caixa
+// não pode afirmar que o plano clicado (nem o do corpo) já foi pago, senão manda
+// o cliente esperar um acesso que ele não comprou.
+//
+// Negativo: volte a frase antiga ("Esse ano já é seu" / "Você já pagou esse
+// plano até …") e ESTE caso fica vermelho — ele estava verde.
+test("conflito: a caixa não afirma QUAL plano foi pago", async () => {
+  const page = await tentarComprar({ httpStatus: 409, corpo: CONFLITO });
+  const t = await tela(page);
+  assert.doesNotMatch(t.caixa, /esse plano|este plano|já é seu|seu plano/i,
+    `a caixa afirma posse do plano pedido: ${JSON.stringify(t.caixa)}`);
+  assert.doesNotMatch(t.caixa, /\b(pro|pro_max|plus|essencial)\b/i,
+    `a caixa nomeia um plano que pode não ser o pago: ${JSON.stringify(t.caixa)}`);
+  assert.match(t.caixa, /06\/07\/2028/, "a data já paga sumiu junto com a frase");
+  await page.close();
+});
+
+// Controle POSITIVO da dupla acima: sem ele, uma caixa VAZIA (ou só "Entendi")
+// passaria nas duas asserções de ausência. O caso simples — o plano do corpo é o
+// mesmo que foi clicado — tem de continuar dizendo o que houve e até quando.
+test("conflito do MESMO plano: a caixa segue dizendo até quando e que não cobrou",
+  async () => {
+    const page = await tentarComprar({ httpStatus: 409, corpo: {
+      error: "pix_future_purchase_conflict", plan: "plus",
+      covered_until: "2027-03-02T00:00:00+00:00" } });
+    const t = await tela(page);
+    assert.match(t.caixa, /02\/03\/2027/, "a data de covered_until não apareceu");
+    assert.match(t.caixa, /não cobramos nada agora/i,
+      `a caixa não explica que a compra não foi cobrada: ${JSON.stringify(t.caixa)}`);
+    await page.close();
+  });
 
 // Controle POSITIVO: sem este caso, um código que desse mensagem específica para
 // qualquer erro passaria no caso de cima.
@@ -140,7 +178,7 @@ test("500 continua no genérico", async () => {
   const t = await tela(page);
   assert.equal(t.toast, GENERICO, "o 500 devia cair no aviso genérico");
   assert.equal(t.toastVisivel, true);
-  assert.ok(!t.caixa.includes("Esse ano já é seu"), "o 500 abriu a caixa do conflito");
+  assert.ok(!t.caixa.includes("Você já tem tempo pago"), "o 500 abriu a caixa do conflito");
   await page.close();
 });
 
@@ -151,7 +189,7 @@ test("conflito sem covered_until cai no genérico, sem 'undefined'", async () =>
   const t = await tela(page);
   assert.equal(t.toast, GENERICO);
   assert.ok(!t.corpo.includes("undefined"), "escreveu 'undefined' na tela");
-  assert.ok(!t.caixa.includes("Esse ano já é seu"));
+  assert.ok(!t.caixa.includes("Você já tem tempo pago"));
   await page.close();
 });
 

--- a/tests/frontend/precos_pix_ja_pago.test.mjs
+++ b/tests/frontend/precos_pix_ja_pago.test.mjs
@@ -7,15 +7,23 @@
  * indisponibilidade real de 2026-09-10 (ASAAS_BASE_URL errada), com a data que
  * veio na resposta jogada fora.
  *
+ * E a causa RAIZ, que o primeiro conserto deixou aberta: `det.message` num
+ * `detail` que é STRING dá `undefined`, então toda frase que o servidor escreve
+ * em `HTTPException(detail="…")` era descartada — os dois 400, o 429, o 503 e o
+ * 403 do CSRF liam o genérico. A tabela `FRASES_DO_SERVIDOR` é esses cinco.
+ *
  * Os dois controles do CLAUDE.md §3:
- *   · negativo — apague as 3 linhas do `pago` em `pix-checkout.js:296` e o caso
- *     "conflito" fica VERMELHO (ele estava verde com o conserto);
+ *   · negativo — (a) apague as 3 linhas do `pago` no `pixEnviar` e o caso
+ *     "conflito" fica VERMELHO; (b) devolva o `det` para `(d && d.detail) || {}`
+ *     e os 5 casos de `FRASES_DO_SERVIDOR` ficam vermelhos. Os dois eram verdes;
  *   · positivo — o caso "500" prova que o genérico continua existindo. Sem ele,
  *     um código que desse mensagem específica para TODO erro passaria.
  *
  * Os dois últimos casos são a fronteira: sem `covered_until`, ou com ele em
- * formato que não é ISO, a tela NÃO pode escrever "undefined" nem uma data
- * inventada — volta para o genérico, que é o que o erro é.
+ * formato que não é ISO, a tela NÃO pode escrever "undefined" nem jogar o valor
+ * cru na tela — volta para o genérico, que é o que o erro é. A guarda é de
+ * FORMA e só: "2028-13-45" passa por ela e vira "45/13/2028" (medido), o que não
+ * é alcançável — quem manda o campo é um timestamptz do banco.
  *
  * O que este arquivo NÃO alcança: o Asaas de verdade, o 409 do servidor real
  * (aqui ele é `page.route`) e o CPF inválido — ver o relato.
@@ -77,6 +85,11 @@ const tela = (page) => page.evaluate(() => ({
   toastVisivel: document.getElementById("toast").classList.contains("show"),
   campos: document.querySelectorAll(".pix-doc").length,
   corpo: document.body.innerText,
+  // PII medida de VERDADE. `page.content()` serializa ATRIBUTOS e o `page.fill`
+  // escreve a PROPRIEDADE `value`: procurar o CPF no HTML devolve "não achei"
+  // com o campo cheio dele na tela (medido nas duas colunas). Quem mede é ler o
+  // `.value` vivo. NÃO copie `page.content()` para os outros arquivos de Pix.
+  valores: [...document.querySelectorAll("input")].map((i) => i.value).join(" "),
 }));
 
 const CONFLITO = { error: "pix_future_purchase_conflict", plan: "pro_max",
@@ -91,7 +104,7 @@ test("conflito: a caixa nomeia a data já paga, e não o genérico", async () =>
   assert.ok(!t.corpo.includes(GENERICO), "a tela ainda mostra a frase genérica");
   // PII: o formulário sai da tela junto com o documento digitado.
   assert.equal(t.campos, 0, "o campo do CPF continuou no DOM depois da recusa");
-  assert.ok(!(await page.content()).includes(CPF), "o CPF sobreviveu no DOM");
+  assert.ok(!t.valores.includes(CPF), "o CPF sobreviveu no value de um <input>");
   await page.close();
 });
 
@@ -109,8 +122,15 @@ test("conflito em 390x844: a caixa cabe na tela do celular", async () => {
 
 // Controle POSITIVO: sem este caso, um código que desse mensagem específica para
 // qualquer erro passaria no caso de cima.
+//
+// `corpo: undefined` é o 500 REAL desta app, não uma facilidade: o handler de
+// exceção não tratada responde `{"error": "Erro interno do servidor."}`
+// (finance_bot_websocket_custom.py:2416) — sem `detail` nenhum, que é o que o
+// `JSON.stringify({detail: undefined})` daqui produz. Antes deste commit o caso
+// mandava `detail: "erro interno"`, e ele passava por ler a frase do servidor
+// como se fosse o genérico.
 test("500 continua no genérico", async () => {
-  const page = await tentarComprar({ httpStatus: 500, corpo: "erro interno" });
+  const page = await tentarComprar({ httpStatus: 500, corpo: undefined });
   const t = await tela(page);
   assert.equal(t.toast, GENERICO, "o 500 devia cair no aviso genérico");
   assert.equal(t.toastVisivel, true);
@@ -140,3 +160,31 @@ test("conflito com covered_until malformado cai no genérico, sem 'undefined'", 
   assert.ok(!t.corpo.includes("em breve"), "jogou o valor cru do servidor na tela");
   await page.close();
 });
+
+// ── A causa raiz: `detail` STRING ───────────────────────────────────────────
+//
+// Cada frase é COPIADA do servidor, com o arquivo:linha que a escreve — se
+// alguém reescrever a frase lá, este arquivo não fica vermelho (o §0.7 não
+// alcança copy de erro). O que ele prende é a CATEGORIA: `detail` string chega
+// à tela em vez de virar o genérico.
+const FRASES_DO_SERVIDOR = [
+  [400, "plan inválido (use 'essencial', 'plus' ou 'pro').", "billing_pix.py:88"],
+  [400, "Informe um CPF ou CNPJ válido.", "billing_pix.py:93"],
+  [429, "Muitas tentativas. Aguarde alguns minutos e tente novamente.",
+    "finance_bot_websocket_custom.py:2285 — o limitador é por IP (shared.py:98)"],
+  [503, "Não consegui emitir o Pix agora. Tenta de novo em instantes.",
+    "billing_pix.py:137"],
+  [403, "Token CSRF inválido ou ausente.",
+    "finance_bot_websocket_custom.py:2247 — o checkout não tem isenção de CSRF"],
+];
+
+for (const [status, frase, onde] of FRASES_DO_SERVIDOR) {
+  test(`${status}: a frase do servidor chega à tela (${onde})`, async () => {
+    const page = await tentarComprar({ httpStatus: status, corpo: frase });
+    const t = await tela(page);
+    assert.equal(t.toast, frase, "a frase do servidor foi descartada");
+    assert.equal(t.toastVisivel, true);
+    assert.ok(!t.corpo.includes(GENERICO), "mostrou o genérico junto da frase");
+    await page.close();
+  });
+}

--- a/tests/frontend/precos_pix_ja_pago.test.mjs
+++ b/tests/frontend/precos_pix_ja_pago.test.mjs
@@ -46,7 +46,7 @@ const CPF = "11122233344";
 const GENERICO = "Não consegui gerar o código Pix agora.";
 
 /** Abre a /precos com o checkout mockado, digita o CPF e envia. */
-async function tentarComprar({ httpStatus, corpo, viewport } = {}) {
+async function tentarComprar({ httpStatus, corpo, corpoBruto, viewport } = {}) {
   const page = await browser.newPage({
     viewport: viewport || { width: 1440, height: 900 },
   });
@@ -64,7 +64,7 @@ async function tentarComprar({ httpStatus, corpo, viewport } = {}) {
   }));
   await page.route("**/billing/pix/checkout", (r) => r.fulfill({
     status: httpStatus, contentType: "application/json",
-    body: JSON.stringify({ detail: corpo }),
+    body: corpoBruto || JSON.stringify({ detail: corpo }),
   }));
 
   await page.goto(`${ORIGIN}/precos.html`);
@@ -123,14 +123,20 @@ test("conflito em 390x844: a caixa cabe na tela do celular", async () => {
 // Controle POSITIVO: sem este caso, um código que desse mensagem específica para
 // qualquer erro passaria no caso de cima.
 //
-// `corpo: undefined` é o 500 REAL desta app, não uma facilidade: o handler de
-// exceção não tratada responde `{"error": "Erro interno do servidor."}`
-// (finance_bot_websocket_custom.py:2416) — sem `detail` nenhum, que é o que o
-// `JSON.stringify({detail: undefined})` daqui produz. Antes deste commit o caso
-// mandava `detail: "erro interno"`, e ele passava por ler a frase do servidor
-// como se fosse o genérico.
+// O corpo é o do 500 REAL desta app, byte a byte: o handler de exceção não
+// tratada responde `{"error": "Erro interno do servidor."}`
+// (finance_bot_websocket_custom.py:2415) — sem `detail` nenhum. Vai como
+// `corpoBruto` de propósito: `JSON.stringify({detail: undefined})` dá `{}`, que
+// é mais POBRE que o real — no dia em que alguém somar `|| d.error` como fonte
+// de mensagem (a app tem DOIS formatos de erro em circulação), o `{}` continua
+// verde com a tela mostrando "Erro interno do servidor." ao cliente. Hoje os
+// dois dão o mesmo porque ninguém lê `d.error` no topo: o corpo real mede o
+// requisito, o `{}` media o código de hoje.
 test("500 continua no genérico", async () => {
-  const page = await tentarComprar({ httpStatus: 500, corpo: undefined });
+  const page = await tentarComprar({
+    httpStatus: 500,
+    corpoBruto: JSON.stringify({ error: "Erro interno do servidor." }),
+  });
   const t = await tela(page);
   assert.equal(t.toast, GENERICO, "o 500 devia cair no aviso genérico");
   assert.equal(t.toastVisivel, true);

--- a/tests/frontend/precos_pix_ja_pago.test.mjs
+++ b/tests/frontend/precos_pix_ja_pago.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * O 409 de quem JÁ pagou o período (issue #353).
+ *
+ * O `POST /billing/pix/checkout` devolve `409 {error: "pix_future_purchase_conflict",
+ * covered_until}` para quem tenta comprar cobertura que já tem. Antes disso, o
+ * cliente pagante lia "Não consegui gerar o código Pix agora." — a MESMA frase da
+ * indisponibilidade real de 2026-09-10 (ASAAS_BASE_URL errada), com a data que
+ * veio na resposta jogada fora.
+ *
+ * Os dois controles do CLAUDE.md §3:
+ *   · negativo — apague as 3 linhas do `pago` em `pix-checkout.js:296` e o caso
+ *     "conflito" fica VERMELHO (ele estava verde com o conserto);
+ *   · positivo — o caso "500" prova que o genérico continua existindo. Sem ele,
+ *     um código que desse mensagem específica para TODO erro passaria.
+ *
+ * Os dois últimos casos são a fronteira: sem `covered_until`, ou com ele em
+ * formato que não é ISO, a tela NÃO pode escrever "undefined" nem uma data
+ * inventada — volta para o genérico, que é o que o erro é.
+ *
+ * O que este arquivo NÃO alcança: o Asaas de verdade, o 409 do servidor real
+ * (aqui ele é `page.route`) e o CPF inválido — ver o relato.
+ *
+ * Rodar:  node --test tests/frontend/precos_pix_ja_pago.test.mjs
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+// String improvável de aparecer por acaso: os casos procuram por ela no DOM
+// depois da recusa (o CPF não pode sobreviver à troca de estado do modal).
+const CPF = "11122233344";
+const GENERICO = "Não consegui gerar o código Pix agora.";
+
+/** Abre a /precos com o checkout mockado, digita o CPF e envia. */
+async function tentarComprar({ httpStatus, corpo, viewport } = {}) {
+  const page = await browser.newPage({
+    viewport: viewport || { width: 1440, height: 900 },
+  });
+  await page.route("**/auth/me", (r) => r.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ user_id: 42, needs_plan_selection: true }),
+  }));
+  await page.route("**/billing/plans-config", (r) => r.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify({ essencial_available: true, plus_available: true,
+                           pro_available: true, pix_annual_available: true }),
+  }));
+  await page.route("**/billing/subscription", (r) => r.fulfill({
+    contentType: "application/json", body: JSON.stringify({ active: false }),
+  }));
+  await page.route("**/billing/pix/checkout", (r) => r.fulfill({
+    status: httpStatus, contentType: "application/json",
+    body: JSON.stringify({ detail: corpo }),
+  }));
+
+  await page.goto(`${ORIGIN}/precos.html`);
+  await page.waitForSelector("#plans-v2 .plan");
+  await page.waitForTimeout(600);        // loadPlansState = 2 awaits de rede
+  await page.click("#cycle-annual");
+  await page.click('[data-pix-cta="plus"]');
+  await page.waitForSelector(".pix-doc");
+  await page.fill(".pix-doc", CPF);
+  await page.click('.pix-form button[type="submit"]');
+  await page.waitForTimeout(300);
+  return page;
+}
+
+const tela = (page) => page.evaluate(() => ({
+  caixa: (document.querySelector(".pix-box") || {}).textContent || "",
+  toast: document.getElementById("toast").textContent,
+  toastVisivel: document.getElementById("toast").classList.contains("show"),
+  campos: document.querySelectorAll(".pix-doc").length,
+  corpo: document.body.innerText,
+}));
+
+const CONFLITO = { error: "pix_future_purchase_conflict", plan: "pro_max",
+                   covered_until: "2028-07-06T00:00:00+00:00" };
+
+test("conflito: a caixa nomeia a data já paga, e não o genérico", async () => {
+  const page = await tentarComprar({ httpStatus: 409, corpo: CONFLITO });
+  const t = await tela(page);
+  assert.match(t.caixa, /06\/07\/2028/, "a data de covered_until não apareceu na tela");
+  assert.match(t.caixa, /Esse ano já é seu/);
+  assert.equal(t.toastVisivel, false, "o aviso genérico apareceu junto da caixa");
+  assert.ok(!t.corpo.includes(GENERICO), "a tela ainda mostra a frase genérica");
+  // PII: o formulário sai da tela junto com o documento digitado.
+  assert.equal(t.campos, 0, "o campo do CPF continuou no DOM depois da recusa");
+  assert.ok(!(await page.content()).includes(CPF), "o CPF sobreviveu no DOM");
+  await page.close();
+});
+
+test("conflito em 390x844: a caixa cabe na tela do celular", async () => {
+  const page = await tentarComprar({ httpStatus: 409, corpo: CONFLITO,
+                                     viewport: { width: 390, height: 844 } });
+  const cx = await page.$eval(".pix-box", (e) => {
+    const r = e.getBoundingClientRect();
+    return { left: r.left, right: r.right, largura: r.width };
+  });
+  assert.ok(cx.left >= 0 && cx.right <= 390, `a caixa vazou: ${JSON.stringify(cx)}`);
+  assert.match(await page.$eval(".pix-box", (e) => e.textContent), /06\/07\/2028/);
+  await page.close();
+});
+
+// Controle POSITIVO: sem este caso, um código que desse mensagem específica para
+// qualquer erro passaria no caso de cima.
+test("500 continua no genérico", async () => {
+  const page = await tentarComprar({ httpStatus: 500, corpo: "erro interno" });
+  const t = await tela(page);
+  assert.equal(t.toast, GENERICO, "o 500 devia cair no aviso genérico");
+  assert.equal(t.toastVisivel, true);
+  assert.ok(!t.caixa.includes("Esse ano já é seu"), "o 500 abriu a caixa do conflito");
+  await page.close();
+});
+
+test("conflito sem covered_until cai no genérico, sem 'undefined'", async () => {
+  const page = await tentarComprar({
+    httpStatus: 409, corpo: { error: "pix_future_purchase_conflict", plan: "pro_max" },
+  });
+  const t = await tela(page);
+  assert.equal(t.toast, GENERICO);
+  assert.ok(!t.corpo.includes("undefined"), "escreveu 'undefined' na tela");
+  assert.ok(!t.caixa.includes("Esse ano já é seu"));
+  await page.close();
+});
+
+test("conflito com covered_until malformado cai no genérico, sem 'undefined'", async () => {
+  const page = await tentarComprar({
+    httpStatus: 409,
+    corpo: { error: "pix_future_purchase_conflict", covered_until: "em breve" },
+  });
+  const t = await tela(page);
+  assert.equal(t.toast, GENERICO);
+  assert.ok(!t.corpo.includes("undefined"), "escreveu 'undefined' na tela");
+  assert.ok(!t.corpo.includes("em breve"), "jogou o valor cru do servidor na tela");
+  await page.close();
+});

--- a/tests/test_pix_409_contrato.py
+++ b/tests/test_pix_409_contrato.py
@@ -1,0 +1,67 @@
+"""O CONTRATO do 409 de cobertura já paga: a CHAVE e o FORMATO que a tela lê.
+
+`grep -rn covered_until tests/` dava ZERO até este arquivo — o nome da chave e o
+ISO eram consumidos pelo `pix-checkout.js` e não eram prendidos por teste nenhum
+dos dois lados. Trocar o formato, ou renomear a chave, devolvia o cliente
+PAGANTE ao genérico "Não consegui gerar o código Pix agora." (a frase da
+indisponibilidade real) com as duas suítes verdes.
+
+Arquivo próprio, e não uma função a mais no `test_pix_rotas_billing.py`, por
+TETO: aquele está em 329 linhas e com este teste dentro ia a 371 — o
+`test_max_lines_python.py` (teto 350) fica vermelho. Medido, não estimado.
+
+Rodar:  .venv/bin/python -m pytest tests/test_pix_409_contrato.py -q
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timezone
+
+from fastapi.testclient import TestClient
+
+import frontend.finance_bot_websocket_custom as dashboard
+import frontend.routes.billing_pix as rotas
+from _billing_grants_helpers import conta
+from core.services.pix_pricing import CoberturaJaPaga
+
+client = TestClient(dashboard.app)
+
+
+def _csrf() -> dict[str, str]:
+    """Mesmas duas linhas do `test_pix_rotas_billing.py`: os NOMES vêm do
+    `dashboard`, então não há constante duplicada aqui — só a mecânica."""
+    token = "test-csrf-token"
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, token)
+    return {dashboard.CSRF_HEADER_NAME: token}
+
+
+def test_409_de_cobertura_paga_leva_covered_until_em_iso(user_id, monkeypatch):
+    """A tela lê `detail.covered_until` e só nomeia a data quando ela casa com
+    `/^\\d{4}-\\d{2}-\\d{2}/` (o `pixEnviar` do pix-checkout.js). Qualquer outro
+    formato — e qualquer outro NOME de chave — cai no genérico.
+
+    NEGATIVO MEDIDO, no `except CoberturaJaPaga` de billing_pix.py:
+      * `.isoformat()` -> `.strftime("%d/%m/%Y")` -> vermelho aqui (o `re.match`);
+      * `covered_until` -> `coberto_ate` -> vermelho aqui (o `in`).
+    As duas passam verdes no resto das duas suítes.
+
+    `criar_checkout` vira a recusa por monkeypatch de propósito: o que se mede é
+    a TRADUÇÃO da exceção em HTTP, não a regra de recompra (test_pix_recompra.py).
+    """
+    conta(user_id, "free", None)
+    monkeypatch.setattr(rotas.shared, "resolve_dashboard_user_id", lambda req: user_id)
+    ate = datetime(2028, 7, 6, 3, 0, tzinfo=timezone.utc)
+
+    def _recusa(*_args, **_kwargs):
+        raise CoberturaJaPaga("pro_max", ate)
+
+    monkeypatch.setattr(rotas, "criar_checkout", _recusa)
+    r = client.post("/billing/pix/checkout", headers=_csrf(),
+                    json={"plan": "pro", "cpf_cnpj": "12345678901"})
+    assert r.status_code == 409, r.text
+    detalhe = r.json()["detail"]
+    assert detalhe["error"] == CoberturaJaPaga.ERRO
+    assert "covered_until" in detalhe, f"a chave do contrato sumiu: {sorted(detalhe)}"
+    # `06/07/2028` e um epoch passariam pelo `in` de cima e morreriam na tela.
+    assert re.match(r"^\d{4}-\d{2}-\d{2}", detalhe["covered_until"]), detalhe["covered_until"]
+    assert date.fromisoformat(detalhe["covered_until"][:10]) == ate.date()

--- a/tests/test_pix_409_contrato.py
+++ b/tests/test_pix_409_contrato.py
@@ -56,8 +56,11 @@ def test_409_de_cobertura_paga_leva_covered_until_em_iso(user_id, monkeypatch):
         raise CoberturaJaPaga("pro_max", ate)
 
     monkeypatch.setattr(rotas, "criar_checkout", _recusa)
+    # O #355 pôs mod-11 no servidor: `12345678901` agora para no 400 do documento
+    # e nunca chega ao `criar_checkout`. Este é o mesmo CPF estruturalmente válido
+    # do test_pix_documento_invalido.py — uma fonte só para o número (§0.7).
     r = client.post("/billing/pix/checkout", headers=_csrf(),
-                    json={"plan": "pro", "cpf_cnpj": "12345678901"})
+                    json={"plan": "pro", "cpf_cnpj": "52998224725"})
     assert r.status_code == 409, r.text
     detalhe = r.json()["detail"]
     assert detalhe["error"] == CoberturaJaPaga.ERRO

--- a/tests/test_static_pages_routes.py
+++ b/tests/test_static_pages_routes.py
@@ -692,3 +692,32 @@ def test_401_de_autenticacao_declara_familia():
         "classificado como True acima), atualize o 8 para o número novo. Se você "
         f"não mexeu em nenhum 401, alguém apagou um `headers=`: {com_header}"
     )
+
+
+def test_par_pix_sai_versionado_por_hash_do_conteudo():
+    """O par pix-poll/pix-checkout não pode divergir de versão entre si.
+
+    Antes do #361 quem CHAMAVA `pixModalJaPago` e quem a DEFINIA moravam no
+    mesmo arquivo — não havia como divergir. Agora a chamada está no
+    pix-checkout.js e a definição no pix-poll.js, e o service worker busca e faz
+    fallback de cada asset de forma independente (frontend/service-worker.js:111).
+    Um cliente com o pix-poll.js VELHO em cache e o pix-checkout.js novo chamaria
+    um handler que não existe.
+
+    Quem fecha isso é o `stamp_asset_versions`: o `?v=1` literal da precos.html
+    NUNCA chega ao navegador — sai o hash do conteúdo, e os dois arquivos mudam
+    juntos neste commit. `caches.match` casa a URL INTEIRA (query incluída), então
+    a entrada velha deixa de ser consultada. Não há bump manual a fazer.
+
+    Vermelho se alguém referenciar a URL nua (ou com `?v=` não-numérico, que o
+    `_ASSET_VER_RE` não casa) — aí o cache-buster morre e a divergência volta.
+    """
+    html = client.get("/precos").text
+    for nome in ["pix-poll.js", "pix-checkout.js"]:
+        esperado = _asset_hash(nome, (FRONTEND_DIR / nome).stat().st_mtime_ns)
+        m = re.search(rf"/{re.escape(nome)}\?v=([0-9a-f]{{12}})\b", html)
+        assert m, f"/{nome} sai sem hash na /precos — o cache velho continua valendo"
+        assert m.group(1) == esperado, nome
+    # E o literal do arquivo não vaza: `?v=1` seria a MESMA chave de cache de antes.
+    assert "/pix-poll.js?v=1\"" not in html
+    assert "/pix-checkout.js?v=1\"" not in html


### PR DESCRIPTION
Endereça a issue #353 **pela metade — não fechar a issue no merge.** O que ficou de fora
e por quê está no fim. Independente dos outros três PRs desta leva.

## O que estava errado

Quem tentava comprar um período **que já pagou** lia:

> Não consegui gerar o código Pix agora.

A mesma frase que aparece quando o sistema está genuinamente fora do ar. O servidor
devolve 409 com a data até onde a cobertura vai, e essa informação era descartada.

## A causa raiz é uma linha, e engolia cinco erros

```js
const det = (d && d.detail) || {};
```

Quando o FastAPI manda `detail` como **string**, `det` vira a string e `det.message` é
`undefined` — a frase que o servidor escreveu é jogada fora inteira. Medido:

| status | o que o servidor manda | o que a tela mostrava |
|---|---|---|
| 400 plano | "plan inválido…" | genérico |
| 400 documento | "Informe um CPF ou CNPJ válido." | genérico |
| 429 | "Muitas tentativas. Aguarde alguns minutos…" | genérico |
| 503 | "Não consegui emitir o Pix agora…" | genérico |
| 403 CSRF | "Token CSRF inválido ou ausente." | genérico |

Dois deles a varredura inicial não tinha pego, e são alcançáveis de verdade: o limitador
é **por endereço de rede**, não por usuário (casa e escritório compartilham), e a sessão
de proteção vencida exige recarregar a página, coisa que a tela nunca dizia.

A forma do conserto **já existia no repositório**, em `frontend/comecar.js:175`.

## A tela nova

O 409 de cobertura já paga abre uma caixa com a data, e não um aviso passageiro. O motivo
é mecânico: reenviar dá o mesmo erro, e o aviso some em menos de 4 segundos deixando o
campo com o documento no DOM esperando uma retentativa impossível.

## Uma pré-condição que ninguém tinha checado

O conserto inteiro depende de a resposta chegar como dado e não como página. Se o
cabeçalho que o navegador manda caísse no ramo HTML, a leitura falharia e tudo voltaria ao
genérico. Verificado: o valor que o navegador envia não conta como HTML, e a docstring da
função diz que é exatamente isso que mantém o contrato.

## O teto de linhas, resolvido movendo

O arquivo bateu **350 de 350**. Em vez de encolher comentário, duas funções de modal foram
para o arquivo par, que declara no próprio cabeçalho — **desde antes deste PR** — ser "a
metade de trás" partida pelo mesmo teto. Ficou 333 e 312.

## Evidência

Quatro mutações rodadas, cada uma com o nome do teste vermelho.

O controle positivo estava **quebrado e foi consertado duas vezes**: ele mandava a
mensagem no formato de texto simples, então depois do conserto passaria a ler a frase do
servidor e continuaria verde por motivo errado; e depois mandava um corpo vazio em vez do
corpo real do erro 500, que é estritamente mais pobre.

Uma asserção de dados sensíveis **não media nada** — ela lê o texto da página, e o valor
digitado num campo não aparece ali. Trocada por leitura do campo vivo, com aviso para o
padrão não ser copiado.

`tests/test_pix_409_contrato.py` prende a chave e o formato que a tela consome: antes,
uma busca por esse nome nos testes dava zero.

```
npm run test:frontend  →  429 pass, 0 fail
pytest -q              →  6886 passed, 4 xfailed
```

## O que a issue pedia e NÃO foi feito

O segundo item do conserto — separar a falha de criação de cliente para o CPF inválido
dizer "confere o CPF". **Quem tirou do escopo fui eu**, não a issue, por duas razões: o
tratamento fica num arquivo que outra sessão estava editando, e a pré-condição que a
própria issue nomeia (qual código o Asaas devolve para documento inválido) **nunca foi
verificada contra a API real**.

**Ganho de tabela:** com a correção da linha única, o CPF inválido passa a mostrar
"Não consegui emitir o Pix agora. Tenta de novo em instantes." em vez do genérico. Ainda
não é "confere o CPF", mas já não é a frase de outra coisa.

**Efeito colateral que a issue nomeia e continua de pé:** a cobrança fica em `creating`.
Medido nesta rodada: **existe varredura que fecha o caso** — pega linhas paradas há mais
de 15 minutos, consulta o provedor pela referência, e devolve ao estado inicial quando não
há cobrança lá. Alerta acima de 24 horas. Não é linha presa.

## Notas

Uma anotação registra que a data é recortada em UTC, então compra feita entre 21h e
meia-noite de Brasília nomeia o dia seguinte. Categoria pré-existente em três pontos;
fechar é converter fuso, não recortar string.

A skill de frontend foi invocada **depois** de escrever o JavaScript, não antes. O diff
não cria superfície visual nova, e a verificação que ela exige foi feita nos dois
tamanhos, com números.

## Não verificado

Nada passou pelo Asaas real nem pelo servidor real — os status vêm de rota interceptada.
Mudança de frontend só aparece no app depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
