### PR TITLE
Avisa quem perde o acesso Grátis, e cria o predicado do direito

### DIFF
--- a/core/services/billing_dunning.py
+++ b/core/services/billing_dunning.py
@@ -4,10 +4,27 @@ core/services/billing_dunning.py — vocabulário da inadimplência de cartão.
 Este módulo NÃO tira acesso de ninguém. Quem está com a cobrança do cartão
 falhada continua com o plano e o bot exatamente como antes; o que existe aqui é
 a mecânica de cobrança: a lista de status que descreve "cartão em atraso" e a
-janela de 7 dias usada pelo lembrete de pagamento
-(`core/services/payment_reminder.py`) e pela dedupe do e-mail de falha no
-webhook. A regra de acesso é assunto de outro PR — não escreva aqui, nem em
-mensagem, e-mail ou docstring, nada que prometa perda de acesso.
+janela de 7 dias.
+
+**São TRÊS os consumidores da janela, não dois** (a enumeração anterior parava
+em dois e envelheceu no PR do aviso de corte):
+
+  1. o lembrete de pagamento (`core/services/payment_reminder.py`);
+  2. a dedupe do e-mail de falha no webhook;
+  3. o **aviso de fim do Grátis** — `carencia_aberta` (abaixo) é o lado
+     direito do OR de `core.services.plan_service.tem_direito_hoje`, que a
+     população de `scripts/aviso_fim_do_gratis.py` nega no `where` e cujo
+     coorte decide a copy do e-mail.
+
+**A DIREÇÃO DO OR importa e é o que segura as células 18, 29 e 30 de
+`docs/dunning_estados_eventos.md` fora daquele trabalho**: a autoridade é o
+direito pago; o relógio só CONCEDE tempo a quem já o perdeu, nunca subtrai. Lê
+isto antes de escrever qualquer gate — lido como autoridade, o status de
+cobrança bloquearia cliente pagante por um ciclo inteiro de retentativa.
+
+Nem aqui nem no aviso alguém perde acesso: o aviso manda e-mail. A regra de
+acesso é assunto do PR seguinte — não escreva aqui, nem em mensagem, e-mail ou
+docstring, nada que prometa perda de acesso enquanto ela não existir.
 
 **A INVARIANTE**: relógio (`auth_accounts.past_due_since`) não nulo só existe
 em conta cujo `last_payment_status` está em `PAST_DUE_PAYMENT_STATUSES`. Quem a
@@ -80,3 +97,44 @@ DUNNING_GRACE_DAYS = 7
 # é ele que eleva o caso.
 PAYMENT_REMINDER_WINDOW_DAYS = 3
 PAYMENT_REMINDER_DEDUPE_DAYS = 6.0
+
+
+def carencia_aberta(past_due_since, last_payment_status, agora) -> bool:
+    """A carência de `DUNNING_GRACE_DAYS` deste ciclo ainda está correndo?
+
+    Os três termos são o par relógio × status da INVARIANTE mais a idade:
+    relógio carimbado, `last_payment_status` em `PAST_DUE_PAYMENT_STATUSES`, e
+    MENOS de `DUNNING_GRACE_DAYS` desde o carimbo. Qualquer outra combinação é
+    False.
+
+    **Ela só CONCEDE tempo, nunca tira acesso.** Quem chama a usa no lado
+    DIREITO de um OR cujo lado esquerdo é o direito pago
+    (`plan_service.tem_direito_hoje`): False aqui não bloqueia ninguém que
+    tenha plano vigente. É isso que impede o status de cobrança de virar
+    autoridade sobre o acesso — lido como autoridade, ele bloquearia cliente
+    pagante por um ciclo inteiro de retentativa (célula 29 de
+    `docs/dunning_estados_eventos.md`).
+
+    Mora aqui porque `DUNNING_GRACE_DAYS` mora aqui (§0.7): o 7 não se repete
+    em `plan_service`. O módulo continua com import ZERO no topo — o `datetime`
+    entra DENTRO da função, o padrão que a docstring do módulo prescreve.
+
+    Normalização IDÊNTICA à do SQL irmão (`db/dunning.py`,
+    `lower(coalesce(last_payment_status, ''))`): `lower()` e nada mais. Sem
+    `strip()`, de propósito — o que o SQL não apara, o Python também não pode
+    aparar, ou os dois lados discordam em `' past_due '`.
+
+    Naive vira UTC nos dois lados: `past_due_since` é `timestamptz` e chega
+    aware do banco, mas script e teste podem passar naive, e misturar naive com
+    aware levanta TypeError no meio de uma decisão de acesso.
+    """
+    if past_due_since is None:
+        return False
+    if (last_payment_status or "").lower() not in PAST_DUE_PAYMENT_STATUSES:
+        return False
+    from datetime import timedelta, timezone
+    if past_due_since.tzinfo is None:
+        past_due_since = past_due_since.replace(tzinfo=timezone.utc)
+    if agora.tzinfo is None:
+        agora = agora.replace(tzinfo=timezone.utc)
+    return agora - past_due_since < timedelta(days=DUNNING_GRACE_DAYS)

--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1293,3 +1293,83 @@ def send_subscription_canceled_email(to: str, expires_at, dashboard_url: str = "
         to=to, subject="PigBank+ — assinatura cancelada",
         html_body=html, text_body=text,
     )
+
+
+def send_free_plan_sunset_email(to: str, corte, dashboard_url: str = "",
+                                cobranca_pendente: bool = False) -> bool:
+    """Aviso de que o acesso Grátis termina na DATA DO CORTE.
+
+    Disparado à mão por `scripts/aviso_fim_do_gratis.py`, antes de a regra de
+    acesso entrar no ar (o merge daquele PR é o evento de corte, porque o
+    Railway faz deploy da `main`). Vai para quem tem acesso HOJE e não terá
+    depois — quem já está barrado pela escolha de plano não recebe.
+
+    **TRANSACIONAL, no molde de `send_payment_failed_email` e
+    `send_subscription_canceled_email`: sem `make_unsub_url` e sem
+    `unsub_headers`.** Quem desligou os e-mails do Piggy desligou dicas e
+    insights (`engagement_opt_out` é derivado de `tip_email_opt_out AND
+    insight_email_opt_out`, `db/reports.py`), e o bot lhe prometeu que "os
+    emails de segurança continuam normais" (`core/intent_router.py`). Ninguém
+    consentiu em abrir mão do aviso de que o serviço acaba.
+
+    **SEM promessa de trial**, e isso é requisito medido, não estilo: o trial é
+    de 15 dias por TELEFONE, na vida (`db/plans.py::claim_trial_for_user`), e
+    esta lista tem ex-assinante que já o usou. Prometer "teste 15 dias grátis"
+    a quem não pode mais tê-lo é copy falsa.
+
+    **DOIS COORTES, e `cobranca_pendente` é o que os separa.** A população do
+    aviso não é só gente no Grátis: entra também quem tem assinatura VIVA na
+    Stripe com o cartão recusado há mais que a carência (o smart retry vai a
+    ~3 semanas) e o período pago já vencido. Chamar essa conta de "plano
+    Grátis" é falso e contradiz os dois e-mails que ela já recebeu (falha de
+    pagamento e lembrete de cobrança) — então a frase da situação e o CTA
+    mudam: para ela o caminho é atualizar o cartão, não escolher um plano.
+    Quem passa o flag é `scripts/aviso_fim_do_gratis.py`, com leitura fresca
+    de `db.dunning.ciclo_de_atraso_aberto` no ponto do envio.
+    """
+    data = _fmt_brl_date(corte)
+    dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
+    if cobranca_pendente:
+        situacao_html = ("A cobrança da sua assinatura <strong>não passou</strong> "
+                         "e o período que você já pagou venceu")
+        situacao_text = ("A cobranca da sua assinatura nao passou e o periodo que "
+                         "voce ja pagou venceu")
+        acao_html, acao_text = "Atualizar cartão", "Atualize o cartao"
+        destino = f"{dash}/conta"
+    else:
+        situacao_html = ("Sua conta hoje está no plano <strong>Grátis</strong> "
+                         "(ou sem plano ativo)")
+        situacao_text = "Sua conta hoje esta no plano Gratis (ou sem plano ativo)"
+        acao_html, acao_text = "Ver os planos", "Escolha um plano"
+        destino = f"{dash}/precos"
+    content = f"""
+      <p>🐷 Oi! Preciso te contar uma mudança importante.</p>
+      <p>A partir de <strong>{data}</strong>, o PigBank passa a funcionar
+      <strong>só para assinantes</strong>. {situacao_html}, então nessa data o
+      <strong>Piggy no WhatsApp</strong> e o <strong>dashboard</strong> param
+      de responder.</p>
+      <p>Seus dados continuam guardados — nada é apagado. Para não ter
+      interrupção, resolva antes de {data}:</p>
+      <p style="text-align:center;margin:24px 0">
+        <a class="btn" href="{destino}">{acao_html}</a>
+      </p>
+      <p style="font-size:13px;color:rgba(255,255,255,.55)">Se sua assinatura
+      já estiver ativa quando você ler isto, pode ignorar este email: quem está
+      com plano ativo não é afetado.</p>
+    """
+    html = _base_html(f"Seu acesso ao PigBank termina em {data}", content)
+    text = (
+        f"PigBank — seu acesso termina em {data}.\n\n"
+        f"A partir de {data} o PigBank passa a funcionar so para assinantes. "
+        f"{situacao_text}, entao nessa data o Piggy no WhatsApp e o dashboard "
+        "param de responder.\n\n"
+        "Seus dados continuam guardados — nada e apagado. Para nao ter "
+        f"interrupcao, resolva antes de {data}:\n"
+        f"{acao_text}: {destino}\n\n"
+        "Se sua assinatura ja estiver ativa quando voce ler isto, pode ignorar "
+        "este email: quem esta com plano ativo nao e afetado."
+    )
+    return send_email(
+        to=to, subject=f"🐷 PigBank — seu acesso termina em {data}",
+        html_body=html, text_body=text,
+    )

--- a/core/services/plan_service.py
+++ b/core/services/plan_service.py
@@ -28,6 +28,7 @@ from utils_date import day_tz
 
 from db import get_auth_user
 
+from .billing_dunning import carencia_aberta
 from .plan_limits import (
     PlanLimits,
     PlanLimitExceeded,
@@ -89,6 +90,79 @@ def _paid_plan_active(user: dict) -> bool:
     return expires_at > datetime.now(timezone.utc)
 
 
+def _tem_plano_pago_vigente(user: dict | None) -> bool:
+    """A conta tem DIREITO pago vigente — o par (`plan`, `plan_expires_at`)?
+
+    EXTRAÍDA, não criada (§0.1): o par `_STORED_PLAN_TO_TIER` +
+    `_paid_plan_active` já estava escrito inline em `get_plan_tier` e em
+    `needs_plan_selection`, e os dois passaram a chamar daqui — não há um
+    terceiro lugar guardando a mesma regra.
+
+    **`plan_expires_at` NULL é VITALÍCIO e devolve True** (grandfathered), que é
+    o que `_paid_plan_active` já dizia. Quem reescrever isto como
+    `plan_expires_at > now()` sem essa perna trata todo grandfathered como
+    expirado — e num aviso de corte por e-mail isso é a base inteira dos
+    vitalícios recebendo "seu acesso acaba".
+    """
+    if not user:
+        return False
+    tier = _STORED_PLAN_TO_TIER.get((user.get("plan") or "").lower(), "free")
+    return tier != "free" and _paid_plan_active(user)
+
+
+def tem_direito_hoje(user: dict | None) -> bool:
+    """Esta conta tem direito de uso HOJE: plano pago vigente OU carência aberta.
+
+    **A direção do OR é o desenho.** A AUTORIDADE é o direito
+    (`plan`/`plan_expires_at`, que já são a projeção de `plan_grants`); o
+    relógio de inadimplência entra só do lado direito, e só CONCEDE tempo extra
+    a quem já perdeu o direito. Invertida, ela faria o status de cobrança
+    bloquear cliente pagante durante um ciclo de retentativa — as células 18,
+    29 e 30 de `docs/dunning_estados_eventos.md` ficam fora deste trabalho
+    justamente por causa dessa direção.
+
+    `user is None` (conta só-WhatsApp, sem linha em `auth_accounts`) é False.
+    **DECISÃO REGISTRADA DO DONO, não constatação técnica** — e a versão
+    anterior desta docstring dizia "não há para onde mandar aviso", que é
+    FALSO e escondia a decisão:
+
+      • quem usa o bot só pelo WhatsApp e nunca fez cadastro web não tem linha
+        em `auth_accounts` e tem o produto COMPLETO hoje: `has_app_access`
+        devolve True incondicional com o v2 ligado, e o gate do bot só exige
+        plano quando a linha existe (`core/handle_incoming._paywall_gate`:
+        `sem_plano = estado is not None and ...`, com
+        `db.reports.get_plan_gate_state` devolvendo None sem cadastro web). O
+        comentário de lá chama essa população de "a maioria aqui";
+      • ela NÃO entra na varredura do aviso, que é sobre `auth_accounts`, e
+        PERDE acesso no corte, porque este predicado devolve False;
+      • **existe** canal para alcançá-la — o WhatsApp, o canal principal do
+        produto. O que falta é template aprovado na Meta, e submeter um tem
+        prazo de aprovação;
+      • **o dono decidiu, explicitamente, cortar essa população sem aviso
+        prévio.** A comunicação dela passa a ser a mensagem de bloqueio do
+        próprio bot, que é do PR A.
+
+    Logo, a garantia deste PR é **"ninguém com cadastro web e e-mail é cortado
+    sem aviso"** — não "ninguém é cortado sem aviso".
+
+    **REQUISITO PARA O PR A, que nasce dessa decisão**: se a mensagem de
+    bloqueio do bot vira a ÚNICA comunicação dessa população, ela tem de fazer
+    sentido para quem nunca viu o dashboard e não tem conta web — sem "acesse
+    seu painel", sem supor cadastro existente.
+
+    **Neste PR ela não gateia nada**: `has_app_access` continua como está (é
+    assunto do PR A). Quem a consome são `scripts/aviso_fim_do_gratis.py` e o
+    teste diferencial que compara aquela SQL com este predicado.
+    """
+    if not user:
+        return False
+    return _tem_plano_pago_vigente(user) or carencia_aberta(
+        user.get("past_due_since"),
+        user.get("last_payment_status"),
+        datetime.now(timezone.utc),
+    )
+
+
 def get_trial_status(user_id: int, user: dict | None = None) -> dict:
     """{"active": bool, "days_left": int, "started_at": datetime|None}.
 
@@ -126,11 +200,8 @@ def get_plan_tier(user_id: int) -> str:
     user = get_auth_user(int(user_id))
     if not user:
         return "free"
-    stored = (user.get("plan") or "").lower()
-    tier = _STORED_PLAN_TO_TIER.get(stored, "free")
-    if tier != "free" and _paid_plan_active(user):
-        return tier
-    return "free"
+    tier = _STORED_PLAN_TO_TIER.get((user.get("plan") or "").lower(), "free")
+    return tier if _tem_plano_pago_vigente(user) else "free"
 
 
 def is_pro(user_id: int) -> bool:
@@ -316,11 +387,7 @@ def needs_plan_selection(user_id: int, user: dict | None = None) -> bool:
     if user.get("plan_selected_at"):
         return False
     # Assinante pago/trial ativo já escolheu implicitamente no checkout.
-    stored = (user.get("plan") or "").lower()
-    tier = _STORED_PLAN_TO_TIER.get(stored, "free")
-    if tier != "free" and _paid_plan_active(user):
-        return False
-    return True
+    return not _tem_plano_pago_vigente(user)
 
 
 def get_user_limits(user_id: int) -> PlanLimits:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -154,12 +154,15 @@ pagamento/cancelamento (`clear_past_due_since`, que os ramos `checkout` e
 decidiu o acesso). Os três helpers moram em `db/dunning.py`, não em `db/plans.py`.
 `DUNNING_GRACE_DAYS = 7` é a carência.
 
-**Nada perde acesso por inadimplência hoje** — não existe gate, e a coluna só
-alimenta duas coisas: o **lembrete de pagamento do 6º dia**
+**Nada perde acesso por inadimplência hoje** — não existe gate, e a coluna
+alimenta **três** coisas: o **lembrete de pagamento do 6º dia**
 (`core/services/payment_reminder.py`, no tick de `engagement_scheduler`; e-mail
 sempre, WhatsApp só se `WA_TEMPLATE_PAYMENT_REMINDER` apontar para um template
-aprovado na Meta — vazio por padrão → caminho dormente) e a janela de dedupe do
-e-mail de falha no webhook. O lembrete fica atrás de `PAYMENT_REMINDER_ENABLED`
+aprovado na Meta — vazio por padrão → caminho dormente), a janela de dedupe do
+e-mail de falha no webhook e o predicado `carencia_aberta`, lado DIREITO do OR
+de `plan_service.tem_direito_hoje` (o relógio só CONCEDE tempo; a autoridade é
+o direito pago), consumido pelo aviso de corte
+(`scripts/aviso_fim_do_gratis.py`). O lembrete fica atrás de `PAYMENT_REMINDER_ENABLED`
 (**default off**, lida a cada tick, sem redeploy; a guarda é a 1ª linha de
 `check_payment_reminder`, então desligada nem consulta o funil). Grant
 `pix`/`admin` vigente pula o lembrete (`legacy` não). Nenhuma copy deste caminho

--- a/docs/controles_declarados.md
+++ b/docs/controles_declarados.md
@@ -53,7 +53,17 @@ coisa que o conserto **é**, e o nome da variável é só onde ele mora hoje.
 
 E um corolário, quando a mesma injeção tem mais de uma grafia: **se duas
 variantes produzem o MESMO vermelho, fique com uma** (é a patologia
-"degenerado", abaixo); **se produzem vermelhos DIFERENTES, elas são injeções
+"degenerado", abaixo) — **e "mesmo vermelho" é critério de GRAFIA, não de
+controle.** Num teste DIFERENCIAL (uma SQL comparada com um predicado Python
+sobre um espaço de contas) qualquer injeção em qualquer termo do `where` cai
+nas mesmas duas ou três asserções, então o nome do vermelho não separa nada:
+medidos, três controles de `tests/test_aviso_fim_do_gratis.py` (caixa do
+status, largura da janela, restrição do relógio ao Grátis) dão o MESMO
+conjunto de vermelhos e nenhum é degenerado. Ali o critério é **qual CONTA
+muda de lado e em que DIREÇÃO** — falso positivo (avisa quem tem direito) e
+falso negativo (corta sem avisar) são propriedades opostas, e um controle que
+só existe numa das direções não é cópia do outro. Nesses arquivos, **nomeie a
+conta e a direção junto com o vermelho**; **se produzem vermelhos DIFERENTES, elas são injeções
 diferentes — nomeie qual delas a instrução manda aplicar.** O segundo caso não
 é teórico: um controle desta família oferecia "descarte o retorno do gate" e
 "apague o bloco do gate" como equivalentes, e um teste novo de fail-closed
@@ -100,10 +110,38 @@ O remédio não é redigir com mais cuidado, é **trocar o eixo da injeção: AL
 em vez de apagar.** Onde a instrução mandava apagar o termo de status do `where`,
 ela passou a mandar trocar `list(PAST_DUE_PAYMENT_STATUSES)` por
 `list(PAST_DUE_PAYMENT_STATUSES) + ["active"]` — o termo continua lá e deixa de
-discriminar, nada é removido, **não há expressão para quebrar sob nenhuma
-leitura**, e as duas grafias plausíveis foram medidas dando o mesmo vermelho.
-Regra prática: se o guard é fail-closed, prefira injeção que muda um VALOR à
-que apaga um PEDAÇO DE CÓDIGO.
+discriminar, nada é removido, e as duas grafias plausíveis foram medidas dando
+o mesmo vermelho. Regra prática: se o guard é fail-closed, prefira injeção que
+muda um VALOR à que apaga um PEDAÇO DE CÓDIGO.
+
+**Mas "alargar" não é seguro por construção, e esta seção já afirmou que era.**
+A versão anterior dizia que assim "não há expressão para quebrar sob nenhuma
+leitura". Há: alargar ALÉM DO DOMÍNIO do tipo quebra igual. Medido na guarda de
+data de `scripts/aviso_fim_do_gratis.py`, cuja faixa é
+`hoje <= corte <= hoje + timedelta(days=MAX_DIAS_ATE_O_CORTE)`:
+
+| injeção | resultado |
+|---|---|
+| `MAX_DIAS_ATE_O_CORTE = 100000` | **tudo verde** — não alcança o caso |
+| `= 100_000_000` | **cinco vermelhos, incluindo o POSITIVO**, e o declarado entre eles por motivo errado |
+| trocar o teto por `date.max` | só o vermelho declarado |
+
+No caso de `100_000_000` quem estoura **não é sempre a comparação**: para uma
+data no passado a comparação encadeada faz curto-circuito em `hoje <= corte` e
+nunca avalia o teto — quem morre é a **própria mensagem de erro**, que recomputa
+`hoje + timedelta(days=MAX)` para dizer a faixa ao operador. Nos dois ramos sai
+`OverflowError` no lugar do `SystemExit` esperado, e a leitura se inverte do
+mesmo jeito. Alargue **até o valor que faz o guard deixar de discriminar**, não
+até o infinito; se o tipo tiver domínio finito (data, inteiro de coluna,
+enum), a injeção certa é a CONSTANTE DE FRONTEIRA daquele domínio.
+
+**Injeção pela constante de que o próprio caso do teste é DERIVADO** — a
+segunda patologia nova, e ela deixa tudo verde. O caso de borda daquele teste
+era `hoje + MAX_DIAS_ATE_O_CORTE + 1`: alargar `MAX` move o caso junto com o
+guard, e a injeção fica invisível. O remédio é o teste ter também um caso
+**absoluto** (ali, `9999-12-31`, o ano digitado errado que a guarda existe para
+pegar). Regra prática: **se o caso do teste se escreve em função da constante,
+ele não pode ser o único caso.**
 
 ## Como conferir
 

--- a/docs/dunning_estados_eventos.md
+++ b/docs/dunning_estados_eventos.md
@@ -15,8 +15,24 @@ escrita aqui de propósito**: ela sobe a cada rodada e envelhece em silêncio
 
 Vocabulário e constantes: `core/services/billing_dunning.py`.
 Escrita: `db/dunning.py`. Leitura: `core/services/payment_reminder.py`.
-**Nada aqui tira acesso de ninguém** — o relógio alimenta o lembrete do 6º dia e
-a janela de dedupe do e-mail de falha, e só.
+**Nada aqui tira acesso de ninguém** — o relógio alimenta TRÊS coisas: o
+lembrete do 6º dia, a janela de dedupe do e-mail de falha e, desde o PR do
+aviso de corte, o predicado `core.services.billing_dunning.carencia_aberta`.
+
+Esse terceiro é o lado DIREITO do OR de `plan_service.tem_direito_hoje`
+(`_tem_plano_pago_vigente(user) or carencia_aberta(...)`), consumido por
+`scripts/aviso_fim_do_gratis.py`. **A direção do OR é o que mantém as células
+18, 29 e 30 fora daquele trabalho**: a autoridade é o direito pago e o relógio
+só CONCEDE tempo a quem já o perdeu. Quem for escrever o gate de acesso (o PR
+seguinte) reusa aquele predicado em vez de ler o status como autoridade — do
+contrário a célula 29 bloqueia cliente pagante por um ciclo de retentativa.
+
+**Dois recados do PR do aviso para quem escrever o gate**: (a) `has_app_access`
+e `needs_plan_selection` continuam intocados, de propósito; (b) o dono decidiu
+cortar SEM aviso prévio a população só-WhatsApp (sem linha em `auth_accounts`,
+"a maioria" segundo `core/handle_incoming.py`), então a **mensagem de bloqueio
+do bot é a única comunicação que ela recebe** — ela tem de fazer sentido para
+quem nunca viu o dashboard e não tem conta web.
 
 ---
 

--- a/scripts/aviso_fim_do_gratis.py
+++ b/scripts/aviso_fim_do_gratis.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Avisa por e-mail quem PERDE o acesso quando a regra de plano entrar no ar.
+
+O corte acontece no MERGE do PR que liga a regra (o Railway faz deploy da
+`main`), então este aviso tem de ser mergeado E EXECUTADO antes daquele. Ele é
+o que garante que ninguém é cortado sem ter sido avisado — hoje toda a base
+Grátis legada passa no gate de escolha de plano, porque `db/schema.py` carimbou
+`plan_selected_at = now()` em todas as contas existentes numa migration.
+
+**A população é quem tem acesso HOJE e não terá depois.** Em quatro termos,
+todos no `where` de `listar_contas_do_aviso`:
+
+  1. `plan_selected_at is not null` — quem já está barrado pela escolha de
+     plano (`plan_service.needs_plan_selection`) não perde nada no corte;
+  2. o par (`plan`, `plan_expires_at`) NÃO é plano pago vigente — com
+     `plan_expires_at is null` valendo VITALÍCIO, que é o caso que um
+     `plan_expires_at > now()` ingênuo poria na lista inteirinha;
+  3. o relógio de inadimplência NÃO está na carência de `DUNNING_GRACE_DAYS`;
+  4. tem e-mail.
+
+Os termos 2 e 3 são a NEGAÇÃO de `plan_service.tem_direito_hoje`, e a
+concordância entre as duas escritas é medida por
+`tests/test_aviso_fim_do_gratis.py` — mexeu num lado, o teste fica vermelho.
+
+**A população tem DOIS coortes e a copy do e-mail muda entre eles**: quem está
+no Grátis/sem plano, e quem tem assinatura VIVA na Stripe com cartão recusado
+além da carência (esse já recebeu falha de pagamento e lembrete — chamá-lo de
+"plano Grátis" seria falso). Quem separa é `db.dunning.ciclo_de_atraso_aberto`,
+lido no ponto do envio.
+
+**`engagement_opt_out` NÃO entra**, e a razão é uma promessa: quem desliga os
+e-mails do Piggy desliga dicas e insights (a coluna é derivada de
+`tip_email_opt_out AND insight_email_opt_out`, `db/reports.py`), e o bot lhe
+responde que "os emails de segurança continuam normais"
+(`core/intent_router.py`). Ninguém consentiu em abrir mão do aviso de fim de
+serviço — este e-mail é TRANSACIONAL, como o de falha de pagamento e o de
+cancelamento, e por isso também não leva link de descadastro.
+
+**Re-executável sem reenviar, em execuções SEQUENCIAIS**, porque ele roda duas
+vezes: na abertura da janela de aviso e na véspera do merge, para pegar quem
+venceu no meio. A dedupe é `system_event_logs` via `recent_event_exists`, o
+mesmo padrão do lembrete de pagamento — e não coluna nova, que depois
+precisaria ser zerada. Quatro limites declarados dela:
+
+  • **duas execuções SIMULTÂNEAS duplicam.** É check-then-act (consulta,
+    envia, grava) sem lock e sem unique — não rode duas ao mesmo tempo;
+  • `system_event_logs` é purgável: um "Limpar" no painel de admin faz o aviso
+    sair repetido (mesmo custo que o lembrete de pagamento já aceita);
+  • a dedupe é por `event_type`, NÃO por `(event_type, corte)`. Uma segunda
+    rodada com `--corte` diferente **não corrige a data de quem já recebeu** —
+    para isso não existe caminho automático, seria e-mail de errata à mão;
+  • ela **falha ABERTA nas duas pontas**: `recent_event_exists` devolve False
+    em qualquer erro (contrato dele: "melhor mandar duplicado que perder") e
+    `log_system_event_sync` é silencioso. Um soluço de banco na segunda rodada
+    reenvia para quem já recebeu.
+
+**DRY-RUN MEDE A POPULAÇÃO, NÃO O ENVIO** — não é ensaio geral. Ele não chama
+`_email_de` (nenhuma decriptação), não consulta o coorte e não fala com o
+Resend, então `PII_ENCRYPTION_KEY` errada, chave de e-mail inválida ou domínio
+suspenso são INVISÍVEIS no ensaio e viram `falhas` em massa no `--apply`.
+
+**`falhas > 0`: re-rodar é seguro.** Falha não grava dedupe, então a rodada
+seguinte tenta de novo só quem falhou. Mas `send_email` não tem retry nem
+backoff: um 429 do Resend numa base grande vira falha em massa de uma vez —
+espere, confira o painel do Resend, e só então re-rode.
+
+**Custo: o laço é O(N × custo por candidato) com constante alta**, e cresce com
+o quadrado da base no pior caso — `auth_accounts` não tem índice em `user_id`,
+então a revalidação de cada candidato é um seq scan, e cada `recent_event_exists`
+abre uma conexão nova (`psycopg.connect`, sem pool). Nunca medido em escala:
+para base grande, espere minutos, não segundos.
+
+**Varredura de base, e o isolamento por usuário é por LINHA**: a query não tem
+`user_id` (é a população inteira, por natureza), então nenhum valor atravessa
+de uma linha para outra — o endereço de cada aviso é decifrado no ponto do
+envio, a partir da revalidação daquele `user_id`, e nada do lote anterior
+sobrevive à iteração.
+
+**`--corte` é recusado fora da faixa [hoje, hoje + MAX_DIAS_ATE_O_CORTE]**, e a
+guarda é sobre o VALOR que vai para a copy, não sobre a GRAFIA: `20260924` e
+`2026-W39-4` são aceitos porque `date.fromisoformat` resolve os dois para
+2026-09-24, que é uma data de corte plausível. O que ela pega é o ano digitado
+errado (`9999-12-31`) e o corte no passado — o erro que a dedupe impede de
+consertar re-executando.
+
+Uso:
+    python -m scripts.aviso_fim_do_gratis --corte 2026-09-24            # dry-run
+    python -m scripts.aviso_fim_do_gratis --corte 2026-09-24 --apply    # envia
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import date, datetime, time, timedelta, timezone
+
+from core.crypto import PiiAccessContext, decrypt_pii_optional
+from core.observability import log_system_event_sync, recent_event_exists
+from core.services.billing_dunning import (
+    DUNNING_GRACE_DAYS,
+    PAST_DUE_PAYMENT_STATUSES,
+)
+from core.services.email_service import send_free_plan_sunset_email
+from core.services.plan_service import _STORED_PLAN_TO_TIER
+from db.connection import get_conn
+from db.dunning import ciclo_de_atraso_aberto
+
+EVENTO = "free_plan_sunset_notice_sent"
+
+# Teto de distância do corte. Não é regra de produto: é a guarda contra o ano
+# digitado errado (`9999-12-31` passava). A janela de aviso real é de dias a
+# poucas semanas — se algum dia um corte legítimo precisar de mais, o número
+# sobe aqui, à vista de quem revisa.
+MAX_DIAS_ATE_O_CORTE = 90
+
+# Janela da dedupe. Tem de ser MAIOR que o intervalo entre as duas execuções
+# (abertura da janela de aviso × véspera do merge), senão a segunda reenvia
+# para quem já recebeu na primeira.
+AVISO_DEDUPE_DAYS = 90.0
+
+# Os valores de `auth_accounts.plan` que são PAGOS, derivados da fonte única
+# (§0.7): tudo que `_STORED_PLAN_TO_TIER` não mapeia para 'free'. Uma lista
+# literal aqui divergiria no dia em que a escada ganhar um degrau.
+PLANOS_PAGOS = sorted(p for p, t in _STORED_PLAN_TO_TIER.items() if t != "free")
+
+
+def listar_contas_do_aviso(user_id: int | None = None) -> list[dict]:
+    """As contas que perdem acesso no corte. Com `user_id`, revalida UMA.
+
+    UMA função para os dois usos de propósito: o funil e a revalidação do ponto
+    de envio fazem a MESMA pergunta, e duas cópias do `where` são duas versões
+    da mesma regra esperando para divergir (§0.7). O lote é um snapshot e o
+    envio leva minutos — quem assinar no meio dele não pode receber "seu acesso
+    acaba", que é justamente a mensagem errada para cliente pagante.
+    """
+    filtro = " and user_id = %s" if user_id is not None else ""
+    params: list = [PLANOS_PAGOS, list(PAST_DUE_PAYMENT_STATUSES), DUNNING_GRACE_DAYS]
+    if user_id is not None:
+        params.append(int(user_id))
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                select user_id, email, email_enc
+                from auth_accounts
+                where plan_selected_at is not null
+                  and email is not null and email <> ''
+                  and not (lower(coalesce(plan, '')) = any(%s)
+                           and (plan_expires_at is null
+                                or plan_expires_at > now()))
+                  and not (past_due_since is not null
+                           and lower(coalesce(last_payment_status, '')) = any(%s)
+                           and past_due_since > now() - make_interval(days => %s))
+                  {filtro}
+                order by user_id
+                """,
+                params,
+            )
+            return [dict(r) for r in cur.fetchall() or []]
+
+
+def _email_de(user_id: int, linha: dict) -> str | None:
+    """Endereço do aviso, da linha que a revalidação acabou de ler.
+
+    `email_enc` manda; o claro é o caso legado. Uma decriptação por e-mail
+    ENVIADO, e não por candidato — mesma escolha de
+    `core.services.payment_reminder._resolver_email`, pelas mesmas duas razões:
+    minimizar PII decifrada e deixar a trilha de auditoria verdadeira. Não
+    reusa aquela função porque o `purpose` dela é o do lembrete de pagamento, e
+    `purpose` errado é trilha de auditoria mentindo.
+    """
+    if linha.get("email_enc"):
+        return decrypt_pii_optional(
+            linha["email_enc"],
+            ctx=PiiAccessContext(
+                purpose="send_free_plan_sunset_email",
+                actor="system:script",
+                subject_user_id=user_id,
+                field="email",
+            ),
+        )
+    return linha.get("email")
+
+
+def _corte_para_email(corte: date) -> datetime:
+    """MEIO-DIA UTC, não meia-noite: `email_service._fmt_brl_date` converte para
+    BRT (-3) antes de formatar, e 00:00Z vira o DIA ANTERIOR na data do corte."""
+    return datetime.combine(corte, time(12), tzinfo=timezone.utc)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corte", required=True,
+                    help="data do corte, AAAA-MM-DD (entra na copy do e-mail)")
+    ap.add_argument("--apply", action="store_true",
+                    help="envia de verdade (sem isso, só reporta — dry-run)")
+    args = ap.parse_args()
+    # A ÚNICA entrada humana do script, e ela vai direto para a copy de um
+    # envio irreversível para a base inteira — a dedupe de AVISO_DEDUPE_DAYS
+    # impede consertar re-executando. `date.fromisoformat` aceita muita coisa
+    # que não é uma data de corte plausível: `2020-01-01` (passado), `20260924`,
+    # `2026-W39-4` (semana ISO), `0001-01-01`, `9999-12-31`. A guarda é uma
+    # FAIXA, não um validador: hoje ou depois, e no máximo
+    # MAX_DIAS_ATE_O_CORTE à frente — o que pega o ano digitado errado.
+    # A confirmação interativa fica de fora de propósito: o dry-run é o padrão
+    # e `--apply` já é o gesto deliberado.
+    corte_dia = date.fromisoformat(args.corte)
+    hoje = date.today()
+    if not hoje <= corte_dia <= hoje + timedelta(days=MAX_DIAS_ATE_O_CORTE):
+        ap.error(f"--corte {args.corte} fora da faixa: use de hoje ({hoje}) até "
+                 f"{hoje + timedelta(days=MAX_DIAS_ATE_O_CORTE)}.")
+    corte = _corte_para_email(corte_dia)
+
+    candidatos = listar_contas_do_aviso()
+    enviados = ja_avisados = desistidos = falhas = 0
+    for linha in candidatos:
+        uid = int(linha["user_id"])
+        if recent_event_exists(EVENTO, uid, AVISO_DEDUPE_DAYS):
+            ja_avisados += 1
+            continue
+        if not args.apply:
+            print(f"  user {uid}: avisaria")
+            continue
+        # `try` por LINHA, e ele COMEÇA na revalidação: ela é uma chamada de
+        # rede como as outras, e fora do `try` uma conta ruim abandonava os
+        # candidatos SEGUINTES (medido — o lote inteiro morria na primeira).
+        # As outras duas dependências externas do laço (`recent_event_exists`,
+        # `log_system_event_sync`) já tratam a exceção por dentro.
+        try:
+            # Revalida IMEDIATAMENTE antes do envio, e usa o endereço DESTA
+            # leitura: o snapshot pode ter envelhecido (assinatura nova,
+            # carência reaberta, e-mail trocado — endereço removido da conta
+            # pode já não ser da pessoa). Falha de leitura NÃO manda: aqui o
+            # silêncio é o erro recuperável, a rodada seguinte tenta de novo.
+            atual = listar_contas_do_aviso(user_id=uid)
+            if not atual:
+                print(f"  user {uid}: pulado (deixou de perder acesso durante o lote)")
+                desistidos += 1
+                continue
+            email = _email_de(uid, atual[0])
+            # Qual dos DOIS coortes da população é esta conta? Leitura fresca,
+            # no ponto do envio, e o predicado é o que já existe
+            # (`db.dunning.ciclo_de_atraso_aberto`) em vez de uma segunda
+            # cópia dele aqui (§0.1).
+            if not email or not send_free_plan_sunset_email(
+                email, corte, cobranca_pendente=ciclo_de_atraso_aberto(uid),
+            ):
+                falhas += 1
+                continue
+        except Exception as exc:
+            print(f"  user {uid}: FALHOU ({exc})")
+            falhas += 1
+            continue
+        enviados += 1
+        log_system_event_sync(
+            "info", EVENTO,
+            "Aviso de fim do plano Gratis enviado.",
+            source="scripts.aviso_fim_do_gratis",
+            user_id=uid,
+            details={"corte": args.corte},
+        )
+
+    print(f"\n{len(candidatos)} conta(s) na população do aviso; "
+          f"{enviados} enviado(s), {ja_avisados} já avisado(s) na rodada "
+          f"anterior, {desistidos} que deixaram de perder acesso durante o "
+          f"lote, {falhas} falha(s).")
+    if not args.apply:
+        print("Dry-run: nenhum e-mail saiu. Rode de novo com --apply.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/_aviso_fim_do_gratis_helpers.py
+++ b/tests/_aviso_fim_do_gratis_helpers.py
@@ -1,0 +1,119 @@
+"""Espaço de estados do aviso de fim do Grátis, compartilhado pelos dois
+arquivos de teste do assunto.
+
+Sem prefixo `test_` de propósito (mesmo motivo de `_billing_grants_helpers.py`):
+o pytest não coleta este arquivo. Ele existe para
+`test_aviso_fim_do_gratis.py` (o diferencial SQL × predicado) e
+`test_aviso_fim_do_gratis_lote.py` (o laço do script) não carregarem duas
+cópias do mesmo `montar_base` — cópia de helper é como dois testes passam a
+medir coisas diferentes achando que medem a mesma.
+
+Cada conta aqui é um jeito conhecido de a SQL do aviso e
+`plan_service.tem_direito_hoje` divergirem; os controles declarados dos dois
+arquivos citam estes nomes.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from _billing_grants_helpers import conta as _conta
+from db.connection import get_conn
+from db_support import invalidate_auth_user_cache
+from scripts.aviso_fim_do_gratis import EVENTO, listar_contas_do_aviso
+
+# Faixa própria deste assunto — a SQL do aviso é uma VARREDURA DE BASE (não tem
+# `user_id`), então o universo da comparação é recortado por estes ids.
+BASE = 771000
+
+GRANDFATHERED = BASE + 1
+PAGO_VIGENTE = BASE + 2
+PAGO_EXPIRADO = BASE + 3
+TRIALING = BASE + 4
+GRANT_ADMIN = BASE + 5
+CARENCIA_3D = BASE + 6
+CARENCIA_8D = BASE + 7
+CAIXA_MISTA = BASE + 8
+FREE_PURO = BASE + 9
+SEM_PLANO = BASE + 10
+NUNCA_ESCOLHEU = BASE + 11
+SO_WHATSAPP = BASE + 12
+PAGO_EXPIRADO_EM_CARENCIA = BASE + 13
+
+UNIVERSO = {
+    GRANDFATHERED, PAGO_VIGENTE, PAGO_EXPIRADO, TRIALING, GRANT_ADMIN,
+    CARENCIA_3D, CARENCIA_8D, CAIXA_MISTA, FREE_PURO, SEM_PLANO,
+    PAGO_EXPIRADO_EM_CARENCIA,
+}
+
+# Quem PERDE acesso no corte — a lista que o e-mail tem de alcançar.
+ESPERADO_AVISAR = {PAGO_EXPIRADO, CARENCIA_8D, FREE_PURO, SEM_PLANO}
+
+
+def agora() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def montar(uid, plan, expires, status="active", relogio_dias=None,
+           escolheu=True) -> None:
+    """Uma conta do espaço de estados. `relogio_dias` = idade de
+    `past_due_since` em dias (None = relógio zerado)."""
+    from db import ensure_user
+    ensure_user(uid)          # FK auth_accounts.user_id → users.id
+    _conta(uid, plan, expires, status)
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "update auth_accounts set plan_selected_at = %s,"
+                "       past_due_since = %s where user_id = %s",
+                (agora() - timedelta(days=200) if escolheu else None,
+                 None if relogio_dias is None
+                 else agora() - timedelta(days=relogio_dias),
+                 uid),
+            )
+        conn.commit()
+    invalidate_auth_user_cache(uid)
+
+
+def montar_base() -> None:
+    hoje = agora()
+    montar(GRANDFATHERED, "pro", None, "active")
+    montar(PAGO_VIGENTE, "essencial", hoje + timedelta(days=30), "active")
+    montar(PAGO_EXPIRADO, "pro", hoje - timedelta(days=1), "canceled")
+    montar(TRIALING, "pro_max", hoje + timedelta(days=10), "trialing")
+    montar(CARENCIA_3D, "free", None, "past_due", relogio_dias=3)
+    # O ASSINANTE REAL em dunning: plano pago, período vencido, relógio na
+    # carência. Os dois `CARENCIA_*` são `plan='free'` e não cobrem isto —
+    # ver o controle E.
+    montar(PAGO_EXPIRADO_EM_CARENCIA, "pro", hoje - timedelta(days=1),
+           "past_due", relogio_dias=3)
+    montar(CARENCIA_8D, "free", None, "past_due", relogio_dias=8)
+    montar(CAIXA_MISTA, "free", None, "Past_Due", relogio_dias=3)
+    montar(FREE_PURO, "free", None, "inactive")
+    # `plan` é NOT NULL no schema, então "sem plano" no banco é string vazia —
+    # o valor fora da escada que os dois lados normalizam (`coalesce`/`get`).
+    montar(SEM_PLANO, "", None, "inactive")
+    montar(NUNCA_ESCOLHEU, "free", None, "inactive", escolheu=False)
+
+    # Grant do admin: a MESMA escrita do painel (`set_account_plan`), que grava
+    # `plan`/`plan_expires_at` e não fala com a Stripe.
+    montar(GRANT_ADMIN, "free", None, "inactive")
+    from core.admin_dashboard import set_account_plan
+    set_account_plan("pro", 12, user_id=GRANT_ADMIN)
+    invalidate_auth_user_cache(GRANT_ADMIN)
+
+
+def avisados() -> set[int]:
+    return {int(r["user_id"]) for r in listar_contas_do_aviso()}
+
+
+def limpar_dedupe() -> None:
+    """Apaga a marca de dedupe destas contas. Sem isto, um teste que roda
+    `--apply` cala o próximo — dependência de ORDEM disfarçada de teste verde."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "delete from system_event_logs where event_type = %s"
+                "   and user_id = any(%s)",
+                (EVENTO, sorted(UNIVERSO)),
+            )
+        conn.commit()

--- a/tests/test_aviso_fim_do_gratis.py
+++ b/tests/test_aviso_fim_do_gratis.py
@@ -1,0 +1,167 @@
+"""
+tests/test_aviso_fim_do_gratis.py — a SQL do aviso × o predicado Python, com
+banco real.
+
+O aviso de corte (`scripts/aviso_fim_do_gratis.py`) e o gate de acesso
+(`plan_service.tem_direito_hoje`) respondem à MESMA pergunta em duas
+linguagens: "esta conta tem direito de uso hoje?". Discordando, alguém é
+cortado sem aviso ou avisado à toa. Este arquivo monta o espaço de estados,
+roda os dois lados e afirma que as partições são COMPLEMENTARES — ninguém nos
+dois lados, ninguém fora dos dois. O que ele mede é CONCORDÂNCIA: fica vermelho
+no dia em que alguém mexer num lado só.
+
+O espaço de estados mora em `_aviso_fim_do_gratis_helpers.py`, e cada conta
+dele é um jeito conhecido de os dois lados divergirem — vitalício
+(`plan_expires_at IS NULL`, o que sozinho justifica o arquivo), pago vigente ×
+expirado, `trialing`, grant do admin, as duas bordas de `DUNNING_GRACE_DAYS`,
+status em caixa mista, e o assinante em dunning com período vencido.
+
+**O LAÇO do script (dry-run, dedupe, lote, copy, guarda do `--corte`) é o
+arquivo irmão `test_aviso_fim_do_gratis_lote.py`** — assunto diferente, e o
+teto de 350 linhas do `tests/test_max_lines_python.py` chegou junto com a
+segunda responsabilidade (§0.5).
+
+A conta só-WhatsApp e a que nunca escolheu plano ficam FORA do universo de
+propósito: as duas são "sem direito E sem aviso", o par que a complementaridade
+proíbe DENTRO dele. O universo é a população possível pela política — conta com
+`plan_selected_at` e e-mail —, e cada uma das duas tem asserção própria.
+
+O §3 do `CLAUDE.md` dispensa os DOIS CONTROLES para tabela de entrada/saída
+como esta; os abaixo existem porque foram medidos, não por cerimônia.
+
+CONTROLES MEDIDOS (`docs/controles_declarados.md`: injeção que muda VALOR, nunca
+que apaga pedaço de expressão; só os VERMELHOS nomeados; sem contagem). Todos
+mexem no `where` de `listar_contas_do_aviso` ou no predicado Python, então
+reprovam também testes do arquivo irmão — os nomes de lá estão marcados
+`[lote]`:
+
+  • A — trate vitalício como expirado: troque
+    `(plan_expires_at is null or plan_expires_at > now())` por
+    `(coalesce(plan_expires_at, now() - interval '1 day') > now())`:
+      VERMELHO: test_sql_do_aviso_e_o_predicado_sao_complementares,
+                test_vitalicio_e_grant_admin_ficam_de_fora,
+                [lote] test_dry_run_nao_envia_e_a_segunda_rodada_nao_reenvia,
+                [lote] test_revalidacao_que_estoura_nao_aborta_o_lote,
+                [lote] test_o_coorte_de_cada_conta_decide_a_copy.
+    **NÃO use `(plan_expires_at > now())` sozinho**: medido, todos passam.
+    `null > now()` é NULL, o `not (... and NULL)` é NULL e a linha cai fora do
+    `where` do mesmo jeito — a lógica de três valores mascara a injeção.
+  • B — tire a normalização de caixa do status da SQL: troque
+    `lower(coalesce(last_payment_status, ''))` por
+    `coalesce(last_payment_status, '')`:
+      VERMELHO: test_sql_do_aviso_e_o_predicado_sao_complementares,
+                [lote] test_dry_run_nao_envia_e_a_segunda_rodada_nao_reenvia,
+                [lote] test_revalidacao_que_estoura_nao_aborta_o_lote,
+                [lote] test_o_coorte_de_cada_conta_decide_a_copy.
+    Discrimina por `CAIXA_MISTA`, que ENTRA na população indevidamente — falso
+    positivo: aviso de fim de acesso para quem está na carência.
+  • C — alargue a janela SÓ na SQL: em `params`, troque `DUNNING_GRACE_DAYS`
+    por `DUNNING_GRACE_DAYS + 30`:
+      VERMELHO: os mesmos quatro do B.
+    Discrimina por `CARENCIA_8D`, que SAI da população — falso negativo, a
+    direção OPOSTA à do B: corte sem aviso. **B e C não são duas grafias da
+    mesma injeção**: contas diferentes, direções opostas, propriedades
+    diferentes (caixa do status × largura da janela). O corolário do
+    `docs/controles_declarados.md` ("mesmo vermelho → apague uma") não se
+    aplica a teste diferencial, onde toda injeção no `where` cai nas mesmas
+    asserções — o critério certo é "a mesma conta, na mesma direção", e está
+    corrigido lá.
+  • D — alargue a janela SÓ no Python: em `billing_dunning.carencia_aberta`,
+    troque `timedelta(days=DUNNING_GRACE_DAYS)` por
+    `timedelta(days=DUNNING_GRACE_DAYS + 30)`:
+      VERMELHO: test_sql_do_aviso_e_o_predicado_sao_complementares.
+    C e D são a MESMA janela vista dos dois lados, e é por isso que as duas
+    entram: o par prova que o arquivo mede a CONCORDÂNCIA, não um lado só.
+  • E — restrinja o termo do relógio ao Grátis: dentro do
+    `not (past_due_since is not null ...)`, acrescente
+    `lower(coalesce(plan, '')) = 'free' and` antes do primeiro termo:
+      VERMELHO: test_sql_do_aviso_e_o_predicado_sao_complementares,
+                [lote] test_dry_run_nao_envia_e_a_segunda_rodada_nao_reenvia,
+                [lote] test_revalidacao_que_estoura_nao_aborta_o_lote,
+                [lote] test_o_coorte_de_cada_conta_decide_a_copy.
+    Quem discrimina é UMA conta — `PAGO_EXPIRADO_EM_CARENCIA`, o assinante com
+    cartão recusado, que SAI da população (falso negativo). Medido: com ela
+    trocada por `plan='free'` (a cobertura anterior, só `CARENCIA_*` no
+    Grátis) esta injeção fica INVISÍVEL.
+
+DOIS TERMOS DO `where` FICAM SEM CONTROLE, e a razão é alcançabilidade medida,
+não esquecimento:
+
+  • **a caixa do `plan`** (só o `status` tem `CAIXA_MISTA`). `plan` em caixa
+    mista não tem writer: `core.admin_dashboard.set_account_plan` faz
+    `.strip().lower()` contra `ADMIN_PLAN_VALUES`, e o webhook grava o valor de
+    `TIER_TO_STORED_PLAN`, todo minúsculo. **Vale registrar a direção do dano,
+    que é a pior possível**: sem o `lower()`, um cliente PAGANTE com `plan` em
+    caixa mista cairia na população e receberia "seu acesso acaba";
+  • **o termo de e-mail** (`email is not null and email <> ''`):
+    `auth_accounts.email` é `not null` no schema e nenhum writer o esvazia.
+
+Fechá-los seria blindagem de teste contra estado que o banco não produz — a
+decisão é não fechar, e reabri-la exige antes um writer que crie o estado.
+"""
+from __future__ import annotations
+
+from _aviso_fim_do_gratis_helpers import (
+    ESPERADO_AVISAR,
+    GRANDFATHERED,
+    GRANT_ADMIN,
+    NUNCA_ESCOLHEU,
+    SO_WHATSAPP,
+    UNIVERSO,
+    avisados as _avisados,
+    montar_base,
+)
+from core.services.plan_service import tem_direito_hoje
+from db import get_auth_user
+
+
+def test_sql_do_aviso_e_o_predicado_sao_complementares():
+    montar_base()
+    avisados = _avisados() & UNIVERSO
+    com_direito = {uid for uid in UNIVERSO if tem_direito_hoje(get_auth_user(uid))}
+
+    # A tabela explícita vem ANTES da complementaridade de propósito: sozinha,
+    # a complementaridade também passaria com os dois lados errados do mesmo
+    # jeito (o vitalício avisado por ambos, por exemplo).
+    assert avisados == ESPERADO_AVISAR
+    assert com_direito == UNIVERSO - ESPERADO_AVISAR
+
+    assert avisados & com_direito == set(), "conta nos DOIS lados"
+    assert avisados | com_direito == UNIVERSO, "conta FORA dos dois lados"
+
+
+def test_vitalicio_e_grant_admin_ficam_de_fora():
+    """Os dois casos que uma reescrita ingênua da SQL quebra primeiro, com
+    asserção nomeada — o teste acima só diz "conjunto diferente"."""
+    montar_base()
+    avisados = _avisados()
+    assert GRANDFATHERED not in avisados, "vitalício (plan_expires_at NULL) avisado"
+    assert GRANT_ADMIN not in avisados, "grant do admin avisado"
+    assert tem_direito_hoje(get_auth_user(GRANDFATHERED)) is True
+    assert tem_direito_hoje(get_auth_user(GRANT_ADMIN)) is True
+
+
+def test_fora_do_universo_os_dois_lados_dizem_nao_avisa():
+    """Nunca escolheu plano e só-WhatsApp: sem direito E sem aviso.
+
+    As duas contas estão fora do universo por razões DIFERENTES, e a segunda é
+    uma decisão, não uma limitação técnica. Quem nunca escolheu plano já está
+    barrado e não perde nada no corte. Já o **só-WhatsApp** (sem linha em
+    `auth_accounts`) tem hoje o produto completo — `has_app_access` é True
+    incondicional com o v2 ligado e o gate do bot só exige plano quando a linha
+    existe —, **perde acesso no corte** e **não é avisado**. Existe canal para
+    alcançá-lo (o WhatsApp); o que falta é template aprovado na Meta, e **o
+    dono decidiu cortar essa população sem aviso prévio**, deixando a
+    comunicação para a mensagem de bloqueio do bot (PR A). A garantia deste PR
+    é "ninguém com cadastro web e e-mail é cortado sem aviso" — o registro
+    completo está na docstring de `plan_service.tem_direito_hoje`.
+    """
+    montar_base()
+    avisados = _avisados()
+
+    assert NUNCA_ESCOLHEU not in avisados
+    assert tem_direito_hoje(get_auth_user(NUNCA_ESCOLHEU)) is False
+
+    assert get_auth_user(SO_WHATSAPP) is None
+    assert SO_WHATSAPP not in avisados
+    assert tem_direito_hoje(None) is False

--- a/tests/test_aviso_fim_do_gratis_lote.py
+++ b/tests/test_aviso_fim_do_gratis_lote.py
@@ -1,0 +1,283 @@
+"""
+tests/test_aviso_fim_do_gratis_lote.py — o LAÇO de `scripts/aviso_fim_do_gratis.py`:
+dry-run, dedupe entre as duas rodadas, isolamento de linha ruim, a guarda do
+`--corte` e a copy dos dois coortes.
+
+Assunto separado do irmão `test_aviso_fim_do_gratis.py` (que mede a SQL contra
+o predicado Python): ali a pergunta é "a população está certa?", aqui é "o
+disparo se comporta?". A divisão é o §0.5 — o teto de 350 linhas chegou junto
+com a segunda responsabilidade, e o espaço de estados compartilhado mora em
+`_aviso_fim_do_gratis_helpers.py`.
+
+CONTROLES MEDIDOS (`docs/controles_declarados.md`: injeção que ALARGA um valor,
+nunca que apaga texto; só os VERMELHOS nomeados; sem contagem). Os controles
+A–E, que mexem no `where` da população, estão no arquivo irmão e reprovam
+testes daqui — a lista deles está lá.
+
+  • F — desfaça o conserto do lote: no laço de `main`, mova a chamada
+    `listar_contas_do_aviso(user_id=uid)` (e o `if not atual`) para ANTES do
+    `try`, como estava:
+      VERMELHO: test_revalidacao_que_estoura_nao_aborta_o_lote, sozinho.
+    **É o único controle daqui que cita POSIÇÃO de bloco**, a categoria que
+    `docs/controles_declarados.md` mostrou morrer na primeira refatoração. É
+    inerente: o conserto É a posição da chamada, não um valor. Se o laço for
+    reescrito, reescreva a instrução — o que ela afirma é "a revalidação está
+    coberta pelo `try` da linha".
+  • I — inverta a escolha do coorte: em `main`, troque
+    `cobranca_pendente=ciclo_de_atraso_aberto(uid)` por
+    `cobranca_pendente=not ciclo_de_atraso_aberto(uid)`:
+      VERMELHO: test_o_coorte_de_cada_conta_decide_a_copy, sozinho.
+    Antes desse teste, esta MESMA injeção passava com tudo verde — o coletor
+    descartava o flag e o teste de copy chamava a função de e-mail direto, com
+    os dois valores na mão. A copy forkava e ninguém media QUEM escolhe o
+    fork.
+  • G — alargue a borda de BAIXO da faixa do `--corte`: em `main`, troque
+    `hoje <= corte_dia` por `hoje - timedelta(days=3650) <= corte_dia`:
+      VERMELHO: test_corte_no_passado_e_recusado.
+  • H — alargue o TETO: em `main`, troque
+    `corte_dia <= hoje + timedelta(days=MAX_DIAS_ATE_O_CORTE)` por
+    `corte_dia <= date.max`:
+      VERMELHO: test_corte_absurdamente_longe_e_recusado.
+    **NÃO injete pela constante**, e as duas grafias foram medidas:
+    `MAX_DIAS_ATE_O_CORTE = 100000` deixa TODOS verdes (o caso de borda do
+    teste é derivado da própria constante, então alargá-la move o caso junto,
+    e o caso absoluto `9999-12-31` continua fora — ele está a 2,9 milhões de
+    dias); `= 100_000_000` reprova CINCO testes, inclusive o POSITIVO, com
+    `OverflowError` no lugar do `SystemExit` — e o estouro não é sempre na
+    comparação: com data no passado a comparação encadeada curto-circuita em
+    `hoje <= corte_dia` e quem morre é a MENSAGEM de erro, que recomputa
+    `hoje + timedelta(days=MAX)`; com data legítima morre a comparação. Nos
+    dois ramos a leitura se inverte. As duas patologias estão registradas em
+    `docs/controles_declarados.md`. `date.max` alarga sem estourar.
+    G e H são bordas SEPARADAS: nenhuma das duas reprova o teste da outra.
+    **Nenhuma delas reprova `test_corte_de_hoje_e_o_caminho_legitimo_passam`**
+    — é o controle POSITIVO, e é ele que separa "a guarda discrimina" de "a
+    guarda recusa tudo", que seria pior que não ter guarda nenhuma.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+
+import pytest
+
+from _aviso_fim_do_gratis_helpers import (
+    CARENCIA_8D,
+    ESPERADO_AVISAR,
+    FREE_PURO,
+    PAGO_EXPIRADO,
+    SEM_PLANO,
+    limpar_dedupe,
+    montar_base,
+)
+from _billing_grants_helpers import garantir_system_event_logs
+
+# Data RELATIVA em todo lugar: `main` recusa corte fora da faixa
+# [hoje, hoje + MAX_DIAS_ATE_O_CORTE], e uma data fixa apodreceria — o teste
+# passaria a morrer no `ap.error` no dia em que ela ficasse no passado.
+CORTE_OK = (date.today() + timedelta(days=14)).isoformat()
+
+
+def _argv(monkeypatch, corte: str, *flags) -> None:
+    monkeypatch.setattr(sys, "argv", ["aviso", "--corte", corte, *flags])
+
+
+def _coletor(monkeypatch, aviso) -> list[tuple[str, bool]]:
+    """Registra `(destinatário, cobranca_pendente)` de cada envio.
+
+    O flag entra na lista de propósito: um fake que o descartasse deixaria a
+    ESCOLHA do coorte sem medição nenhuma — a copy forkaria e ninguém veria se
+    o fork foi escolhido ao contrário (medido: `cobranca_pendente=not ...`
+    passava com todos verdes)."""
+    enviados: list[tuple[str, bool]] = []
+
+    def _fake_send(to, corte, dashboard_url="", **kw):
+        enviados.append((to, kw.get("cobranca_pendente")))
+        return True
+
+    monkeypatch.setattr(aviso, "send_free_plan_sunset_email", _fake_send)
+    return enviados
+
+
+def test_dry_run_nao_envia_e_a_segunda_rodada_nao_reenvia(monkeypatch):
+    """O script roda DUAS vezes em produção (abertura da janela e véspera do
+    merge). A sequência inteira, contra o banco: dry-run, `--apply`, `--apply`
+    de novo — e a dedupe real de `system_event_logs`, não um mock dela."""
+    import scripts.aviso_fim_do_gratis as aviso
+
+    garantir_system_event_logs()
+    montar_base()
+    limpar_dedupe()
+    enviados = _coletor(monkeypatch, aviso)
+
+    def _rodar(*flags):
+        _argv(monkeypatch, CORTE_OK, *flags)
+        aviso.main()
+        # Só os desta faixa: a varredura é de base e pega conta de outro teste.
+        meus = {to for to, _ in enviados if to.startswith("gr-77")}
+        enviados.clear()
+        return meus
+
+    assert _rodar() == set(), "dry-run mandou e-mail"
+
+    esperado = {f"gr-{uid}@t.local" for uid in ESPERADO_AVISAR}
+    assert _rodar("--apply") == esperado
+    assert _rodar("--apply") == set(), "segunda rodada reenviou"
+
+
+def test_revalidacao_que_estoura_nao_aborta_o_lote(monkeypatch):
+    """Uma conta ruim não pode levar os candidatos SEGUINTES junto. A
+    revalidação é a terceira chamada de rede do laço (as outras duas tratam a
+    exceção por dentro), e FORA do `try` ela matava o lote na primeira falha."""
+    import scripts.aviso_fim_do_gratis as aviso
+
+    garantir_system_event_logs()
+    montar_base()
+    limpar_dedupe()
+
+    real = aviso.listar_contas_do_aviso
+    vitima = min(ESPERADO_AVISAR)          # a SQL ordena por user_id
+
+    def _estoura_na_vitima(user_id=None):
+        if user_id == vitima:
+            raise RuntimeError("banco caiu na revalidação")
+        return real(user_id)
+
+    enviados = _coletor(monkeypatch, aviso)
+    monkeypatch.setattr(aviso, "listar_contas_do_aviso", _estoura_na_vitima)
+    _argv(monkeypatch, CORTE_OK, "--apply")
+    aviso.main()
+
+    meus = {to for to, _ in enviados if to.startswith("gr-77")}
+    assert f"gr-{vitima}@t.local" not in meus, "a conta que estourou foi avisada"
+    assert meus == {f"gr-{uid}@t.local" for uid in ESPERADO_AVISAR - {vitima}}, \
+        "o lote abandonou os candidatos seguintes"
+
+
+def test_o_coorte_de_cada_conta_decide_a_copy(monkeypatch):
+    """A copy forka em dois coortes; este teste mede QUEM escolhe o fork.
+
+    Sem ele, a decisão (`ciclo_de_atraso_aberto`) e o resultado (a frase que o
+    cliente lê) ficam desligados: o Manager injetou
+    `cobranca_pendente=not ciclo_de_atraso_aberto(uid)` — a inversão completa,
+    que manda "sua cobrança não passou" para quem está no Grátis e chama de
+    Grátis o cliente com cartão recusado — e a bateria inteira passou.
+
+    O par: `CARENCIA_8D` é o assinante em dunning (relógio carimbado + status
+    na lista, carência VENCIDA, por isso está na população) e tem de receber
+    True; `PAGO_EXPIRADO` (cancelado), `FREE_PURO` e `SEM_PLANO` não têm
+    relógio nenhum e têm de receber False. As duas direções no mesmo assert:
+    uma inversão troca os dois lados de uma vez.
+    """
+    import scripts.aviso_fim_do_gratis as aviso
+
+    garantir_system_event_logs()
+    montar_base()
+    limpar_dedupe()
+    enviados = _coletor(monkeypatch, aviso)
+    _argv(monkeypatch, CORTE_OK, "--apply")
+    aviso.main()
+
+    coorte = {to: flag for to, flag in enviados if to.startswith("gr-77")}
+    assert coorte == {
+        f"gr-{CARENCIA_8D}@t.local": True,
+        f"gr-{PAGO_EXPIRADO}@t.local": False,
+        f"gr-{FREE_PURO}@t.local": False,
+        f"gr-{SEM_PLANO}@t.local": False,
+    }
+
+
+# ── A guarda do `--corte` ────────────────────────────────────────────────────
+#
+# É a ÚNICA entrada humana do script, ela vai direto para a copy de um envio
+# irreversível para a base inteira, e a dedupe de `AVISO_DEDUPE_DAYS` impede
+# consertar re-executando. Ano digitado errado não tem desfazer.
+#
+# Os três casos abaixo rodam em DRY-RUN: o que se mede é a guarda, e nenhum
+# e-mail precisa sair para isso. `ap.error` sai por `SystemExit`.
+
+def test_corte_no_passado_e_recusado(monkeypatch):
+    import scripts.aviso_fim_do_gratis as aviso
+    _argv(monkeypatch, (date.today() - timedelta(days=1)).isoformat())
+    with pytest.raises(SystemExit):
+        aviso.main()
+
+
+def test_corte_absurdamente_longe_e_recusado(monkeypatch):
+    """DOIS casos, e eles medem coisas diferentes: `9999-12-31` é o ano
+    digitado errado (o valor real que passava antes da guarda), ABSOLUTO; o
+    outro é UM DIA além de `MAX_DIAS_ATE_O_CORTE`, derivado da constante, e
+    prende a posição exata da borda.
+
+    Medido: só o caso ABSOLUTO discrimina o valor do teto — alargar a
+    constante move junto o caso derivado dela, e a injeção fica invisível (é a
+    armadilha do controle H)."""
+    import scripts.aviso_fim_do_gratis as aviso
+
+    borda = date.today() + timedelta(days=aviso.MAX_DIAS_ATE_O_CORTE + 1)
+    for alvo in ("9999-12-31", borda.isoformat()):
+        _argv(monkeypatch, alvo)
+        with pytest.raises(SystemExit):
+            aviso.main()
+
+
+def test_corte_de_hoje_e_o_caminho_legitimo_passam(monkeypatch):
+    """CONTROLE POSITIVO da guarda, e ele tem duas metades: HOJE é a borda de
+    baixo (inclusiva — o corte pode ser no mesmo dia do merge) e `CORTE_OK` é o
+    uso normal. Sem este teste, uma guarda que recusasse tudo passaria nos dois
+    de cima — e recusar tudo é pior que não ter guarda, porque o aviso nunca
+    sai e o corte pega a base inteira sem avisar ninguém."""
+    import scripts.aviso_fim_do_gratis as aviso
+
+    montar_base()
+    enviados = _coletor(monkeypatch, aviso)
+    for corte in (date.today().isoformat(), CORTE_OK):
+        _argv(monkeypatch, corte)
+        aviso.main()                       # dry-run: não pode levantar
+    assert enviados == [], "dry-run mandou e-mail"
+
+
+def test_copy_traz_a_data_do_corte_e_nao_promete_trial(monkeypatch):
+    """A data tem de atravessar o script inteiro (`--corte` → `_corte_para_email`
+    → `_fmt_brl_date`): meia-noite UTC vira o DIA ANTERIOR em BRT. E a copy não
+    pode prometer trial — são 15 dias por TELEFONE na vida
+    (`db.plans.claim_trial_for_user`), e esta lista tem ex-assinante que já
+    usou o dele."""
+    import core.services.email_service as es
+    from scripts.aviso_fim_do_gratis import _corte_para_email
+
+    capturado: dict = {}
+
+    def _fake(to, subject, html_body, text_body="", **kw):
+        capturado.update(to=to, subject=subject, html=html_body,
+                         text=text_body, kw=kw)
+        return True
+
+    monkeypatch.setattr(es, "send_email", _fake)
+    corte = _corte_para_email(date(2026, 9, 24))
+    es.send_free_plan_sunset_email("quem@exemplo.com", corte)
+
+    assert "24/09/2026" in capturado["html"]
+    assert "24/09/2026" in capturado["text"]
+    assert "24/09/2026" in capturado["subject"]
+    corpo = (capturado["html"] + capturado["text"]).lower()
+    for proibido in ("15 dias", "trial", "teste grátis", "teste gratis"):
+        assert proibido not in corpo, f"copy promete {proibido!r}"
+    # Transacional: sem link nem cabeçalho de descadastro (o molde do
+    # `send_payment_failed_email`, não o dos e-mails de ciclo de vida).
+    assert "unsub" not in corpo
+    assert "descadastr" not in corpo
+    assert capturado["kw"] == {}
+    # Coorte 1: Grátis/sem plano — a frase da situação é essa mesma.
+    assert "grátis" in corpo
+
+    # Coorte 2: assinatura VIVA com cartão recusado além da carência. Ela entra
+    # na população (vai perder acesso), mas chamá-la de "plano Grátis" é falso
+    # e contradiz o e-mail de falha e o lembrete que ela já recebeu.
+    capturado.clear()
+    es.send_free_plan_sunset_email("quem@exemplo.com", corte,
+                                   cobranca_pendente=True)
+    corpo2 = (capturado["html"] + capturado["text"]).lower()
+    assert "grátis" not in corpo2 and "gratis" not in corpo2
+    assert "cartão" in corpo2 or "cartao" in corpo2
+    assert "24/09/2026" in corpo2


### PR DESCRIPTION
## O que este PR NÃO garante

**Quem usa o bot só pelo WhatsApp e nunca fez cadastro web não será avisado.** Sem linha em `auth_accounts`, essa população tem produto completo hoje (`has_app_access` devolve `True` incondicional com o v2 ligado, e o gate do bot só exige plano quando a linha existe), **perde acesso no corte**, e **não entra na varredura do aviso**, que é sobre `auth_accounts`. O comentário do próprio `core/handle_incoming.py` chama essa população de "a maioria aqui".

O canal existe — é o WhatsApp — e o que falta é template aprovado na Meta, que tem prazo. **Decisão explícita do dono: cortar sem aviso prévio.** A comunicação dela passa a ser a mensagem de bloqueio do bot, que vem no PR do corte e precisa fazer sentido para quem nunca viu o dashboard e não tem conta web (o requisito está registrado em `docs/dunning_estados_eventos.md` e na docstring de `tem_direito_hoje`).

A garantia real deste PR é: **ninguém com cadastro web e e-mail é cortado sem aviso.**

## Por que ele vem antes

O dono redefiniu a regra de acesso ao bot: fim do acesso gratuito, bloqueio por cancelamento no fim do período pago, e bloqueio por inadimplência após 7 dias de carência. **O corte vem no PR seguinte.**

A ordem não é preferência: o deploy sai da `main`, então **mergear o PR do corte é o evento de corte**. E `db/schema.py` carimbou `plan_selected_at` em **todas** as contas numa migration, então hoje a base Grátis legada inteira passa no gate e seria cortada de uma vez, sem aviso.

## A direção do OR é o desenho

> A autoridade é o **direito** (`plan` + `plan_expires_at`, que já são a projeção de `plan_grants`). O relógio de inadimplência **só CONCEDE** tempo extra; ele **nunca tira acesso**.

É isso que mantém as células **18, 29 e 30** de `docs/dunning_estados_eventos.md` fora do caminho do gate. Se ele lesse o status como autoridade, a célula 29 (a corrida check/write que grava `past_due` numa conta paga) **bloquearia um cliente pagante por um ciclo inteiro de cobrança**, porque a conta não se auto-cura até o próximo `invoice.paid`.

O predicado nasce aqui e o PR do corte o consome, em vez de cada um ter o seu: a janela de duplicação seria exatamente quando o aviso é disparado.

## O aviso é transacional, não marketing

`engagement_opt_out` fica **fora** do filtro. A coluna é **derivada** de `tip_email_opt_out AND insight_email_opt_out` (`db/reports.py`), a UI só expõe dicas e insights, e o bot promete a quem desliga que *"seus emails de segurança continuam normais"* (`core/intent_router.py`). Ninguém consentiu em abrir mão de aviso de fim de serviço.

Consequência assumida: o disparo alcança toda a base Grátis legada, inclusive quem pediu menos e-mail. Sem `List-Unsubscribe`, no molde dos outros transacionais.

## O script roda DUAS vezes, de propósito

Na abertura da janela de aviso e **na véspera do merge do PR do corte**. A deriva entre os dois dias não é alcançável por teste, e as direções não são simétricas:

- avisado e assinou antes do corte → um e-mail à toa, custo zero;
- **não avisado porque o plano venceu no meio → cortado sem nunca ter sido avisado.**

Daí a dedupe por `system_event_logs` (`recent_event_exists`), que torna a re-execução segura sem coluna nova.

## Os dois consertos que o ciclo achou

**A copy chamava de "Grátis" um cliente pagante com cartão recusado.** Uma conta com assinatura viva na Stripe em `past_due` e período vencido entra na população legitimamente, mas o texto era falso e contradizia o e-mail de falha e o lembrete que ela já recebeu. A copy forka por coorte, separada por `db.dunning.ciclo_de_atraso_aberto` lido fresco no envio, e a palavra "Grátis" saiu do assunto e do título.

**`--corte` não tinha validação nenhuma.** Aceitava `2020-01-01` e mandava para a base inteira "seu acesso termina em 01/01/2020". É a única entrada humana de um envio irreversível cuja dedupe de 90 dias impede corrigir re-executando. Ganhou faixa `[hoje, hoje+90]`, com a razão escrita: pegar ano digitado errado, não regra de produto.

## Testes

Duas colunas, mesma árvore, com stub de `ofxparse` (o pacote não constrói no sandbox):

| coluna | resultado |
|---|---|
| `main` | `6 failed, 6897 passed, 1 skipped, 4 xfailed` |
| este branch | `6 failed, 6907 passed, 1 skipped, 4 xfailed` |

**Mesmos seis nomes nas duas**, zero regressão. Três são artefato do sandbox (stub e gate pré-existente); os outros três são versão do Python — aqui 3.11, no CI 3.13, e o `RecursionError` acontece dentro do `json.loads` do setup do teste, não no código medido.

**Nove controles negativos declarados**, cada um remedido e nomeando **a conta que discrimina e a direção do erro**. O teste central é diferencial: compara a SQL contra o predicado Python conta a conta e exige que as partições sejam complementares.

Dois deles corrigem `docs/controles_declarados.md`, e valem além deste PR:

1. **"alargue em vez de apagar" não é seguro por si.** O arquivo prometia que alargando "não há expressão para quebrar sob nenhuma leitura". Há: alargar demais estoura `OverflowError` e a guarda morre nos **dois** ramos, inclusive ao montar a própria mensagem de recusa — a mesma leitura invertida, pela porta indicada como segura.
2. **Injetar pela constante de que o caso do teste é derivado não mede nada**, porque o caso se move junto com a injeção. É por isso que a guarda precisa de um caso **absoluto** além do derivado.

## Não verificado

- **Envio real** (Resend) e renderização em cliente de e-mail. Todo envio foi contra um fake.
- **Execução contra a base de produção**: o tamanho da população e a proporção entre as duas coortes só se medem lá. **Rode o dry-run em produção antes do `--apply`** — ele imprime a população e nenhum e-mail sai.
- **Entregabilidade**: é um disparo em massa sem `List-Unsubscribe`; se cair em Promoções, o aviso não chega e o corte pega gente que "foi avisada" só no nosso log. Nenhum teste alcança isso.
- **Stripe real**: a semântica de `incomplete` e o comportamento do smart retry vieram da documentação interna, não de medição.
- O **dry-run mede a população, não o envio**: ele não decifra PII nem consulta o coorte, então uma `PII_ENCRYPTION_KEY` errada é invisível no ensaio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF

---
_Generated by [Claude Code](https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF)_