### PR TITLE
A js-yaml deixa de ser carona do eslint — e o teste dela deixa de poder pular calado

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@eslint/js": "^9.39.5",
         "eslint": "^9.39.5",
         "globals": "^17.12.0",
+        "js-yaml": "^4.3.2",
         "playwright": "^1.56.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@eslint/js": "^9.39.5",
     "eslint": "^9.39.5",
     "globals": "^17.12.0",
+    "js-yaml": "^4.3.2",
     "playwright": "^1.56.0"
   }
 }

--- a/tests/frontend/npm_audit_report.test.mjs
+++ b/tests/frontend/npm_audit_report.test.mjs
@@ -226,14 +226,22 @@ nodeTest("stderr do npm não vira comando do Actions", () => {
 // requirements.txt, zero imports no repo, `Required-by:` vazio) — o teste
 // ficaria vermelho no CI.
 let YAML;
+let semYaml = false;
 try {
-  YAML = (await import("js-yaml")).default;
+  const mod = await import("js-yaml");
+  // A 4.x exporta `default`, a 5.x só nomeados. Sem o `?? mod` o `.default` vinha
+  // `undefined` com a 5.x, o catch nada via (o import SUCEDE) e o teste pulava em
+  // silêncio no CI — medido em 2026-09-10 com js-yaml 5.4.1.
+  YAML = mod.default ?? mod;
+  // O import suceder não prova a forma: sem esta checagem, uma 6.x que renomeie
+  // `load` cairia num TypeError longe daqui em vez de reprovar no CI (ou pular local).
+  if (typeof YAML.load !== "function") {
+    throw new Error(`js-yaml sem \`.load\` (exporta: ${Object.keys(mod).join(", ")})`);
+  }
 } catch (erro) {
   if (process.env.CI) throw erro;
+  semYaml = `js-yaml indisponível (${erro.message}): rode \`npm ci\` na raiz (no CI isto REPROVA, não pula)`;
 }
-const semYaml = YAML
-  ? false
-  : "js-yaml não está no node_modules: rode `npm ci` na raiz (no CI a ausência REPROVA, não pula)";
 
 nodeTest("o workflow chama o script nos dois locks, sem `|| echo`", { skip: semYaml }, () => {
   const doc = YAML.load(readFileSync(join(RAIZ, ".github/workflows/tests.yml"), "utf8"));

--- a/tests/frontend/npm_audit_report.test.mjs
+++ b/tests/frontend/npm_audit_report.test.mjs
@@ -219,12 +219,12 @@ nodeTest("stderr do npm não vira comando do Actions", () => {
 // dois steps podiam ser APAGADOS e o mesmo texto deixado num comentário do YAML
 // que o teste continuava verde — e o CI parava de auditar npm.
 //
-// ponytail: js-yaml é dependência TRANSITIVA do eslint (eslint > @eslint/eslintrc
-// > js-yaml), instalada pelo mesmo `npm ci` do job `frontend`, e está no
-// package-lock.json. Não é declarada nossa: se um bump do eslint a deixar cair, a
-// saída é declarar `js-yaml` em devDependencies. Não usei `yaml.safe_load` do
-// Python: PyYAML NÃO é premissa paga aqui (ausente do requirements.txt, zero
-// imports no repo, `Required-by:` vazio) — o teste ficaria vermelho no CI.
+// ponytail: js-yaml é declarada em devDependencies porque só o eslint a trazia
+// (eslint > @eslint/eslintrc > js-yaml) e o bump do eslint 10 (PR #344) faz o
+// `@eslint/eslintrc` sumir inteiro do lock — medido em 2026-09-10. Não usei
+// `yaml.safe_load` do Python: PyYAML NÃO é premissa paga aqui (ausente do
+// requirements.txt, zero imports no repo, `Required-by:` vazio) — o teste
+// ficaria vermelho no CI.
 let YAML;
 try {
   YAML = (await import("js-yaml")).default;


### PR DESCRIPTION
## Por que agora

O `tests/frontend/npm_audit_report.test.mjs`, que mergeou ontem no #326, faz `import("js-yaml")` para parsear o `.github/workflows/tests.yml` **de verdade** — foi o que substituiu a busca por substring, que passava verde com os dois steps apagados.

O pacote nunca foi declarado. Chegava de carona: `eslint > @eslint/eslintrc > js-yaml`.

O Dependabot abriu o #344 subindo o eslint para **10.9.1**, e ali o `@eslint/eslintrc` **some inteiro** do lock — com ele, a `js-yaml`. Como o guard do teste reprova de propósito quando `CI` está setado, em vez de pular em silêncio, mergear o #344 hoje deixaria o job `frontend` vermelho.

Medido com o lock real do #344 (`origin/dependabot/npm_and_yarn/eslint-d3820027f2`), eslint 10.9.1 instalado:

| | resultado |
|---|---|
| sem a declaração | `tests 10 / pass 9 / fail 1` — `ERR_MODULE_NOT_FOUND` derruba o arquivo inteiro |
| com a declaração | `tests 10 / pass 10 / fail 0` |

Não é simulação: é `npm ci` com o `package.json` e o lock daquele PR.

## O segundo commit, que nasceu do primeiro

O guard media **erro de import**, não **forma do módulo**. A `js-yaml` 5.x não tem default export: o import sucede, o `.default` vem `undefined`, o `catch` nada vê, o `throw` sob `CI` nunca dispara — e o teste **pula**, imprimindo `"não está no node_modules"` sobre um pacote que está instalado.

Verde, exit 0, e a fiação do workflow deixando de ser medida. É o **falso limpo** que este arquivo inteiro existe para matar, dentro do próprio arquivo. Medido com `js-yaml` 5.4.1: `skipped 1`, exit 0.

O buraco é anterior a este branch. Foi o primeiro commit que o tornou alcançável: como transitiva, a `js-yaml` estava presa em `^4.3.2` pelo eslintrc, e o Dependabot não bumpa transitiva por version-update. Como **direta**, o 4→5 é major e ganha PR próprio.

O `?? mod` sozinho fecharia só a diferença 4 × 5. A checagem de que `.load` é função fecha a categoria. O `throw` cai no `catch` que já existia — a política skip-local/throw-CI **não mudou**, só mudou o que a dispara.

Quatro estados medidos: 5.4.1 pulava e agora roda 10/10; 4.3.2 segue 10/10; sem o pacote continua reprovando sob `CI`; e um `js-yaml` falso que exporta só `parse` reprova nomeando o que exporta.

## Caret e não pin

As outras quatro entradas usam caret, e o CI instala com `npm ci`, que obedece o lock e ignora a faixa — pinar só esta seria inconsistência sem ganho onde importa. (`4.3.2` é a última 4.x publicada: `latest` é `5.4.1`, `v4-legacy` é `4.3.2`. O caret não tem para onde escorregar hoje.)

## Isto fecha a classe, não uma instância

Varredura de `import`/`from`/`require()`/`import()` em todos os 40 `.mjs`/`.cjs` e 15 `.js` rastreados. Especificadores bare que existem no repositório: `@eslint/js`, `eslint`, `eslint/config`, `globals`, `js-yaml`, `playwright`. Com esta linha, os seis estão declarados — **não sobra nenhum parasita transitivo**.

## Depois de mergear: o #344 precisa de rebase

`git merge-tree` de `HEAD` com o #344 sai limpo textualmente, mas a árvore resultante combina "o #344 apagou a entrada `node_modules/js-yaml`" com "nós declaramos a js-yaml na raiz" — e `npm ci` sai 1 com `Missing: js-yaml@4.3.2 from lock file`. Como `pull_request` roda em `refs/pull/N/merge`, o job `frontend` do #344 fica vermelho **antes** de chegar no teste.

**Comentar `@dependabot rebase` no #344 depois deste merge.** A declaração sobrevive ao rebase (o merge de 3 vias do `package.json` sai limpo, com `eslint ^10.9.1` e `js-yaml ^4.3.2` convivendo) e o lock regenerado fica correto. Que o bot rebaseie sozinho é hipótese — não testei o comportamento dele.

## Medido aqui

`npm run test:frontend` **419/419, fail 0, skipped 0**, igual à baseline. `npx eslint .` exit 0, `223 problems (0 errors)`, igual. `npm ci` aceita. A árvore resolvida do lock é **idêntica** (as 91 entradas de `packages` batem em versão, integrity e `dev`), então o job `audit` reporta igual.

## Não medido

O runner do GitHub Actions — tudo aqui é local, com `CI=true` simulando a variável. Local roda node 23.9.0; o CI usa node 22. E se alguém passar a usar `dump`/schemas da js-yaml aqui, a compatibilidade com a 5.x precisa ser remedida: o teste só usa `YAML.load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)