### PR TITLE
fix: NUL e surrogate apagavam a linha de auditoria, em silencio

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -156,7 +156,16 @@ async def log_auth_login_event(
     failure_reason: str | None = None,
 ):
     try:
-        normalized_email = (email or "").strip().lower() or None
+        # Mesmo mecanismo do `log_system_event` 50 linhas abaixo (issue #357):
+        # NUL/surrogate em QUALQUER campo `text` recusa o INSERT inteiro e o
+        # `except` no fim engole — a linha de auditoria some sem 500 e sem
+        # rastro. Aqui é pior: `auth_login_events` é a trilha de tentativa de
+        # login, e o vetor vivo é o `email` do corpo JSON de `/auth/login`
+        # (`LoginBody.email` é `str` puro, sem `EmailStr`).
+        # O e-mail é saneado ANTES de cifrar, senão a coluna clara e a
+        # `email_enc` guardariam valores diferentes — e `encrypt_pii` faz
+        # `.encode("utf-8")`, que estoura com surrogate solitário.
+        normalized_email = limpa_para_pg((email or "").strip().lower()) or None
         async with await db_connect() as conn:
             async with conn.cursor() as cur:
                 await cur.execute(
@@ -167,7 +176,8 @@ async def log_auth_login_event(
                     VALUES (%s, %s, %s, %s, %s, %s, %s)
                     """,
                     (user_id, normalized_email, encrypt_pii_optional(normalized_email),
-                     success, ip_address, user_agent, failure_reason),
+                     success, limpa_para_pg(ip_address), limpa_para_pg(user_agent),
+                     limpa_para_pg(failure_reason)),
                 )
             await conn.commit()
         # A09 — spike de falha de login: agenda a detecção FORA desta transação
@@ -201,7 +211,9 @@ async def log_system_event(
                     INSERT INTO system_event_logs (level, event_type, message, source, user_id, details)
                     VALUES (%s, %s, %s, %s, %s, %s)
                     """,
-                    (level, event_type, message[:1000], source, user_id, Jsonb(details or {})),
+                    (limpa_para_pg(level), limpa_para_pg(event_type),
+                     limpa_para_pg(message[:1000]), limpa_para_pg(source),
+                     user_id, Jsonb(limpa_para_pg(details or {}))),
                 )
             await conn.commit()
     except Exception as exc:

--- a/core/audit.py
+++ b/core/audit.py
@@ -20,6 +20,7 @@ from typing import Any
 from psycopg.types.json import Jsonb
 
 from core.crypto import PiiAccessContext, decrypt_pii_optional
+from core.pg_text import limpa_para_pg
 from db.connection import get_conn
 
 
@@ -150,7 +151,8 @@ def record_audit_event(
                     insert into audit_events (user_id, event, ip, user_agent, details)
                     values (%s, %s, %s, %s, %s)
                     """,
-                    (user_id, event, ip, user_agent, Jsonb(details or {})),
+                    (user_id, limpa_para_pg(event), limpa_para_pg(ip),
+                     limpa_para_pg(user_agent), Jsonb(limpa_para_pg(details or {}))),
                 )
             conn.commit()
     except Exception as exc:

--- a/core/observability.py
+++ b/core/observability.py
@@ -9,6 +9,7 @@ import psycopg
 from psycopg.types.json import Jsonb
 
 from config.env import load_app_env
+from core.pg_text import limpa_para_pg
 
 
 load_app_env()
@@ -233,10 +234,15 @@ def log_system_event_sync(
                     INSERT INTO system_event_logs (level, event_type, message, source, user_id, details)
                     VALUES (%s, %s, %s, %s, %s, %s)
                     """,
-                    (level, event_type, message[:1000], source, user_id, Jsonb(details or {})),
+                    (limpa_para_pg(level), limpa_para_pg(event_type),
+                     limpa_para_pg(message[:1000]), limpa_para_pg(source),
+                     user_id, Jsonb(limpa_para_pg(details or {}))),
                 )
             conn.commit()
     except Exception as exc:
+        # Desde o saneamento com `limpa_para_pg` na tupla acima, NUL e surrogate
+        # solitário não derrubam mais este INSERT (issue #357): das duas causas
+        # conhecidas de perda silenciosa aqui, sobra só a de baixo.
         # ponytail: teto conhecido — `user_id` fora de `users` derruba o INSERT
         # INTEIRO pela `system_event_logs_user_id_fkey` e o evento se PERDE; antes
         # deste PR ele ficava gravado com a coluna NULL. Caminho medido: token de

--- a/core/pg_text.py
+++ b/core/pg_text.py
@@ -34,6 +34,13 @@ def _limpa_str(s: str) -> str:
     # ponytail: um surrogate solitário vira 3 U+FFFD (são 3 bytes em
     # `surrogatepass`). Cosmético — o que importa é não casar com id real. A
     # alternativa char-a-char é O(n) em Python puro num corpo de 100 KB.
+    # Consequência para quem trunca ANTES de sanear (é o caso dos dois
+    # `message[:1000]` de `system_event_logs`, e a ordem é de propósito: saneia
+    # 1000 chars em vez do log inteiro): o valor gravado chega a 3× o corte —
+    # MEDIDO, `len(message) == 3000` com a entrada toda de surrogates. Cabe:
+    # `message` é `TEXT` e nenhum índice a cobre (`core/admin_dashboard.py:117`
+    # e os dois `CREATE INDEX` de `:137`/`:143`, que são `created_at` e
+    # `(level, event_type, created_at)`).
     return s.replace("\x00", _FFFD).encode("utf-8", "surrogatepass").decode("utf-8", "replace")
 
 
@@ -42,6 +49,22 @@ def limpa_para_pg(valor):
 
     `str` → string saneada. `dict`/`list` → percorridos **no lugar** (chave e
     valor) e devolvidos. Qualquer outra coisa volta como veio.
+
+    **"No lugar" é visível para quem chamou, e há chamador vivo que reusa o
+    objeto**: `adapters/whatsapp/wa_app.py:311` passa a lista `status["errors"]`
+    do payload por referência para o `details`, e `:325` enfileira o MESMO
+    payload — a lista chega na fila com U+FFFD onde estava o byte podre
+    (MEDIDO). Aceito: a troca é veneno→U+FFFD, ninguém compara byte a byte, e
+    um `deepcopy` custaria mais que o saneamento inteiro. Quem precisar do
+    original intacto copia ANTES de chamar.
+
+    ponytail: teto conhecido — **`tuple` NÃO é percorrida**, volta como veio, e
+    um NUL lá dentro derruba o INSERT do mesmo jeito:
+    `details={"campo": ("valor\\x00podre",)}` → 0 linhas gravadas; a mesma coisa
+    em `list` → 1 linha (medido). Não há chamador vivo com tupla no `details`
+    (grep), por isso está documentado e não implementado. Se aparecer um, o
+    conserto é tratar `tuple` no laço devolvendo `list` — `tuple` é imutável,
+    então não dá para sanear no lugar.
 
     Cada `dict`/`list` é visitado **uma vez**: estrutura cíclica termina em vez
     de rodar para sempre, e o mesmo objeto alcançável por N caminhos custa N,
@@ -81,6 +104,14 @@ def limpa_para_pg(valor):
                 # Não é explorável: o saneamento só introduz U+FFFD, e as chaves
                 # que este código lê são ASCII — `{"itemId":"REAL",
                 # "itemI\x00d":"FALSO"}` sai com `itemId` intacto.
+                # RESSALVA (#357): isso vale para o webhook da Pluggy, que LÊ
+                # chaves ASCII fixas. NÃO vale para o `details` forense de
+                # auditoria, que grava o dict INTEIRO e é lido por humano:
+                # `{"cpf�": "111.222.333-44", "cpf\x00": "ATACANTE"}` grava
+                # `{"cpf�": "ATACANTE"}` — o campo legítimo SOME e o valor
+                # do atacante é que fica. Registrado, não consertado: alternativa
+                # (sufixar chave em colisão) inventa chave que não veio de
+                # ninguém, e a linha existir saneada continua melhor que sumir.
                 no[_limpa_str(chave) if isinstance(chave, str) else chave] = (
                     _limpa_str(filho) if isinstance(filho, str) else filho
                 )

--- a/tests/test_log_event_nul.py
+++ b/tests/test_log_event_nul.py
@@ -1,0 +1,326 @@
+"""Issue #357 — a linha de auditoria que SOME em silêncio, sem 500 e sem rastro.
+
+Quinto mecanismo da família #310/#317, e o único que status nenhum mede: aqui o
+`except Exception` é **por projeto** (perder um log não pode derrubar a
+requisição), então NUL (`\\u0000`) ou surrogate solitário em qualquer parâmetro
+faz o INSERT ser recusado e a linha simplesmente não existir. Nos campos
+`text` quem levanta é o psycopg, antes do servidor (`PostgreSQL text fields
+cannot contain NUL`); no `details` (`jsonb`) é o servidor. Mesma consequência.
+
+São **três tabelas e quatro INSERTs**, não só o `details` de um deles:
+`system_event_logs` (duas cópias do mesmo INSERT — `core/observability.py` e
+`core/admin_dashboard.py`), `audit_events` (`core/audit.py`) e
+`auth_login_events` (`core/admin_dashboard.py:150`, o irmão direto que fica
+50 linhas ACIMA do primeiro conserto e que a varredura inicial não pegou).
+
+E são todos os campos `text`, não só o `details` — sanear só o `details`
+deixaria o `core/services/pix_drain.py:170-174` (event_type do webhook do
+Asaas no `message`) e o `_DashboardHandler` (`core/observability.py:59`:
+qualquer `logger.warning(f"…{entrada}")` do repo vira `message`) abertos.
+
+CONTROLE NEGATIVO do grupo: `limpa_para_pg` → identidade (`lambda v: v`) nos
+três módulos (`observability`, `audit`, `admin_dashboard`). Quem discrimina está NOMEADO: toda a matriz venenosa e o teste
+anônimo do `wa_verify` ficam vermelhos; os controles positivos continuam verdes.
+Injetar num caso hoje verde (acento, emoji) não discriminaria nada.
+
+CONTROLES POSITIVOS: `test_controle_positivo_details_limpo_grava_identico` e o
+irmão da auditoria LEEM O BANCO DE VOLTA e comparam o dict — sem eles, um
+saneador destrutivo (`_limpa_str` → `""`) passaria em toda a matriz. O
+`test_email_claro_e_email_enc_guardam_o_MESMO_valor` cobre o par
+clara/cifrada, que a matriz não vê: ela só lê a coluna clara.
+"""
+import asyncio
+import copy
+import uuid
+
+import pytest
+from starlette.requests import Request
+
+import adapters.whatsapp.wa_app as wa_app
+import core.admin_dashboard as admin_dashboard
+import core.audit as audit
+import core.observability as observability
+from _corpo_json_helpers import _admin_tables  # noqa: F401  (fixture autouse)
+from core.crypto import PiiAccessContext, decrypt_pii_optional
+from db.connection import get_conn
+
+NUL = "\x00"
+SURR_ALTO = "\ud800"
+SURR_BAIXO = "\udc00"
+VENENOS = [NUL, SURR_ALTO, SURR_BAIXO]
+VENENO_IDS = ["nul", "surrogate_alto", "surrogate_baixo"]
+FFFD = "�"
+
+CAMPOS = ["level", "event_type", "message", "source", "details"]
+CAMPOS_AUDIT = ["event", "ip", "user_agent", "details"]
+CAMPOS_LOGIN = ["email", "ip_address", "user_agent", "failure_reason"]
+
+
+def _marcador(prefixo: str) -> str:
+    """Chave limpa dentro do `details`: é por ela que a linha é reencontrada,
+    inclusive quando o campo envenenado é o próprio `event_type`."""
+    return f"{prefixo}-357-{uuid.uuid4()}"
+
+
+def _select(sql: str, param):
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, (param,))
+            return [dict(r) for r in cur.fetchall() or []]
+
+
+def _eventos(marcador: str):
+    return _select(
+        "select level, event_type, message, source, details from system_event_logs "
+        "where details->>'marcador' = %s",
+        marcador,
+    )
+
+
+def _auditorias(marcador: str):
+    return _select(
+        "select event, ip, user_agent, details from audit_events "
+        "where details->>'marcador' = %s",
+        marcador,
+    )
+
+
+def _campos(campo: str, veneno: str, marcador: str) -> dict:
+    """Envio limpo com UM campo envenenado. `AAA…BBB` cerca o veneno: prova que
+    o resto da string sobrevive e que o campo não virou vazio (vazio passaria
+    por vários asserts de graça)."""
+    p = f"AAA{veneno}BBB"
+    kw = {
+        "level": "warning",
+        "event_type": "log_event_nul_357",
+        "message": "mensagem de teste",
+        "source": "test_log_event_nul",
+        "details": {"marcador": marcador},
+    }
+    if campo == "details":
+        kw["details"]["veneno"] = p
+    else:
+        kw[campo] = p
+    return kw
+
+
+def _grava_sync(kw: dict) -> None:
+    observability.log_system_event_sync(
+        kw["level"], kw["event_type"], kw["message"],
+        source=kw["source"], details=kw["details"],
+    )
+
+
+def _grava_async(kw: dict) -> None:
+    asyncio.run(admin_dashboard.log_system_event(
+        kw["level"], kw["event_type"], kw["message"],
+        source=kw["source"], details=kw["details"],
+    ))
+
+
+GRAVADORES = [_grava_sync, _grava_async]
+GRAVADOR_IDS = ["sync_observability", "async_admin_dashboard"]
+
+
+def _assert_saneado(linhas, campo):
+    assert len(linhas) == 1, f"a linha de auditoria sumiu em silêncio: {linhas}"
+    valor = linhas[0]["details"]["veneno"] if campo == "details" else linhas[0][campo]
+    assert FFFD in valor, valor
+    assert valor.startswith("AAA") and valor.endswith("BBB"), valor
+
+
+# --------------------------------------------------------------------------
+# Matriz — 5 campos × 3 venenos × 2 funções (as duas cópias do mesmo INSERT)
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("grava", GRAVADORES, ids=GRAVADOR_IDS)
+@pytest.mark.parametrize("veneno", VENENOS, ids=VENENO_IDS)
+@pytest.mark.parametrize("campo", CAMPOS)
+def test_campo_venenoso_nao_perde_o_system_event_log(campo, veneno, grava):
+    marcador = _marcador(campo)
+    grava(_campos(campo, veneno, marcador))
+    _assert_saneado(_eventos(marcador), campo)
+
+
+@pytest.mark.parametrize("veneno", VENENOS, ids=VENENO_IDS)
+@pytest.mark.parametrize("campo", CAMPOS_AUDIT)
+def test_campo_venenoso_nao_perde_o_audit_event(campo, veneno):
+    """`audit_events` é a tabela LGPD (senha, MFA, Open Finance, IP novo) — e o
+    `user_agent` vem de header do cliente. Perder linha aqui é pior que em
+    `system_event_logs`, que é purgável por projeto."""
+    marcador = _marcador(campo)
+    p = f"AAA{veneno}BBB"
+    kw = {"event": "account_reset", "ip": "10.0.0.1", "user_agent": "curl/8",
+          "details": {"marcador": marcador}}
+    if campo == "details":
+        kw["details"]["veneno"] = p
+    else:
+        kw[campo] = p
+    audit.record_audit_event(
+        None, kw["event"], ip=kw["ip"], user_agent=kw["user_agent"],
+        details=kw["details"],
+    )
+    _assert_saneado(_auditorias(marcador), campo)
+
+
+# --------------------------------------------------------------------------
+# `auth_login_events` — o irmão direto, no MESMO arquivo, 50 linhas acima
+# --------------------------------------------------------------------------
+
+def _login_events(marcador: str):
+    return _select(
+        "select email, ip_address, user_agent, failure_reason from auth_login_events "
+        "where email like %s",
+        f"%{marcador}%",
+    )
+
+
+@pytest.mark.parametrize("veneno", VENENOS, ids=VENENO_IDS)
+@pytest.mark.parametrize("campo", CAMPOS_LOGIN)
+def test_campo_venenoso_nao_perde_o_auth_login_event(campo, veneno):
+    """Mesma forma, mesmo `except Exception` que engole — e o vetor aqui é o
+    mais exposto dos três: `email` vem do corpo JSON de `/auth/login`, rota
+    anônima, e `LoginBody.email` é `str` puro (sem `EmailStr`,
+    `frontend/finance_bot_websocket_custom.py:2671`), então o NUL chega cru.
+
+    Header morreu como vetor (medido: o h11 recusa NUL em header, e header é
+    latin-1, então surrogate solitário também não passa) — quem chega
+    envenenado é corpo JSON e query string. `ip_address`, `user_agent` e
+    `failure_reason` entram na matriz porque são campos `text` do MESMO
+    INSERT: um só derruba a linha inteira.
+
+    `success=True` de propósito: com `False`, `log_auth_login_event` agenda o
+    `schedule_auth_failure_spike_check` numa task de fundo que o `asyncio.run`
+    mata ao fechar o loop — ruído, e não é o que está sob teste.
+    """
+    marcador = _marcador(campo)
+    p = f"AAA{veneno}BBB"
+    # O marcador vive DENTRO do e-mail: `auth_login_events` não tem `details`,
+    # e o e-mail é o único campo presente em toda linha. Quando é ele o
+    # envenenado, o marcador (limpo) sobrevive ao saneamento e o `like` acha.
+    kw = {"email": f"{marcador}@x.com", "ip_address": "10.0.0.1",
+          "user_agent": "curl/8", "failure_reason": "invalid_credentials"}
+    kw[campo] = f"{p}-{marcador}@x.com" if campo == "email" else p
+    asyncio.run(admin_dashboard.log_auth_login_event(
+        kw["email"], True, ip_address=kw["ip_address"],
+        user_agent=kw["user_agent"], failure_reason=kw["failure_reason"],
+    ))
+
+    linhas = _login_events(marcador)
+    assert len(linhas) == 1, f"a linha de auth_login_events sumiu em silêncio: {linhas}"
+    valor = linhas[0][campo]
+    assert FFFD in valor, valor
+    # `.upper()` na volta porque o `email` é gravado com `.lower()`.
+    assert valor.upper().startswith("AAA") and "BBB" in valor.upper(), valor
+
+
+# --------------------------------------------------------------------------
+# Controles positivos — leem o banco de volta e comparam o VALOR
+# --------------------------------------------------------------------------
+
+LIMPO = {"texto": "pão à vista 😀", "n": [1, 2.5, None, True], "obj": {"k": "ok"}}
+MSG_LIMPA = "conta paga: R$ 1,50 à vista 😀"
+
+
+@pytest.mark.parametrize("grava", GRAVADORES, ids=GRAVADOR_IDS)
+def test_controle_positivo_details_limpo_grava_identico(grava):
+    """Um saneador destrutivo responderia igual em toda a matriz acima. Aqui o
+    `details` volta do jsonb IDÊNTICO — inclusive na ordem das chaves, que o
+    `pop`+reinsere do `limpa_para_pg` preserva — e o emoji continua um
+    caractere só."""
+    marcador = _marcador("positivo")
+    details = {"marcador": marcador, **copy.deepcopy(LIMPO)}
+    esperado = copy.deepcopy(details)
+    grava({"level": "info", "event_type": "log_event_nul_357",
+           "message": MSG_LIMPA, "source": "test_log_event_nul",
+           "details": details})
+
+    # A ordem das chaves NÃO se mede lendo de volta — o `jsonb` normaliza
+    # (comprimento, depois bytes), MEDIDO. O que dá para medir é o dict que o
+    # `limpa_para_pg` mutou NO LUGAR: o `pop`+reinsere preserva a ordem.
+    assert list(details) == list(esperado), details
+
+    linhas = _eventos(marcador)
+    assert len(linhas) == 1, linhas
+    assert linhas[0]["details"] == esperado, linhas[0]["details"]
+    assert linhas[0]["message"] == MSG_LIMPA, linhas[0]["message"]
+
+
+def test_controle_positivo_audit_limpo_grava_identico():
+    marcador = _marcador("positivo-audit")
+    details = {"marcador": marcador, **copy.deepcopy(LIMPO)}
+    esperado = copy.deepcopy(details)
+    audit.record_audit_event(
+        None, "account_reset", ip="10.0.0.1", user_agent="curl/8 à toa 😀",
+        details=details,
+    )
+
+    linhas = _auditorias(marcador)
+    assert len(linhas) == 1, linhas
+    assert linhas[0]["details"] == esperado, linhas[0]["details"]
+    assert linhas[0]["user_agent"] == "curl/8 à toa 😀", linhas[0]["user_agent"]
+
+
+@pytest.mark.parametrize("local", ["Fulano", f"fu{NUL}lano"], ids=["limpo", "nul"])
+def test_email_claro_e_email_enc_guardam_o_MESMO_valor(local):
+    """A coluna clara e a cifrada não podem divergir — a `email_enc` é o que o
+    `scripts/migrate_pii_to_encrypted.py` e o painel leem. Por isso o
+    saneamento é aplicado ao `normalized_email` ANTES de cifrar, e não dentro
+    da tupla do INSERT: sanear só a tupla gravaria o NUL dentro do blob.
+
+    O caso limpo é o controle positivo do par — sem ele, um saneador que
+    zerasse os dois lados passaria (`None == None`)."""
+    marcador = _marcador("enc")
+    # Espaco e maiuscula de proposito: o `.strip().lower()` roda ANTES do
+    # saneamento, e e o resultado dele que tem de ir para as DUAS colunas.
+    asyncio.run(admin_dashboard.log_auth_login_event(
+        f"  {local}-{marcador}@X.com  ", True))
+
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "select email, email_enc from auth_login_events where email like %s",
+                (f"%{marcador}%",),
+            )
+            linhas = [dict(r) for r in cur.fetchall() or []]
+    assert len(linhas) == 1, linhas
+    claro = decrypt_pii_optional(
+        linhas[0]["email_enc"],
+        ctx=PiiAccessContext(purpose="test", actor="pytest", subject_user_id=None),
+    )
+    assert linhas[0]["email"], linhas[0]
+    assert claro == linhas[0]["email"], (claro, linhas[0]["email"])
+    assert NUL not in claro, repr(claro)
+
+
+# --------------------------------------------------------------------------
+# Ponta a ponta ANÔNIMO — o caso da issue
+# --------------------------------------------------------------------------
+
+def test_wa_verify_anonimo_com_nul_no_mode_nao_perde_a_auditoria(monkeypatch):
+    """`GET /webhook` não pede autenticação, e `hub.mode` vai cru para o
+    `details`. Antes do saneamento, `hub.mode=sub%00` apagava o próprio registro
+    `whatsapp_webhook_verify_failed` (medido: 0 linhas).
+
+    O `log_system_event_sync` NÃO é mockado aqui — é o INSERT de verdade que
+    está sob teste. (Por isso o `_wa_verify` de `test_wa_webhook_signature.py`,
+    que mocka o log, não serve.)
+    """
+    monkeypatch.setattr(wa_app, "VERIFY_TOKEN", "verify-token-de-teste")
+    # O `mode` carrega um uuid: `event_type` é constante da rota e não escopa
+    # nada, então sem isto uma segunda passagem pela rota na mesma base daria
+    # `linhas = 2` e o assert quebraria por acúmulo, não por regressão.
+    sufixo = uuid.uuid4().hex
+    req = Request({"type": "http", "method": "GET", "headers": [],
+                   "query_string": f"hub.mode=sub%00{sufixo}&hub.verify_token=errado".encode()})
+
+    resp = asyncio.run(wa_app.wa_verify(req))
+
+    assert resp.status_code == 403
+    linhas = _select(
+        "select details->>'mode' as mode from system_event_logs "
+        "where event_type = 'whatsapp_webhook_verify_failed' "
+        "and details->>'mode' = %s",
+        f"sub{FFFD}{sufixo}",
+    )
+    assert len(linhas) == 1, "a linha whatsapp_webhook_verify_failed sumiu em silêncio"


### PR DESCRIPTION
Fecha #357.

## O bug

Os helpers de log engolem a exceção do Postgres num `except Exception` — **por projeto**, para que perder um log nunca derrube a requisição. O efeito colateral: entrada com **NUL** ou **surrogate solitário** faz o INSERT ser recusado e **a linha de auditoria não existir**. Sem erro, sem 500, sem rastro.

**O caso que dói é anônimo:** `GET /webhook` monta `details={"mode": mode}` com o `mode` vindo da query string. Quem manda `hub.mode=sub%00` **apaga o próprio registro** `whatsapp_webhook_verify_failed`. Perda de auditoria escolhida pelo atacante, em rota sem autenticação.

## A enumeração derrubou a premissa da issue duas vezes

**Não era só o `details`.** Os cinco campos somem igual — medido contra o banco:

| parâmetro | coluna | NUL | surrogate |
|---|---|---|---|
| `level` | `TEXT NOT NULL` | 0 | 0 |
| `event_type` | `TEXT NOT NULL` | 0 | 0 |
| `message[:1000]` | `TEXT NOT NULL` | 0 | 0 |
| `source` | `TEXT` | 0 | 0 |
| `details` | `JSONB` | 0 | 0 |

Nos campos `text` quem levanta é o **psycopg**, antes do servidor; no `details` é o servidor. Mesma consequência. Vetores externos confirmados: `core/services/pix_drain.py:170-174` põe dado do webhook do Asaas no `message` **e** no `details`; e `core/observability.py:59` faz `message = self.format(record)`, então **qualquer `logger.warning(f"...{entrada}")` do repo alcança o `message`** — é o caminho mais largo.

**E não era um helper: são quatro INSERTs com a mesma forma.** Dois são cópias um do outro (`core/observability.py` sync e `core/admin_dashboard.py` async), um está na tabela **LGPD** (`core/audit.py` → `audit_events`, onde perder linha é pior porque não é purgável por projeto), e um está **a cinquenta linhas do primeiro conserto** (`log_auth_login_event` → `auth_login_events`) — a primeira varredura passou por cima dele, e foi o ataque que pegou.

## As duas ordens que importam, ambas medidas

- **`message` saneado DEPOIS do `[:1000]`**: 1,0 µs contra **79,5 µs** numa message de 117 KB (traceback via `format(record)`).
- **E-mail saneado ANTES de cifrar**: `encrypt_pii` faz `plain.encode("utf-8")`, então sanear só a tupla gravaria o NUL dentro do blob `email_enc` e as duas colunas **divergiriam** — além de o surrogate estourar ali antes do psycopg, por uma segunda causa que sanear a tupla não remove.

## Sem pré-checagem, e o custo

A saída "checa se está sujo antes de sanear" foi medida e **descartada**: é **2× a 43× mais cara** que sanear direto (percorre a mesma estrutura sem o atalho em C) e seria código novo. O custo real do saneamento é **6% do INSERT no pior caso** (200 itens aninhados) e **0,03% no típico** — contra os 2100–3700 µs do `connect()+INSERT` já documentados no próprio arquivo.

## O que foi medido

- **60 testes novos** (`tests/test_log_event_nul.py`) — `observability` não tinha nenhum.
- **Provas negativas por módulo**, cada uma com os vermelhos nomeados: `observability` → 16, `admin_dashboard` → 28 (dois INSERTs), `audit` → 12.
- **Controles positivos que discriminam**: dado limpo com acento, emoji e par bem-formado é **lido de volta idêntico** do banco (comparado contra um deepcopy pré-chamada, não contado). Mutantes de corrupção de valor e destrutivo (`return ""`) matam **os 60**.
- **Um mutante que saneia só o `details`** (o escopo original da issue) deixa **12 vermelhos** — é o que prova que a ampliação está medida, e não é escopo inflado.
- **Ponta a ponta anônimo**: `wa_verify` com `hub.mode=sub%00`, **sem mockar** o log. Hoje: 0 linhas. Depois: 1 linha, com `U+FFFD` no lugar do byte podre.
- Suíte: **6952 passed, 4 xfailed, 0 failed**.

## Tetos documentados, não consertados

- **Tupla dentro de `details` continua perdendo a linha** — `limpa_para_pg` trata str/dict/list. Medido: tupla → 0 linhas, a mesma coisa em lista → 1. Sem chamador vivo hoje (grep); latente.
- **Colisão de chave saneada perde campo legítimo, e o valor do atacante vence**: `{"cpf<FFFD>": "111.222.333-44", "cpf<NUL>": "ATACANTE"}` grava `{"cpf<FFFD>": "ATACANTE"}`. O `ponytail:` do #320 diz que não é explorável porque as chaves lidas são ASCII — **isso vale para o webhook da Pluggy, não para o `details` forense**. A ressalva está registrada no código.
- **`message` pode chegar a 3000 chars** apesar do `[:1000]` (1 surrogate vira 3 `U+FFFD`). A coluna é `TEXT` e nenhum dos dois índices a cobre — conferido no DDL, não na afirmação.
- **`limpa_para_pg` muta no lugar**, e há um chamador que passa lista por referência (`adapters/whatsapp/wa_app.py:311`, cujo payload é enfileirado em `:325`). O dano é a substituição do byte podre por `U+FFFD`; `deepcopy` custaria mais que o saneamento inteiro. Está escrito no helper para o próximo chamador.

## Fora de escopo

- **`_check_persistent_rate_limit` (`frontend/finance_bot_websocket_custom.py:2300`) não tem `try/except` nenhum**, e 4 rotas **anônimas** dão **500** com NUL no corpo. Provado ponta a ponta: `POST /auth/login` → HTTP 500, `auth_login_events = 0`. **Mecanismo diferente** (500, não perda silenciosa) e pior nos três eixos. Pré-existente; issue própria.
- `core/services/security_alerts.py:138` foi **rastreado e descartado**: o `ip_address` vem sempre de `get_remote_address(request)` nos 8 call sites, que devolve o peer do socket ou o `X-Forwarded-For` — e h11 recusa NUL em linha de header, além de header ser latin-1 (nunca produz surrogate). Ressalva honesta: essa guarda é do **parser**, não do nosso código; trocar de parser HTTP invalida o rastreio.
- `log_admin_startup_warnings` (literais fixos), o teto de FK do `ponytail:` existente, e o `QueueHandler`.

## Não verificado

Nada foi exercitado em produção nem no aparelho. O efeito visível — `U+FFFD` no painel admin no lugar do byte podre — só aparece depois do deploy. Backend puro: nenhum arquivo de frontend tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
