### PR TITLE
O xmldom do app sai da faixa vulnerável, sem tocar no package.json

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -275,9 +275,9 @@
       "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Três linhas do `mobile/package-lock.json`: `@xmldom/xmldom` de **0.9.10** para **0.9.12**.

## Por que dá para resolver só no lock

Quem puxa é o `plist`, dentro do `@capacitor/cli`, declarando `^0.9.10`. Caret em `0.x` trava o **minor**, então só admite `0.9.z` — e a 0.9.12 existe (publicada 2026-08-21). O `mobile/package.json` nunca declarou o `@xmldom/xmldom`; não há nada a mudar lá.

`npm install --package-lock-only` **não** resolve: dá diff de zero linhas, porque a 0.9.10 já satisfaz o `^0.9.10`. Só o `npm update --package-lock-only @xmldom/xmldom` mexe.

## Por que 0.9.12 e não 0.9.11

Não é margem de segurança — é obrigatório. A advisory `GHSA-jxjr-3g7g-3944` tem faixa **`= 0.9.11`**: aquela versão *introduziu* um buraco novo. Consultando os advisories do GitHub um a um (`gh api /advisories --paginate`, não só o `npm audit`): em 0.9.11 sobram **11**; em 0.9.12, **zero**. Todas as 13 têm `first_patched_version` ≤ 0.9.12; nenhuma exige 0.9.13 ou 1.x.

## O que foi conferido, e não só aceito

**O integrity.** O lock *afirma* um hash, e hash errado quebra o `npm ci` de quem instalar — é fronteira de confiança, não formalidade. Tarball baixado e digerido à mão:

```
openssl dgst -sha512 -binary xmldom-0.9.12.tgz | openssl base64 -A
5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==
```

Igual ao lock e ao `dist.integrity` do registry.

**Que nada mais mudou.** Dump das entradas de `packages` por versão, integrity, `resolved`, `dev` e deps: **95 antes, 95 depois**, uma linha de diferença — a do xmldom. `plist` continua 3.1.1, `dev: true` preservado, chaves de topo idênticas. Um único pai no lock inteiro, sem range disjunto, sem cópia aninhada.

**Que `npm ci` funciona**: `added 94 packages, audited 95, found 0 vulnerabilities`, uma só cópia do xmldom no disco.

**Controle negativo**: revertendo o lock, o audit volta a acusar a HIGH e o gate do CI volta a emitir o `::warning`. A medição discrimina.

## Sobre a contagem do `npm audit` — de propósito, ela não está fixada aqui

Ela oscilou dentro de uma única sessão: `4 vulnerabilities (3 moderate, 1 high)` de manhã, `1 high` à tarde em três rodadas seguidas na mesma árvore. O advisory database é vivo e a atribuição aos pais transitivos muda com ele. Fixar o número aqui seria criar mais um que apodrece sem commit nenhum. O invariante é o outro lado: **depois disto, `found 0 vulnerabilities`.**

## O risco real é menor do que "13 advisories" sugere

Lendo o código instalado: `plist/lib/parse.js` faz `new DOMParser().parseFromString(...)` **sem `errorHandler`**, e `plist/dist/plist-build.js` constrói com **`xmlbuilder`, não com o xmldom**. Ou seja, o `plist` nunca chama `serializeToString` nem passa `requireWellFormed: true` — as ~8 advisories de bypass de serialização **não eram alcançáveis** pelo `cap sync ios`. O que era alcançável são as de parse: ReDoS de processing instruction, tempo e memória quadráticos, raw-text, injeção de fragmento.

## O que este PR NÃO prova

**Que o app ainda monta.** Nada neste repositório testa o build do iOS: `mobile/package.json` só tem `cap sync ios` e `cap open ios`, manuais, com Xcode. Não há job de build, `eas`, nem `npm ci` de `mobile/` no CI. O único consumidor automatizado do lock é o `node scripts/npm_audit_report.mjs mobile` do job `audit`, que é informativo.

O que **foi** provado como equivalente funcional: round-trip do `mobile/ios/App/App/Info.plist` **real** via `plist`, nas duas versões — `sha` do reconstruído idêntico, mesmas 18 chaves, `reparse_equal: true` — mais 24 casos adversariais de serialização e 8 de parse hostil, saída byte a byte igual. A **única** diferença observável em 32 sondas foi o texto de uma mensagem de erro (`"Error constructing the DOM: "` prefixado), que só morde quem casa string nela. Nada neste repositório executa xmldom.

Roteiro na máquina do dono, e o que é sinal de erro:

```bash
cd mobile && npm ci && npx cap sync ios && git status --short ios
```

Deu errado se o `cap sync` lançar erro de parse/serialização, **ou** se o `Info.plist` sair reescrito diferente. Hipótese não provada, para não assustar à toa: o CHANGELOG diz que a 0.9.12 passou a **reportar** um end tag malformado que a 0.9.10 aceitava calada — como o `plist` usa o handler padrão, o pior caso plausível é uma linha nova de ruído no stderr, não uma falha.

## Duas coisas fora do escopo, que este PR expõe e não conserta

**Se o lock regredir amanhã, nada fica vermelho.** O `scripts/npm_audit_report.mjs` sempre sai 0 (é informativo por decisão do dono) e o job `audit` é `continue-on-error: true`. Não escrevi teste aqui porque o escopo está travado em um arquivo — não porque estamos cobertos.

**O Dependabot não é a rede que o gate promete.** O `npm_audit_report.mjs` imprime "o Dependabot abre os PRs de correcao". Para esta classe, é falso: `automated-security-fixes` está `{"enabled": false}` e `dependabot/alerts` responde `403 "Dependabot alerts are disabled"`; e o bloco `/mobile` do `dependabot.yml` é `applies-to: version-updates`, que só mexe em dependência **direta declarada** — e esta é transitiva. Foi por isso que a HIGH ficou parada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)