### PR TITLE
fix: cliente que desconecta no meio do envio virava 500 com traceback

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -19,6 +19,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 from pydantic import BaseModel
 from slowapi.util import get_remote_address
+from starlette.requests import ClientDisconnect
 
 from config.env import load_app_env
 
@@ -1556,6 +1557,15 @@ async def admin_error_logging_middleware(request: Request, call_next):
         return await call_next(request)
     except HTTPException:
         raise
+    except ClientDisconnect:
+        # Cliente sumiu antes de mandar o corpo (rede móvel caindo no meio de um
+        # upload). Não é erro do servidor: 499 e NENHUM evento — o uvicorn já
+        # descartou a resposta (`if self.disconnected: return` em
+        # RequestResponseCycle.send), e gravar poluiria o feed de erro do painel
+        # com um evento por cliente que some. O `except` carrega 100% do
+        # diagnóstico: a mensagem é sempre a mesma constante.
+        _admin_log.info("client disconnect: %s %s", request.method, request.url.path)
+        return Response(status_code=499)
     except Exception as exc:
         import traceback
         tb_str = traceback.format_exc()

--- a/tests/test_error_pages.py
+++ b/tests/test_error_pages.py
@@ -5,6 +5,8 @@ Os asserts de `Accept: text/html` são a medição (falham sem a correção); os
 """
 
 import asyncio
+import hashlib
+import hmac
 import html as html_lib
 import json
 import logging
@@ -16,10 +18,14 @@ import pytest
 from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 
+import adapters.whatsapp.wa_app as wa_app
 import core.admin_dashboard as admin_dashboard
 import db
 import frontend.finance_bot_websocket_custom as dashboard
 import frontend.routes.shared as shared
+# PAYLOAD_META e SEGREDO vêm de lá para não virar segunda fonte da mesma
+# constante (CLAUDE.md §0.7); o helper `_wa_webhook` de lá fica intocado.
+from test_wa_webhook_signature import PAYLOAD_META, SEGREDO
 
 HTML = {"Accept": "text/html,application/xhtml+xml"}
 
@@ -200,6 +206,97 @@ def test_500_html_na_navegacao_json_na_api_e_log_preservado(monkeypatch, boom_ro
     assert "accept" in _vary_values(response)
     assert len(logged) == 1
     assert logged[0][0][1] == "http_unhandled_exception"
+
+
+# ─── 499 (cliente some antes de mandar o corpo) ──────────────────────────────
+# 9 rotas leem corpo cru e 5 ficam fora de qualquer try — o upload de OFX
+# autenticado (celular com sinal ruim) é o mais provável em produção, o webhook
+# da Meta é só um deles. O ponto comum das 5 é este middleware, então o grupo
+# mede aqui e não junto de uma rota específica. Antes: 500 + 1
+# `http_unhandled_exception` por cliente que some, poluindo o feed de erro do
+# painel com uma mensagem que é sempre a mesma constante.
+
+
+@pytest.fixture
+def rotas_de_corpo():
+    """Três rotas efêmeras no app REAL (mesmo middleware do boom_route): perder
+    o cliente lendo o corpo, quebrar de verdade, e responder 200."""
+    base = f"/__cd-{uuid.uuid4().hex}"
+
+    @dashboard.app.post(base + "/disconnect")
+    async def _disconnect(request: Request):
+        async def _receive():
+            return {"type": "http.disconnect"}
+
+        # ClientDisconnect vem do ponto REAL onde starlette a levanta
+        # (Request.stream(), o único do pacote), não de um `raise` sintético.
+        await Request(request.scope, _receive).body()
+        return {"inalcancavel": True}
+
+    @dashboard.app.post(base + "/bug")
+    async def _bug():
+        raise ValueError("bug de verdade")
+
+    @dashboard.app.post(base + "/ok")
+    async def _ok():
+        return {"ok": True}
+
+    yield base
+    dashboard.app.router.routes = [
+        r for r in dashboard.app.router.routes
+        if not (getattr(r, "path", "") or "").startswith(base)
+    ]
+
+
+@pytest.mark.parametrize("sufixo, status, eventos", [
+    pytest.param("/disconnect", 499, 0, id="cliente_sumiu"),
+    pytest.param("/bug", 500, 1, id="bug_de_verdade"),
+    pytest.param("/ok", 200, 0, id="rota_normal"),
+])
+def test_cliente_que_some_da_499_sem_evento_e_bug_de_verdade_segue_500(
+    monkeypatch, rotas_de_corpo, sufixo, status, eventos
+):
+    """Prova negativa: apagando o `except ClientDisconnect` de
+    admin_error_logging_middleware, o caso `cliente_sumiu` (verde hoje) fica
+    vermelho em status E em eventos. Os outros dois são o controle positivo — é
+    `bug_de_verdade` que mata o mutante "engole tudo e devolve 499 mudo", que
+    seria pior que o ruído que estamos removendo."""
+    logged = []
+
+    async def _spy(*args, **kwargs):
+        logged.append((args, kwargs))
+
+    monkeypatch.setattr(admin_dashboard, "log_system_event", _spy)
+
+    client = TestClient(dashboard.app, raise_server_exceptions=False)
+    response = client.post(rotas_de_corpo + sufixo, headers=_csrf_headers(client))
+
+    assert response.status_code == status
+    assert len(logged) == eventos
+
+
+def test_payload_da_meta_continua_enfileirado_pelo_app(monkeypatch):
+    """Controle positivo ponta a ponta: o 499 não pode ter custado o caminho
+    legítimo de quem mais lê corpo cru neste app. Vai pelo POST /webhook real,
+    com HMAC calculado de verdade e passando pelo MESMO middleware — o helper
+    `_wa_webhook` do outro arquivo chama o handler direto e pularia o
+    middleware, que é justamente o que mudou."""
+    corpo = json.dumps(PAYLOAD_META).encode()
+    monkeypatch.setattr(wa_app, "APP_SECRET", SEGREDO)
+    monkeypatch.setattr(wa_app, "log_system_event_sync", lambda *a, **k: None)
+    fila = asyncio.Queue(maxsize=500)
+    monkeypatch.setattr(wa_app, "_queue", fila)
+    digest = hmac.new(SEGREDO.encode(), corpo, hashlib.sha256).hexdigest()
+
+    response = TestClient(dashboard.app, raise_server_exceptions=False).post(
+        "/webhook",
+        content=corpo,
+        headers={"X-Hub-Signature-256": f"sha256={digest}"},
+    )
+
+    assert response.status_code == 200
+    assert fila.qsize() == 1
+    assert fila.get_nowait() == PAYLOAD_META
 
 
 # ─── 405 (Allow do exc.headers tem que sobreviver ao ramo HTML) ──────────────


### PR DESCRIPTION
Fecha #356.

## O bug

`ClientDisconnect` escapava de todo handler que lê o corpo cru do `Request`, virando **500 com traceback** e — pior — **um INSERT em `system_event_logs` com `level="error"` por cliente que some**, poluindo o feed de erro do painel admin.

Medido na `main`:

```
status devolvido pelo middleware: 500
eventos gravados em system_event_logs: 1
  level      = error
  event_type = http_unhandled_exception
  message    = 'ClientDisconnect'
  traceback  = 406 chars
```

## A issue apontava 1 site. São 5, e o apontado é o MENOS provável

| site | quem |
|---|---|
| `adapters/whatsapp/wa_app.py:247` | webhook da Meta (o da issue) |
| `frontend/finance_bot_websocket_custom.py:4849` | webhook do Stripe |
| `frontend/routes/open_finance.py:1648` | webhook da Pluggy |
| `frontend/finance_bot_websocket_custom.py:6803` | upload de OFX — **não coberto**, morre antes (ver abaixo) |
| `frontend/finance_bot_websocket_custom.py:2272` | dev-only (`ENABLE_DEV_ENDPOINTS`) |

**Correção à afirmação original deste PR:** eu havia escrito que o `:6803` é o cenário mais provável em produção. **Está errado, e a revisão mediu:** ele usa `request.form()`, que levanta `AssertionError` ("The `python-multipart` library must be installed") **antes** de tocar no stream — `python-multipart` não está no `requirements.txt`, não é dependência do FastAPI e não é instalado pelo CI. Ou seja, `ClientDisconnect` nunca nasce ali, e o conserto cobre **4 sites, não 5**. (Que essa rota esteja quebrada por outro motivo é achado separado, com issue própria.)

Os três webhooks leem os bytes crus porque **precisam**: é o corpo exato que a assinatura HMAC cobre.

**Rota com body tipado já é imune**: o `fastapi/routing.py` envolve o próprio `await request.body()` num `except Exception → HTTPException(400)`. A exposição é exatamente quem lê o corpo cru na mão.

## Por que o conserto é global, e por que isso é seguro

`grep -rn "ClientDisconnect" --include="*.py"` = **0 ocorrências** no repo antes deste PR. Os cinco sites leem **dentro** do `try` do `admin_error_logging_middleware`, registrado para todas as rotas do app — então um `except` lá cobre os cinco, e cinco `try` locais seriam corrigir a instância e deixar a classe aberta (§2/§4).

O raio de alcance é estreito apesar do lugar ser global: o starlette levanta `ClientDisconnect` num **único** ponto (`Request.stream()`, no `http.disconnect`), verificado nos 3 sites do pacote. Não pode disparar por outro motivo. E nenhum dos 3 middlewares externos (`security_headers`, `csrf`, `CORSMiddleware`) lê corpo — a cobertura é dos cinco, não de um subconjunto.

## 499, e não gravar

O uvicorn descarta a resposta antes de escrever status, headers e access log (`RequestResponseCycle.send`: `if self.disconnected: return`), então o status só existe para métrica. `499 in STATUS_PHRASES` → `True`.

**E não há diagnóstico a perder.** Diferente do #327 — onde a classe da exceção variava entre quatro e por isso o `details` guarda `type(e).__name__` — aqui `message` e `details.exc_type` são a **constante** `"ClientDisconnect"` em toda linha. O `except` já carrega 100% da informação.

## `OSError` fica de fora, de propósito

A evidência original vinha de um `receive` sintético. Sob uvicorn a desconexão chega como mensagem ASGI `http.disconnect` → `ClientDisconnect`, nunca como `OSError`. Um `except OSError` global engoliria bug de verdade — arquivo ausente, socket para Asaas/Meta/Pluggy — num 499 mudo e sem evento. Regressão pior que o ruído que se está consertando.

## O que foi medido

As quatro colunas, nas duas árvores:

| caso | sem patch | com patch |
|---|---|---|
| `ClientDisconnect` | `status=500 eventos=1` | **`status=499 eventos=0`** |
| `ValueError` (bug de verdade) | `status=500 eventos=1` | inalterado |
| rota normal | `status=200 eventos=0` | inalterado |
| payload real da Meta (HMAC de verdade, pelo middleware) | `status=200 fila=1` | inalterado |

**Prova negativa, os dois sentidos, por nome:**

| árvore | `[cliente_sumiu]` | `[bug_de_verdade]` |
|---|---|---|
| `except ClientDisconnect` apagado | **FAILED** | PASSED |
| mutante `except Exception` (engole tudo → 499) | PASSED | **FAILED** |
| árvore final | PASSED | PASSED |

O positivo `bug_de_verdade` é **load-bearing**: mata o mutante que devolveria 499 mudo para tudo — que seria pior que o bug.

O teste levanta a exceção no **ponto real** (`Request(scope, receive).body()` com `receive` devolvendo `http.disconnect`), não com um `raise` sintético. Ele foi para o grupo do middleware em `tests/test_error_pages.py`, ao lado do `boom_route`, porque o conserto deixou de ser do `wa_app` — o helper `_wa_webhook` ficou intocado.

Hierarquia confirmada nesta árvore (py 3.13.2 / starlette 0.41.3): `ClientDisconnect` é `Exception`; `CancelledError`, `KeyboardInterrupt` e `SystemExit` **não** são, então o `except` novo não os alcança.

Suíte: **6918 passed, 4 xfailed, 0 failed**, comparada por nome contra `91ed9b1` (6914/0). Os +4 são os testes novos.

## Não verificado

Que o uvicorn de verdade descarta a resposta 499 foi **lido no fonte** de `h11_impl.py`, não exercitado com socket real — o `TestClient` entrega o 499 porque não é uvicorn. E a desconexão real (celular perdendo sinal no upload de OFX) só se prova no deploy.

Backend puro: middleware + teste de pytest, nenhum arquivo de frontend tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

