### PR TITLE
A recusa do CPF ficava atrás do modal e o cliente não lia

### DIFF
--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -248,6 +248,7 @@ function pixFormulario(plano, ctx) {
     e.preventDefault();
     const d = pixDigitos(campo.value);
     if (!pixFormaOk(d)) {
+      showToast("");   // o único desfecho que NÃO passa pelo `pixEnviar` (limpeza lá)
       erro.textContent = "Informe os 11 dígitos do CPF ou os 14 do CNPJ.";
       campo.focus();
       return;
@@ -265,6 +266,9 @@ function pixFormulario(plano, ctx) {
 async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, botao) {
   if (botao.disabled) return;   // Enter repetido não vira duas cobranças
   botao.disabled = true;
+  // Clicou em enviar: a mensagem anterior deixou de valer, DÊ NO QUE DER — QR,
+  // migração, "já pago", inline do 400 ou toast novo. Um ponto só, em vez de um por desfecho.
+  showToast("");
   const rotulo = botao.textContent;
   pixRotular(botao, "ph-clock", "Gerando o código…");
   const corpo = { plan: plano, interval: "annual", cpf_cnpj: documento };
@@ -316,6 +320,9 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     const pago = det.error === "pix_future_purchase_conflict"
       && /^\d{4}-\d{2}-\d{2}/.exec(det.covered_until || "");
     if (r.status === 409 && pago) return pixModalJaPago(pago[0], ctx);
+    // 400 é erro DO CAMPO: vai para o `#pix-doc-erro` (alvo do `aria-describedby`), DENTRO do modal, e não para o toast. O `disabled` largou o foco no <body>: volta pro campo.
+    const alvo = r.status === 400 && det.message && document.getElementById("pix-doc-erro");
+    if (alvo) { alvo.textContent = det.message; pixDoc?.focus(); return; }
     if (!r.ok) return showToast(det.message || "Não consegui gerar o código Pix agora.", "err");
     pixApagarDoc();          // o QR vai entrar: o documento sai da tela antes
     pixModalQr(d, plano, ctx);

--- a/frontend/precos.html
+++ b/frontend/precos.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="/phosphor.css?v=1" />
 <link rel="stylesheet" href="/site.css?v=4" />
 <style>
-  #toast { position: fixed; bottom: 26px; left: 50%; transform: translateX(-50%) translateY(20px); background: rgba(23,23,26,.96); border: 1px solid rgba(255,45,142,.3); color: #fff; padding: 12px 20px; border-radius: 12px; font-size: .88rem; font-weight: 600; opacity: 0; pointer-events: none; transition: all .25s; z-index: 999; backdrop-filter: blur(12px); }
+  #toast { position: fixed; bottom: 26px; left: 50%; transform: translateX(-50%) translateY(20px); background: rgba(23,23,26,.96); border: 1px solid rgba(255,45,142,.3); color: #fff; padding: 12px 20px; border-radius: 12px; font-size: .88rem; font-weight: 600; opacity: 0; pointer-events: none; transition: all .25s; z-index: 1000; backdrop-filter: blur(12px); }
   #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
   #toast.err { border-color: rgba(255,45,45,.5); }
   .btn.loading { opacity: .7; pointer-events: none; }
@@ -676,7 +676,11 @@ function showToast(msg, type) {
   if (!el) return;
   el.textContent = msg;
   el.classList.toggle("err", type === "err");
-  el.classList.add("show");
+  // `toggle` e não `add`: showToast("") APAGA o toast, e é assim que o modal do
+  // Pix zera a mensagem anterior ao enviar. O texto já saiu na linha de cima de
+  // propósito — `remove("show")` sozinho só zera a opacidade, e o `role="status"`
+  // seguia ditando a frase velha ao leitor de tela (medido com ariaSnapshot).
+  el.classList.toggle("show", !!msg);
   clearTimeout(showToast._t);
   showToast._t = setTimeout(() => el.classList.remove("show"), 3800);
 }

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -1180,7 +1180,7 @@ test("PT17: fechar durante o download do corpo não deixa QR nem poll órfãos",
 });
 
 /**
- * PT18 — A MENSAGEM DA RECUSA CHEGA À TELA, NOS DOIS FORMATOS DE `detail`.
+ * PT18 — A RECUSA CHEGA À TELA, NO LUGAR ONDE ELA SE LÊ.
  *
  * O `detail` do FastAPI é STRING quando o `raise` passa texto (o 400 do CPF
  * inválido) e OBJETO nos 409. O ramo do `!r.ok` lia só `det.message`: com
@@ -1188,21 +1188,251 @@ test("PT17: fechar durante o download do corpo não deixa QR nem poll órfãos",
  * consegui gerar o código Pix agora" — que sugere problema nosso, quando o
  * conserto é digitar o documento certo.
  *
- * *Negativo (rodado): volte o `!r.ok` para `det.message || …` → PT18a vermelho.*
- * O PT18b é o par que uma correção do tipo `String(d.detail)` destruiria: o
- * objeto tem de continuar sendo lido pela `message`.
+ * Ler a mensagem certa não bastava: ela ia toda para o `#toast`, que fica ATRÁS
+ * do véu do modal. Quem digita 11 dígitos com DV errado (o caminho comum desde
+ * que o servidor passou a conferir o mod-11) via a caixa não fazer nada. Agora
+ * o 400 é erro DO CAMPO e vai para o `#pix-doc-erro` — o alvo do
+ * `aria-describedby` do `<input>`, dentro do modal —, e o resto (409, 503, 429,
+ * 403, 401), que NÃO é erro do documento, continua no toast, que passou a ficar
+ * por cima do véu.
+ *
+ * E a mensagem velha morre num PONTO SÓ: no início do envio. A enumeração
+ * (desfecho do `pixEnviar` × toast) não achou um único desfecho em que o toast
+ * anterior devesse sobreviver — o que trocasse o corpo do modal (QR, migração,
+ * inline) deixava a frase velha por cima do véu, agora perfeitamente legível
+ * com o z-index 1000. `showToast("")` limpa CLASSE e TEXTO: o `#toast` é
+ * `role="status"` e o texto velho seguia na árvore de acessibilidade.
+ *
+ * *Negativos (rodados um a um, medidos em 2026-09-10 sobre a ceca7ff; remeça
+ * antes de reusar os números):*
+ * - troque `r.status === 400` por `false` → PT18a vermelho (inline sai `""`);
+ * - volte o `#toast` da `precos.html` para `z-index: 999` → PT18c vermelho nos
+ *   2 viewports (brilho máximo cai para 30/255);
+ * - tire o `showToast("")` do início do `pixEnviar` → PT18d, PT18e e os DOIS
+ *   PT18f vermelhos nos 2 viewports, 8 falhas (o toast do 503 fica por cima do
+ *   campo, do QR, da migração e do "já pago");
+ * - tire o `showToast("")` do ramo da forma inválida → PT18g vermelho (só ele:
+ *   é o único desfecho que não passa pelo `pixEnviar`);
+ * - `.pix-erro { display: none !important }` → só PT18a vermelho, nos 2
+ *   viewports (era o buraco: o grupo media o toast por pixel e o inline só por
+ *   `textContent`);
+ * - `showToast` de volta ao `add("show")` → PT18d (×2) e PT18g vermelhos: o
+ *   `remove` implícito é o que apaga a frase velha do `role="status"`.
+ * *Positivos do grupo:* PT18b (o 409 objeto continua sendo lido pela `message`,
+ * o par que um `String(d.detail)` destruiria) e o PT12c (documento válido ainda
+ * vende — uma correção que sequestrasse todo erro para o campo passaria no a/c
+ * e mataria a venda).
  */
-test("PT18a: o 400 com detail string mostra a mensagem do servidor no toast", async () => {
-  const { page } = await abrirForm({
-    pix: { httpStatus: 400, corpo: { detail: "Informe um CPF ou CNPJ válido." } },
+const TELAS = [["desktop", { width: 1280, height: 900 }],
+               ["mobile", { width: 390, height: 844 }]];
+// A falha do provedor: é ela que convida ao reenvio ("tenta de novo"), e é o
+// reenvio que põe o toast velho por cima do desfecho novo.
+const FALHA_503 = "Não consegui emitir o Pix agora. Tenta de novo em instantes.";
+
+/**
+ * Brilho máximo (0–255) dentro do retângulo de um elemento — o instrumento do
+ * PT18c. `elementFromPoint` NÃO serve aqui: o `#toast` tem `pointer-events:
+ * none`, então o hit-test devolve o `pix-ov` com z-index 999 E com 1000, e o
+ * teste ficaria vermelho com e sem o conserto (§3, teatro). O que discrimina é
+ * a foto: com o toast atrás do véu, o pixel mais claro do retângulo é o preto
+ * translúcido do overlay.
+ */
+async function brilhoMax(page, seletor) {
+  const r = await page.$eval(seletor, (e) => {
+    const b = e.getBoundingClientRect();
+    return { x: b.x, y: b.y, width: b.width, height: b.height };
   });
+  const png = (await page.screenshot({ clip: r })).toString("base64");
+  return page.evaluate(async (b64) => {
+    const img = new Image();
+    img.src = "data:image/png;base64," + b64;
+    await img.decode();
+    const c = document.createElement("canvas");
+    c.width = img.width;
+    c.height = img.height;
+    const ctx2 = c.getContext("2d");
+    ctx2.drawImage(img, 0, 0);
+    const d = ctx2.getImageData(0, 0, c.width, c.height).data;
+    let max = 0;
+    for (let i = 0; i < d.length; i += 4) max = Math.max(max, d[i], d[i + 1], d[i + 2]);
+    return max;
+  }, png);
+}
+
+for (const [tela, viewport] of TELAS) {
+  test(`PT18a (${tela}): o 400 do documento fica DENTRO do modal, não no toast`, async () => {
+    const { page } = await abrirForm({
+      viewport,
+      pix: { httpStatus: 400, corpo: { detail: "Informe um CPF ou CNPJ válido." } },
+    });
+    await enviarDoc(page);
+    await page.waitForTimeout(300);
+    const visto = await page.evaluate(() => ({
+      texto: document.getElementById("pix-doc-erro").textContent,
+      foco: document.activeElement.className,
+      toast: document.getElementById("toast").textContent,
+    }));
+    assert.equal(visto.texto, "Informe um CPF ou CNPJ válido.",
+      `a recusa do documento não chegou ao campo: "${visto.texto}"`);
+    assert.equal(visto.toast, "",
+      `a recusa do documento ainda foi para o toast, atrás do véu: "${visto.toast}"`);
+    // O `botao.disabled` do envio largou o foco no <body>: quem vai corrigir o
+    // número tem de estar com o cursor nele.
+    assert.equal(visto.foco, "pix-doc",
+      `depois da recusa o foco ficou em ".${visto.foco}" em vez do campo`);
+    // Texto no `textContent` não é texto NA TELA: com `.pix-erro { display: none }`
+    // as três asserções acima passam (medido, rects=0). A vizinha `:empty` já mexe
+    // no `display` deste seletor — uma regra de CSS reintroduzia o bug original com
+    // o grupo inteiro verde. O brilho é o mesmo instrumento do toast: o `#ffb4b4`
+    // do `.pix-erro` pinta o retângulo bem acima do fundo da caixa.
+    assert.ok(await page.$eval("#pix-doc-erro", (e) => e.getClientRects().length > 0),
+      "a recusa está no DOM mas não ocupa área nenhuma: ninguém a lê na tela");
+    const brilhoInline = await brilhoMax(page, "#pix-doc-erro");
+    assert.ok(brilhoInline >= 150,
+      `a recusa não foi pintada: brilho máximo ${brilhoInline}/255 no retângulo do <p>`);
+    await page.close();
+  });
+
+  test(`PT18c (${tela}): o 503 não sequestra o campo, e o toast é legível`, async () => {
+    const { page } = await abrirForm({
+      viewport,
+      pix: { httpStatus: 503, corpo: { detail: FALHA_503 } },
+    });
+    await enviarDoc(page);
+    await page.waitForTimeout(500);          // o toast entra com transição de .25s
+    const visto = await page.evaluate(() => ({
+      inline: document.getElementById("pix-doc-erro").textContent,
+      toast: document.getElementById("toast").textContent,
+    }));
+    assert.equal(visto.inline, "",
+      `falha do provedor virou erro do CPF no campo: "${visto.inline}"`);
+    assert.equal(visto.toast, FALHA_503,
+      `a falha do provedor não chegou ao toast: "${visto.toast}"`);
+    const brilho = await brilhoMax(page, "#toast");
+    assert.ok(brilho >= 200,
+      `o toast ficou atrás do véu do modal: brilho máximo ${brilho}/255 no retângulo dele`);
+    await page.close();
+  });
+
+  test(`PT18d (${tela}): o inline do 400 apaga o toast anterior — UMA mensagem na tela`, async () => {
+    // O objeto `pix` é lido pela rota a CADA requisição: mudá-lo aqui troca a
+    // resposta do REENVIO sem tocar no harness. É a sequência real — o Pix caiu,
+    // a pessoa tenta de novo, e agora o servidor recusa o documento.
+    const pix = { httpStatus: 503, corpo: { detail: FALHA_503 } };
+    const { page } = await abrirForm({ viewport, pix });
+    await enviarDoc(page);
+    await page.waitForTimeout(500);
+    assert.ok(await page.$eval("#toast", (e) => e.classList.contains("show")),
+      "o 503 nem chegou a mostrar o toast: o cenário das duas mensagens não foi montado");
+    pix.httpStatus = 400;
+    pix.corpo = { detail: "Informe um CPF ou CNPJ válido." };
+    await enviarDoc(page, CPF);            // dentro dos 3800 ms do timer do showToast
+    await page.waitForTimeout(400);        // > .25s da transição de opacidade
+    const visto = await page.evaluate(() => {
+      const t = document.getElementById("toast");
+      return {
+        inline: document.getElementById("pix-doc-erro").textContent,
+        toastVisivel: t.classList.contains("show"),
+        opacidade: getComputedStyle(t).opacity,
+        toastTexto: t.textContent,
+      };
+    });
+    assert.equal(visto.inline, "Informe um CPF ou CNPJ válido.",
+      `a recusa do documento não chegou ao campo: "${visto.inline}"`);
+    assert.equal(visto.toastVisivel, false,
+      `DUAS mensagens na tela: o toast do 503 ("${await page.textContent("#toast")}") continua`
+      + " por cima do véu, contradizendo o campo");
+    assert.ok(parseFloat(visto.opacidade) <= 0.05,
+      `o toast velho ainda está visível: opacidade ${visto.opacidade}`);
+    // Opacidade 0 não some para leitor de tela: o `#toast` é `role="status"` e
+    // seguia com `display: block`, `visibility: visible` e o TEXTO velho na
+    // árvore de acessibilidade, contradizendo o campo para quem não vê a tela.
+    assert.equal(visto.toastTexto, "",
+      `o texto velho continua no \`role="status"\`: "${visto.toastTexto}"`);
+    await page.close();
+  });
+
+  test(`PT18e (${tela}): reenviar depois do 503 não deixa o toast velho por cima do QR`,
+    async () => {
+      const pix = { httpStatus: 503, corpo: { detail: FALHA_503 } };
+      const { page } = await abrirForm({ viewport, pix });
+      await enviarDoc(page);
+      await page.waitForTimeout(500);
+      assert.ok(await page.$eval("#toast", (e) => e.classList.contains("show")),
+        "o 503 nem mostrou o toast: o cenário das duas mensagens não foi montado");
+      pix.httpStatus = 200;
+      pix.corpo = null;                    // volta ao corpo padrão do harness: o QR
+      await enviarDoc(page, CPF);          // dentro dos 3800 ms do timer do showToast
+      await page.waitForSelector(".pix-code");
+      await page.waitForTimeout(400);
+      const brilho = await brilhoMax(page, "#toast");
+      assert.ok(brilho < 100,
+        `o QR está na tela e o toast do 503 ("${await page.textContent("#toast")}")`
+        + ` continua por cima: brilho máximo ${brilho}/255 no retângulo dele`);
+      await page.close();
+    });
+
+  // Os DOIS 409 que TROCAM o corpo do modal — migração e "já pago" (este entrou
+  // no #361, depois da enumeração) — são a mesma classe: caixa nova por baixo do
+  // toast velho. Mesmo corpo de teste, um `for` em vez de um irmão copiado.
+  for (const [caso, corpo, marca] of [
+    ["migração", { detail: { error: "stripe_active", current_period_end: "2026-12-05" } },
+      /trocar o cartão pelo pix/i],
+    ["já pago", { detail: { error: "pix_future_purchase_conflict",
+                            covered_until: "2027-03-04T00:00:00+00:00" } },
+      /já tem tempo pago/i],
+  ]) {
+    test(`PT18f (${tela}, ${caso}): reenviar depois do 503 não deixa o toast por cima da caixa nova`,
+      async () => {
+        const pix = { httpStatus: 503, corpo: { detail: FALHA_503 } };
+        const { page } = await abrirForm({ viewport, pix });
+        await enviarDoc(page);
+        await page.waitForTimeout(500);
+        assert.ok(await page.$eval("#toast", (e) => e.classList.contains("show")),
+          "o 503 nem mostrou o toast: o cenário das duas mensagens não foi montado");
+        pix.httpStatus = 409;
+        pix.corpo = corpo;
+        await enviarDoc(page, CPF);
+        await page.waitForTimeout(400);
+        assert.match(await page.textContent(".pix-box"), marca,
+          `o 409 de ${caso} não trocou o corpo do modal: o cenário não foi montado`);
+        const brilho = await brilhoMax(page, "#toast");
+        assert.ok(brilho < 100,
+          `a caixa de ${caso} está na tela e o toast do 503 continua por cima:`
+          + ` brilho máximo ${brilho}/255 no retângulo dele`);
+        await page.close();
+      });
+  }
+}
+
+/**
+ * O desfecho que NÃO passa pelo `pixEnviar`: a forma inválida é recusada no
+ * submit e volta na hora. Sem a limpeza no início do submit, o único ponto do
+ * `pixEnviar` não alcança este caso — e era o que a mutação do Tester provou
+ * (só o sítio da forma revertido: 47 pass, 0 fail).
+ */
+test("PT18g: a recusa de FORMA também apaga o toast do 503, sem POST nenhum", async () => {
+  const pix = { httpStatus: 503, corpo: { detail: FALHA_503 } };
+  const { page, chamadas } = await abrirForm({ pix });
   await enviarDoc(page);
-  await page.waitForTimeout(300);
-  const toast = await page.textContent("#toast");
-  assert.equal(toast, "Informe um CPF ou CNPJ válido.",
-    `a recusa do documento virou outra coisa na tela: "${toast}"`);
-  assert.ok(await page.$eval("#toast", (e) => e.classList.contains("err")),
-    "a recusa apareceu sem a classe de erro");
+  await page.waitForTimeout(500);
+  assert.ok(await page.$eval("#toast", (e) => e.classList.contains("show")),
+    "o 503 nem mostrou o toast: o cenário das duas mensagens não foi montado");
+  await enviarDoc(page, "1112223334");     // 10 dígitos: nem chega a sair
+  await page.waitForTimeout(400);
+  assert.equal(chamadas.pixCheckout, 1,
+    `o documento malformado foi para o servidor (${chamadas.pixCheckout} chamadas)`);
+  const visto = await page.evaluate(() => ({
+    inline: document.getElementById("pix-doc-erro").textContent,
+    toast: document.getElementById("toast").classList.contains("show"),
+  }));
+  assert.equal(visto.inline, "Informe os 11 dígitos do CPF ou os 14 do CNPJ.",
+    `a recusa de forma não chegou ao campo: "${visto.inline}"`);
+  assert.equal(visto.toast, false,
+    "DUAS mensagens na tela: o toast do 503 continua por cima do véu, contradizendo o campo");
+  const brilho = await brilhoMax(page, "#toast");
+  assert.ok(brilho < 100,
+    `o toast do 503 continua legível por cima do modal: brilho máximo ${brilho}/255`);
   await page.close();
 });
 

--- a/tests/frontend/precos_pix_anual.test.mjs
+++ b/tests/frontend/precos_pix_anual.test.mjs
@@ -1213,9 +1213,10 @@ test("PT17: fechar durante o download do corpo não deixa QR nem poll órfãos",
  *   campo, do QR, da migração e do "já pago");
  * - tire o `showToast("")` do ramo da forma inválida → PT18g vermelho (só ele:
  *   é o único desfecho que não passa pelo `pixEnviar`);
- * - `.pix-erro { display: none !important }` → só PT18a vermelho, nos 2
- *   viewports (era o buraco: o grupo media o toast por pixel e o inline só por
- *   `textContent`);
+ * - `.pix-erro { display: none !important }` → 6 vermelhos: PT18a nos 2
+ *   viewports e os 4 PT12b junto (a `isVisible(".pix-erro")` da linha 873, que
+ *   já existia). O que o PT18a acrescenta é a visibilidade do inline no caminho
+ *   do 400 DO SERVIDOR — o da forma inválida já tinha quem o medisse;
  * - `showToast` de volta ao `add("show")` → PT18d (×2) e PT18g vermelhos: o
  *   `remove` implícito é o que apaga a frase velha do `role="status"`.
  * *Positivos do grupo:* PT18b (o 409 objeto continua sendo lido pela `message`,

--- a/tests/frontend/precos_pix_ja_pago.test.mjs
+++ b/tests/frontend/precos_pix_ja_pago.test.mjs
@@ -83,6 +83,7 @@ const tela = (page) => page.evaluate(() => ({
   caixa: (document.querySelector(".pix-box") || {}).textContent || "",
   toast: document.getElementById("toast").textContent,
   toastVisivel: document.getElementById("toast").classList.contains("show"),
+  docErro: (document.getElementById("pix-doc-erro") || {}).textContent || "",
   campos: document.querySelectorAll(".pix-doc").length,
   corpo: document.body.innerText,
   // PII medida de VERDADE. `page.content()` serializa ATRIBUTOS e o `page.fill`
@@ -211,6 +212,14 @@ test("conflito com covered_until malformado cai no genérico, sem 'undefined'", 
 // alguém reescrever a frase lá, este arquivo não fica vermelho (o §0.7 não
 // alcança copy de erro). O que ele prende é a CATEGORIA: `detail` string chega
 // à tela em vez de virar o genérico.
+//
+// O DESTINO mudou por status: o 400 é erro DO CAMPO e escreve no `#pix-doc-erro`
+// dentro do modal; 429/503/403 continuam no toast. Ressalva medida: a guarda do
+// `pix-checkout.js:324` chaveia por STATUS 400, não por qual erro é — então o
+// "plan inválido…" também vira "erro do campo do documento". Ele é inalcançável
+// pela tela (`PIX_PLANOS` em `pix-checkout.js:32` é exatamente o conjunto de
+// chaves de `TIER_TO_STORED_PLAN`, `plan_service.py:54`) e só esta tabela o
+// dirige — mas quem acrescentar um 400 NOVO àquela rota precisa saber disso.
 const FRASES_DO_SERVIDOR = [
   [400, "plan inválido (use 'essencial', 'plus' ou 'pro').", "billing_pix.py:88"],
   [400, "Informe um CPF ou CNPJ válido.", "billing_pix.py:93"],
@@ -226,8 +235,14 @@ for (const [status, frase, onde] of FRASES_DO_SERVIDOR) {
   test(`${status}: a frase do servidor chega à tela (${onde})`, async () => {
     const page = await tentarComprar({ httpStatus: status, corpo: frase });
     const t = await tela(page);
-    assert.equal(t.toast, frase, "a frase do servidor foi descartada");
-    assert.equal(t.toastVisivel, true);
+    if (status === 400) {
+      assert.equal(t.docErro, frase, "a frase do servidor foi descartada");
+      assert.equal(t.toast, "", "o 400 deixou frase velha no toast");
+      assert.equal(t.toastVisivel, false, "o 400 ainda foi parar no toast");
+    } else {
+      assert.equal(t.toast, frase, "a frase do servidor foi descartada");
+      assert.equal(t.toastVisivel, true);
+    }
     assert.ok(!t.corpo.includes(GENERICO), "mostrou o genérico junto da frase");
     await page.close();
   });


### PR DESCRIPTION
Fixes #364

## O que o dono viu na produção

No modal "…anual no Pix", campo do CPF/CNPJ:

| entrada | onde a mensagem aparece | o cliente lê? |
|---|---|---|
| mais de 11 dígitos | dentro do modal, embaixo do campo | sim |
| exatos 11 dígitos, CPF inválido | `#toast`, **atrás do overlay** | **não** |

Medido: brilho máximo de **30/255** no retângulo do toast com o modal aberto. O texto branco está literalmente apagado — a queixa é medição, não impressão.

O #355 não criou isto. Antes dele quase todo CPF de 11 dígitos passava e este caminho era raro; ao passar a recusar dígito verificador errado, ele tornou o caminho **comum**.

## As três mudanças

**1. `#toast` de `z-index: 999` → 1000** (`precos.html:16`), acima do `.pix-ov`. Conserta a **categoria**: 503, 429, 403 e 401 também sumiam atrás do véu. Inventário na página viva com o modal aberto: `[{id:"toast",z:1000},{cls:"pix-ov",z:999}]`, nada mais ≥ 100. Sobreposição do toast com `.pix-box`, `.pix-ghost`, submit e `.pix-qr` = **0 px²** nos dois viewports.

**2. O 400 escreve no `#pix-doc-erro`** e devolve o foco ao campo. É o alvo do `aria-describedby` do input, tem `role="alert"` (o toast é `role="status"`, polite, e some em 3,8 s) e é onde a validação do cliente já escreve.

**Só o 400.** Enumerado no endpoint: 409 `stripe_active` → modal de migração; 409 `pix_future_purchase_conflict` → `pixModalJaPago`; 409 `lifetime`, 503, 429, 403 e 401 **não são erro do campo** — mandá-los para o `<p>` que o leitor de tela anuncia como descrição do CPF seria mentir. Ficam no toast, que a mudança 1 torna legível. O outro 400 da rota (`plan inválido`) é inalcançável pelo JS: `PIX_PLANOS` é exatamente o conjunto de chaves de `TIER_TO_STORED_PLAN`.

**Sobre o foco:** não é mover foco sem o usuário pedir — é **restaurar** um foco que a própria UI perdeu. Medido: depois do 400, `document.activeElement` é o `<body>`, porque `botao.disabled = true` desfoca e o `finally` reabilita sem devolver.

**3. `showToast("")` apaga o toast, e o `pixEnviar` chama isso ao começar o envio.**

Sem isto o conserto 1 **piorava** a tela. Medido em duas colunas, sequência 503 → reenvio → 200:

| | `main` | só com o conserto 1 |
|---|---|---|
| brilho do toast com o QR na tela | 30/255 | **255/255** |

Ou seja: o toast velho, agora legível, ficava por cima do QR **de sucesso** dizendo "Não consegui emitir o Pix agora. Tenta de novo em instantes." O caminho é realista — a mensagem manda tentar de novo, a pessoa tenta, e o campo continua preenchido.

O ponto único vem de **enumerar desfecho × toast** (`CLAUDE.md §4`, em vez de remendar transição por transição):

| desfecho | toast velho deve |
|---|---|
| forma inválida → inline | sumir |
| 400 → inline | sumir |
| 409 `stripe_active` → migração | sumir |
| 409 `pix_future_purchase_conflict` → "já pago" | sumir |
| sucesso → QR | sumir |
| 401 / outros / `catch` → toast novo | sumir (o `showToast` sobrescreve) |
| fechou no meio | sumir |

**Nenhum precisa do toast velho vivo** → a limpeza é uma, no início do envio, e não uma por desfecho. Dois sítios apenas porque a recusa de **forma** volta no próprio submit e não chega ao `pixEnviar` — e cada sítio tem um teste que só ele derruba.

`toggle("show", !!msg)` em vez de `add`: `remove("show")` sozinho só zera a `opacity`. Medido com `ariaSnapshot()` do Chromium — o nó seguia `display: block`, `visibility: visible`, `rects 1`, e o `role="status"` continuava ditando a frase velha ao leitor de tela.

## Instrumento: por que não é `elementFromPoint`

O `#toast` tem `pointer-events: none`. O hit-test devolve `pix-ov` com z-index **999 e 1000** — medido. Um teste escrito assim ficaria vermelho com e sem a correção. O que discrimina é **pixel**: `page.screenshot({clip})` → `<canvas>` → maior R/G/B. O helper foi aferido contra alvos de cor conhecida (preto 0, branco 255, cinza30 30, branco sob véu `rgba(0,0,0,.72)` = **71** ≈ 255×0,28), e alvo vazio/fora **estoura** em vez de devolver número falso.

## Testes

`node --test tests/frontend/precos_pix_anual.test.mjs` → **54 pass, 0 fail**. `npx eslint frontend/pix-checkout.js` → **exit 0** (5 warnings, os mesmos da base). `wc -l` = 343/350.

PT18a-g, cada um nos dois viewports: 400 no inline com o `<p>` ocupando área; 503 sozinho com toast legível (≥ 200); 503 → reenvio → 400/200/migração/"já pago" com uma mensagem só; forma inválida apagando o toast.

## O que este PR NÃO prova — leia antes de mergear

**Os cinco controles negativos foram medidos contra a base ANTERIOR** (`91ed9b1`) e **não foram refeitos depois do rebase**. A `main` reescreveu o `pix-checkout.js` nesse intervalo (o #359 passou a normalizar o `detail` string, o #361 acrescentou o `pixModalJaPago`). Os 54 verdes acima são da base atual; a prova de que eles **discriminam** não é. Pelo §3 deste repositório isso é exatamente o que não basta.

O que as mutações mostravam na base antiga:

| mutação | ficava vermelho |
|---|---|
| sem o `showToast("")` do início do envio | PT18d/e/f (×2) |
| sem o `showToast("")` da forma inválida | só PT18g |
| `z-index` de volta para 999 | só PT18c (×2), brilho 30/255 |
| `.pix-erro { display: none }` | só PT18a (×2) |
| `showToast` de volta ao `add("show")` | PT18d (×2) e PT18g |

Refazer as cinco na base atual é o primeiro pedido de revisão.

**Também não verificado:** nada no aparelho nem em produção (a /precos é servida ao vivo, só aparece depois do deploy); o 400 real do servidor é mockado nos testes; e o comportamento em leitor de tela real (VoiceOver/NVDA) — o achado de acessibilidade foi medido pela árvore do Chromium, que é indício forte e não é o anúncio.

## Fora de escopo, medido e registrado

- **`#toast` da `settings.html:989`**: `z-index: 50` sob `.mfa-overlay` **9999** — mesmo bug, outra página. Issue própria.
- **O `#toast` fica fora do `aria-modal="true"`** do `.pix-ov` (medido: `ov.contains(toast) === false`). Hipótese: leitores de tela podem não anunciar 503/429 mesmo com o z-index certo. O ramo do 400 não tem esse problema — o `#pix-doc-erro` está dentro do diálogo.
- **O foco só volta no ramo do 400.** 503 e 409 deixam em `<body>`; o `pigTrapTab` devolve no Tab seguinte.
- **`overflowX` de 153 px** em 390 px na /precos: preexistente, medido sem modal aberto, causado pela `TABLE.cmp-table`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)