### PR TITLE
Põe preço e o que o plano faz na copy do aviso de fim do Grátis

### DIFF
--- a/core/services/email_service.py
+++ b/core/services/email_service.py
@@ -1329,6 +1329,12 @@ def send_free_plan_sunset_email(to: str, corte, dashboard_url: str = "",
     """
     data = _fmt_brl_date(corte)
     dash = (dashboard_url or "https://pigbankai.com").rstrip("/")
+    # Preço E frase de valor só na coorte Grátis (decisão do dono, 2026-09-10):
+    # quem tem cobrança pendente já COMPROU o plano — está inadimplente, não
+    # indecisa. Pitch de produto quando a ação dela é atualizar o cartão é o
+    # mesmo desconforto que tirou a palavra "Grátis" da mensagem dela, e menos
+    # superfície de marketing reforça o caráter transacional deste e-mail.
+    pitch_html = pitch_text = ""
     if cobranca_pendente:
         situacao_html = ("A cobrança da sua assinatura <strong>não passou</strong> "
                          "e o período que você já pagou venceu")
@@ -1342,6 +1348,33 @@ def send_free_plan_sunset_email(to: str, corte, dashboard_url: str = "",
         situacao_text = "Sua conta hoje esta no plano Gratis (ou sem plano ativo)"
         acao_html, acao_text = "Ver os planos", "Escolha um plano"
         destino = f"{dash}/precos"
+        # Preço DERIVADO do anual (§0.7): o mensal só existe na
+        # `frontend/precos.html` (markup e script, as duas metades); o anual é
+        # constante em código, atada às duas metades daquela página por teste.
+        # `min` para o "a partir de" não cravar qual plano é o mais barato —
+        # ATENÇÃO: `PRECOS_ANUAIS_CENTS` é o que a rota do PIX vende, e este
+        # e-mail linka para a página do CARTÃO; plano que saia de linha só no
+        # cartão continua entrando neste `min`.
+        # Import local como o resto do arquivo — `pix_pricing` arrasta
+        # `billing_access` → `db.connection`, e o topo aqui não importa banco.
+        from core.services.pix_pricing import PRECOS_ANUAIS_CENTS
+        from utils_text import fmt_brl
+        _anual_cents = min(PRECOS_ANUAIS_CENTS.values())
+        _anual, _mensal = fmt_brl(_anual_cents / 100), fmt_brl(_anual_cents / 12 / 100)
+        # "no plano anual" com todas as letras: a `/precos` abre em Mensal e não
+        # lê `?cycle=`, então quem clicar vê o preço mensal avulso.
+        pitch_html = (
+            "\n      <p>Com um plano ativo, o Piggy registra seus gastos por "
+            "texto, áudio e foto de cupom no WhatsApp, com boletos, caixinhas e "
+            "cartões sem limite.</p>"
+            f"\n      <p>Planos a partir de {_anual}/ano — {_mensal} por mês "
+            "no plano anual.</p>")
+        pitch_text = (
+            "\nCom um plano ativo, o Piggy registra seus gastos por texto, "
+            "audio e foto de cupom no WhatsApp, com boletos, caixinhas e "
+            "cartoes sem limite.\n\n"
+            f"Planos a partir de {_anual}/ano — {_mensal} por mes no plano "
+            "anual.\n\n")
     content = f"""
       <p>🐷 Oi! Preciso te contar uma mudança importante.</p>
       <p>A partir de <strong>{data}</strong>, o PigBank passa a funcionar
@@ -1349,7 +1382,7 @@ def send_free_plan_sunset_email(to: str, corte, dashboard_url: str = "",
       <strong>Piggy no WhatsApp</strong> e o <strong>dashboard</strong> param
       de responder.</p>
       <p>Seus dados continuam guardados — nada é apagado. Para não ter
-      interrupção, resolva antes de {data}:</p>
+      interrupção, resolva antes de {data}:</p>{pitch_html}
       <p style="text-align:center;margin:24px 0">
         <a class="btn" href="{destino}">{acao_html}</a>
       </p>
@@ -1365,6 +1398,7 @@ def send_free_plan_sunset_email(to: str, corte, dashboard_url: str = "",
         "param de responder.\n\n"
         "Seus dados continuam guardados — nada e apagado. Para nao ter "
         f"interrupcao, resolva antes de {data}:\n"
+        f"{pitch_text}"
         f"{acao_text}: {destino}\n\n"
         "Se sua assinatura ja estiver ativa quando voce ler isto, pode ignorar "
         "este email: quem esta com plano ativo nao e afetado."

--- a/tests/test_aviso_fim_do_gratis_lote.py
+++ b/tests/test_aviso_fim_do_gratis_lote.py
@@ -31,6 +31,15 @@ testes daqui — a lista deles está lá.
     descartava o flag e o teste de copy chamava a função de e-mail direto, com
     os dois valores na mão. A copy forkava e ninguém media QUEM escolhe o
     fork.
+  • J — na copy do e-mail, alargue o "a partir de" para o plano mais caro:
+    `min(PRECOS_ANUAIS_CENTS.values())` → `max(...)`:
+      VERMELHO: test_copy_traz_a_data_do_corte_e_nao_promete_trial.
+  • K — troque a derivação do preço pelos valores de hoje escritos à mão
+    (R$ 99,00 e R$ 8,25):
+      VERMELHO: test_copy_traz_a_data_do_corte_e_nao_promete_trial.
+  • L — faça o pitch (frase de valor + preço) sair também quando
+    `cobranca_pendente` é verdadeiro:
+      VERMELHO: test_copy_traz_a_data_do_corte_e_nao_promete_trial.
   • G — alargue a borda de BAIXO da faixa do `--corte`: em `main`, troque
     `hoje <= corte_dia` por `hoje - timedelta(days=3650) <= corte_dia`:
       VERMELHO: test_corte_no_passado_e_recusado.
@@ -237,14 +246,42 @@ def test_corte_de_hoje_e_o_caminho_legitimo_passam(monkeypatch):
     assert enviados == [], "dry-run mandou e-mail"
 
 
+def _corpos(capturado: dict):
+    """`(nome, corpo, tokens da frase de valor)` dos dois corpos.
+
+    Espaço normalizado — o HTML quebra linha no meio da frase e o token não pode
+    depender de onde caiu a quebra; o `text_body` é sem acento por convenção. Os
+    tokens saem DAQUI para os dois coortes: a 1 exige, a 2 proíbe, e com listas
+    separadas um dos lados pararia de medir. Nenhum colide com o resto da copy da
+    coorte 2 (medido) — "cartões" colidiria com o CTA "Atualizar cartão"."""
+    return ((nome, " ".join(capturado[nome].lower().split()),
+             ("cupom", "boletos", audio, "sem limite"))
+            for nome, audio in (("html", "áudio"), ("text", "audio")))
+
+
 def test_copy_traz_a_data_do_corte_e_nao_promete_trial(monkeypatch):
     """A data tem de atravessar o script inteiro (`--corte` → `_corte_para_email`
     → `_fmt_brl_date`): meia-noite UTC vira o DIA ANTERIOR em BRT. E a copy não
     pode prometer trial — são 15 dias por TELEFONE na vida
     (`db.plans.claim_trial_for_user`), e esta lista tem ex-assinante que já
-    usou o dele."""
+    usou o dele.
+
+    O preço é medido por DERIVAÇÃO: a fonte (`PRECOS_ANUAIS_CENTS`) é trocada em
+    runtime e o e-mail tem de renderizar o valor NOVO — literal cravado na copy
+    reprova, que é o modo de falha que importa (o preço muda e o e-mail mente).
+    A divisão por 12 continua duplicada aqui; quem a mede contra fonte
+    independente é `test_aviso_fim_do_gratis_preco.py`."""
     import core.services.email_service as es
+    import core.services.pix_pricing as pp
     from scripts.aviso_fim_do_gratis import _corte_para_email
+    from utils_text import fmt_brl
+
+    # A fonte do preço trocada ANTES do envio. 30000 é ACIMA do `pro` de
+    # propósito: o mínimo deixa de ser o `essencial`, e trocar o `min(...)` da
+    # produção por `["essencial"]` reprova (com 8900 os dois coincidiam). Não é
+    # valor de produção nem redondo, então literal cravado não coincide por acaso.
+    monkeypatch.setitem(pp.PRECOS_ANUAIS_CENTS, "essencial", 30000)
+    proibidos = ("15 dias", "trial", "teste grátis", "teste gratis")
 
     capturado: dict = {}
 
@@ -261,7 +298,7 @@ def test_copy_traz_a_data_do_corte_e_nao_promete_trial(monkeypatch):
     assert "24/09/2026" in capturado["text"]
     assert "24/09/2026" in capturado["subject"]
     corpo = (capturado["html"] + capturado["text"]).lower()
-    for proibido in ("15 dias", "trial", "teste grátis", "teste gratis"):
+    for proibido in proibidos:
         assert proibido not in corpo, f"copy promete {proibido!r}"
     # Transacional: sem link nem cabeçalho de descadastro (o molde do
     # `send_payment_failed_email`, não o dos e-mails de ciclo de vida).
@@ -270,6 +307,19 @@ def test_copy_traz_a_data_do_corte_e_nao_promete_trial(monkeypatch):
     assert capturado["kw"] == {}
     # Coorte 1: Grátis/sem plano — a frase da situação é essa mesma.
     assert "grátis" in corpo
+    # ...e o pitch. Esperado calculado DEPOIS do envio, da fonte já trocada.
+    anual_cents = min(pp.PRECOS_ANUAIS_CENTS.values())
+    preco_anual = fmt_brl(anual_cents / 100).lower()
+    preco_mensal = fmt_brl(anual_cents / 12 / 100).lower()
+    # HTML e texto conferidos SEPARADO: concatenar deixaria passar o parágrafo
+    # perdido em um dos dois corpos, com metade dos leitores vendo cada um. Os
+    # tokens são DISCRIMINANTES ("plano ativo" já existe na copy, seria verde por
+    # construção) e cobrem quatro promessas: "cupom boletos" sozinho reprova.
+    for nome, parte, tokens in _corpos(capturado):
+        assert preco_anual in parte, f"coorte 1, {nome}: sem o anual ({preco_anual})"
+        assert preco_mensal in parte, f"coorte 1, {nome}: sem o mensal ({preco_mensal})"
+        for token in tokens:
+            assert token in parte, f"coorte 1, {nome}: sem a frase de valor ({token!r})"
 
     # Coorte 2: assinatura VIVA com cartão recusado além da carência. Ela entra
     # na população (vai perder acesso), mas chamá-la de "plano Grátis" é falso
@@ -281,3 +331,16 @@ def test_copy_traz_a_data_do_corte_e_nao_promete_trial(monkeypatch):
     assert "grátis" not in corpo2 and "gratis" not in corpo2
     assert "cartão" in corpo2 or "cartao" in corpo2
     assert "24/09/2026" in corpo2
+    # Nem preço nem frase de valor (decisão do dono, 2026-09-10): essa conta já
+    # COMPROU o plano e está inadimplente, não indecisa — a ação dela é o cartão,
+    # e o e-mail dela encolhe em vez de crescer. Mesmos tokens da coorte 1, pela
+    # mesma fonte, com o sinal trocado.
+    for nome, parte, tokens in _corpos(capturado):
+        assert preco_anual not in parte, f"coorte 2, {nome}: recebeu o 'a partir de'"
+        assert preco_mensal not in parte, f"coorte 2, {nome}: recebeu o mensal"
+        for token in tokens:
+            assert token not in parte, f"coorte 2, {nome}: recebeu o pitch ({token!r})"
+    # Proibição de trial: aqui a direção segura é a oposta — tem de valer nos
+    # dois corpos, e a concatenação garante isso.
+    for proibido in proibidos:
+        assert proibido not in corpo2, f"copy da coorte 2 promete {proibido!r}"

--- a/tests/test_aviso_fim_do_gratis_preco.py
+++ b/tests/test_aviso_fim_do_gratis_preco.py
@@ -1,0 +1,57 @@
+"""O equivalente mensal que o AVISO publica é o que a `/precos` publica.
+
+Arquivo próprio por dois motivos: `test_aviso_fim_do_gratis_lote.py` está no
+teto de 350 linhas (§0.5), e o assunto aqui é outro — lá se mede a copy, aqui
+uma duplicação inevitável de ARITMÉTICA. O e-mail divide o anual por 12; a
+`/precos` traz o resultado escrito à mão no markup ("Equivale a R$&nbsp;8,25 por
+mês"). Nenhuma das duas cópias pode andar sozinha (§0.7), e a `/precos` é a
+única fonte do mensal que NÃO compartilha a divisão com o e-mail.
+
+Não é caso para o `test_pix_preco_bate_com_a_precos.py`: aquele exclui os
+`price-eq` do conjunto dele de propósito (filtro `if "/ano" in texto`, senão o
+rateio entraria como se fosse preço anual), então este gancho não conflita.
+
+CONTROLE MEDIDO (`docs/controles_declarados.md`): troque o divisor `/ 12` do
+equivalente mensal por `/ 10`, na produção E em toda cópia da mesma aritmética
+que houver em `tests/`:
+  VERMELHO: test_o_equivalente_mensal_do_email_e_o_que_a_precos_publica.
+Injetar nos dois lados, e não só na produção, é o que faz este controle
+DISCRIMINAR: aritmética duplicada erra junto e não separa os dois casos — é
+exatamente a cegueira que este arquivo fecha.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from datetime import date
+
+import core.services.email_service as es
+
+
+def test_o_equivalente_mensal_do_email_e_o_que_a_precos_publica(monkeypatch):
+    """O preço NÃO é trocado aqui: a comparação é contra o valor publicado.
+
+    Cegueira declarada: casa contra o CONJUNTO dos equivalentes publicados,
+    porque o markup não nomeia o plano no `price-eq`. O e-mail anunciar o equivalente de
+    OUTRO plano passaria aqui — quem prende o valor à fonte é o
+    `monkeypatch.setitem` do `test_aviso_fim_do_gratis_lote.py`.
+    """
+    capturado: dict = {}
+    monkeypatch.setattr(es, "send_email",
+                        lambda **kw: capturado.update(kw) or True)
+    es.send_free_plan_sunset_email("quem@exemplo.com", date(2026, 9, 24))
+
+    html = (pathlib.Path(__file__).resolve().parent.parent
+            / "frontend" / "precos.html").read_text(encoding="utf-8")
+    publicados = set(re.findall(
+        r'class="price-eq"[^>]*>[^<]*?(R\$ ?[\d.,]+)',
+        html.replace("&nbsp;", " ")))
+    assert len(publicados) > 1, (
+        f"a varredura dos `price-eq` da /precos achou {sorted(publicados)} — "
+        "o markup mudou de forma e o comparador virou verde vazio"
+    )
+    assert any(p in capturado["html_body"] for p in publicados), (
+        "o equivalente mensal do e-mail não é nenhum dos publicados na "
+        f"/precos ({sorted(publicados)}) — a divisão das duas fontes divergiu"
+    )

--- a/tests/test_pix_inerte.py
+++ b/tests/test_pix_inerte.py
@@ -298,11 +298,32 @@ def test_pix_pricing_so_e_importado_pelo_checkout_e_pela_rota():
     aritmética pura —, mas medir o chamador separado continua valendo: é o que
     impede alguém de ligar o preço a outra tela achando que "pricing não conta".
 
-    São DOIS chamadores e não um: o checkout chama `plano_da_cobranca`, e a rota
-    importa `CoberturaJaPaga` para traduzir a recusa em 409 sem reconsultar o
-    banco (é o contrato escrito na docstring da própria exceção).
+    **O que este portão afirma, desde o consumidor não-Pix:** preço LIDO pode
+    sair do módulo; caminho de COBRANÇA não. Ele continua reprovando pelo nome
+    do arquivo um import novo em `db/`, num handler ou num scheduler — não virou
+    "qualquer um importa". O critério do dono (topo deste arquivo) é sobre EMITIR
+    cobrança sem o caminho que recebe o pagamento; ler um `dict[str, int]` não
+    emite nada, e o preço ANUAL não é do Pix (o cartão vende anual por
+    `STRIPE_PRICE_ID_*_ANUAL` desde antes, e o Pix anual ainda está atrás de
+    `ASAAS_PIX_ANNUAL_ENABLED`). Abrir o esperado, em vez de apagar o teste, é a
+    mesma escolha que o 1b-B fez com a allowlist.
+
+    São TRÊS chamadores: o checkout chama `plano_da_cobranca`, a rota importa
+    `CoberturaJaPaga` para traduzir a recusa em 409 sem reconsultar o banco (é o
+    contrato escrito na docstring da própria exceção), e o e-mail só LÊ o preço.
+
+    **Gatilho para o futuro:** um consumidor não-Pix é exceção justificada; no
+    dia em que aparecer o SEGUNDO, a constante está no módulo errado e o
+    conserto é extraí-la para um módulo neutro — PR próprio, porque mexe no
+    caminho de emissão de cobrança e arrisca ciclo de import.
     """
-    esperado = {"core/services/pix_checkout.py", "frontend/routes/billing_pix.py"}
+    esperado = {
+        "core/services/pix_checkout.py",      # chama `plano_da_cobranca`
+        "frontend/routes/billing_pix.py",     # traduz `CoberturaJaPaga` em 409
+        # o aviso de fim do Grátis lê só `PRECOS_ANUAIS_CENTS` para a copy;
+        # não emite cobrança e não fala com o Asaas
+        "core/services/email_service.py",
+    }
     achados = set(_quem_importa(("core.services.pix_pricing",), raiz=""))
     assert achados == esperado, (
         f"chamadores de pix_pricing mudaram — sobrando: {sorted(achados - esperado)}; "


### PR DESCRIPTION
## Por que

O dry-run em produção mediu a população: **59 contas** recebem o aviso, mas só **9 usuários ativos** de fato perdem acesso. Para essas 9 este e-mail é o pitch de conversão, e ele era um aviso seco — dizia que o acesso acaba, mandava para a `/precos`, e não dizia preço nem por que vale a pena continuar.

## Preço derivado, não escrito (§0.7)

**O preço mensal não tem fonte de verdade neste repositório.** Ele existe em duas metades da `frontend/precos.html` (o markup e o `PLAN_PRICES` do script) e **nenhum teste as compara** — `test_pix_preco_bate_com_a_precos` filtra por `"/ano"` de propósito. Escrever mensal à mão em Python seria a **terceira** cópia, num arquivo que manda e-mail para cliente.

Então o e-mail deriva do **anual**, que é constante em código atada àquela página por teste: `min(PRECOS_ANUAIS_CENTS.values())` para o "a partir de" e `÷12` para o equivalente mensal, com `fmt_brl`. **Divisão float e não `//`**: se o preço deixar de ser redondo, a divisão inteira anuncia **menos** do que se cobra.

O "no plano anual" na frase não é enfeite: a `/precos` abre em **Mensal** e não lê `?cycle=` no load (medido), então quem clicar vê o mensal avulso.

## Pitch só no coorte Grátis

Decisão do dono. Quem tem cobrança pendente **já comprou** o plano — está inadimplente, não indecisa — e a ação dela é o cartão. Efeito medido: **o corpo do coorte 2 ficou byte-idêntico ao `HEAD`**.

A frase de valor cita só o que é falso no `FREE_LIMITS` e verdadeiro já no `ESSENCIAL_LIMITS`, que é o plano que o "a partir de" anuncia: áudio, OCR de cupom e boletos ligam; caixinhas, cartões e lançamentos perdem o teto. **Nada de "conversas ilimitadas"** (`ai_monthly_messages = 200` no Essencial) e **nada de trial** (é 15 dias por **telefone**, na vida, e esta lista tem ex-assinante que já o usou).

## O e-mail continua transacional

Sem `unsub_headers`, sem descadastro, sem urgência fabricada. Não é estilo: **é a base do consentimento.** Ele vai para quem desligou os e-mails do Piggy **porque** é transacional, e o bot promete a essa pessoa que "os emails de segurança continuam normais".

## Este PR abre um portão do caminho de cobrança, de propósito

`tests/test_pix_inerte.py` mede quem importa `core/services/pix_pricing.py`, e o aviso passa a ser o terceiro chamador.

A abertura **não afrouxa o critério do dono** ("nenhuma versão intermediária deve conseguir emitir uma cobrança sem já possuir o caminho que recebe o pagamento e concede o acesso"): ler um `dict[str, int]` não emite cobrança; o próprio arquivo **já deixava** `pix_pricing` fora de `MODULOS_INERTES` por ser função pura; e o preço anual não é do Pix — o cartão vende anual por `STRIPE_PRICE_ID_*_ANUAL` desde antes, enquanto o Pix anual segue atrás de `ASAAS_PIX_ANNUAL_ENABLED`.

O portão **mudou de pergunta, não foi desligado**: a asserção continua sendo igualdade exata de conjunto, e ele segue reprovando import novo em `db/`, num handler ou num scheduler — medido plantando um em `db/plans.py`. `CHAMADORES_PERMITIDOS`, `MODULOS_INERTES`, o portão de destino e o de DDL não foram tocados.

**Gatilho registrado na docstring**: um consumidor não-Pix é exceção justificada; no **segundo**, a constante está no módulo errado e o conserto é extraí-la para um módulo neutro, em PR próprio.

## Testes

Duas colunas, mesma árvore, com stub de `ofxparse`:

| coluna | resultado |
|---|---|
| `main` | `6 failed, 6957 passed, 1 skipped, 4 xfailed` |
| este branch | `6 failed, 6958 passed, 1 skipped, 4 xfailed` |

**Mesmos seis nomes**, zero regressão; o `+1` é o arquivo de teste novo.

**Onze controles declarados**, cada um remedido. **Quatro cegueiras foram fechadas nesta rodada, e as quatro eram reais:**

1. cravar `"R$ 99,00"` literal no e-mail passava → fechada trocando a constante em tempo de execução;
2. perder a frase em **um** dos dois corpos (HTML ou texto) passava → fechada conferindo os dois separados;
3. o `min()` não era distinguido de uma chave cravada, porque o valor injetado era ao mesmo tempo o mínimo **e** o valor de `essencial` → fechada injetando **acima** de outro plano;
4. errar o divisor `÷12` nos **dois** lados, produção e teste, passava — sairia um e-mail dizendo "R$ 8,90 por mês" → fechada em arquivo próprio, comparando o mensal impresso com os `price-eq` publicados na `/precos`, que é fonte que **não compartilha a aritmética**.

## Não verificado

- **Envio real** (Resend) e **renderização em cliente de e-mail**. A conferência que dava para fazer foi feita: Chromium a 390px e 800px, sem overflow, com o pitch ausente do coorte 2 no próprio render.
- **Stripe ↔ HTML nunca foi atado.** Verde aqui significa "as fontes deste repositório concordam", nunca "o cartão cobra R$ 99,00" — isso mora no painel do Stripe.
- **Buraco pré-existente que este e-mail põe no caminho principal**: `essencial_available` é calculado **só** pelo preço mensal, e o e-mail manda a pessoa para o **anual**. Se `STRIPE_PRICE_ID_ESSENCIAL_ANUAL` estiver vazio e o mensal não, o botão fica clicável e o checkout anual resolve para `""`. Conferir as duas envs antes do disparo.
- **Se `PLANS_V2_ENABLED` for desligado**, o assinante Essencial recebe `FREE_LIMITS` e os cinco itens da frase de valor viram falsos, para exatamente o plano que o e-mail vende.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF

---
_Generated by [Claude Code](https://claude.ai/code/session_013S7fSbm9LLr264qsbeRoAF)_