### PR TITLE
fix: upload de OFX (Pro) dava 500 em producao — python-multipart faltando

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,6 +57,11 @@ fastapi==0.141.1
 # declara `starlette>=0.46.0` SEM teto, entao o pin exato e nosso: sem ele, uma
 # resolucao limpa sobe de major sozinha.
 starlette==1.6.0
+# `await request.form()` no upload de OFX (frontend/finance_bot_websocket_custom.py:6911).
+# A starlette so declara python-multipart no extra `full` (nao instalado aqui), entao
+# sem esta linha a rota /ofx/import/{user_id} da 500 com AssertionError em producao —
+# foi o que aconteceu no deploy 7a9dc67d (issue #375). Piso da starlette 1.6.0: >=0.0.18.
+python-multipart==0.0.32
 uvicorn[standard]==0.52.4
 websockets==17.1
 slowapi==0.1.10

--- a/tests/test_ofx_import_route.py
+++ b/tests/test_ofx_import_route.py
@@ -1,0 +1,128 @@
+# tests/test_ofx_import_route.py
+"""A rota HTTP de upload de OFX — `POST /ofx/import/{user_id}`.
+
+Existe por causa da issue #375: a rota caiu em PRODUÇÃO com 500
+(`AssertionError: The python-multipart library must be installed to use form
+parsing`) e nenhum teste viu, porque toda a cobertura de OFX
+(`test_category_normalization.py`, `test_statement_import.py`) chama os parsers
+DIRETO. Parser verde não prova rota viva: o `await request.form()` da
+`finance_bot_websocket_custom.py:6911` só existe no caminho HTTP.
+
+Controle negativo deste arquivo NÃO é tirar a linha do `requirements.txt` — o
+pytest lê o venv, não o arquivo. É desinstalar `python-multipart` do venv: os
+testes que chegam no `request.form()` ficam vermelhos com o mesmo AssertionError
+do traceback de produção.
+"""
+import pytest
+
+import db
+from conftest import promote_to_pro
+from db.users import ensure_user
+
+# Reuso (CLAUDE.md §0.1): o extrato OFX de exemplo e o TestClient com os 3
+# cookies do dashboard já existem — não crio a terceira cópia de nenhum dos dois.
+from test_category_normalization import _OFX_BANCO
+from test_category_launches_query import _cliente_logado
+
+import frontend.finance_bot_websocket_custom as dashboard
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """A rota tem `@limiter.limit("5/hour")` e o storage do slowapi é em memória,
+    compartilhado entre testes. Com 5 testes de 1 POST cada, o último cairia em
+    429 em vez de exercitar o que o teste mede. Mesmo padrão de
+    `test_billing_checkout.py:34`."""
+    try:
+        dashboard.limiter._storage.reset()
+    except Exception:
+        pass
+    yield
+
+
+def _upload(user_id: int, *, como: int | None = None, arquivo=("extrato.ofx", None, "application/x-ofx")):
+    """POST multipart em /ofx/import/{user_id}, logado como `como` (default: o
+    próprio dono). `arquivo=None` manda um multipart SEM o campo `file`."""
+    client, headers = _cliente_logado(como if como is not None else user_id)
+    del headers["Content-Type"]  # multipart: o httpx monta o boundary sozinho
+    if arquivo is None:
+        files = {"outro_campo": ("x.txt", b"x", "text/plain")}
+    else:
+        nome, corpo, ctype = arquivo
+        if corpo is None:
+            corpo = _OFX_BANCO.format(acct=user_id % 100000).encode()
+        files = {"file": (nome, corpo, ctype)}
+    return client.post(f"/ofx/import/{user_id}", files=files, headers=headers)
+
+
+def _launches(user_id: int) -> list:
+    with db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select id, tipo, valor, categoria from launches where user_id = %s", (user_id,))
+            return cur.fetchall()
+
+
+# ─── o defeito da #375: a rota tem de responder E importar ───────────────────
+
+def test_ofx_bancario_importa_pela_rota(pro_user_id):
+    """O teste que faltava. Sem `python-multipart` no ambiente isto é 500.
+
+    Não basta `!= 500`: uma rota que devolvesse 400 para tudo passaria nesse
+    assert. Aqui o desfecho é o lançamento gravado no Postgres.
+    """
+    assert _launches(pro_user_id) == []
+
+    r = _upload(pro_user_id)
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["type"] == "bank"
+
+    linhas = _launches(pro_user_id)
+    assert len(linhas) == 1, linhas
+    # o -39.90 do <STMTTRN> vira saída de 39,90 (o sinal mora no `tipo`), e a
+    # categoria só existe se o parser rodou de verdade — não é linha em branco.
+    assert (linhas[0]["tipo"], float(linhas[0]["valor"]), linhas[0]["categoria"]) == \
+        ("despesa", 39.90, "alimentação"), linhas[0]
+
+
+# ─── controles negativos: o conserto não mexeu nos 400 que já existiam ───────
+
+def test_sem_campo_file_continua_400(pro_user_id):
+    r = _upload(pro_user_id, arquivo=None)
+    assert r.status_code == 400, r.text
+    assert "campo 'file' ausente" in r.json()["detail"]
+    assert _launches(pro_user_id) == []
+
+
+def test_extensao_errada_continua_400(pro_user_id):
+    r = _upload(pro_user_id, arquivo=("extrato.pdf", b"%PDF-1.4 nao e ofx", "application/octet-stream"))
+    assert r.status_code == 400, r.text
+    assert "extensao .ofx" in r.json()["detail"]
+    assert _launches(pro_user_id) == []
+
+
+# ─── isolamento por usuário (CLAUDE.md §0, regra dura) ───────────────────────
+
+def test_nao_importa_ofx_na_conta_de_outro(pro_user_id):
+    """Vítima também é Pro de propósito: assim o 403 vem de QUEM é o dono, e não
+    do `_require_pro` — que barraria os dois casos e esconderia o buraco."""
+    vitima = int(pro_user_id) + 1
+    ensure_user(vitima)
+    promote_to_pro(vitima)
+
+    r = _upload(vitima, como=pro_user_id)
+
+    assert r.status_code == 403, r.text
+    assert _launches(vitima) == []
+    assert _launches(pro_user_id) == []  # nem cai na conta do atacante
+
+
+# ─── o gate de plano continua fechado ────────────────────────────────────────
+
+def test_usuario_sem_pro_continua_barrado(user_id):
+    r = _upload(user_id)
+    assert r.status_code == 403, r.text
+    assert r.json()["detail"]["error"] == "pro_required"
+    assert _launches(user_id) == []


### PR DESCRIPTION
Fecha #375. **Feature paga fora do ar em produção** — confirmado pelo dono, não é hipótese.

## O bug

`POST /ofx/import/{user_id}` (`frontend/finance_bot_websocket_custom.py:6792`) faz `await request.form()`, e o starlette só consegue parsear form com `python-multipart`. Traceback do Railway (deploy `7a9dc67d`, 2026-09-10 17:12 EDT):

```
File "/app/frontend/finance_bot_websocket_custom.py", line 6911, in ofx_import_route
    form = await request.form()
File "/app/.venv/lib/python3.13/site-packages/starlette/requests.py", line 276, in _get_form
    assert parse_options_header is not None, (
AssertionError: The `python-multipart` library must be installed to use form parsing.
```

O pacote **não está no `requirements.txt`**, **não é dependência do FastAPI** (que declara só `pydantic`, `starlette`, `typing-extensions`) e a **starlette só o pede no extra `full`**, que ninguém instala aqui. Toda importação de OFX 500. É feature **Pro-only** (`_require_pro(user_id, "ofx_import")`).

## Por que ninguém viu

**Nenhum teste cobria a rota.** A cobertura de OFX é farta — `ofx_import.py`, `ofx_credit_import.py`, `statement_import.py` — e chama os parsers **todos direto**, sem passar pelo HTTP. É exatamente a classe cega que o §3 do CLAUDE.md descreve: teste que chama a função direto é cego ao caminho que o usuário percorre.

## O conserto

Uma linha no `requirements.txt`, e **a versão foi conferida, não chutada**: os metadados da starlette 1.6.0 declaram `python-multipart>=0.0.18; extra == "full"`. O `0.0.32` fornece os dois nomes de módulo (`python_multipart` e `multipart`), então o venv local (starlette 0.41.3, que tenta os dois) e produção (1.6.0) usam o mesmo pin.

`UploadFile` do FastAPI **não** seria alternativa: depende do mesmo pacote, e daria diff maior pelo mesmo 500.

## O teste que faltava

5 testes **pela rota HTTP**, com `.ofx` de verdade. E ele afirma o **lançamento no Postgres** (`despesa`, `39.90`, `alimentação`), não `!= 500` — isso pegou dois erros meus enquanto escrevia: `launches` grava o valor **positivo** com o sinal no `tipo`, e o `tipo` é `despesa`, não o legado `saida`. Um `!= 500` teria passado nas duas versões erradas.

Reusa em vez de duplicar (§0.1): `_OFX_BANCO` de `tests/test_category_normalization.py`, `_cliente_logado` de `tests/test_category_launches_query.py`, e o padrão de reset do rate limiter de `tests/test_billing_checkout.py` (a rota tem `@limiter.limit("5/hour")` e o arquivo faz 5 POSTs).

## O que foi medido

**Prova negativa — desinstalando o pacote do venv**, porque o pytest lê o venv e não o `requirements.txt`:

```
3 failed, 2 passed
AssertionError: The `python-multipart` library must be installed to use form parsing.
```

Os 3 vermelhos são os que chegam ao `request.form()`. Os 2 verdes são os de autorização, que levantam 403 **antes** daquela linha — comportamento correto, não teste cego. Reinstalado → 5 passed.

**Os dois controles de segurança foram mutados para provar que discriminam:**

| mutação | vermelhos |
|---|---|
| `_authorize_dashboard_access` → `pass` | **exatamente 1**: `test_nao_importa_ofx_na_conta_de_outro` |
| `_require_pro` → `pass` | **exatamente 1**: `test_usuario_sem_pro_continua_barrado` |

A vítima do teste de isolamento é Pro de propósito — se não fosse, o `_require_pro` barraria os dois casos e o teste passaria verde com o buraco de isolamento aberto.

**Controles negativos intactos**: `file` ausente → 400 `"campo 'file' ausente"`; extensão `.pdf` → 400 `"extensao .ofx"`. Os dois com zero lançamentos criados.

Suíte: **7381 passed, 4 xfailed, 0 failed**, comparada por nome contra `842cc49` (7376/0).

**CI**: `.github/workflows/tests.yml:81` roda `pip install -r requirements.txt`, então o pacote chega lá e o teste novo roda com ele presente. Não há lista própria de dependências.

## Mudança de ambiente que quem clonar precisa saber

O venv local **não tinha** o pacote, e sem ele o teste novo fica vermelho localmente mesmo com o `requirements.txt` certo — o pytest lê o venv. Foi instalado (`python-multipart==0.0.32`) para permitir a verificação.

Duas notas laterais achadas no caminho: o shim `.venv/bin/pip` está **quebrado** (shebang aponta para um caminho que não existe) — use `.venv/bin/python -m pip`. E `ofxparse` **está** presente neste venv, ao contrário do que o §6 do CLAUDE.md sugere.

## Fora de escopo

- **Só o caminho `bank`.** O `credit_card` (`handle_credit_ofx_import`) e o `unknown` não ganharam teste de rota. O `request.form()` é o mesmo para os três, então o defeito da #375 está coberto; o roteamento de fatura não.
- **Nenhuma outra rota de upload existe** no repo (`request.form()`/`UploadFile`/`File(` → só esta), então não há irmão a varrer.

## Não verificado

Que o deploy volta a funcionar só o próprio deploy prova — a garantia aqui é o Railway resolver o `requirements.txt`, que é a mesma lista única que o CI usa (não há Dockerfile nem pyproject; o `Procfile` é o entrypoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
