### PR TITLE
Documento que o Asaas recusa deixa de virar "tenta de novo em instantes"

### DIFF
--- a/core/services/asaas_customers.py
+++ b/core/services/asaas_customers.py
@@ -33,7 +33,10 @@ class TitularRecusado(RuntimeError):
         que este módulo não pode sequer NOMEAR: o portão de
         `tests/test_pix_destino_inerte.py` mede a marca no texto). Foi o
         incidente de 10/09, e acusar o CPF do cliente por chave nossa errada é o
-        pior desfecho possível;
+        pior desfecho possível. Os dois têm caso próprio desde 2026-09-10
+        (`test_erro_que_nao_e_do_cliente_continua_503`): até lá, esta lista
+        AFIRMAVA a separação e nenhum teste a media — pôr 401/403 dentro do
+        `in (...)` de `criar_cliente` deixava a suíte Pix inteira verde;
       * **429** — throttle. Retentar ajuda, que é exatamente o que o 503 pede;
       * **5xx** e falha de transporte (`status_code is None`) — o Asaas, não o
         dado. Continuam 503.

--- a/core/services/asaas_customers.py
+++ b/core/services/asaas_customers.py
@@ -19,6 +19,38 @@ from __future__ import annotations
 
 from core.services.asaas import AsaasApiError, _request
 
+
+class TitularRecusado(RuntimeError):
+    """O Asaas recusou o CADASTRO do titular → **400**, e não os nossos 503.
+
+    A separação é por CULPA, e ela é medível pelo status HTTP:
+
+      * **400 e 422** — o Asaas leu o corpo e disse que o dado não presta
+        (`cpfCnpj`, ou o e-mail que veio do nosso cadastro). Retentar com o mesmo
+        corpo dá o mesmo erro para sempre, então 503 "tenta de novo em instantes"
+        é mentira: o cliente tem de saber que precisa mudar alguma coisa;
+      * **401 e 403** — é a NOSSA credencial de API (a env que `asaas.py` lê, e
+        que este módulo não pode sequer NOMEAR: o portão de
+        `tests/test_pix_destino_inerte.py` mede a marca no texto). Foi o
+        incidente de 10/09, e acusar o CPF do cliente por chave nossa errada é o
+        pior desfecho possível;
+      * **429** — throttle. Retentar ajuda, que é exatamente o que o 503 pede;
+      * **5xx** e falha de transporte (`status_code is None`) — o Asaas, não o
+        dado. Continuam 503.
+
+    Carrega **só** o `code`, que já passou pelo `_codigo_seguro` (`asaas.py:96`).
+    Nunca `str(exc)`, nunca o corpo, nunca o `description`: a descrição do erro do
+    Asaas vem no mesmo objeto que o `code` e traz o documento do titular por
+    extenso — e o `details` de quem loga isto é PERSISTIDO em `system_event_logs`,
+    que a purga do §13.3 não alcança. Mesma forma de `CheckoutIndisponivel`: uma
+    classe com `codigo`, e não uma classe por motivo.
+    """
+
+    def __init__(self, codigo: str | None = None):
+        super().__init__(codigo or "titular_recusado")
+        self.codigo = codigo
+
+
 def criar_cliente(*, nome: str, cpf_cnpj: str, email: str | None = None) -> str:
     """`POST /v3/customers` — devolve **só o `id`** do cliente no Asaas.
 
@@ -34,8 +66,15 @@ def criar_cliente(*, nome: str, cpf_cnpj: str, email: str | None = None) -> str:
     corpo: dict = {"name": nome, "cpfCnpj": cpf_cnpj}
     if email:
         corpo["email"] = email
-    dados = _request("POST", "/v3/customers",
-                     contexto="Falha ao criar cliente no Asaas", json=corpo)
+    try:
+        dados = _request("POST", "/v3/customers",
+                         contexto="Falha ao criar cliente no Asaas", json=corpo)
+    except AsaasApiError as exc:
+        # Só o que o Asaas classificou como corpo ruim. Todo o resto sobe INTACTO
+        # e continua virando o 503 de quem chama — ver a classe acima.
+        if exc.status_code in (400, 422):
+            raise TitularRecusado(exc.code) from exc
+        raise
     cliente_id = dados.get("id") if isinstance(dados, dict) else None
     if not isinstance(cliente_id, str) or not cliente_id:
         raise AsaasApiError(

--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -212,7 +212,7 @@ def criar_checkout(user_id: int, *, plan_stored: str, cpf_cnpj: str, nome: str,
     # **Sem default, nunca** — ver o topo. Inline: virou a única leitura de env
     # de dinheiro do módulo quando o preço deixou de ser env (§0.2).
     bruto = (os.getenv("ASAAS_MIN_CHARGE_CENTS") or "").strip()
-    if not bruto.isdigit() or int(bruto) <= 0:
+    if not (bruto.isascii() and bruto.isdigit()) or int(bruto) <= 0:
         raise CheckoutIndisponivel("asaas_min_charge_nao_configurado")
     min_cents = int(bruto)
     # `None` = plano fora da tabela (`free`, ou lixo que passou pela rota) → 503.

--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -211,8 +211,9 @@ def criar_checkout(user_id: int, *, plan_stored: str, cpf_cnpj: str, nome: str,
     from db import get_auth_user  # noqa: PLC0415
     if ((get_auth_user(user_id) or {}).get("last_payment_status") or "").lower() == "grandfathered":
         raise Vitalicio()
-    # **Sem default, nunca** — ver o topo. Inline: virou a única leitura de env
-    # de dinheiro do módulo quando o preço deixou de ser env (§0.2).
+    # **Sem default, nunca** — ver o topo. Inline: única leitura de env de dinheiro do módulo
+    # desde que o preço deixou de ser env (§0.2). O `isascii()` fecha o ALFABETO — nada estoura
+    # no `int()`, nada vira dígito de outro alfabeto — e **não** a FAIXA: `'9'*30` passa.
     bruto = (os.getenv("ASAAS_MIN_CHARGE_CENTS") or "").strip()
     if not (bruto.isascii() and bruto.isdigit()) or int(bruto) <= 0:
         raise CheckoutIndisponivel("asaas_min_charge_nao_configurado")
@@ -333,8 +334,8 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
             descricao=f"{plan_display_name(linha['plan'])} - plano anual")
         qr = asaas.obter_qr_pix(str(pagamento.get("id") or ""))
     except TitularRecusado:
-        # Nada existe no Asaas: `criar_pagamento_pix` nem rodou (o porquê, em
-        # `asaas_customers`). `draft` poupa a passada seguinte de perguntar.
+        # ANTES do `except Exception`, que engoliria esta e a devolveria como o 503 de "tenta de novo".
+        # Nada existe no Asaas (`criar_pagamento_pix` nem rodou): `draft`, e a passada seguinte não pergunta.
         voltar_para_draft(linha["id"])
         raise
     except Exception as exc:  # noqa: BLE001 — a linha fica `creating` de propósito

--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -198,8 +198,10 @@ def criar_checkout(user_id: int, *, plan_stored: str, cpf_cnpj: str, nome: str,
     """Emite (ou reaproveita) a cobrança Pix anual. **Roda sob lock do usuário.**
 
     Levanta `CheckoutIndisponivel` (503), `Vitalicio`, `StripeAtivo` e
-    `CoberturaJaPaga` (409) — nenhum dos quatro escreve nada antes de levantar. O
-    `cpf_cnpj` atravessa sem tocar em disco: vai para `criar_cliente` e morre lá."""
+    `CoberturaJaPaga` (409) — esses quatro decidem ANTES de escrever qualquer
+    coisa. A quinta é `TitularRecusado` (400, de `asaas_customers`): ela sai do
+    meio da saga e **deixa a linha em `draft`** (ver `_emitir`). O `cpf_cnpj`
+    atravessa sem tocar em disco: vai para `criar_cliente` e morre lá."""
     if not pix_annual_available():
         raise CheckoutIndisponivel("pix_annual_desligado")
     # DEPOIS da env: com a flag em 0 o vitalício leva 503 `pix_annual_desligado`, não
@@ -305,10 +307,10 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
     haver cobrança lá que não conhecemos". Depois, seria um `draft` que a regra
     (b) do §10.1 acharia seguro apagar.
     """
-    from core.services.asaas_customers import criar_cliente
+    from core.services.asaas_customers import TitularRecusado, criar_cliente
     from core.services.email_service import plan_display_name
     from db.pix_charges import transicionar
-    from db.pix_charges_saga import attach_pagamento
+    from db.pix_charges_saga import attach_pagamento, voltar_para_draft
 
     transicionar(linha["id"], de=("draft",), para="creating")
     vence = date.today() + timedelta(days=VENCIMENTO_DIAS)
@@ -330,6 +332,11 @@ def _emitir(linha: dict, cpf_cnpj: str, nome: str, email: str | None) -> dict:
             # e o hífen não perde nada. O texto era ASCII puro antes do #350.
             descricao=f"{plan_display_name(linha['plan'])} - plano anual")
         qr = asaas.obter_qr_pix(str(pagamento.get("id") or ""))
+    except TitularRecusado:
+        # Nada existe no Asaas: `criar_pagamento_pix` nem rodou (o porquê, em
+        # `asaas_customers`). `draft` poupa a passada seguinte de perguntar.
+        voltar_para_draft(linha["id"])
+        raise
     except Exception as exc:  # noqa: BLE001 — a linha fica `creating` de propósito
         raise CheckoutIndisponivel("asaas_emissao_falhou") from exc
 

--- a/core/services/pix_checkout.py
+++ b/core/services/pix_checkout.py
@@ -15,10 +15,6 @@ Cada seta é um commit local. O mundo remoto NÃO é transacional, então a
 varredura (`core/services/pix_sweeps.py`) é quem fecha o que morrer no meio —
 `creating` é o estado ambíguo por definição e **nunca** é apagado por relógio.
 
-**A substituição cancela no Asaas ANTES de criar a nova** (§10, correção nº 6), igual
-ao `Session.expire` do caminho do Stripe. Falhando o `DELETE`, é 503 e **nada é criado**:
-dois QRs pagáveis do mesmo usuário seriam duas cobranças contra o mesmo crédito.
-
 ## O caso "fechei a aba e voltei" — 200 com o MESMO QR
 
 Decisão do dono, 2026-09-09: cobrança ativa **do mesmo plano** devolve o mesmo
@@ -197,11 +193,15 @@ def criar_checkout(user_id: int, *, plan_stored: str, cpf_cnpj: str, nome: str,
                    confirm_cancel_stripe: bool = False) -> dict:
     """Emite (ou reaproveita) a cobrança Pix anual. **Roda sob lock do usuário.**
 
-    Levanta `CheckoutIndisponivel` (503), `Vitalicio`, `StripeAtivo` e
-    `CoberturaJaPaga` (409) — esses quatro decidem ANTES de escrever qualquer
-    coisa. A quinta é `TitularRecusado` (400, de `asaas_customers`): ela sai do
-    meio da saga e **deixa a linha em `draft`** (ver `_emitir`). O `cpf_cnpj`
-    atravessa sem tocar em disco: vai para `criar_cliente` e morre lá."""
+    Levanta `CheckoutIndisponivel` (503), `Vitalicio`, `StripeAtivo` e `CoberturaJaPaga`
+    (409); a quinta é `TitularRecusado` (400, de `asaas_customers`). **Nem todo 503 sai
+    antes da primeira escrita**: dos nove do módulo, três levantam com a linha JÁ gravada
+    — `asaas_cancelamento_falhou` (em `canceling`), `cobranca_ativa_persistiu` (a antiga
+    em `canceled`, e a cobrança que houvesse no Asaas já apagada) e `asaas_emissao_falhou`
+    (a nova em `creating`). O que distingue a `TitularRecusado` não é escrever ou não: é o
+    ESTADO que sobra. `draft` diz que NENHUMA cobrança existe lá, e a passada seguinte não
+    precisa perguntar; `creating` é o ambíguo, que só a varredura fecha (§10.1). O
+    `cpf_cnpj` atravessa sem tocar em disco: vai para `criar_cliente` e morre lá."""
     if not pix_annual_available():
         raise CheckoutIndisponivel("pix_annual_desligado")
     # DEPOIS da env: com a flag em 0 o vitalício leva 503 `pix_annual_desligado`, não

--- a/frontend/pix-checkout.js
+++ b/frontend/pix-checkout.js
@@ -297,9 +297,9 @@ async function pixEnviar(plano, documento, confirmarCancelamentoStripe, ctx, bot
     // `detail` STRING é a metade que faltava: o FastAPI manda `{"detail": "<frase>"}`
     // em todo `HTTPException(detail="…")`, e aqui isso caía num `det.message`
     // undefined — a frase que o servidor escreveu era descartada e o cliente lia o
-    // genérico. São cinco: os dois 400 (plano, documento), o 429 do limitador (por
-    // IP — routes/shared.py:98, então não é só quem digitou que o toma), o 503 da
-    // indisponibilidade e o 403 do CSRF, de que o checkout não tem isenção.
+    // genérico. São seis: os três 400 (plano, documento e o titular recusado pelo
+    // Asaas), o 429 do limitador (por IP — routes/shared.py:98, então não é só quem
+    // digitou que o toma), o 503 da indisponibilidade e o 403 do CSRF, sem isenção.
     // Mesma forma do `apiError` do comecar.js:175 — o 500 real não tem `detail`
     // nenhum (`{"error": …}`, finance_bot_websocket_custom.py:2415), então segue
     // no genérico. O #355 consertou o mesmo defeito só no toast; normalizar aqui

--- a/frontend/routes/billing_pix.py
+++ b/frontend/routes/billing_pix.py
@@ -142,9 +142,9 @@ async def billing_pix_checkout(request: Request, payload: PixCheckoutBody):
             "current_period_end": exc.current_period_end.date().isoformat(),
         }) from exc
     except TitularRecusado as exc:
-        # ANTES do `CheckoutIndisponivel`: as duas descem de `RuntimeError` e a
-        # herança não separa nada — `except` na ordem errada engoliria esta e
-        # devolveria o 503 de "tenta de novo", que aqui é mentira.
+        # A ordem entre este `except` e o do `CheckoutIndisponivel` NÃO importa: as duas
+        # são IRMÃS (`RuntimeError` direto), então nenhuma engole a outra — invertendo os
+        # dois blocos, o grupo segue verde. A ordem que importa é a de `_emitir`.
         # `details` leva o motivo e o `code` JÁ filtrado, e NADA mais: nome,
         # e-mail e `cpf_cnpj` não entram: `system_event_logs` é a tabela que a
         # purga do §13.3 não alcança. O `detail` é literal NOSSO, jamais o texto

--- a/frontend/routes/billing_pix.py
+++ b/frontend/routes/billing_pix.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel
 
 from core.observability import log_system_event_sync
 from core.secure_compare import constant_time_eq
+from core.services.asaas_customers import TitularRecusado
 from core.services.pix_checkout import (
     CheckoutIndisponivel,
     StripeAtivo,
@@ -140,6 +141,25 @@ async def billing_pix_checkout(request: Request, payload: PixCheckoutBody):
             "error": exc.ERRO,
             "current_period_end": exc.current_period_end.date().isoformat(),
         }) from exc
+    except TitularRecusado as exc:
+        # ANTES do `CheckoutIndisponivel`: as duas descem de `RuntimeError` e a
+        # herança não separa nada — `except` na ordem errada engoliria esta e
+        # devolveria o 503 de "tenta de novo", que aqui é mentira.
+        # `details` leva o motivo e o `code` JÁ filtrado, e NADA mais: nome,
+        # e-mail e `cpf_cnpj` não entram: `system_event_logs` é a tabela que a
+        # purga do §13.3 não alcança. O `detail` é literal NOSSO, jamais o texto
+        # do Asaas — e não acusa o CPF de propósito, porque a recusa pode vir do
+        # e-mail do cadastro, que o cliente não digitou nesta tela.
+        log_system_event_sync("warning", "pix_titular_recusado",
+                              "Asaas recusou o titular do checkout Pix.",
+                              source="pix", user_id=user_id,
+                              details={"motivo": "titular_recusado",
+                                       "code": exc.codigo or ""})
+        raise HTTPException(
+            status_code=400,
+            detail="O banco recusou esses dados. Confere o CPF ou CNPJ — se "
+                   "estiver certo, fala com a gente.",
+        ) from exc
     except CheckoutIndisponivel as exc:
         log_system_event_sync("warning", "pix_checkout_indisponivel",
                               "Checkout Pix recusado.", source="pix",

--- a/tests/_pix_checkout_helpers.py
+++ b/tests/_pix_checkout_helpers.py
@@ -50,12 +50,26 @@ def asaas_falso(monkeypatch):
     # `descricoes` guarda o que foi para o campo que o PAGADOR lê na fatura —
     # a única saída deste PR visível para cliente hoje. Lista, e não o último
     # valor: um teste que compra duas vezes tem de conseguir ver as duas.
+    # `cliente_falha` é o `AsaasApiError` que o `POST /v3/customers` levanta —
+    # o interruptor do `qr_falha`/`delete_falha`, com o erro dentro em vez de um
+    # booleano: quem classifica 400/422 é o `criar_cliente` DE VERDADE, e o
+    # status é justamente o que se quer variar.
     estado = {"ordem": [], "delete_falha": False, "n": 0, "marca": marca,
-              "remotas": [], "qr_falha": False, "descricoes": []}
+              "remotas": [], "qr_falha": False, "descricoes": [],
+              "cliente_falha": None}
+    real_cliente = ac.criar_cliente
+
+    def _request_falso(*a, **kw):
+        raise estado["cliente_falha"]
 
     def _cliente(**kw):
         estado["ordem"].append("customer")
         estado["cpf_visto"] = kw.get("cpf_cnpj")
+        if estado["cliente_falha"] is not None:
+            # Passa pelo `criar_cliente` real, só sem transporte: um falso que
+            # já levantasse `TitularRecusado` mediria a si mesmo, e a regra dos
+            # status (400/422 sim, 401/403/429/5xx não) não seria testada.
+            return real_cliente(**kw)
         return "cus_1"
 
     def _pagamento(**kw):
@@ -82,6 +96,7 @@ def asaas_falso(monkeypatch):
             raise a.AsaasApiError("Falha ao cancelar", status_code=502)
         return {"deleted": True}
 
+    monkeypatch.setattr(ac, "_request", _request_falso)
     monkeypatch.setattr(ac, "criar_cliente", _cliente)
     monkeypatch.setattr(a, "criar_pagamento_pix", _pagamento)
     monkeypatch.setattr(a, "obter_qr_pix", _qr)

--- a/tests/_pix_checkout_helpers.py
+++ b/tests/_pix_checkout_helpers.py
@@ -60,6 +60,11 @@ def asaas_falso(monkeypatch):
     real_cliente = ac.criar_cliente
 
     def _request_falso(*a, **kw):
+        if estado["cliente_falha"] is None:
+            raise AssertionError(
+                "`asaas_customers._request` foi chamado com `cliente_falha` desligado: "
+                "há caminho novo no módulo que este falso não cobre (o `criar_cliente` "
+                "patchado só delega ao real quando o interruptor está ligado).")
         raise estado["cliente_falha"]
 
     def _cliente(**kw):

--- a/tests/test_pix_checkout.py
+++ b/tests/test_pix_checkout.py
@@ -18,6 +18,10 @@ CONTROLES NEGATIVOS MEDIDOS (um a um, com o resto do grupo verde):
   * dê default a `ASAAS_MIN_CHARGE_CENTS` →
     `test_env_de_dinheiro_ausente_recusa_a_venda` VERMELHO, e é o caso em que um
     número inventado vira cobrança de verdade;
+  * devolva a leitura da env para `if not bruto.isdigit() or int(bruto) <= 0` →
+    `test_env_de_dinheiro_malformada_recusa_a_venda` VERMELHO em `²` (o `int()`
+    estoura, 500 no lugar do 503) e em `٥٠٠` (`int("٥٠٠") == 500` e a venda SAI, a
+    500 centavos que ninguém digitou). `-5` e `abc` seguem verdes com e sem;
   * apague a guarda de `grandfathered` de `criar_checkout` →
     `test_vitalicio_nao_compra_o_anual` VERMELHO, com a cobrança criada e o Asaas
     chamado — o dinheiro entrando por acesso que o cliente já tem.
@@ -113,6 +117,24 @@ def test_env_de_dinheiro_ausente_recusa_a_venda(user_id, vendavel, asaas_falso,
     """
     conta(user_id, "free", None)
     monkeypatch.delenv("ASAAS_MIN_CHARGE_CENTS")
+    with pytest.raises(CheckoutIndisponivel):
+        _comprar(user_id)
+    assert _linhas(user_id) == [] and asaas_falso["ordem"] == []
+
+
+@pytest.mark.parametrize("bruto", ["²", "٥٠٠", "-5", "abc"])
+def test_env_de_dinheiro_malformada_recusa_a_venda(user_id, vendavel, asaas_falso,
+                                                   monkeypatch, bruto):
+    """DISCRIMINA. Env MALFORMADA é o mesmo estado da ausente: recusa, não default.
+
+    Os dois primeiros casos são os que mordiam. `"²"` tem `isdigit()` True e
+    `int()` que estoura — `ValueError` cru saindo do contrato do módulo. `"٥٠٠"`
+    é pior porque é silencioso: `int("٥٠٠") == 500` (medido), então a venda ia
+    até o fim com um mínimo que ninguém digitou. `-5` e `abc` já eram recusados
+    com e sem o conserto, e estão aqui como a moldura da categoria.
+    """
+    conta(user_id, "free", None)
+    monkeypatch.setenv("ASAAS_MIN_CHARGE_CENTS", bruto)
     with pytest.raises(CheckoutIndisponivel):
         _comprar(user_id)
     assert _linhas(user_id) == [] and asaas_falso["ordem"] == []

--- a/tests/test_pix_checkout.py
+++ b/tests/test_pix_checkout.py
@@ -21,7 +21,13 @@ CONTROLES NEGATIVOS MEDIDOS (um a um, com o resto do grupo verde):
   * devolva a leitura da env para `if not bruto.isdigit() or int(bruto) <= 0` →
     `test_env_de_dinheiro_malformada_recusa_a_venda` VERMELHO em `²` (o `int()`
     estoura, 500 no lugar do 503) e em `٥٠٠` (`int("٥٠٠") == 500` e a venda SAI, a
-    500 centavos que ninguém digitou). `-5` e `abc` seguem verdes com e sem;
+    500 centavos que ninguém digitou). `-5` e `abc` seguem verdes com e sem.
+    **O que a guarda fecha é o ALFABETO, não a FAIXA**: `'9'*30` é aceito como
+    mínimo, e um mínimo maior que o crédito faz `plano_da_cobranca` DESCARTAR o
+    crédito e AGENDAR a compra (medido em 2026-09-10, chamando a função pura com um
+    grant Pix de 30 dias restantes: crédito 1636 → 0, cobrança 48264 → 49900,
+    `agendada` False → True). Teto conhecido e deixado de fora de propósito —
+    nenhum limite salva `500` digitado como `5000`, e onde cortar é do dono;
   * apague a guarda de `grandfathered` de `criar_checkout` →
     `test_vitalicio_nao_compra_o_anual` VERMELHO, com a cobrança criada e o Asaas
     chamado — o dinheiro entrando por acesso que o cliente já tem.
@@ -125,13 +131,16 @@ def test_env_de_dinheiro_ausente_recusa_a_venda(user_id, vendavel, asaas_falso,
 @pytest.mark.parametrize("bruto", ["²", "٥٠٠", "-5", "abc"])
 def test_env_de_dinheiro_malformada_recusa_a_venda(user_id, vendavel, asaas_falso,
                                                    monkeypatch, bruto):
-    """DISCRIMINA. Env MALFORMADA é o mesmo estado da ausente: recusa, não default.
+    """DISCRIMINA. Env com dígito que não é 0-9 é o mesmo estado da ausente: recusa.
 
     Os dois primeiros casos são os que mordiam. `"²"` tem `isdigit()` True e
     `int()` que estoura — `ValueError` cru saindo do contrato do módulo. `"٥٠٠"`
     é pior porque é silencioso: `int("٥٠٠") == 500` (medido), então a venda ia
     até o fim com um mínimo que ninguém digitou. `-5` e `abc` já eram recusados
     com e sem o conserto, e estão aqui como a moldura da categoria.
+
+    O que este grupo NÃO mede: valor absurdo em dígito ASCII. `'9'*30` passa e a
+    venda sai (ver o topo) — o conserto fechou o alfabeto, não a faixa.
     """
     conta(user_id, "free", None)
     monkeypatch.setenv("ASAAS_MIN_CHARGE_CENTS", bruto)

--- a/tests/test_pix_documento_invalido.py
+++ b/tests/test_pix_documento_invalido.py
@@ -33,14 +33,16 @@ dá o mesmo erro para sempre. Agora é 400 com texto próprio, e a linha volta p
 CONTROLES NEGATIVOS MEDIDOS (um a um, com o resto do grupo verde):
 
   * apague o `raise TitularRecusado(exc.code)` de
-    `core/services/asaas_customers.py` →
-    `test_asaas_recusa_o_titular_devolve_400_e_deixa_a_linha_em_draft` VERMELHO
-    (503 no lugar do 400) e
-    `test_retentativa_depois_da_recusa_nao_pergunta_nada_ao_asaas` VERMELHO junto;
+    `core/services/asaas_customers.py` → TRÊS VERMELHOS, todos com 503 no lugar
+    do 400: `test_asaas_recusa_o_titular_devolve_400_e_deixa_a_linha_em_draft`,
+    `test_retentativa_depois_da_recusa_nao_pergunta_nada_ao_asaas` e
+    `test_a_recusa_nao_vaza_o_documento_nem_o_corpo` — este último também exige o
+    400, e ficava de fora desta lista;
   * apague **só** o `voltar_para_draft(linha["id"])` de `_emitir`, mantendo o
-    `raise` → o primeiro VERMELHO na asserção `status == "draft"` e o segundo
-    VERMELHO pela `consulta` extra: a linha fica `creating` e a passada seguinte
-    vai PERGUNTAR ao Asaas por uma cobrança que nunca existiu;
+    `raise` → o primeiro VERMELHO na asserção `status == "draft"` e o segundo na
+    ordem do Asaas, que vira `['consulta', 'customer', 'create', 'qr']`: a linha
+    fica `creating` e a passada seguinte vai PERGUNTAR ao Asaas por uma cobrança
+    que nunca existiu;
   * troque `exc.status_code in (400, 422)` por `400 <= exc.status_code < 500` →
     `test_erro_que_nao_e_do_cliente_continua_503` VERMELHO nos TRÊS casos (429, 401
     e 403), todos acusando o CPF do cliente por erro que não é dele;
@@ -208,7 +210,9 @@ def test_retentativa_depois_da_recusa_nao_pergunta_nada_ao_asaas(
 
     assert r.status_code == 200, r.text
     assert r.json()["qr_payload"]
-    assert "consulta" not in asaas_falso["ordem"], asaas_falso["ordem"]
+    # A ordem INTEIRA, não só a ausência de `consulta`: o nome promete "nada ao
+    # Asaas", e um `delete:pay_...` na retentativa passaria verde num `not in`.
+    assert asaas_falso["ordem"] == ["customer", "create", "qr"], asaas_falso["ordem"]
 
 
 def test_asaas_fora_do_ar_continua_503_com_a_linha_em_creating(

--- a/tests/test_pix_documento_invalido.py
+++ b/tests/test_pix_documento_invalido.py
@@ -42,8 +42,14 @@ CONTROLES NEGATIVOS MEDIDOS (um a um, com o resto do grupo verde):
     VERMELHO pela `consulta` extra: a linha fica `creating` e a passada seguinte
     vai PERGUNTAR ao Asaas por uma cobrança que nunca existiu;
   * troque `exc.status_code in (400, 422)` por `400 <= exc.status_code < 500` →
-    `test_throttle_do_asaas_nao_acusa_o_dado_do_cliente` VERMELHO, que é o 429 (e,
-    pela mesma condição, o 401/403 da NOSSA chave) acusando o CPF do cliente.
+    `test_erro_que_nao_e_do_cliente_continua_503` VERMELHO nos TRÊS casos (429, 401
+    e 403), todos acusando o CPF do cliente por erro que não é dele;
+  * troque por `exc.status_code in (400, 422, 401, 403)` — a mutação que
+    DISCRIMINA, porque atinge só a nossa credencial e deixa o 429 de fora → o mesmo
+    teste VERMELHO em 401 e 403, e verde em 429. Até 2026-09-10 essa mutação não
+    derrubava caso NENHUM da suíte: o parêntese "e, pela mesma condição, o 401/403"
+    estava escrito aqui e não era medido. É o incidente de 10/09 — a NOSSA chave de
+    API errada dizendo ao cliente que o CPF dele não presta.
 
 POSITIVOS do grupo (`..._cpf_valido_...`, `..._cnpj_valido_...` e
 `test_asaas_fora_do_ar_continua_503_com_a_linha_em_creating`): sem eles, um
@@ -219,17 +225,26 @@ def test_asaas_fora_do_ar_continua_503_com_a_linha_em_creating(
     assert _linhas(user_id)[0]["status"] == "creating"
 
 
-def test_throttle_do_asaas_nao_acusa_o_dado_do_cliente(
-        user_id, vendavel, asaas_falso, monkeypatch):
-    """429 é fila cheia, e retentar ajuda — exatamente o que o 503 pede. Um
-    `400 <= status < 500` levaria junto o 401/403 da NOSSA `ASAAS_API_KEY`, que
-    foi o incidente de 10/09: o cliente lendo que o CPF dele não presta."""
+@pytest.mark.parametrize("status", [429, 401, 403])
+def test_erro_que_nao_e_do_cliente_continua_503(
+        user_id, vendavel, asaas_falso, monkeypatch, status):
+    """4xx que NÃO é o dado do titular: 503, e nunca "confere o CPF".
+
+    429 é fila cheia e retentar ajuda — exatamente o que o 503 pede. 401 e 403 são
+    a NOSSA `ASAAS_API_KEY`, e foram o incidente de 10/09: acusar o documento do
+    cliente por credencial nossa errada é o pior desfecho possível. Os três juntos
+    porque a condição que os separa é uma só, e 401/403 não tinham caso nenhum.
+
+    A linha fica `creating` como no 502: daqui em diante o estado é ambíguo para a
+    varredura, e é o que separa este grupo do `draft` da recusa do titular.
+    """
     conta(user_id, "free", None)
-    asaas_falso["cliente_falha"] = _recusa(429, code=None)
+    asaas_falso["cliente_falha"] = _recusa(status, code=None)
     r = _checkout(user_id, monkeypatch, CPF_OK)
 
     assert r.status_code == 503, r.text
     assert r.json()["detail"] == INDISPONIVEL
+    assert _linhas(user_id)[0]["status"] == "creating"
 
 
 def test_a_recusa_nao_vaza_o_documento_nem_o_corpo(user_id, vendavel, asaas_falso,

--- a/tests/test_pix_documento_invalido.py
+++ b/tests/test_pix_documento_invalido.py
@@ -24,9 +24,32 @@ CONTROLES NEGATIVOS MEDIDOS (um a um, em `frontend/routes/billing_pix.py`):
     positivo `52998224725５` vermelho junto (400: o `５` sobrevive e viram 12
     dígitos). Os demais positivos seguem verdes.
 
-POSITIVOS do grupo (`..._cpf_valido_...` e `..._cnpj_valido_...`): sem eles, um
-`_documento_valido` que devolvesse `False` para tudo passaria em todos os
-negativos e mataria a venda inteira.
+O SEGUNDO grupo (desde 2026-09-10) é o documento que passa aqui e o **Asaas**
+recusa: estruturalmente válido, e mesmo assim o `POST /v3/customers` devolve 400.
+Isso virava o 503 de "tenta de novo em instantes" — mentira, porque o mesmo corpo
+dá o mesmo erro para sempre. Agora é 400 com texto próprio, e a linha volta para
+`draft` (nada existe no Asaas: `criar_pagamento_pix` nem chegou a rodar).
+
+CONTROLES NEGATIVOS MEDIDOS (um a um, com o resto do grupo verde):
+
+  * apague o `raise TitularRecusado(exc.code)` de
+    `core/services/asaas_customers.py` →
+    `test_asaas_recusa_o_titular_devolve_400_e_deixa_a_linha_em_draft` VERMELHO
+    (503 no lugar do 400) e
+    `test_retentativa_depois_da_recusa_nao_pergunta_nada_ao_asaas` VERMELHO junto;
+  * apague **só** o `voltar_para_draft(linha["id"])` de `_emitir`, mantendo o
+    `raise` → o primeiro VERMELHO na asserção `status == "draft"` e o segundo
+    VERMELHO pela `consulta` extra: a linha fica `creating` e a passada seguinte
+    vai PERGUNTAR ao Asaas por uma cobrança que nunca existiu;
+  * troque `exc.status_code in (400, 422)` por `400 <= exc.status_code < 500` →
+    `test_throttle_do_asaas_nao_acusa_o_dado_do_cliente` VERMELHO, que é o 429 (e,
+    pela mesma condição, o 401/403 da NOSSA chave) acusando o CPF do cliente.
+
+POSITIVOS do grupo (`..._cpf_valido_...`, `..._cnpj_valido_...` e
+`test_asaas_fora_do_ar_continua_503_com_a_linha_em_creating`): sem eles, um
+`_documento_valido` que devolvesse `False` para tudo — ou um `criar_cliente` que
+levantasse `TitularRecusado` para qualquer erro — passaria em todos os negativos e
+mataria a venda inteira.
 """
 from __future__ import annotations
 
@@ -41,6 +64,15 @@ from _pix_checkout_helpers import (  # noqa: F401 - `asaas_falso`/`vendavel` sã
     asaas_falso,
     vendavel,
 )
+from core.services.asaas import AsaasApiError
+from db.connection import get_conn
+
+# O CPF estruturalmente válido dos casos do Asaas: ele PRECISA passar pelo
+# `_documento_valido` para a recusa medida ser a de lá, não a daqui.
+CPF_OK = "52998224725"
+RECUSA_DO_ASAAS = ("O banco recusou esses dados. Confere o CPF ou CNPJ — se "
+                   "estiver certo, fala com a gente.")
+INDISPONIVEL = "Não consegui emitir o Pix agora. Tenta de novo em instantes."
 
 client = TestClient(dashboard.app)
 
@@ -125,3 +157,97 @@ def test_cpf_com_lixo_ao_redor_dos_digitos_passa(user_id, vendavel, asaas_falso,
 
     assert r.status_code == 200, r.text
     assert len(_linhas(user_id)) == 1
+
+
+# ── o documento que passa aqui e o ASAAS recusa ──────────────────────────────
+
+def _recusa(status: int, code: str | None = "invalid_cpfCnpj") -> AsaasApiError:
+    """O erro como `_raise_for_asaas_response` o constrói: contexto + status +
+    `code` já filtrado, e **sem** corpo."""
+    return AsaasApiError(
+        f"Falha ao criar cliente no Asaas: Asaas retornou HTTP {status}"
+        + (f" (code={code})" if code else ""),
+        status_code=status, code=code)
+
+
+def test_asaas_recusa_o_titular_devolve_400_e_deixa_a_linha_em_draft(
+        user_id, vendavel, asaas_falso, monkeypatch):
+    """DISCRIMINA. 400 do Asaas é culpa do dado, e o 503 dizia o contrário."""
+    conta(user_id, "free", None)
+    asaas_falso["cliente_falha"] = _recusa(400)
+    r = _checkout(user_id, monkeypatch, CPF_OK)
+
+    assert r.status_code == 400, r.text
+    assert r.json()["detail"] == RECUSA_DO_ASAAS
+    linhas = _linhas(user_id)
+    assert len(linhas) == 1 and linhas[0]["status"] == "draft", linhas
+    # Nem `create` nem `qr`: a saga parou no titular, então NÃO há cobrança lá.
+    assert asaas_falso["ordem"] == ["customer"], asaas_falso["ordem"]
+
+
+def test_retentativa_depois_da_recusa_nao_pergunta_nada_ao_asaas(
+        user_id, vendavel, asaas_falso, monkeypatch):
+    """A CONVERSA, não a função (§3): duas requisições, mesmo usuário, mesmo
+    banco. É este teste que mede a escolha do `draft` — com a linha em `creating`
+    a substituição chama `id_remoto_vivo`, que é um GET no Asaas por uma cobrança
+    que nunca existiu (e cujo modo de falha, `asaas_cancelamento_falhou`, já foi
+    visto em produção)."""
+    conta(user_id, "free", None)
+    asaas_falso["cliente_falha"] = _recusa(400)
+    assert _checkout(user_id, monkeypatch, CPF_OK).status_code == 400
+
+    asaas_falso["cliente_falha"] = None
+    asaas_falso["ordem"].clear()
+    r = _checkout(user_id, monkeypatch, CPF_OK)
+
+    assert r.status_code == 200, r.text
+    assert r.json()["qr_payload"]
+    assert "consulta" not in asaas_falso["ordem"], asaas_falso["ordem"]
+
+
+def test_asaas_fora_do_ar_continua_503_com_a_linha_em_creating(
+        user_id, vendavel, asaas_falso, monkeypatch):
+    """POSITIVO do grupo. 5xx é o Asaas, não o dado: segue 503, com o mesmo texto
+    de antes, e a linha fica `creating` — o estado ambíguo que a varredura trata,
+    porque daí em diante pode haver cobrança lá."""
+    conta(user_id, "free", None)
+    asaas_falso["cliente_falha"] = _recusa(502, code=None)
+    r = _checkout(user_id, monkeypatch, CPF_OK)
+
+    assert r.status_code == 503, r.text
+    assert r.json()["detail"] == INDISPONIVEL
+    assert _linhas(user_id)[0]["status"] == "creating"
+
+
+def test_throttle_do_asaas_nao_acusa_o_dado_do_cliente(
+        user_id, vendavel, asaas_falso, monkeypatch):
+    """429 é fila cheia, e retentar ajuda — exatamente o que o 503 pede. Um
+    `400 <= status < 500` levaria junto o 401/403 da NOSSA `ASAAS_API_KEY`, que
+    foi o incidente de 10/09: o cliente lendo que o CPF dele não presta."""
+    conta(user_id, "free", None)
+    asaas_falso["cliente_falha"] = _recusa(429, code=None)
+    r = _checkout(user_id, monkeypatch, CPF_OK)
+
+    assert r.status_code == 503, r.text
+    assert r.json()["detail"] == INDISPONIVEL
+
+
+def test_a_recusa_nao_vaza_o_documento_nem_o_corpo(user_id, vendavel, asaas_falso,
+                                                   monkeypatch):
+    """O corpo do erro do Asaas traz o documento por extenso ("O CPF 529... é
+    inválido"), e `system_event_logs` é a tabela que a purga do §13.3 NÃO alcança.
+    Nem a resposta nem a linha de log podem carregar os 11 dígitos."""
+    conta(user_id, "free", None)
+    asaas_falso["cliente_falha"] = AsaasApiError(
+        f"Falha ao criar cliente no Asaas: o CPF {CPF_OK} e invalido",
+        status_code=400, code="invalid_cpfCnpj")
+    r = _checkout(user_id, monkeypatch, CPF_OK)
+
+    assert r.status_code == 400, r.text
+    assert CPF_OK not in r.text
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("select message, details from system_event_logs "
+                    "where user_id = %s", (user_id,))
+        linhas = [dict(x) for x in cur.fetchall()]
+    assert linhas, "o log da recusa não foi escrito"
+    assert not [x for x in linhas if CPF_OK in str(x)], linhas


### PR DESCRIPTION
Fixes #363
Fixes #365

## #363 — todo erro do Asaas virava o mesmo 503

`core/services/pix_checkout.py` engolia tudo num `except Exception` e o router devolvia 503 com frase fixa: **"Não consegui emitir o Pix agora. Tenta de novo em instantes."** Consequências: manda **tentar de novo** para um erro que retentativa nunca resolve; cada tentativa gasta 1 dos 20/hora e deixa uma linha `creating` que a seguinte tem de cancelar **no Asaas**; e indisponibilidade real produz a mesma tela — foi o que confundiu em 10/09, quando o `ASAAS_BASE_URL` estava errado.

### O desenho não depende do mapa de códigos do Asaas

O bloqueio histórico era *"não sabemos qual `code` ele manda para documento inválido"*. **Não é preciso saber.** Basta **qual chamada** falhou e a **classe do status**:

| | |
|---|---|
| `criar_cliente` com **400/422** | o dado do titular foi recusado → **400** com frase própria |
| `criar_pagamento_pix` / `obter_qr_pix`, ou **401/403/429/5xx/timeout** | indisponibilidade → **503 de hoje, inalterado** |

`AsaasApiError` já carrega `status_code`, e o `code` já passa pelo `_codigo_seguro`. **401/403 continuam 503 de propósito** — são a NOSSA `ASAAS_API_KEY` errada, e 429 é throttle, onde retentar ajuda.

Se o Asaas usar um status que não prevemos, **cai no 503 de hoje**: falha degradada, não regressão.

### A linha volta para `draft`, e isso poupa uma ida ao provedor

A exceção saiu de `criar_cliente`, então o controle **nunca chegou** em `criar_pagamento_pix` — não pode existir cobrança com a nossa `external_reference` lá.

| linha fica em | próxima tentativa do cliente |
|---|---|
| `creating` (antes) | `_cancelar_remota` → `id_remoto_vivo` → **GET no Asaas**, cujo modo de falha (`asaas_cancelamento_falhou`) já foi visto em produção |
| `draft` (agora) | o ramo remoto é guardado por `status == "creating"` → **zero chamada remota** |

Não é transição nova: `voltar_para_draft` é a função que a **própria reconciliação** chama para esta situação — aplicamos o veredito dela 15 min antes. A guarda é SQL (`where id = %s and status = 'creating' and asaas_payment_id is null`), então se algo correu por baixo é no-op. **Falha de transporte** (`status_code=None`) não vira `TitularRecusado` e a linha fica em `creating`, como hoje.

### A frase

**"O banco recusou esses dados. Confere o CPF ou CNPJ — se estiver certo, fala com a gente."**

Escolhida pelo dono **por não culpar o CPF**: `nome` e `email` vêm de `_titular(user_id)`, não do formulário, e uma recusa pelo e-mail guardado no cadastro é alcançável. Ela aparece **dentro do modal, embaixo do campo**, com o foco de volta no input — de graça, porque o #373 fez isso hoje. Zero linha de JS.

## #365 — a env de dinheiro em dígito não-ASCII vendia

`if not bruto.isdigit() or int(bruto) <= 0:` sobre `ASAAS_MIN_CHARGE_CENTS`. Dois modos, não um:

- `'²'.isdigit()` é `True` e `int('²')` **estoura** — a mesma forma do bug que derrubava a rota com 500 antes do #355;
- **`'٥٠٠'.isdigit()` é `True` e `int('٥٠٠') == 500`** — hoje a env em dígito árabe **passa e vende**, a 500 centavos que ninguém digitou.

`isascii() and isdigit()` fecha os dois. Idioma que já existe em `db/accounts.py:1229`. Env malformada **recusa**, igual à ausente — `pix_pricing.py:156-158` já escreveu que *"um default inventado aqui viraria cobrança recusada pelo Asaas"*, e o precedente do `_timeout` não transfere (timeout é operacional, mínimo é dinheiro).

**O que fechou foi o alfabeto, não a faixa:** `'9'*30` continua passando. Medido em `plano_da_cobranca` (grant Pix de 30 dias, R$ 199 → Pro R$ 499): `min=500` → crédito 1636, cobrança 48264, imediata; `min='9'*30` → crédito **0**, cobrança 49900, **agendada para 11 meses depois**. Um zero a mais no painel não recusa nem loga. Teto superior é decisão de produto — issue à parte.

## Testes — os dois controles, com os negativos rodados

| mutação | fica vermelho |
|---|---|
| apagar o `raise TitularRecusado` | os 3: `..._devolve_400_e_deixa_a_linha_em_draft`, `..._retentativa_...`, `..._nao_vaza_o_documento_...` |
| apagar só o `voltar_para_draft` | 2, com `ordem == ['consulta','customer','create','qr']` |
| `(400,422)` → `(400,422,401,403)` | `..._continua_503[401]` e `[403]` |
| `(400,422)` → `400 <= status < 500` | `[429]`, `[401]`, `[403]` |
| inverter os `except` em `_emitir` | 3 |
| `isascii()` fora | `[²]` e `[٥٠٠]` |

**Positivos do grupo** (sem eles, um `criar_cliente` que recusasse tudo passaria em todos os negativos e mataria a venda): o 502 continuando 503 com a linha em `creating`, e os casos de CPF/CNPJ válidos já existentes.

**A conversa, não a função** (§3): `test_retentativa_depois_da_recusa_nao_pergunta_nada_ao_asaas` manda **duas** requisições com o mesmo usuário e o banco real, e assere `ordem == ["customer","create","qr"]` — nenhuma `consulta`.

Suíte: **7392 passed, 4 xfailed**, lista de nomes com falha **vazia**, medida depois do rebase. `wc -l`: `pix_checkout.py` **349/350**.

## O que este PR NÃO prova

- **O Asaas é falso em 100% dos testes.** Que ele devolva **400/422** quando o `cpfCnpj` ou o e-mail não prestam, e **401/403** para chave errada, é **assunção nossa, não observação**. O desenho existe para degradar em vez de quebrar se estiver errada — mas está dito.
- **Nada foi visto no navegador nem no aparelho.** A frase chegando ao `#pix-doc-erro` é leitura de código; só se confirma depois do deploy.
- O `code` real (`invalid_cpfCnpj`) **nunca foi conferido contra produção** — aparece só como valor de teste, e nada aqui depende dele.

## Registrado, fora de escopo

- **Teto superior do `ASAAS_MIN_CHARGE_CENTS`** (números acima) — issue.
- **A mensagem do commit `c0ed17c`** ainda diz "malformada recusa" sem a ressalva do alfabeto × faixa; corrigida nos 5 lugares do código e aqui. `rebase -i` não está disponível neste ambiente.
- **Colocação do 400**: o dono decidiu **manter inline no campo**, ciente de que para leitor de tela a frase vira a descrição do campo CPF — e que se a causa foi o e-mail do cadastro, o cliente é mandado ao único campo que ele tem ali.
- **`_codigo_seguro` passou a alimentar `system_event_logs.details`.** Teto pré-existente; medido que ele bloqueia toda grafia realista de CPF/CNPJ (`52998224725`, `529.982.247-25`, `CPF52998224725`, `11222333000181` → todos `None`).
- **Varredura da classe do #365**: dos 18 sites de `isdigit()` em produção, `pix_checkout.py` era **a única instância viva**. `investments.py:81/:159` passam por `normalize_text` (NFKD), `db/mfa.py:270` não faz `int()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)