### PR TITLE
O teste de fatura para de medir o calendário do dia em que foi escrito

### DIFF
--- a/tests/test_pendencia_credito_respostas_legitimas.py
+++ b/tests/test_pendencia_credito_respostas_legitimas.py
@@ -16,6 +16,7 @@ from datetime import date
 import pytest
 
 import db
+from core.handlers.credit import _MONTH_NAMES_PT
 from _pendencia_credito_helpers import (
     AVISO as _AVISO,
     AS_CINCO as _AS_CINCO,
@@ -93,13 +94,31 @@ def test_installment_todas_as_descricoes_registram(descricao):
         f"{descricao!r} virou lançamento: {db.list_launches(uid)!r}"
 
 
-@pytest.mark.parametrize("resposta_do_user", ["1", "nubank", "setembro"])
+# NÃO volte ao literal "setembro" (4bce49c): era verde só de 11/ago a 10/set —
+# compra de HOJE, `cartao()` fechando dia 10; nos outros 334 dias a fatura em
+# aberto é a do mês SEGUINTE (§3, "verde por construção"). Apagar o caso não
+# serve: desligar o ramo de mês (credit.py:285-292) deixa vermelhos SÓ estes 2.
+_MES = "mes-da-fatura-em-aberto"
+
+
+def _mes_da_fatura(uid: int) -> str:
+    """O mês que o bot IMPRIMIU na pergunta, lido da fatura em aberto."""
+    abertas = db.list_open_bills(uid)
+    assert len(abertas) == 1, f"esperava 1 fatura em aberto, veio {len(abertas)}"
+    return _MONTH_NAMES_PT[abertas[0]["period_end"].month - 1].lower()
+
+
+def _resolve(uid: int, resposta: str) -> str:
+    return _mes_da_fatura(uid) if resposta == _MES else resposta
+
+
+@pytest.mark.parametrize("resposta_do_user", ["1", "nubank", _MES])
 def test_pay_bill_choice_paga_com_resposta_legitima(resposta_do_user):
     """O número e o nome do cartão sozinhos continuam escolhendo a fatura."""
     uid = _uid()
     _arma_pay_bill_choice(uid)
 
-    resposta = _diga(uid, resposta_do_user)
+    resposta = _diga(uid, _resolve(uid, resposta_do_user))
 
     assert _AVISO not in resposta, f"{resposta_do_user!r} foi abandonada: {resposta!r}"
     assert db.list_open_bills(uid) == [], \
@@ -116,7 +135,7 @@ def test_pay_bill_choice_paga_com_resposta_legitima(resposta_do_user):
 # funcionar é feature, e feature não entra em PR de dinheiro.
 # Medido em duas colunas (main × branch): as 20 dão o MESMO resultado nas duas.
 _PAY_LEGITIMAS = [
-    "1", "#1", "setembro", "nubank", "Nubank", "NUBANK", "o nubank",
+    "1", "#1", _MES, "nubank", "Nubank", "NUBANK", "o nubank",
     "a do nubank", "a fatura do nubank", "minha fatura do nubank",
     "fatura do nubank", "essa do nubank",
 ]
@@ -127,7 +146,7 @@ def test_pay_bill_choice_legitimas_continuam_pagando(resposta_do_user):
     uid = _uid()
     _arma_pay_bill_choice(uid)
 
-    resposta = _diga(uid, resposta_do_user)
+    resposta = _diga(uid, _resolve(uid, resposta_do_user))
 
     assert _AVISO not in resposta, f"{resposta_do_user!r} foi abandonada: {resposta!r}"
     assert db.list_open_bills(uid) == [], \


### PR DESCRIPTION
`tests/test_pendencia_credito_respostas_legitimas.py::test_pay_bill_choice_*[setembro]`
falha em `origin/main` **pura**, e deixa **todo PR aberto do repositório
vermelho** por motivo alheio a ele — hoje são 11.

## Não é a janela 00–03 UTC

O primeiro reflexo é chamar de "janela 00–03 UTC", que é o defeito que o #180
fechou. **Está errado.** Medido com relógio congelado:

| FREEZE_UTC | São Paulo | |
|---|---|---|
| 2026-09-11T02:59 | 10/09 23:59 | passa |
| 2026-09-11T03:00 | 11/09 00:00 | **falha** ← a virada |
| 2026-08-10T12:00 | 10/08 | falha |
| 2026-08-11T12:00 | 11/08 | **passa** ← reabre |

É **virada de calendário**, e a virada é meia-noite local **no fuso do app**, do
dia `closing_day + 1` — não uma hora UTC. O "00–03 UTC" é coincidência de São
Paulo ser UTC−3.

## A causa

`arma_pay_bill_choice` compra com `purchased_at=date.today()`, o cartão fecha no
dia 10, e `_bill_period_for_purchase` (`db/cards.py:29-39`) joga o período para
o mês seguinte quando a compra passa do fechamento. A fatura em aberto é
**Outubro**; o teste responde `"setembro"`, literal, fixado em `4bce49c`
(09/09) — **dois dias dentro da única janela em que ele funciona**.

A janela verde é `[11 de agosto, 10 de setembro]`: **31 dias verdes, 334
vermelhos por ano.** É o "verde por construção" do §3 na forma mais cara — o
teste mediu o calendário do dia em que foi escrito.

## Por que não bastava apagar o parâmetro

Mutação medida: desligar o ramo de mês (`core/handlers/credit.py:286`) deixa
vermelhos **exatamente esses 2** entre 208 casos. **Não há outra cobertura** —
apagar o `"setembro"` trocaria um teste que quebra 334 dias por ano por
nenhum teste.

## O conserto

O parâmetro vira sentinela e o nome do mês é lido da **fatura realmente em
aberto**, pela mesma lista que o bot imprime na pergunta (`_MONTH_NAMES_PT`).
O teste passa a afirmar o que sempre quis dizer: *o nome do mês da fatura
escolhe a fatura*.

| | teste novo | literal `"setembro"` |
|---|---|---|
| 2026 | **365/365** | 31/365 |
| 2028 (bissexto) | **366/366** | 31/366 |

Cobertura preservada: com o ramo de mês desligado, os 2 voltam a ficar
vermelhos entre 208 — agora sob o id `[mes-da-fatura-em-aberto]`.

## Medido

- `pytest -q` na árvore inteira: **7392 passed, 4 xfailed, 0 failed**;
- alvo (4 arquivos do grupo + o portão do teto): 216 passed;
- enumeração dia a dia dos 365/366 dias, chamando a função de período.

## Não verificado

`freezegun` **não** foi usado (não está no `requirements.txt`) — a prova é
relógio real, hoje, dentro da janela vermelha, mais a enumeração da função.

## A classe, registrada e NÃO consertada

Contadas por AST nesta árvore: **142 chamadas de `.today()`/`.now()` sem
argumento em 32 arquivos de `tests/`**. Cada uma é candidata ao mesmo "verde por
construção". Não são desta tarefa.

E dois arquivos desta família ficaram a **1 linha** do teto de 350
(`test_pendencia_credito_respostas_legitimas.py` e
`_pendencia_credito_helpers.py`, 349 cada) — a próxima alteração em qualquer um
terá de quebrar o arquivo antes de acrescentar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
