### PR TITLE
Resposta da Pluggy com NUL/surrogate perdia a linha em silêncio

### DIFF
--- a/core/services/pluggy.py
+++ b/core/services/pluggy.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 
+from core.pg_text import limpa_para_pg
 from core.services.pluggy_health import safe_code
 
 
@@ -95,6 +96,24 @@ def create_pluggy_api_key() -> str:
     return str(api_key)
 
 
+# `limpa_para_pg` na RESPOSTA da Pluggy (#321): o `raw` de cada conta/transação/
+# item vai a `jsonb` e o `name`/`description` vai a `text`, e o Postgres não
+# guarda NUL nem surrogate solitário em nenhum dos dois. Fronteira diferente da
+# do #320 (lá é corpo de WEBHOOK), e sintoma diferente: isto roda em background,
+# sem 5xx e sem laço de reenvio — a falha não vira erro, vira linha que não nasce.
+#
+# SANEAR e não recusar (ao contrário do `tem_veneno` do path e da query): é blob
+# forense de terceiro, e perder a conta inteira é pior que gravar `U+FFFD` num
+# campo. Mesma política e mesma função do #320 (§0.1/§0.7).
+#
+# Aqui e não nos 8 `Jsonb(...)` de `db/open_finance.py`: `_pluggy_get` é a ÚNICA
+# porta de leitura da API (`/items/{id}`, `/accounts`, `/v2/transactions`,
+# `/investments`, `/connectors` — grep), então um ponto cobre também os campos
+# `text` que os `Jsonb` deixariam de fora. O `PATCH /items/{id}` não passa por
+# aqui e leva a sua própria chamada — os 2 chamadores descartam o retorno HOJE
+# (medido), e ela existe para a porta não ficar meio fechada quando alguém usar.
+# `create_pluggy_api_key` e `create_pluggy_connect_token` ficam de fora: o que
+# devolvem (`apiKey`, `accessToken`) vira header HTTP e hash, nunca linha.
 def _pluggy_get(path: str, api_key: str, params: dict[str, Any] | None = None) -> dict:
     """GET autenticado na Pluggy. `path` começa com '/'."""
     with httpx.Client(timeout=_pluggy_timeout()) as client:
@@ -104,7 +123,7 @@ def _pluggy_get(path: str, api_key: str, params: dict[str, Any] | None = None) -
             params=params or {},
         )
     _raise_for_pluggy_response(resp, f"Falha ao consultar {path} na Pluggy")
-    return resp.json()
+    return limpa_para_pg(resp.json())
 
 
 # O que a Pluggy emite como id de item é um UUID; o que CHEGA aqui pode não ser.
@@ -146,7 +165,7 @@ def update_pluggy_item(item_id: str, api_key: str | None = None) -> dict:
             json={},
         )
     _raise_for_pluggy_response(resp, f"Falha ao atualizar item {item_id} na Pluggy")
-    return resp.json()
+    return limpa_para_pg(resp.json())
 
 
 def delete_pluggy_item(item_id: str, api_key: str | None = None) -> bool:

--- a/tests/test_pluggy_resposta_venenosa.py
+++ b/tests/test_pluggy_resposta_venenosa.py
@@ -1,0 +1,171 @@
+"""Issue #321, a fatia que ela mandou para issue própria: NUL/surrogate na
+RESPOSTA da API da Pluggy (fronteira de terceiro, não entrada de usuário).
+
+O que muda em relação às outras fatias do #321: isto roda em BACKGROUND (sync,
+refresh periódico). Não há 5xx nem laço de reenvio — o sintoma é linha que não
+nasce. A política também muda: aqui é SANEAR (`limpa_para_pg`, o mesmo do #320),
+porque o `raw` é blob forense e perder a conta inteira é pior que gravar
+`U+FFFD` num campo.
+
+ONDE O CONSERTO MORA: `core/services/pluggy.py`, no `return` de `_pluggy_get` e
+no do `update_pluggy_item` — as duas portas de leitura da API. Não nos 8
+`Jsonb(...)` de `db/open_finance.py`, porque a resposta também alimenta campos
+`text` (`name` da instituição, `name` da conta, `description` da transação) que
+os `Jsonb` deixariam de fora. MEDIDO abaixo pelo `name` da conta, não só pelo
+`raw`.
+
+CONTROLE NEGATIVO (§3): `test_negativo_*` troca o `limpa_para_pg` do módulo por
+identidade e exige que a gravação ESTOURE — nos dois caminhos (o item, que vira
+a conexão, e a conta/transação do espelho), porque são dois `execute` diferentes.
+
+CONTROLE POSITIVO (§3): `test_positivo_*` — resposta limpa grava exatamente o
+mesmo `jsonb` e o mesmo `name` de antes. Sem ele, um saneamento que destruísse
+dado bom (apagar o campo, trocar acento) passaria nos negativos.
+"""
+import psycopg
+import pytest
+
+import core.services.pluggy as pluggy
+import db
+from core.services.pluggy_sync import normalize_pluggy_account, normalize_pluggy_transaction
+from db.connection import get_conn
+
+NUL = "\x00"
+FFFD = "�"
+
+ITEM_LIMPO = {"id": "item-limpo", "status": "UPDATED",
+              "connector": {"id": 612, "name": "Nubank"}}
+CONTA_LIMPA = {"id": "acc-1", "name": "Conta Corrente", "type": "BANK",
+               "subtype": "CHECKING_ACCOUNT", "currency": "BRL", "balance": 10}
+TX_LIMPA = {"id": "tx-1", "description": "Mercado", "amount": -12.5,
+            "date": "2026-09-01T00:00:00.000Z", "category": "Food"}
+
+
+def _envenena(dado: dict, campo: str) -> dict:
+    return {**dado, campo: dado[campo] + NUL + "x"}
+
+
+@pytest.fixture()
+def pluggy_responde(monkeypatch):
+    """Fixture que faz o `httpx.Client.get` devolver o que o teste mandar —
+    o caminho real passa por `_pluggy_get`, que é onde o conserto mora."""
+    corpo: dict = {}
+
+    class _Resp:
+        status_code = 200
+        is_success = True
+
+        def json(self):
+            return corpo["payload"]
+
+    def _fake_get(self, url, headers=None, params=None):
+        return _Resp()
+
+    monkeypatch.setattr(pluggy.httpx.Client, "get", _fake_get)
+    return lambda payload: corpo.__setitem__("payload", payload)
+
+
+def _conexao_do_item(user_id: int, item_bruto: dict) -> dict:
+    """O caminho de produção: lê o item pela API e grava a conexão."""
+    item = pluggy.get_pluggy_item(item_bruto["id"], api_key="k")
+    return db.save_pluggy_open_finance_item(user_id, item)
+
+
+def _espelha_conta(connection_id: int, conta_bruta: dict, tx_bruta: dict) -> None:
+    """O outro caminho: /accounts + /v2/transactions → espelho."""
+    conta = normalize_pluggy_account(conta_bruta)
+    conta["transactions"] = [normalize_pluggy_transaction(tx_bruta)]
+    db.save_open_finance_sync(connection_id, [conta])
+
+
+def test_nome_de_instituicao_venenoso_vira_conexao_saneada(user_id, pluggy_responde):
+    """`connector.name` é `text`, não `jsonb` — é o campo que os `Jsonb` não
+    cobririam e o motivo de o conserto estar na porta da API."""
+    item = _envenena(ITEM_LIMPO["connector"], "name")
+    pluggy_responde({**ITEM_LIMPO, "connector": item})
+
+    conexao = _conexao_do_item(user_id, ITEM_LIMPO)
+
+    assert conexao["institution_name"] == "Nubank" + FFFD + "x"
+
+
+def test_conta_e_transacao_venenosas_nascem_saneadas(user_id, pluggy_responde):
+    pluggy_responde(ITEM_LIMPO)
+    conexao = _conexao_do_item(user_id, ITEM_LIMPO)
+
+    pluggy_responde({"results": [_envenena(CONTA_LIMPA, "name")]})
+    conta = pluggy.list_pluggy_accounts("item-limpo", "k")[0]
+    pluggy_responde({"results": [_envenena(TX_LIMPA, "description")]})
+    tx = pluggy.list_pluggy_transactions("acc-1", "k")[0]
+
+    _espelha_conta(conexao["id"], conta, tx)
+
+    with get_conn() as c, c.cursor() as cur:
+        cur.execute("select name, raw from open_finance_accounts where connection_id=%s",
+                    (conexao["id"],))
+        linha = cur.fetchone()
+        cur.execute("""select t.description from open_finance_transactions t
+                       join open_finance_accounts a on a.id = t.account_id
+                       where a.connection_id=%s""", (conexao["id"],))
+        descricao = cur.fetchone()["description"]
+
+    assert linha is not None, "a conta não nasceu"
+    assert linha["name"] == "Conta Corrente" + FFFD + "x"
+    assert linha["raw"]["name"] == "Conta Corrente" + FFFD + "x", "o jsonb bruto não foi saneado"
+    assert descricao == "Mercado" + FFFD + "x"
+
+
+def test_negativo_sem_saneamento_a_conexao_nao_nasce(user_id, pluggy_responde, monkeypatch):
+    """Desliga o conserto no módulo em que ele mora: a gravação estoura e a
+    linha não existe — que é exatamente o sintoma silencioso da issue."""
+    monkeypatch.setattr(pluggy, "limpa_para_pg", lambda valor: valor)
+    pluggy_responde({**ITEM_LIMPO, "connector": _envenena(ITEM_LIMPO["connector"], "name")})
+
+    with pytest.raises(psycopg.Error):
+        _conexao_do_item(user_id, ITEM_LIMPO)
+
+    assert db.count_open_finance_connections(user_id) == 0
+
+
+def test_negativo_sem_saneamento_a_conta_nao_nasce(user_id, pluggy_responde, monkeypatch):
+    """O par do de cima: conexão e espelho são `execute` diferentes, e um
+    negativo só não discriminaria o outro."""
+    pluggy_responde(ITEM_LIMPO)
+    conexao = _conexao_do_item(user_id, ITEM_LIMPO)
+
+    monkeypatch.setattr(pluggy, "limpa_para_pg", lambda valor: valor)
+    pluggy_responde({"results": [_envenena(CONTA_LIMPA, "name")]})
+    conta = pluggy.list_pluggy_accounts("item-limpo", "k")[0]
+    pluggy_responde({"results": [TX_LIMPA]})
+    tx = pluggy.list_pluggy_transactions("acc-1", "k")[0]
+
+    with pytest.raises(psycopg.Error):
+        _espelha_conta(conexao["id"], conta, tx)
+
+    with get_conn() as c, c.cursor() as cur:
+        cur.execute("select count(*) as n from open_finance_accounts where connection_id=%s",
+                    (conexao["id"],))
+        assert cur.fetchone()["n"] == 0
+
+
+def test_positivo_resposta_limpa_grava_igual(user_id, pluggy_responde):
+    """O saneamento não pode tocar em dado bom — inclusive acento, que é o que
+    um `encode('ascii')` apressado estragaria."""
+    conta_com_acento = {**CONTA_LIMPA, "name": "Conta Corrênte ção"}
+    pluggy_responde(ITEM_LIMPO)
+    conexao = _conexao_do_item(user_id, ITEM_LIMPO)
+
+    pluggy_responde({"results": [conta_com_acento]})
+    conta = pluggy.list_pluggy_accounts("item-limpo", "k")[0]
+    pluggy_responde({"results": [TX_LIMPA]})
+    tx = pluggy.list_pluggy_transactions("acc-1", "k")[0]
+    _espelha_conta(conexao["id"], conta, tx)
+
+    assert conexao["institution_name"] == "Nubank"
+    with get_conn() as c, c.cursor() as cur:
+        cur.execute("select name, raw from open_finance_accounts where connection_id=%s",
+                    (conexao["id"],))
+        linha = cur.fetchone()
+
+    assert linha["name"] == "Conta Corrênte ção"
+    assert linha["raw"] == conta_com_acento, "o jsonb mudou com a resposta limpa"


### PR DESCRIPTION
Outra fronteira de confiança, que a #321 mandou para issue própria: não é entrada de usuário, é **resposta de terceiro**. Por isso falha em background — sem 5xx e sem laço de reenvio — e o sintoma é **linha que não nasce**, não erro visível.

As referências da issue andaram e apontavam para o lugar errado: `core/services/pluggy.py:90/106` apontavam (off-by-one) para os dois `resp.json()`, que são a **entrada**, não o `Jsonb`. Refeito por grep: são **8** sites de `Jsonb(` alimentados pela Pluggy — e mais que isso, `account["name"]` e `tx["description"]` são param `text`, que nenhum conserto nos `Jsonb` cobriria.

Por isso o conserto é **na porta, em 2 linhas**, e não nos 9 sinks: `limpa_para_pg(resp.json())` em `_pluggy_get` (a única porta de leitura) e em `update_pluggy_item`. Fecha o `text` e o `jsonb` de uma vez.

**Sanear e não recusar** é o que o #320 já decidiu para o webhook: é blob forense de terceiro, e perder a linha inteira é pior que gravar saneado.

Controle negativo em **dois** `execute`; controle positivo exigindo `raw == payload` byte a byte e `name` com acento intacto — saneamento que altera dado limpo seria pior que o bug. Os 5 testes passam pelo fluxo real (`httpx` falso → `_pluggy_get` → writer → leitura no banco), não pela função isolada.

A Pluggy **real** nunca foi exercitada aqui, e nada foi medido em produção.

Refs #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
