### PR TITLE
O erro que o usuário lê, e o que ele não devia ler

### DIFF
--- a/core/admin_dashboard.py
+++ b/core/admin_dashboard.py
@@ -29,7 +29,7 @@ from core.crypto import (
     encrypt_pii_optional,
     pii_audit_batch,
 )
-from core.pg_text import limpa_para_pg
+from core.pg_text import detalhe_seguro, limpa_para_pg
 from core.secure_compare import constant_time_eq
 
 
@@ -1873,7 +1873,7 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
                 set_account_plan, str(payload.get("plan") or ""), months, user_id=user_id
             )
         except ValueError as exc:
-            raise HTTPException(status_code=422, detail=str(exc))
+            raise HTTPException(status_code=422, detail=detalhe_seguro(exc))
         if not row:
             raise HTTPException(status_code=404, detail="Conta não encontrada.")
         await log_system_event(
@@ -2177,7 +2177,7 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
         try:
             affiliate = await asyncio.to_thread(create_affiliate, int(user_id), code, bps)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=400, detail=detalhe_seguro(exc))
 
         await log_system_event(
             "info",
@@ -2205,7 +2205,7 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
         try:
             ok = await asyncio.to_thread(set_affiliate_status, affiliate_id, status)
         except ValueError as exc:
-            raise HTTPException(status_code=422, detail=str(exc))
+            raise HTTPException(status_code=422, detail=detalhe_seguro(exc))
         if not ok:
             raise HTTPException(status_code=404, detail="Afiliado não encontrado.")
         await log_system_event(
@@ -2243,7 +2243,7 @@ def register_admin_routes(app: FastAPI, frontend_dir: Path, jwt_secret: str, lim
         try:
             brcode = build_pix_brcode(pix_key, amount_cents=int(payout["amount_cents"]))
         except ValueError as exc:
-            raise HTTPException(status_code=422, detail=str(exc))
+            raise HTTPException(status_code=422, detail=detalhe_seguro(exc))
 
         return {
             "brcode": brcode,

--- a/core/pg_text.py
+++ b/core/pg_text.py
@@ -150,3 +150,50 @@ def recusa_veneno(modelo):
         if isinstance(valor, str) and _limpa_str(valor) != valor:
             raise ValueError(f"O campo '{nome}' contém caractere inválido.")
     return modelo
+# A frase que substitui a mensagem do codec. Uma só, e aqui: o texto do erro é
+# o mesmo em toda rota porque a CAUSA é a mesma (byte que o Postgres não
+# guarda), e duas versões dela divergiriam na primeira edição (CLAUDE.md §0.7).
+_ERRO_DE_CODIFICACAO = "Tem um caractere que não consigo salvar nesse texto. Apaga e digita de novo."
+
+
+def detalhe_seguro(exc: Exception) -> str:
+    """`str(exc)` para erro de DOMÍNIO; frase fixa para erro de CODIFICAÇÃO.
+
+    Existe porque **`UnicodeEncodeError` é subclasse de `ValueError`** — o MRO é
+    `UnicodeEncodeError → UnicodeError → ValueError`. Todo handler escrito como
+    `except ValueError as exc: raise HTTPException(400, detail=str(exc))`
+    captura, sem querer, o erro que o psycopg levanta ao codificar um surrogate
+    solitário, e manda a mensagem interna para o cliente. MEDIDO em
+    `POST /pockets/{user_id}` com usuário autenticado comum:
+
+        {"name":"cofre\\ud800x"}
+        → 400 {"detail":"'utf-8' codec can't encode character '\\ud800'
+                          in position 5: surrogates not allowed"}
+
+    O que o cliente recebia dizia o codec, o code point e o OFFSET dentro do
+    campo — nada disso é para ele, e nada disso diz o que fazer.
+
+    **Só `UnicodeError` é trocado**, e é de propósito: o `ValueError` que a
+    camada `db/` levanta É a mensagem do usuário (`EMPTY_NAME`,
+    `INTEREST_RATE_INVALID`, "Valor acima do limite…"), e trocá-lo por um
+    genérico apagaria a única instrução útil da tela — regressão pior que o
+    vazamento. Por isso o helper DISCRIMINA em vez de generalizar.
+
+    ponytail: teto conhecido — NUL (`\\x00`) NÃO passa por aqui. O psycopg o
+    recusa com `psycopg.DataError` ("PostgreSQL text fields cannot contain NUL
+    (0x00) bytes"), que não é `ValueError`, não é capturado por estes handlers e
+    continua virando 500 (MEDIDO em `/auth/login` e `/auth/register`). Fechar o
+    NUL é recusar na fronteira, não remendar no handler — é o que o
+    `recusa_veneno` faz nos corpos de auth. Aqui só se corrige o que ESTES
+    `except` alcançam.
+    """
+    return _ERRO_DE_CODIFICACAO if isinstance(exc, UnicodeError) else str(exc)
+
+
+if __name__ == "__main__":  # pragma: no cover - autocheck
+    try:
+        "cofre\ud800x".encode("utf-8")
+    except UnicodeError as e:
+        assert detalhe_seguro(e) == _ERRO_DE_CODIFICACAO, detalhe_seguro(e)
+    assert detalhe_seguro(ValueError("EMPTY_NAME")) == "EMPTY_NAME"
+    print("ok")

--- a/frontend/cadastro.html
+++ b/frontend/cadastro.html
@@ -99,7 +99,11 @@
 <script>
   function getCookie(n){return document.cookie.split('; ').find(r=>r.startsWith(n+'='))?.split('=')[1]||''}
   function csrfHeaders(e){e=e||{};var c=decodeURIComponent(getCookie('csrf_token')||'');if(c)e['X-CSRF-Token']=c;return e}
-  async function payload(r){var t=await r.text();if(!t)return{};try{return JSON.parse(t)}catch(_){return{detail:t}}}
+  // `detail` NÃO-string vira nulo aqui: o 422 do FastAPI manda uma LISTA de
+  // objetos ({loc,msg,type,input}), que é truthy e chega no `textContent` como
+  // "[object Object]". Zerando aqui, cada chamada cai no próprio fallback — que
+  // já é legível e específico. Mesma regra do `_errDetail` (dashboard.js).
+  async function payload(r){var t=await r.text();if(!t)return{};var d;try{d=JSON.parse(t)}catch(_){return{detail:t}}if(d&&typeof d==='object'&&typeof d.detail!=='string')d.detail=null;return d}
   function goDash(u){u=u||'/home';if(u.indexOf('DASHBOARD_URL=')===0)u=u.slice(14);if(u.indexOf('http')!==0)u=location.origin+'/'+u.replace(/^\//,'');location.replace(u)}
   function err(id,m,ok){var e=document.getElementById(id);e.textContent=m;e.classList.toggle('ok',!!ok);e.classList.add('show')}
   function clrErr(){['reg-error','verify-error'].forEach(function(i){var e=document.getElementById(i);if(e){e.classList.remove('show','ok');e.textContent=''}})}

--- a/frontend/completar-cadastro.html
+++ b/frontend/completar-cadastro.html
@@ -77,6 +77,10 @@ function getCookie(name) { return document.cookie.split("; ").find(function(r){ 
 function csrfHeaders(extra) { extra = extra || {}; var c = decodeURIComponent(getCookie("csrf_token") || ""); if (c) extra["X-CSRF-Token"] = c; return extra; }
 function showError(msg) { msgError.textContent = msg; msgError.classList.add("show"); }
 function hideError() { msgError.textContent = ""; msgError.classList.remove("show"); }
+// O `detail` do 422 do FastAPI é uma LISTA de objetos ({loc,msg,type,input}):
+// truthy, e na tela vira "[object Object]". Só string passa; o resto cai no
+// fallback de cada chamada. Mesma regra do `_errDetail` (dashboard.js).
+function strDetail(d) { return d && typeof d.detail === "string" ? d.detail : ""; }
 
 async function loadPending() {
   if (!signupToken) { showError("Link inválido. Inicie o login com Google novamente."); submitBtn.disabled = true; emailDisplay.textContent = "—"; return; }
@@ -84,7 +88,7 @@ async function loadPending() {
     const res = await fetch("/auth/google/pending/" + encodeURIComponent(signupToken), { credentials: "same-origin" });
     if (!res.ok) {
       const data = await res.json().catch(function(){ return {}; });
-      showError(data.detail || "Cadastro expirado. Faça login com Google novamente.");
+      showError(strDetail(data) || "Cadastro expirado. Faça login com Google novamente.");
       submitBtn.disabled = true; emailDisplay.textContent = "—"; return;
     }
     const data = await res.json();
@@ -113,7 +117,7 @@ document.getElementById("signup-form").addEventListener("submit", async function
       body: JSON.stringify({ token: signupToken, name: name, phone: phone, accepted_terms: true })
     });
     const data = await res.json().catch(function(){ return {}; });
-    if (!res.ok) { showError(data.detail || "Não foi possível criar sua conta."); submitBtn.disabled = false; submitBtn.textContent = "Criar minha conta"; return; }
+    if (!res.ok) { showError(strDetail(data) || "Não foi possível criar sua conta."); submitBtn.disabled = false; submitBtn.textContent = "Criar minha conta"; return; }
     // Meta Ads: conta criada via Google. eventID casa com o CompleteRegistration
     // server-side (CAPI) pro Meta deduplicar.
     if (window.fbq && data.user_id) { fbq("track", "CompleteRegistration", {}, { eventID: "signup_" + data.user_id }); }

--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -107,7 +107,7 @@ from db import (
     LaunchUnsafeRollback,
 )
 from core.observability import _log_falha, get_logger
-from core.pg_text import limpa_para_pg, recusa_veneno
+from core.pg_text import detalhe_seguro, limpa_para_pg, recusa_veneno
 from core.secure_compare import constant_time_eq
 from frontend.routes.affiliates import router as affiliates_router
 from frontend.routes.billing_pix import router as billing_pix_router
@@ -2942,7 +2942,7 @@ async def auth_register(request: Request, body: RegisterBody):
     try:
         normalize_phone_e164(body.phone)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=detalhe_seguro(e))
 
     try:
         code = create_email_verification(
@@ -2963,7 +2963,7 @@ async def auth_register(request: Request, body: RegisterBody):
             logging.getLogger(__name__).warning("account_exists_notice falhou: %s", notice_exc)
         return {"status": "verification_sent", "email": body.email.strip().lower()}
     except ValueError as e:
-        raise HTTPException(status_code=409, detail=str(e))
+        raise HTTPException(status_code=409, detail=detalhe_seguro(e))
 
     sent = send_verification_email(body.email.strip().lower(), code)
     if not sent:
@@ -2993,7 +2993,7 @@ async def auth_verify_email(request: Request, response: Response, body: VerifyEm
             body.email, body.code, source=signup_source_from_request(request)
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=detalhe_seguro(e))
 
     user_id    = result["user_id"]
     link_code  = result["link_code"]
@@ -3912,7 +3912,7 @@ async def auth_delete_account(request: Request, response: Response, body: Delete
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
 
     if email:
         from core.services.email_service import send_account_deletion_scheduled_email
@@ -4202,7 +4202,7 @@ async def auth_google_complete_signup(
             signup_source_from_request(request, google=True),
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc))
 
     user_id = int(result["user_id"])
     email = result["email"]
@@ -6550,7 +6550,7 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
                     reason=inferred.reason,
                 )
             except ValueError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
+                raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
             except Exception as exc:
                 logging.getLogger(__name__).error("registrar_parcelamento user=%s: %s", user_id, exc)
                 raise HTTPException(status_code=500, detail="Erro ao registrar parcelamento. Tente novamente.") from exc
@@ -6591,7 +6591,7 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
                 reason=inferred.reason,
             )
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
         except Exception as exc:
             raise HTTPException(status_code=500, detail=f"Erro ao registrar compra no crédito: {exc}") from exc
 
@@ -6638,7 +6638,7 @@ async def create_launch_route(request: Request, user_id: int, payload: LaunchCre
             reason=inferred.reason,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Erro ao registrar lançamento: {exc}") from exc
 
@@ -7135,7 +7135,7 @@ async def export_email(
         try:
             period_start, period_end = _normalize_export_period(start_date, end_date)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
     else:
         y = year or now.year
         m = month or now.month

--- a/frontend/home.html
+++ b/frontend/home.html
@@ -706,6 +706,11 @@ function csrfHeaders(extra = {}) {
   return csrf ? { ...extra, "X-CSRF-Token": csrf } : { ...extra };
 }
 
+// O `detail` do 422 do FastAPI é uma LISTA de objetos ({loc,msg,type,input}):
+// truthy, e na tela vira "[object Object]". Só string passa; o resto cai no
+// fallback de cada chamada. Mesma regra do `_errDetail` (dashboard.js).
+function strDetail(d) { return d && typeof d.detail === "string" ? d.detail : ""; }
+
 function shortAccount(email) {
   if (!email) return "Minha conta";
   const [name] = email.split("@");
@@ -885,7 +890,7 @@ async function connectWhatsAppFromHome(event) {
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok || !data.whatsapp_link) {
-      await alertModal(data.detail || "Não foi possível gerar seu link do WhatsApp agora.", { title: "WhatsApp" });
+      await alertModal(strDetail(data) || "Não foi possível gerar seu link do WhatsApp agora.", { title: "WhatsApp" });
       return;
     }
     const isMobile = /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent || "");

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -83,7 +83,11 @@
 <script>
   function getCookie(n){return document.cookie.split('; ').find(r=>r.startsWith(n+'='))?.split('=')[1]||''}
   function csrfHeaders(e){e=e||{};var c=decodeURIComponent(getCookie('csrf_token')||'');if(c)e['X-CSRF-Token']=c;return e}
-  async function payload(r){var t=await r.text();if(!t)return{};try{return JSON.parse(t)}catch(_){return{detail:t}}}
+  // `detail` NÃO-string vira nulo aqui: o 422 do FastAPI manda uma LISTA de
+  // objetos ({loc,msg,type,input}), que é truthy e chega no `textContent` como
+  // "[object Object]". Zerando aqui, cada chamada cai no próprio fallback — que
+  // já é legível e específico. Mesma regra do `_errDetail` (dashboard.js).
+  async function payload(r){var t=await r.text();if(!t)return{};var d;try{d=JSON.parse(t)}catch(_){return{detail:t}}if(d&&typeof d==='object'&&typeof d.detail!=='string')d.detail=null;return d}
   function goDash(u){u=u||'/home';if(u.indexOf('DASHBOARD_URL=')===0)u=u.slice(14);if(u.indexOf('http')!==0)u=location.origin+'/'+u.replace(/^\//,'');location.replace(u)}
   // ?next= interno (allowlist anti open-redirect) tem prioridade sobre o destino padrão
   function nextParam(){

--- a/frontend/reset-password.html
+++ b/frontend/reset-password.html
@@ -90,6 +90,10 @@
   function csrfHeaders(extra) { extra = extra || {}; var c = decodeURIComponent(getCookie("csrf_token") || ""); if (c) extra["X-CSRF-Token"] = c; return extra; }
   function showError(msg) { msgError.textContent = msg; msgError.classList.add("show"); }
   function hideError() { msgError.classList.remove("show"); }
+  // O `detail` do 422 do FastAPI é uma LISTA de objetos ({loc,msg,type,input}):
+  // truthy, e na tela vira "[object Object]". Só string passa; o resto cai no
+  // fallback de cada chamada. Mesma regra do `_errDetail` (dashboard.js).
+  function strDetail(d) { return d && typeof d.detail === "string" ? d.detail : ""; }
 
   if (!token) { showError("Link inválido. Verifique o e-mail e clique no link correto."); submitBtn.disabled = true; }
 
@@ -125,7 +129,7 @@
         body: JSON.stringify({ token: token, new_password: pw }),
       });
       var data = await res.json().catch(function(){ return {}; });
-      if (!res.ok) throw new Error(data.detail || "Erro ao salvar a senha.");
+      if (!res.ok) throw new Error(strDetail(data) || "Erro ao salvar a senha.");
       formState.style.display = "none";
       successState.style.display = "block";
     } catch (err) {

--- a/frontend/routes/affiliates.py
+++ b/frontend/routes/affiliates.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
+from core.pg_text import detalhe_seguro
 from db.affiliates import (
     MIN_PAYOUT_CENTS,
     REF_COOKIE_MAX_AGE_DAYS,
@@ -135,7 +136,7 @@ async def affiliate_request_payout(request: Request, body: PayoutRequestBody):
     try:
         payout = await asyncio.to_thread(request_payout, affiliate["id"], pix_enc)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc))
 
     # Guarda a chave no cadastro do afiliado pros próximos saques
     await asyncio.to_thread(set_affiliate_pix_key, affiliate["id"], pix_hash, pix_enc)

--- a/frontend/routes/open_finance.py
+++ b/frontend/routes/open_finance.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from core.admin_dashboard import log_system_event
 from core.audit import AuditEvent, list_audit_events, record_audit_event
 from core.secure_compare import constant_time_eq
-from core.pg_text import limpa_para_pg
+from core.pg_text import detalhe_seguro, limpa_para_pg
 from core.services.pluggy import (
     PluggyApiError,
     PluggyConfigError,
@@ -1457,7 +1457,7 @@ async def open_finance_pluggy_item_route(request: Request, user_id: int, payload
         connection = await _grava_reconexao(
             session_uid, remote, new_item_id, tinha_conexao_propria)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
 
     await asyncio.to_thread(
         register_item, session_uid,

--- a/frontend/routes/pockets.py
+++ b/frontend/routes/pockets.py
@@ -11,6 +11,7 @@ import urllib.parse
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from core.pg_text import detalhe_seguro
 from db import (
     create_pocket,
     delete_pocket,
@@ -76,7 +77,7 @@ async def create_pocket_route(request: Request, user_id: int, payload: PocketCre
             interest_rate=interest_rate,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
 
     shared.invalidate_dashboard_current_cache(user_id)
     return {
@@ -128,7 +129,7 @@ async def update_pocket_meta_route(
             clear_target=payload.clear_target,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=detalhe_seguro(exc))
     if not row:
         raise HTTPException(status_code=404, detail="Caixinha não encontrada.")
     shared.invalidate_dashboard_current_cache(user_id)

--- a/frontend/routes/settings.py
+++ b/frontend/routes/settings.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from core.audit import AuditEvent, list_audit_events, record_audit_event
 from core.crypto import encrypt_pii_optional, hash_pii_optional
+from core.pg_text import detalhe_seguro
 from core.sessions import (
     device_label,
     list_user_sessions,
@@ -302,7 +303,7 @@ async def update_security_contact_route(
         try:
             normalized_phone = normalize_phone_e164(phone)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            raise HTTPException(status_code=400, detail=detalhe_seguro(exc)) from exc
 
     old_email = (auth_user.get("email") or "").strip().lower() or None
     email_actually_changed = bool(email) and email != old_email

--- a/frontend/suporte.html
+++ b/frontend/suporte.html
@@ -142,6 +142,10 @@
     var box = document.getElementById('contact-msg');
     var btn = document.getElementById('contact-btn');
     function show(t, ok){ box.textContent = t; box.className = 'contact-msg show ' + (ok ? 'ok' : 'err'); }
+    // O `detail` do 422 do FastAPI é uma LISTA de objetos ({loc,msg,type,input}):
+    // truthy, e na tela vira "[object Object]". Só string passa; o resto cai no
+    // fallback de cada chamada. Mesma regra do `_errDetail` (dashboard.js).
+    function strDetail(d) { return d && typeof d.detail === "string" ? d.detail : ""; }
     var body = {
       name:    document.getElementById('nome').value.trim(),
       email:   document.getElementById('email').value.trim(),
@@ -160,7 +164,7 @@
       var data = await res.json().catch(function(){ return {}; });
       if (res.ok) { show('Mensagem enviada! Respondemos no seu e-mail em breve.', true); e.target.reset(); }
       else if (res.status === 429) { show('Muitas mensagens em pouco tempo. Tente mais tarde ou escreva pra contato@pigbankai.com.', false); }
-      else { show(data.detail || 'Não foi possível enviar. Escreva pra contato@pigbankai.com.', false); }
+      else { show(strDetail(data) || 'Não foi possível enviar. Escreva pra contato@pigbankai.com.', false); }
     } catch (err) { show('Erro de conexão. Tente de novo ou escreva pra contato@pigbankai.com.', false); }
     finally { btn.disabled = false; btn.textContent = orig; }
   });

--- a/tests/frontend/detail_422_object_object.test.mjs
+++ b/tests/frontend/detail_422_object_object.test.mjs
@@ -1,0 +1,198 @@
+/**
+ * O 422 do FastAPI virava "[object Object]" na cara do usuário.
+ *
+ * `HTTPException(400, detail="frase")` manda `detail` STRING; o 422 de
+ * validação manda uma LISTA de objetos — MEDIDO em `POST /auth/login` sem o
+ * campo `password`, no `origin/main` deste PR:
+ *
+ *   422 {"detail":[{"type":"missing","loc":["body","password"],
+ *                  "msg":"Field required","input":{"email":"a@x.com"}}]}
+ *
+ * A lista é truthy, então `d.detail || 'E-mail ou senha incorretos.'` escolhia
+ * a LISTA, e `e.textContent = <Array>` a renderiza como "[object Object]".
+ * Seis páginas públicas faziam isso; o conserto é o mesmo em todas — só string
+ * passa, o resto cai no fallback que a própria chamada já tinha escrito.
+ *
+ * E o que NÃO pode acontecer: o `loc`/`msg`/`input` chegar à tela. Eles trazem
+ * nome de campo interno (`password`), o tipo do erro (`missing`) e o VALOR
+ * recebido — o mesmo motivo pelo qual `tests/test_error_pages.py:718` proíbe
+ * isso na página de erro. Por isso cada caso mede as três coisas: não tem
+ * "[object Object]", tem a frase de fallback, e não tem nada do corpo do 422.
+ *
+ * Os dois controles do CLAUDE.md §3, no GRUPO:
+ *
+ *   · negativo — desfaça o conserto e o grupo fica VERMELHO. Em `login.html` e
+ *     `cadastro.html`, tire o `if(d&&typeof d==='object'&&...)d.detail=null` do
+ *     `payload()`; nas outras quatro, troque `strDetail(data)` de volta por
+ *     `data.detail`. MEDIDO: com o conserto desfeito nos 6 sites, os 5 casos
+ *     "422" ficam vermelhos com `texto: "[object Object]"` e os 5 "400 string"
+ *     continuam VERDES — ou seja, a injeção discrimina, e discrimina em caso
+ *     que estava verde (§3);
+ *   · positivo — os casos "400 string" provam que a frase que o SERVIDOR
+ *     escreve continua chegando inteira à tela. Sem eles, um conserto que
+ *     jogasse TODO `detail` fora (e mostrasse sempre o genérico) passaria —
+ *     e isso é pior que o bug, porque apaga "E-mail já cadastrado."
+ *
+ * Desktop (1440×900) e mobile (390×844) no mesmo grupo: a caixa de erro é
+ * `.auth-error`/`.contact-msg`, que muda de largura entre os dois, e o teste
+ * confere que o texto está VISÍVEL (não só no DOM) nas duas larguras.
+ *
+ * O que este arquivo NÃO alcança: `home.html` (o 6º site — precisa do bootstrap
+ * autenticado do dashboard, fora do alcance de um servidor de arquivos), o
+ * servidor de verdade (aqui o 422 é `page.route`) e `dashboard.js`/
+ * `admin-dashboard.html`, que têm a MESMA classe de bug e ficaram fora deste PR
+ * de propósito — ver o relato.
+ *
+ * Rodar:  node --test tests/frontend/detail_422_object_object.test.mjs
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+/** O corpo EXATO que o FastAPI devolve — medido, não inventado. */
+const CORPO_422 = JSON.stringify({
+  detail: [{ type: "missing", loc: ["body", "password"],
+             msg: "Field required", input: { email: "a@x.com" } }],
+});
+/** Fragmentos do 422 que não podem aparecer na tela (nome de campo interno,
+ *  tipo do erro e o valor recebido). */
+const VAZAMENTOS = ["[object Object]", "Field required", "missing", "password"];
+
+const DESKTOP = { width: 1440, height: 900 };
+const MOBILE = { width: 390, height: 844 };
+
+/**
+ * Cada página: como abrir, o que mockar, como disparar o envio, e onde a
+ * mensagem aparece. `fallback` é a frase que a própria chamada já escrevia.
+ */
+const PAGINAS = [
+  {
+    nome: "login",
+    url: "/login.html",
+    rota: "**/auth/login",
+    fallback: "E-mail ou senha incorretos.",
+    frase: "Conta bloqueada por tentativas demais.",
+    caixa: "#login-error",
+    async antes(page) {
+      // O IIFE do topo pula o login se a sessão estiver viva — 401 nos dois.
+      for (const r of ["**/auth/validate", "**/auth/refresh"]) {
+        await page.route(r, (x) => x.fulfill({ status: 401, contentType: "application/json", body: "{}" }));
+      }
+    },
+    async enviar(page) {
+      await page.fill("#email", "a@x.com");
+      await page.fill("#senha", "12345678");
+      await page.click("#btn-login");
+    },
+  },
+  {
+    nome: "cadastro",
+    url: "/cadastro.html",
+    rota: "**/auth/register",
+    fallback: "Erro ao enviar código.",
+    frase: "Esse e-mail já tem conta.",
+    caixa: "#reg-error",
+    async enviar(page) {
+      await page.fill("#reg-name", "Ana");
+      await page.fill("#reg-email", "a@x.com");
+      await page.fill("#reg-phone", "11999999999");
+      await page.fill("#reg-password", "12345678");
+      await page.fill("#reg-confirm", "12345678");
+      await page.check("#terms");
+      await page.click("#btn-register");
+    },
+  },
+  {
+    nome: "suporte",
+    url: "/suporte.html",
+    rota: "**/contact",
+    fallback: "Não foi possível enviar. Escreva pra contato@pigbankai.com.",
+    frase: "Assunto muito longo.",
+    caixa: "#contact-msg",
+    async enviar(page) {
+      await page.fill("#nome", "Ana");
+      await page.fill("#email", "a@x.com");
+      await page.fill("#assunto", "Dúvida");
+      await page.fill("#msg", "Oi");
+      await page.click("#contact-btn");
+    },
+  },
+  {
+    nome: "reset-password",
+    url: "/reset-password.html#token=abc123",
+    rota: "**/auth/reset-password",
+    fallback: "Erro ao salvar a senha.",
+    frase: "Esse link já foi usado.",
+    caixa: "#msg-error",
+    async enviar(page) {
+      await page.fill("#password", "12345678");
+      await page.fill("#password2", "12345678");
+      await page.click("#submit-btn");
+    },
+  },
+  {
+    nome: "completar-cadastro",
+    url: "/completar-cadastro.html?token=abc123",
+    rota: "**/auth/google/pending/**",
+    fallback: "Cadastro expirado. Faça login com Google novamente.",
+    frase: "Esse convite expirou ontem.",
+    caixa: "#msg-error",
+    // O `loadPending()` dispara sozinho no fim do script — nada a clicar.
+    async enviar() {},
+  },
+];
+
+/** Abre a página com a rota mockada, dispara o envio e devolve o que a tela
+ *  mostra. `texto` é `innerText` da caixa; `visivel` é o estilo COMPUTADO. */
+async function tela(p, { status, body, viewport }) {
+  const page = await browser.newPage({ viewport });
+  const erros = [];
+  page.on("pageerror", (e) => erros.push(String(e)));
+  if (p.antes) await p.antes(page);
+  await page.route(p.rota, (r) =>
+    r.fulfill({ status, contentType: "application/json", body }));
+  await page.goto(ORIGIN + p.url);
+  await p.enviar(page);
+  await page.waitForTimeout(400);
+  const visto = await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return { texto: "(sem caixa)", visivel: false };
+    const cs = getComputedStyle(el);
+    return {
+      texto: el.innerText,
+      visivel: cs.display !== "none" && cs.visibility !== "hidden" && Number(cs.opacity) > 0,
+    };
+  }, p.caixa);
+  await page.close();
+  return { ...visto, erros };
+}
+
+for (const p of PAGINAS) {
+  for (const [rotulo, viewport] of [["desktop", DESKTOP], ["mobile", MOBILE]]) {
+    test(`${p.nome} (${rotulo}): 422 não vira [object Object] nem vaza o corpo`, async () => {
+      const t = await tela(p, { status: 422, body: CORPO_422, viewport });
+      assert.deepEqual(t.erros, [], "a página estourou JS");
+      for (const proibida of VAZAMENTOS) {
+        assert.ok(!t.texto.includes(proibida),
+          `a tela mostrou "${proibida}" — texto: ${JSON.stringify(t.texto)}`);
+      }
+      assert.equal(t.texto.trim(), p.fallback);
+      assert.ok(t.visivel, "a caixa de erro ficou invisível");
+    });
+
+    // POSITIVO: sem isto, um conserto que descartasse TODO detail passaria.
+    test(`${p.nome} (${rotulo}): a frase do servidor (400 string) continua inteira`, async () => {
+      const t = await tela(p, {
+        status: 400, body: JSON.stringify({ detail: p.frase }), viewport });
+      assert.deepEqual(t.erros, [], "a página estourou JS");
+      assert.equal(t.texto.trim(), p.frase);
+      assert.ok(t.visivel, "a caixa de erro ficou invisível");
+    });
+  }
+}

--- a/tests/test_detalhe_seguro.py
+++ b/tests/test_detalhe_seguro.py
@@ -1,0 +1,108 @@
+"""`UnicodeEncodeError` é `ValueError` — e por isso vazava para o cliente.
+
+O MRO é `UnicodeEncodeError → UnicodeError → ValueError → Exception`, então
+todo handler escrito como
+
+    except ValueError as exc:
+        raise HTTPException(400, detail=str(exc))
+
+captura o erro que o psycopg levanta ao codificar um surrogate solitário e
+devolve a mensagem do CODEC ao cliente. MEDIDO em `POST /pockets/{user_id}`,
+com usuário autenticado comum e na `origin/main` deste PR:
+
+    {"name":"cofre\\ud800x"}
+    → 400 {"detail":"'utf-8' codec can't encode character '\\ud800' in
+                     position 5: surrogates not allowed"}
+
+Os dois controles do CLAUDE.md §3, no GRUPO:
+
+  · negativo — troque `detalhe_seguro(exc)` de volta por `str(exc)` em
+    `frontend/routes/pockets.py:80`, e `test_surrogate_no_post_nao_vaza_o_codec`
+    fica VERMELHO com o texto do codec no `detail` (MEDIDO). É injeção num caso
+    que estava VERDE, que é onde ela discrimina;
+  · positivo — `test_erro_de_dominio_continua_com_a_mensagem_especifica` prova
+    que o `ValueError` da camada `db/` (que É a mensagem do usuário) continua
+    chegando inteiro. Sem ele, um conserto que trocasse TODO `str(exc)` por uma
+    frase genérica passaria — e isso apaga a única instrução útil da tela, o
+    que é pior que o vazamento.
+
+O que este arquivo NÃO alcança: os outros 16 sites da mesma classe (a correção
+é a MESMA linha, mas cada rota tem um caminho de autenticação e um corpo
+diferentes) e o NUL (`\\x00`), que o psycopg recusa com `psycopg.DataError` —
+não é `ValueError`, não é capturado por estes `except`, e continua 500.
+"""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+import db
+import frontend.finance_bot_websocket_custom as dashboard
+
+CODEC = "codec can't encode"
+SURROGATE = "cofre\ud800x"
+
+
+def _client(user_id: int) -> TestClient:
+    client = TestClient(dashboard.app)
+    client.cookies.set(dashboard.AUTH_COOKIE_NAME, dashboard._make_jwt(user_id, "pkt@t.com"))
+    client.cookies.set(dashboard.DASHBOARD_COOKIE_NAME,
+                       dashboard.make_dashboard_token(user_id, hours=1))
+    client.cookies.set(dashboard.CSRF_COOKIE_NAME, "test-csrf-token")
+    client.headers[dashboard.CSRF_HEADER_NAME] = "test-csrf-token"
+    client.headers["Content-Type"] = "application/json"
+    return client
+
+
+def _corpo(payload: dict) -> bytes:
+    """`json.dumps` com `ensure_ascii` escapa o surrogate — o corpo é ASCII
+    legal na rede, e o parser do FastAPI o reconstitui como surrogate solitário.
+    `client.post(json=...)` não serve: o httpx codifica em UTF-8 e estoura ANTES
+    de sair, com o mesmo erro que estamos medindo do outro lado."""
+    return json.dumps(payload).encode("ascii")
+
+
+@pytest.mark.parametrize("campo", ["name", "description"])
+def test_surrogate_no_post_nao_vaza_o_codec(user_id, campo):
+    """O caso medido: o cliente não pode receber codec, code point nem offset."""
+    corpo = {"name": "cofre", campo: SURROGATE}
+    resp = _client(user_id).post(f"/pockets/{user_id}", content=_corpo(corpo))
+
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert CODEC not in detail, detail
+    assert "\\ud800" not in detail and "surrogates not allowed" not in detail, detail
+    assert detail == "Tem um caractere que não consigo salvar nesse texto. Apaga e digita de novo."
+
+
+def test_surrogate_no_patch_de_meta_nao_vaza_o_codec(user_id):
+    """O irmão do mesmo arquivo (`pockets.py:132`): achar um caso não é
+    resolver a categoria (CLAUDE.md §2)."""
+    db.create_pocket(user_id, "viagem")
+    pocket_id = next(p["id"] for p in db.list_pockets(user_id) if p["name"] == "viagem")
+
+    resp = _client(user_id).patch(f"/pockets/{user_id}/{pocket_id}/meta",
+                                  content=_corpo({"description": SURROGATE}))
+
+    assert resp.status_code == 400, resp.text
+    assert CODEC not in resp.json()["detail"], resp.text
+
+
+def test_erro_de_dominio_continua_com_a_mensagem_especifica(user_id):
+    """POSITIVO: o `ValueError` da camada `db/` É a mensagem do usuário e não
+    pode virar genérico. `STATUS_INVALIDO` vem de `db/pockets.py:248`."""
+    db.create_pocket(user_id, "viagem")
+    pocket_id = next(p["id"] for p in db.list_pockets(user_id) if p["name"] == "viagem")
+
+    resp = _client(user_id).patch(f"/pockets/{user_id}/{pocket_id}/meta",
+                                  content=_corpo({"status": "status-que-nao-existe"}))
+
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["detail"] == "STATUS_INVALIDO", resp.text
+
+
+def test_unicode_error_e_subclasse_de_value_error():
+    """A premissa inteira do conserto, medida em vez de assumida."""
+    with pytest.raises(ValueError) as ei:
+        "cofre\ud800x".encode("utf-8")
+    assert isinstance(ei.value, UnicodeEncodeError)


### PR DESCRIPTION
Dois defeitos que se encostam: o erro que o usuário **lê** e o erro que ele **não devia ler**.

### 1. O usuário via `[object Object]`
`login.html` e `cadastro.html` fazem `e.textContent = d.detail`, e o `detail` de um 422 é uma **lista** — truthy, então cai no `textContent` e vira `[object Object]`. Pré-existente para todo 422; o que aumenta a frequência é o PR irmão passar a responder 422 onde antes dava 500 (e o 500 não tem `detail`, então o usuário via a mensagem de fallback legível).

**Varredura: 33 sites** no `frontend/`; **9 fechados**. Os 24 restantes ficam de fora **de propósito**: o `dashboard.js` já tem `_errDetail`, escrito com o comentário "nunca [object Object]", e terminar aquela migração num arquivo de 6.600 linhas é outro PR.

Não criei arquivo novo para isso — custaria rota + `<script>` em 6 páginas + ordem de carga, para poupar uma linha por página.

**Verificado no navegador**, como a skill do projeto exige: caixa de erro 354×40 dentro do card em 1440×900, 324×40 em 390×844, sem overflow horizontal, zero `pageerror`.

### 2. A mensagem do codec vazava para o cliente
`UnicodeEncodeError` **é subclasse de `ValueError`**, então todo handler com `except ValueError as exc: raise HTTPException(400, detail=str(exc))` devolvia a mensagem interna:

```
{"name":"cofre\ud800x"} -> 400 {"detail":"'utf-8' codec can't encode character '\ud800' in position 5..."}
```

Levantamento por AST: **36 sites, não os 21 que eu esperava** — **18 técnicos** (corrigidos) e **18 de domínio** (intocados, porque ali o texto **é** a mensagem do usuário: `PluggyApiError`, `PasswordNotSetError`, …).

Não é 1 ponto e não são 18 remendos: handler de aplicação não resolve (o `except` da rota captura antes de qualquer `add_exception_handler`). O que unifiquei foi a **decisão** — `detalhe_seguro(exc)`, e os 18 sites viram troca de um token, sem julgamento por rota. Só `UnicodeError` é trocado; `EMPTY_NAME`/`STATUS_INVALIDO` continuam chegando inteiros.

**Teto conhecido, medido**: NUL continua dando 500 — `psycopg.DataError` não é `ValueError`. Nas rotas de auth isso é fechado pelo #390; nas autenticadas é a fatia da #321 que segue aberta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
