### PR TITLE
O ofxparse sai do caminho de import e o ambiente reduzido volta a rodar

### DIFF
--- a/core/handle_incoming.py
+++ b/core/handle_incoming.py
@@ -23,7 +23,6 @@ from core.types import IncomingMessage, OutgoingMessage
 from core.intent_classifier import classify
 from core.intent_router import route
 from core.response_formatter import format_for_platform
-from core.services.ofx_service import handle_ofx_import, handle_credit_ofx_import
 from core.services.open_finance import handle_open_finance_whatsapp_command
 from core.services.media_service import (
     is_audio_attachment,
@@ -739,6 +738,17 @@ def handle_incoming(msg: IncomingMessage, *,
 
                 uid = _normalize_user_id(msg)
                 db.ensure_user(uid)
+
+                # Import aqui dentro, e não no topo: `ofx_service` puxa
+                # `ofx_import` -> `ofxparse`, e `core.handle_incoming` é
+                # importado por meio repositório (adaptadores, rotas, testes).
+                # No topo, um anexo OFX — caminho raro — custava o `ofxparse`
+                # a todo mundo. Mesmo motivo do `detect_ofx_type` abaixo e do
+                # `statement_service` no bloco 1b.
+                from core.services.ofx_service import (
+                    handle_ofx_import,
+                    handle_credit_ofx_import,
+                )
 
                 # Detecta se é extrato bancário ou fatura de cartão de crédito
                 from ofx_import import detect_ofx_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,43 +34,56 @@ from db import init_db, ensure_user, get_conn
 #
 # A condição é a ausência do pacote, não o erro: no CI o ofxparse está no
 # requirements.txt, então nada aqui é ignorado e todos rodam normalmente.
+#
+# A lista ENCOLHEU para um nome só quando `core/handle_incoming.py` passou a
+# importar o `ofx_service` dentro do bloco que trata o anexo OFX. Antes disso
+# ela crescia a cada teste novo que tocasse o bot: importar
+# `core.handle_incoming` — o que adaptadores, rotas e helpers de teste fazem —
+# arrastava `ofx_service -> ofx_import -> ofxparse`. O que sobra aqui é o único
+# arquivo que importa o PARSER direto, e esse é dependência legítima dele.
 _OFXPARSE_DEPENDENTES = [
-    "test_audio_clarification.py",
-    "test_audio_multi_launch_ask_value.py",
-    "test_category_normalization.py",
-    "test_full_handler_smoke.py",
-    "test_handle_incoming_routing.py",
-    "test_paywall_gate_bot.py",
-    "test_paywall_gate_isencoes.py",
-    "test_recurring_value.py",
-    "test_split_audio_transactions.py",
-    "test_whatsapp_confirmations.py",
-    "test_whatsapp_daily_report.py",
-    "test_whatsapp_simulation.py",
+    "test_local_rules_marcas_alimentacao.py",
 ]
 
-# Estes quatro NÃO estouram na coleta: importam `core.handle_incoming` ou
-# `statement_import` DENTRO do corpo do teste, e a cadeia
-# handle_incoming -> ofx_service -> ofx_import -> ofxparse só é percorrida
-# quando o teste roda. O collect_ignore acima não os alcança, então sem este
-# skip a suíte "de dependências reduzidas" ainda termina com 4 vermelhos que
-# nada têm a ver com a mudança em revisão.
+# Estes NÃO estouram na coleta: chamam `import_ofx_bytes`/`import_statement_bytes`
+# DENTRO do corpo do teste, e a cadeia até o `ofxparse` só é percorrida quando o
+# teste roda. O collect_ignore acima não os alcança, então sem este skip a suíte
+# "de dependências reduzidas" ainda termina com vermelhos que nada têm a ver com
+# a mudança em revisão.
+#
+# Medido com o pacote bloqueado e a flag DESLIGADA (nenhuma lista em vigor):
+# são exatamente estes 8, todos `ModuleNotFoundError: ofxparse` — nenhum erro de
+# comportamento disfarçado. Os dois que saíram (`test_attachment_detection` e o
+# `test_handle_incoming_clarification_...`) chegavam ao parser por
+# `core.handle_incoming`, caminho que deixou de existir.
 _OFXPARSE_IMPORT_TARDIO = [
-    "tests/test_statement_import.py::test_attachment_detection",
+    "tests/test_category_launches_query.py::test_has_time_e_posted_at_espelham_a_visao_geral",
+    "tests/test_category_launches_query.py::test_editar_a_data_de_um_extrato_vence_o_posted_at",
+    "tests/test_category_normalization.py::test_import_extrato_nao_cria_gemea",
+    "tests/test_category_normalization.py::test_import_ofx_conta_nao_cria_gemea",
+    "tests/test_category_normalization.py::test_import_ofx_fatura_nao_cria_gemea",
+    "tests/test_ofx_import_route.py::test_ofx_bancario_importa_pela_rota",
     "tests/test_statement_import.py::test_import_statement_bytes_csv_idempotente",
     "tests/test_statement_import.py::test_import_statement_bytes_vazio_ou_grande",
-    "tests/test_nlp_and_pending_flow.py::test_handle_incoming_clarification_tem_precedencia_sobre_fallback_ia",
 ]
 
 # O alívio NÃO é automático: exige PYTEST_ALLOW_MISSING_OPTIONAL_DEPS=1.
 #
 # Detectar a ausência sozinho seria pior que o problema — se o ofxparse caísse
-# do requirements.txt por engano, ou sumisse do CI, a suíte silenciaria 9
-# arquivos e pularia 4 testes e passaria VERDE, enquanto `core.handle_incoming`
-# estaria quebrado em produção. Um ambiente de dependências reduzidas é uma
-# decisão consciente de quem o monta (o .claude/hooks/session-start.sh exporta
-# a variável); a execução normal do dev e do CI continua estourando, que é o
-# comportamento certo para dependência obrigatória faltando.
+# do requirements.txt por engano, ou sumisse do CI, a suíte silenciaria as duas
+# listas acima e passaria VERDE com o importador de OFX quebrado em produção. Um
+# ambiente de dependências reduzidas é uma decisão consciente de quem o monta (o
+# .claude/hooks/session-start.sh exporta a variável); a execução normal do dev e
+# do CI continua estourando, que é o comportamento certo para dependência
+# obrigatória faltando.
+#
+# O opt-in é o que segura o sinal agora que o import é preguiçoso. Com o
+# `ofx_service` no topo de `core/handle_incoming.py`, um requirements.txt sem o
+# `ofxparse` derrubava a suíte inteira na coleta — alto e cedo. Agora ele só
+# quebra no caminho do OFX, que é mais tarde e mais baixo. O que compensa:
+# `tests/test_ofx_import_route.py` exercita a rota de upload de ponta a ponta e
+# `tests/test_ofxparse_import_preguicoso.py` o anexo pelo bot, então sem o pacote
+# há vermelho por nome de teste — só não há mais o aborto de coleta.
 _DEPS_REDUZIDAS = os.getenv("PYTEST_ALLOW_MISSING_OPTIONAL_DEPS") == "1"
 
 # find_spec em vez de `try: import`: `except ImportError` também captura um

--- a/tests/test_ofxparse_import_preguicoso.py
+++ b/tests/test_ofxparse_import_preguicoso.py
@@ -1,0 +1,108 @@
+# tests/test_ofxparse_import_preguicoso.py
+"""`core.handle_incoming` não pode arrastar o `ofxparse` no import.
+
+A cadeia era `core/handle_incoming.py` -> `core.services.ofx_service` ->
+`ofx_import` -> `ofxparse`, toda ela em import de TOPO. Como
+`core.handle_incoming` é importado por meio repositório (adaptadores de
+WhatsApp/Discord, rotas do frontend, helpers de teste), um ambiente sem o
+`ofxparse` instalado perdia a suíte inteira em volta dele — medido em
+6281 testes coletados contra 7396, com 18 arquivos estourando na coleta e
+276 falhas de import tardio.
+
+O anexo OFX é caminho raro; o import dele mora dentro do bloco que o trata.
+
+Os dois controles exigidos pelo CLAUDE.md §3 estão aqui:
+
+  * **negativo** — `test_handle_incoming_importa_sem_ofxparse` fica VERMELHO se
+    o import voltar para o topo (medido: com a linha 26 restaurada o subprocesso
+    sai com `ModuleNotFoundError: import of ofxparse halted; None in sys.modules`);
+  * **positivo** — `test_anexo_ofx_ainda_roteia_para_o_importador` prova que o
+    caminho legítimo continua funcionando: um anexo `.ofx` pelo `handle_incoming`
+    ainda chega no `handle_ofx_import`. Import preguiçoso que quebra o upload é
+    pior que o problema que ele resolve.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+import db
+from core.types import Attachment, IncomingMessage
+
+RAIZ = pathlib.Path(__file__).resolve().parent.parent
+
+# `None` em sys.modules é o que o ambiente reduzido produz na prática: faz
+# `import ofxparse` levantar ModuleNotFoundError e
+# `importlib.util.find_spec("ofxparse")` devolver None — o mesmo que o
+# `_TEM_OFXPARSE` do conftest.py consulta.
+_PROGRAMA = (
+    "import sys; sys.modules['ofxparse'] = None; "
+    "import core.handle_incoming; print('ok')"
+)
+
+
+def test_handle_incoming_importa_sem_ofxparse():
+    """Subprocesso limpo: nenhum módulo do repo pré-carregado pelo pytest.
+
+    Importar no processo do teste não mediria nada — `core.handle_incoming` já
+    está em `sys.modules` desde a coleta, com o `ofxparse` real junto.
+    """
+    saida = subprocess.run(
+        [sys.executable, "-c", _PROGRAMA],
+        cwd=RAIZ, capture_output=True, text=True,
+        env={**os.environ, "PYTHONPATH": str(RAIZ)},
+    )
+    assert saida.returncode == 0, (
+        "core.handle_incoming voltou a arrastar o ofxparse no import:\n"
+        + saida.stderr[-2000:]
+    )
+
+
+@pytest.fixture
+def uid_pro_pequeno():
+    """uid < 2bi e com plano ativo.
+
+    O id pequeno é o mesmo idioma de `test_audio_multi_launch_ask_value.py`:
+    `_normalize_user_id` recomprime ids > 2bi via `_internal_user_id`, então o
+    assert leria um id diferente do que o handler repassa — e a fixture
+    `pro_user_id` sorteia até 10bi, o que deixaria este teste intermitente.
+    O plano ativo é o que passa pelo paywall do `handle_incoming`.
+    """
+    import uuid as _uuid
+    from conftest import _cleanup_user, promote_to_pro
+    uid = int(_uuid.uuid4().int % 1_000_000_000)
+    db.ensure_user(uid)
+    promote_to_pro(uid)
+    yield uid
+    _cleanup_user(uid)
+
+
+def test_anexo_ofx_ainda_roteia_para_o_importador(uid_pro_pequeno, monkeypatch):
+    """Controle positivo: o upload de OFX pelo bot continua chegando no parser."""
+    pytest.importorskip("ofxparse", reason="ausente localmente; presente no CI")
+
+    import core.handle_incoming as hi
+    import core.services.ofx_service as ofx_service
+    import ofx_import
+
+    chamadas = []
+    monkeypatch.setattr(ofx_import, "detect_ofx_type", lambda data: "bank")
+    monkeypatch.setattr(
+        ofx_service, "handle_ofx_import",
+        lambda uid, data, filename: chamadas.append((uid, data, filename)) or "importado",
+    )
+
+    msg = IncomingMessage(
+        platform="whatsapp", user_id=uid_pro_pequeno, text="",
+        message_id="m", external_id="e", raw={},
+        attachments=[Attachment(filename="extrato.ofx",
+                                content_type="application/x-ofx",
+                                data=b"OFXHEADER:100")],
+    )
+    out = hi.handle_incoming(msg)
+
+    assert chamadas == [(str(uid_pro_pequeno), b"OFXHEADER:100", "extrato.ofx")]
+    assert out and "importado" in out[0].text


### PR DESCRIPTION
O ambiente remoto (Claude Code na web) instala tudo **menos** `audioop-lts` e `ofxparse`, e liga `PYTEST_ALLOW_MISSING_OPTIONAL_DEPS=1`. Lá a suíte estava rodando **85% de si mesma e parecendo verde**.

| ambiente reduzido | antes | depois |
|---|---|---|
| erros de coleta | 18 | **0** |
| testes coletados | 6281 | **7350** |
| falhas de import tardio | 276 | **8** |

**1115 testes escondidos** — e **11 das 276 falhas saíam como erro de comportamento** (`assert 0 == 3`, "o opt-out do canal de E-MAIL calou o canal de WhatsApp"), não como dependência faltando. Esse é o pior tipo: vermelho que não se parece com a causa.

A cadeia era sempre a mesma, e o culpado era **um** import de topo em `core/handle_incoming.py` — módulo importado por meio repo, que arrastava o `ofxparse` para tudo. O conserto é mover esse import para dentro da função que o usa, e **o idioma já estava três linhas abaixo, no mesmo arquivo**.

### Por que não crescer a lista do conftest
Era a saída que eu ia tomar. A lista `_OFXPARSE_DEPENDENTES` nasceu em `3fc4394` (2026-08-17) e os 18 arquivos quebrados foram **todos criados depois** — ela envelhece a cada teste novo. Com a raiz consertada, ela **encolhe de 12 para 1**; tratando o sintoma, iria de 13 para 31.

### Custo assumido, e está escrito no `conftest.py`
Import preguiçoso faz o pacote sumido quebrar mais **tarde** e mais **baixo**. O que compensa: o alívio continua **opt-in** (sem a variável, o pacote ausente ainda estoura — medido), nada foi engolido num `try/except ImportError`, e agora há vermelho **por nome de teste** (a rota de upload ponta a ponta) em vez de 276 vermelhos sem nome útil.

### Sobrou, não consertado
Três `pytest.importorskip("ofxparse")` cuja justificativa escrita — "importar `handle_incoming` puxa `ofxparse`" — deixou de ser verdade. O repo tem **três** mecanismos para a mesma dependência.

Simulado nesta máquina, **não rodado no ambiente remoto de verdade**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
