### PR TITLE
fix: libera biblioteca do Clarity na CSP

### DIFF
--- a/frontend/finance_bot_websocket_custom.py
+++ b/frontend/finance_bot_websocket_custom.py
@@ -2168,7 +2168,7 @@ _SECURITY_HEADERS = {
         "script-src 'self' 'unsafe-inline' "
         "https://cdnjs.cloudflare.com https://cdn.pluggy.ai https://cdn.jsdelivr.net "
         "https://static.cloudflareinsights.com https://connect.facebook.net "
-        "https://www.googletagmanager.com https://www.clarity.ms; "
+        "https://www.googletagmanager.com https://www.clarity.ms https://scripts.clarity.ms; "
         "style-src 'self' 'unsafe-inline' "
         "https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; "
         "img-src 'self' data: blob: https:; "

--- a/tests/test_clarity_tracking.py
+++ b/tests/test_clarity_tracking.py
@@ -147,3 +147,4 @@ def test_csp_permite_biblioteca_do_clarity():
     csp = _SECURITY_HEADERS["Content-Security-Policy"]
     script_src = csp.split("script-src", 1)[1].split(";", 1)[0]
     assert "https://www.clarity.ms" in script_src
+    assert "https://scripts.clarity.ms" in script_src


### PR DESCRIPTION
O carregador do Clarity em www.clarity.ms busca a biblioteca em scripts.clarity.ms, mas a CSP bloqueava esse segundo domínio e impedia as gravações.

Libera scripts.clarity.ms em script-src e amplia o teste da CSP para exigir ambos os domínios.

Validação: Chromium com a CSP do código aplicada à resposta apenas na sessão local de teste carregou as duas bibliotecas com HTTP 200 e enviou dois POSTs a e.clarity.ms/collect com HTTP 204. Sintaxe Python e git diff --check aprovados. O pytest completo depende da CI; não há .venv local. A mudança ainda exige merge e deploy para valer em produção.
