### PR TITLE
Corrige proporção da mascote no mobile

### DIFF
--- a/frontend/site.css
+++ b/frontend/site.css
@@ -185,7 +185,7 @@ img { max-width: 100%; display: block; }
 .trust .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--neon); box-shadow: 0 0 8px rgba(198,241,26,.6); }
 
 .hero-visual { position: relative; min-height: 500px; }
-.hero-mascot { position: absolute; left: -18px; bottom: -10px; width: 208px; z-index: 3; filter: drop-shadow(0 16px 30px rgba(0,0,0,.55)); pointer-events: none; }
+.hero-mascot { position: absolute; left: -18px; bottom: -10px; width: 208px; height: auto; z-index: 3; filter: drop-shadow(0 16px 30px rgba(0,0,0,.55)); pointer-events: none; }
 
 .chat-card {
   position: relative; z-index: 2; margin: 0 0 -30px auto; width: min(300px,86%);

--- a/tests/test_landing_performance.py
+++ b/tests/test_landing_performance.py
@@ -57,3 +57,10 @@ def test_imagens_exclusivas_da_landing_tem_dimensoes_e_orcamento():
     assert 'preload="none"' in html
     assert 'width="101" height="30"' in html
     assert 'width="300" height="486"' in html
+
+
+def test_mascote_preserva_proporcao_quando_o_mobile_reduz_a_largura():
+    css = (FRONTEND_DIR / "site.css").read_text(encoding="utf-8")
+    regra = re.search(r"\.hero-mascot\s*\{([^}]+)\}", css)
+    assert regra
+    assert "height: auto" in regra.group(1)


### PR DESCRIPTION
## Problema

O PageSpeed após o #405 mostrou a mascote mobile em `150 × 486`, enquanto o arquivo mede `300 × 486`. O breakpoint reduzia apenas `width`; o novo atributo HTML `height="486"` continuava prevalecendo e distorcia a imagem, gerando o alerta de proporção e contribuindo para CLS.

## Correção

- define `height: auto` na regra base de `.hero-mascot`;
- adiciona uma guarda para impedir que a proporção volte a quebrar.

## Validação

- Chromium em viewport `390 × 844`: renderiza `150 × 243`, exatamente a proporção natural `300 × 486`;
- 5 guardas da landing passaram;
- lint passou;
- `git diff --check` passou.
