### PR TITLE
Evita salto do conteúdo ao carregar o menu mobile

### DIFF
--- a/frontend/site.css
+++ b/frontend/site.css
@@ -261,8 +261,18 @@ img { max-width: 100%; display: block; }
 }
 @media (max-width: 900px) {
   .nav { flex-wrap: wrap; }
-  /* Os links só recolhem depois que o botão do menu está disponível. */
-  .nav-links { display: flex; flex-wrap: wrap; width: 100%; }
+  /* Os links só recolhem depois que o botão do menu está disponível. Eles
+     ficam fora do fluxo desde o primeiro paint: assim, o nav-burger.js pode
+     escondê-los sem reduzir a altura da barra e puxar a página inteira para
+     cima. Se o script falhar, continuam visíveis e utilizáveis como painel. */
+  .nav-links {
+    position: absolute; inset: calc(100% + 8px) 0 auto;
+    display: flex; flex-wrap: wrap; width: 100%;
+    margin: 0; padding: 12px;
+    background: rgba(20,20,22,.96); backdrop-filter: blur(26px) saturate(160%);
+    border: 1px solid var(--line); border-radius: var(--radius-sm);
+    box-shadow: 0 16px 36px rgba(0,0,0,.42);
+  }
   .section { padding: 60px 0; }
   /* Alvo de toque na barra mobile: 44px (mínimo iOS/WCAG 2.5.5), o mesmo piso
      que o .pb-burger do nav-burger.js já respeita — e 900px é o mesmo gate que ele

--- a/tests/frontend/nav_sem_cls.test.mjs
+++ b/tests/frontend/nav_sem_cls.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * Reprodução do salto causado pelo aprimoramento progressivo da nav mobile.
+ * Atrasar o nav-burger.js garante um paint com o fallback antes de o menu ser
+ * recolhido, exatamente a sequência que gerou CLS 0,139 em produção.
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { startServer } from "./_server.mjs";
+import { chromium } from "playwright";
+
+let ORIGIN, server, browser;
+before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
+                     browser = await chromium.launch(); });
+after(async () => { await browser?.close(); server?.kill(); });
+
+test("ativar o menu mobile não desloca o conteúdo depois do primeiro paint", async () => {
+  const ctx = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  let liberarScript;
+  const scriptBloqueado = new Promise((resolve) => { liberarScript = resolve; });
+  await ctx.route("**/nav-burger.js*", async (route) => {
+    await scriptBloqueado;
+    await route.continue();
+  });
+
+  const page = await ctx.newPage();
+  const navegacao = page.goto(`${ORIGIN}/index.html`);
+  await page.waitForSelector("main.wrap");
+  // Dois frames garantem que o estado anterior ao script chegou a ser pintado.
+  await page.evaluate(() => new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  const topoAntes = await page.$eval("main.wrap", (el) => el.getBoundingClientRect().top);
+
+  liberarScript();
+  await navegacao;
+  await page.waitForSelector(".nav.pb-nav-ready");
+  const topoDepois = await page.$eval("main.wrap", (el) => el.getBoundingClientRect().top);
+
+  assert.equal(topoDepois, topoAntes,
+    `o conteúdo pulou ${+(topoDepois - topoAntes).toFixed(1)}px quando o menu foi ativado`);
+  await ctx.close();
+});


### PR DESCRIPTION
## O que foi feito

- mantém os links da navegação mobile fora do fluxo vertical desde o primeiro paint
- preserva o fallback acessível quando o JavaScript do menu não carrega
- exibe os links abertos em um painel sobreposto, sem empurrar o conteúdo
- adiciona um teste Playwright que atrasa o nav-burger.js e compara a posição do conteúdo antes e depois da ativação

## Causa

O nav-burger.js era carregado com defer. Antes de sua execução, os links ocupavam uma segunda linha da barra. Ao ativar o menu recolhido, essa linha era escondida, a barra encolhia e todo o conteúdo subia 118,2 px, gerando CLS.

## Validação

- reprodução antes da correção: deslocamento de -118,2 px
- depois da correção: deslocamento de 0 px
- 19 testes direcionados dos menus públicos aprovados
- suíte frontend completa aprovada
- lint sem erros