### PR TITLE
Reduz LCP e TBT da landing mobile

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
 <meta name="description" content="Controle seu dinheiro direto no WhatsApp. Registre gastos, consulte saldo e acompanhe cartões em segundos com a IA da PigBank." />
 <link rel="icon" type="image/png" href="/favicon.png?v=3" />
 <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png?v=3" />
+<link rel="preload" href="/fonts/Inter-Variable.woff2?v=5059ef2a9db0" as="font" type="font/woff2" crossorigin />
 <meta name="theme-color" content="#0c0c0d" />
 <meta name="facebook-domain-verification" content="bkhplpcvt5kouph3e1b9y8jk8aiqsu" />
 <meta property="og:type" content="website" />

--- a/frontend/routes/shared.py
+++ b/frontend/routes/shared.py
@@ -298,16 +298,60 @@ def stamp_asset_versions(html_text: str) -> str:
     return _ASSET_VER_RE.sub(repl, html_text)
 
 
-def html_file(path: pathlib.Path, pixel: bool = True, clarity: bool = False) -> Response:
+def _inline_css_assets(html_text: str, asset_names: tuple[str, ...]) -> str:
+    """Incorpora folhas locais no HTML sem duplicar o CSS-fonte.
+
+    O contrato é deliberadamente estrito: cada asset precisa ser um CSS na raiz
+    de ``frontend/`` e ter exatamente um ``<link>`` correspondente. Assim, uma
+    mudança futura no ``<head>`` falha visivelmente em vez de devolver a landing
+    sem estilos.
+    """
+    for asset_name in asset_names:
+        asset_path = FRONTEND_DIR / asset_name
+        if asset_path.parent != FRONTEND_DIR or asset_path.suffix != ".css":
+            raise ValueError(f"CSS inline inválido: {asset_name}")
+
+        pattern = re.compile(
+            rf'(?P<indent>[ \t]*)<link rel="stylesheet" '
+            rf'href="/{re.escape(asset_name)}\?v=\d+"\s*/?>'
+        )
+        css = asset_path.read_text(encoding="utf-8")
+
+        def replace_link(match: "re.Match[str]") -> str:
+            indent = match.group("indent")
+            return (
+                f'{indent}<style data-pb-inline="{asset_name}">\n'
+                f"{css}\n{indent}</style>"
+            )
+
+        html_text, replacements = pattern.subn(replace_link, html_text)
+        if replacements != 1:
+            raise ValueError(
+                f"Esperava um link para {asset_name}; encontrei {replacements}"
+            )
+
+    return html_text
+
+
+def html_file(
+    path: pathlib.Path,
+    pixel: bool = True,
+    clarity: bool = False,
+    inline_css: tuple[str, ...] = (),
+) -> Response:
     """Serve um .html do frontend com cache desligado.
 
     Com `pixel=True` (padrão), injeta Meta Pixel e GA4 no <head> — cada um só se
     estiver configurado. `clarity=True` é opt-in explícito para páginas públicas
-    sem campos sensíveis. As páginas da área logada (dashboard, settings,
-    onboarding) passam `pixel=False`: o rastreio fica nas páginas públicas e na
-    /home, que é onde a volta do checkout (?upgrade=success) dispara a conversão.
+    sem campos sensíveis. `inline_css` elimina viagens de rede bloqueantes em
+    páginas selecionadas, mantendo os mesmos arquivos como fonte única. As
+    páginas da área logada (dashboard, settings, onboarding) passam
+    `pixel=False`: o rastreio fica nas páginas públicas e na /home, que é onde a
+    volta do checkout (?upgrade=success) dispara a conversão.
     """
     text = path.read_text(encoding="utf-8")
+    if inline_css:
+        text = _inline_css_assets(text, inline_css)
     if pixel:
         text = inject_tracking(text, clarity=clarity)
     response = Response(content=stamp_asset_versions(text),

--- a/frontend/routes/static_pages.py
+++ b/frontend/routes/static_pages.py
@@ -48,7 +48,11 @@ class ContactBody(BaseModel):
 
 @router.get("/")
 async def serve_landing():
-    return html_file(FRONTEND_DIR / "index.html", clarity=True)
+    return html_file(
+        FRONTEND_DIR / "index.html",
+        clarity=True,
+        inline_css=("brand.css", "phosphor.css", "site.css", "site-redesign.css"),
+    )
 
 
 @router.get("/app")

--- a/tests/test_landing_performance.py
+++ b/tests/test_landing_performance.py
@@ -1,31 +1,68 @@
 """Guardas das otimizações de caminho crítico e imagens da landing."""
 
+import asyncio
 import re
 from types import SimpleNamespace
 
 from PIL import Image
 
-from frontend.routes.shared import FRONTEND_DIR, _asset_hash, stamp_asset_versions
-from frontend.routes.static_pages import _CACHE_IMUTAVEL, _cache_asset_versionado
+from frontend.routes.shared import (
+    FRONTEND_DIR,
+    _asset_hash,
+    html_file,
+    stamp_asset_versions,
+)
+from frontend.routes.static_pages import (
+    _CACHE_IMUTAVEL,
+    _cache_asset_versionado,
+    serve_landing,
+)
 
 
 def _landing_servida() -> str:
+    return asyncio.run(serve_landing()).body.decode("utf-8")
+
+
+def _landing_com_links_versionados() -> str:
     return stamp_asset_versions(
         (FRONTEND_DIR / "index.html").read_text(encoding="utf-8")
     )
 
 
-def test_css_da_landing_sai_versionado_por_conteudo():
+def test_css_da_landing_e_incorporado_no_html_para_nao_bloquear_a_primeira_pintura():
     html = _landing_servida()
-    folhas = re.findall(r'<link[^>]+rel="stylesheet"[^>]+href="([^"]+)', html)
-    assert len(folhas) == 4
-    for nome in ("brand.css", "phosphor.css", "site.css", "site-redesign.css"):
-        esperado = _asset_hash(nome, (FRONTEND_DIR / nome).stat().st_mtime_ns)
-        assert f"/{nome}?v={esperado}" in folhas
+    nomes = ("brand.css", "phosphor.css", "site.css", "site-redesign.css")
+    assert re.findall(r'<style data-pb-inline="([^"]+)">', html) == list(nomes)
+    for nome in nomes:
+        assert f'href="/{nome}?v=' not in html
+        inicio_css = (FRONTEND_DIR / nome).read_text(encoding="utf-8")[:200]
+        assert inicio_css in html
+
+
+def test_fonte_do_titulo_e_descoberta_antes_do_css_inline():
+    html = _landing_servida()
+    brand_css = (FRONTEND_DIR / "brand.css").read_text(encoding="utf-8")
+    url_fonte = re.search(
+        r'url\("(/fonts/Inter-Variable\.woff2\?v=[0-9a-f]{12})"\)',
+        brand_css,
+    ).group(1)
+    preload = re.search(
+        rf'<link rel="preload" href="{re.escape(url_fonte)}" '
+        r'as="font" type="font/woff2" crossorigin\s*/?>',
+        html,
+    )
+    assert preload
+    assert preload.start() < html.index('<style data-pb-inline="brand.css">')
+
+
+def test_css_continua_externo_nas_demais_paginas_publicas():
+    html = html_file(FRONTEND_DIR / "precos.html", pixel=False).body.decode("utf-8")
+    assert re.search(r'href="/brand\.css\?v=[0-9a-f]{12}"', html)
+    assert 'data-pb-inline="brand.css"' not in html
 
 
 def test_assets_versionados_tem_cache_imutavel_sem_cachear_url_nua():
-    html = _landing_servida()
+    html = _landing_com_links_versionados()
     versao = re.search(r'/site\.css\?v=([0-9a-f]{12})', html).group(1)
     assert _cache_asset_versionado(SimpleNamespace(query_params={"v": versao})) == _CACHE_IMUTAVEL
     assert _cache_asset_versionado(SimpleNamespace(query_params={})) == "no-cache"


### PR DESCRIPTION
## O que foi feito

- incorpora as quatro folhas de estilo da landing diretamente na resposta HTML da rota inicial;
- mantém os arquivos CSS como fonte única e preserva o carregamento externo nas demais páginas;
- antecipa o download da fonte Inter usada no título principal;
- mantém Clarity, GA4 e Meta Pixel ativos;
- adiciona testes para impedir a volta de CSS bloqueante e garantir que outras páginas não sejam afetadas.

## Resultado medido

Em quatro execuções Lighthouse mobile válidas e sequenciais:

- performance: 97;
- LCP: 2,40 s;
- TBT: 14–23 ms;
- CLS: 0.

Antes, as medições informadas apresentavam LCP entre 6,4–7,0 s e TBT de até 490 ms.

## Validação

- 31 testes Python das rotas e da landing passaram;
- 609 testes frontend passaram;
- lint passou;
- captura mobile da branch ficou byte a byte idêntica à produção.