### PR TITLE
Remove obrigatoriedade do vídeo na landing

### DIFF
--- a/docs/transicao_frontend_fase_0.md
+++ b/docs/transicao_frontend_fase_0.md
@@ -24,7 +24,7 @@ para visitantes.
 
 | Rota ou recurso | Situação | Contratos que uma migração não pode assumir |
 | --- | --- | --- |
-| `/` | pública, candidata após otimização | VSL bloqueia CTAs de `/cadastro`; `vsl_play`, `vsl_progress` e `vsl_unlock`; falha da mídia libera; `pb_vsl_visto`; `nav-auth.js` reescreve CTAs de sessão viva. |
+| `/` | pública, candidata após otimização | VSL opcional; CTAs de `/cadastro` sempre acionáveis; `vsl_play` e `vsl_progress`; `nav-auth.js` reescreve CTAs de sessão viva. |
 | `/como-funciona` | pública, piloto técnico proposto | Conteúdo institucional, tags injetadas pelo FastAPI, navegação convencional e `safe-area.js`. |
 | `/precos` | pública com dados e escrita | Consulta sessão e configuração de planos; inicia checkout; GA4/Meta; não é piloto estático até existir contrato de catálogo e matriz de estados. |
 | `/cadastro`, `/login`, `/completar-cadastro` | entrada | Cookies HttpOnly, CSRF, Google e deduplicação de `sign_up`/`CompleteRegistration`. |
@@ -91,7 +91,9 @@ já tem os metadados no início; a hipótese anterior de download integral de
 10,43 MiB era erro de contagem do coletor. Em comparação controlada no mesmo
 Chromium, `preload="none"` reduziu a transferência pré-interação de cerca de
 194 KB para zero e `play()` iniciou a transmissão normalmente. A fase 1 adota
-essa opção, preservando `src`, reprodução, portão de cadastro e eventos. O vídeo
+essa opção, preservando `src`, reprodução e eventos de consumo. Em 13/09/2026,
+o portão de cadastro foi removido por decisão de produto: o vídeo continua
+opcional e nenhum CTA depende de sua reprodução. O vídeo
 não é o LCP atual; o elemento observado foi o subtítulo da hero.
 
 ## Funil e medição
@@ -105,7 +107,6 @@ indica retorno do provedor e não confirma cobrança. Os eventos a preservar sã
 | visita | `page_view` / Meta `PageView` | Preservar `_ga`, `_fbp`, `_fbc`, UTMs e referenciador. |
 | início do vídeo | `vsl_play` | Uma vez por reprodução iniciada. |
 | progresso | `vsl_progress` | Marcos de 25%, 50% e 75%. |
-| desbloqueio | `vsl_unlock` | Distinguir assistiu, memória, sessão e falha de mídia. |
 | cadastro | `sign_up` / `CompleteRegistration` | Deduplicar cliente e CAPI pelo identificador existente. |
 | checkout | `begin_checkout` e `checkout_funnel_events` | Uma ação deve criar uma única solicitação. |
 | aquisição | confirmação backend/webhook | Separar teste iniciado, compra imediata e primeira cobrança posterior. |

--- a/docs/transicao_frontend_fase_0.md
+++ b/docs/transicao_frontend_fase_0.md
@@ -106,7 +106,7 @@ indica retorno do provedor e não confirma cobrança. Os eventos a preservar sã
 | --- | --- | --- |
 | visita | `page_view` / Meta `PageView` | Preservar `_ga`, `_fbp`, `_fbc`, UTMs e referenciador. |
 | início do vídeo | `vsl_play` | Uma vez por reprodução iniciada. |
-| progresso | `vsl_progress` | Marcos de 25%, 50% e 75%. |
+| progresso | `vsl_progress` | Marcos de 25%, 50% e 75% do tempo realmente reproduzido; saltos na barra não contam. |
 | cadastro | `sign_up` / `CompleteRegistration` | Deduplicar cliente e CAPI pelo identificador existente. |
 | checkout | `begin_checkout` e `checkout_funnel_events` | Uma ação deve criar uma única solicitação. |
 | aquisição | confirmação backend/webhook | Separar teste iniciado, compra imediata e primeira cobrança posterior. |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -756,7 +756,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
 
     video.addEventListener("timeupdate", function () {
       var tempoAtual = video.currentTime;
-      if (!buscando && !video.paused && tempoAtual > ultimoTempo) {
+      if (!buscando && tempoAtual > ultimoTempo) {
         assistido += tempoAtual - ultimoTempo;
       }
       ultimoTempo = tempoAtual;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -741,14 +741,25 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     var video = document.getElementById("vsl-video");
     if (!video) return;
 
-    var assistido = 0, marcos = {};
+    var assistido = 0, ultimoTempo = video.currentTime, buscando = false, marcos = {};
 
     video.addEventListener("play", function () {
+      ultimoTempo = video.currentTime;
       if (window.gtag) gtag("event", "vsl_play", {});
     }, { once: true });
 
+    video.addEventListener("seeking", function () { buscando = true; });
+    video.addEventListener("seeked", function () {
+      buscando = false;
+      ultimoTempo = video.currentTime;
+    });
+
     video.addEventListener("timeupdate", function () {
-      if (video.currentTime > assistido) assistido = video.currentTime;
+      var tempoAtual = video.currentTime;
+      if (!buscando && !video.paused && tempoAtual > ultimoTempo) {
+        assistido += tempoAtual - ultimoTempo;
+      }
+      ultimoTempo = tempoAtual;
       var d = video.duration;
       if (!d || !isFinite(d)) return;
       var pct = Math.floor((assistido / d) * 100);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -58,9 +58,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     .plan-solo-amount { font-size: 2.6rem; }
   }
 
-  /* ── VSL: vídeo obrigatório antes do cadastro ─────────────────────────
-     O portão em si é JS (busque "vsl-gate" no fim do arquivo). Aqui só o
-     que ele precisa poder mostrar: o quadro do vídeo e o CTA travado. */
+  /* ── VSL: demonstração opcional antes do cadastro ───────────────────── */
   .vsl-frame {
     max-width: 860px; margin: 0 auto; overflow: hidden;
     border: 1px solid rgba(255,45,142,.35);
@@ -77,32 +75,16 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
     border-radius: var(--radius-pill);
     box-shadow: 0 16px 44px rgba(255,45,142,.45);
   }
-  /* Travado NÃO é o .btn.is-locked cinza-desbotado: um botão apagado lê-se como
-     quebrado. Aqui ele vira superfície de espera, com a razão escrita nele. */
-  .vsl-cta.is-locked {
-    background: var(--bg-elev); color: var(--text-muted);
-    border: 2px dashed var(--border-strong);
-    box-shadow: none; opacity: 1; filter: none;
-    font-size: .96rem; letter-spacing: 0; padding: 16px 34px;
-  }
-  .vsl-cta.is-locked:hover { transform: none; box-shadow: none; }
-  /* O pulso só existe no estado liberado — é o que puxa o olho pro clique. */
+  /* O pulso puxa o olho para a conversão sem condicionar o cadastro ao vídeo. */
   @keyframes vslPulso {
     0%, 100% { box-shadow: 0 16px 44px rgba(255,45,142,.42), 0 0 0 0 rgba(255,45,142,.45); }
     50%      { box-shadow: 0 16px 44px rgba(255,45,142,.58), 0 0 0 16px rgba(255,45,142,0); }
   }
-  .vsl-cta:not(.is-locked) { animation: vslPulso 2.4s ease-in-out infinite; }
-  @media (prefers-reduced-motion: reduce) { .vsl-cta:not(.is-locked) { animation: none; } }
-  .vsl-status { margin: 14px auto 0; text-align: center; color: var(--text-muted); font-size: .88rem; min-height: 1.2em; }
-  .vsl-status.is-ok { color: var(--pig-neon); }
-  .vsl-status.is-alerta { color: var(--pig-pink); font-weight: 600; }
+  .vsl-cta { animation: vslPulso 2.4s ease-in-out infinite; }
+  @media (prefers-reduced-motion: reduce) { .vsl-cta { animation: none; } }
   @media (max-width: 560px) {
     .vsl-cta { font-size: 1.05rem; padding: 17px 34px; }
-    .vsl-cta.is-locked { padding: 15px 22px; font-size: .9rem; }
   }
-  /* Travado fica VISÍVEL e legível de propósito: CTA que some deixa a pessoa
-     procurando o botão em vez de assistir ao vídeo. */
-  .btn.is-locked { opacity: .55; cursor: not-allowed; filter: grayscale(.35); }
   html.pb-safe body {
     padding-top: env(safe-area-inset-top);
     padding-right: env(safe-area-inset-right);
@@ -244,14 +226,14 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
            404 contra 640 do vídeo — 236px fora do eixo. As outras seções desta
            página apresentam grade de largura cheia e ficam alinhadas à esquerda. -->
       <div class="section-head center" data-reveal>
-        <div class="eyebrow">Assista antes de começar</div>
+        <div class="eyebrow">Veja como funciona</div>
         <h2>Em 1 minuto você entende<br><span class="grad">tudo que a Piggy faz</span></h2>
       </div>
       <div class="vsl-frame" data-reveal>
         <!-- `src` direto, sem <source>: com o `type` no <source> o navegador
              filtra o candidato ANTES de buscar, e um navegador que reporta
              mp4 como "maybe not" nem tenta. Aqui ele busca e decide pelo
-             conteúdo — e o que não tocar cai no `error`, que ABRE o portão.
+             conteúdo.
              O ?v= é manual: /brand/ serve com cache immutable de 1 ano, e o
              stamper de conteúdo do serve-time só reescreve css/js. Trocou o
              vídeo, sobe o número. -->
@@ -263,15 +245,10 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
                preload="none" poster="/brand/vsl-poster-860.webp?v=1"
                src="/brand/vsl.mp4?v=1"></video>
       </div>
-      <!-- É um <a href="/cadastro"> de verdade, e não um <button>: assim ele entra
-           sozinho no `alvos` do vsl-gate e no handler de clique, sem caso especial.
-           Nasce TRAVADO no HTML — se o JS não rodar, o que aparece é o convite a
-           assistir, nunca um botão morto. O rótulo vira "COMECE JÁ" ao liberar. -->
+      <!-- Link real e imediatamente acionável: assistir ao vídeo é opcional. -->
       <div class="vsl-cta-wrap" data-reveal>
-        <a class="btn btn-primary btn-lg vsl-cta is-locked" id="vsl-cta"
-           href="/cadastro" aria-disabled="true"
-           ><span id="vsl-cta-txt">Assista ao vídeo para liberar</span></a>
-        <p class="vsl-status" id="vsl-status" role="status"></p>
+        <a class="btn btn-primary btn-lg vsl-cta" id="vsl-cta"
+           href="/cadastro">COMECE JÁ</a>
       </div>
     </section>
 
@@ -759,109 +736,12 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
   })();
   </script>
   <script>
-  /* ── vsl-gate: o cadastro só destrava depois do vídeo ──────────────────
-     Pedido explícito do dono: assistir é obrigatório e não dá pra pular.
-
-     Isto é portão de PERSUASÃO, não de segurança. /cadastro continua
-     alcançável por URL direta, pelo botão da /precos e pelo nav das outras
-     páginas — quem quiser desviar, desvia. O que ele faz é não deixar o
-     caminho ÓBVIO da landing pular o vídeo.
-
-     Três decisões que não são detalhe:
-     · FALHA ABERTA. Vídeo que não carrega, formato que o navegador não toca,
-       rede caída — libera. Portão que trava por defeito zera o cadastro do
-       dia em silêncio, e quem está do lado de dentro não vê nada.
-     · Rebobinar pode, adiantar não: `seeking` devolve o cursor pro ponto mais
-       longe já assistido. Sem isso, arrastar a barra pro fim vale por assistir.
-     · Uma vez por navegador. Quem assistiu, foi pro /cadastro e voltou não
-       assiste de novo — senão o portão pune justo quem cumpriu.
-
-     O clique é UM handler no documento, não cinco nos botões: os CTAs de
-     /cadastro são 5 hoje (nav, hero, hiw, tech, fim) e o próximo nasce coberto. */
+  /* ── vsl-metrics: o vídeo é opcional; o cadastro está sempre disponível ── */
   (function () {
-    var video  = document.getElementById("vsl-video");
-    var status = document.getElementById("vsl-status");
-    var rotulo = document.getElementById("vsl-cta-txt");
+    var video = document.getElementById("vsl-video");
     if (!video) return;
 
-    var CHAVE = "pb_vsl_visto";
-    var liberado = false, assistido = 0, marcos = {};
-    // Capturados UMA vez, e guardados como elementos. Reconsultar por
-    // `a[href="/cadastro"]` na hora de liberar era um bug: o nav-auth.js troca
-    // esse href por /app quando a sessão está viva, e aí a consulta não acha
-    // mais nada — os CTAs de quem já tem conta ficariam cinzas para sempre.
-    var alvos = [].slice.call(document.querySelectorAll('a[href="/cadastro"]'));
-
-    function travar() {
-      alvos.forEach(function (a) {
-        a.classList.add("is-locked");
-        a.setAttribute("aria-disabled", "true");
-      });
-    }
-
-    function liberar(motivo) {
-      if (liberado) return;
-      liberado = true;
-      alvos.forEach(function (a) {
-        a.classList.remove("is-locked");
-        a.removeAttribute("aria-disabled");
-      });
-      // Quem está logado NÃO recebe "COMECE JÁ": o nav-auth.js já escreveu
-      // "Ir para o dashboard" e o href aponta pro /app. Na prática ele também já
-      // destruiu este <span> (`a.textContent = ...` troca os filhos — medido:
-      // `parentNode` fica null), então a escrita cairia no vazio de qualquer
-      // jeito. A condição fica porque a regra tem de estar dita em algum lugar
-      // que não seja um efeito colateral de outro arquivo.
-      if (motivo !== "logado" && rotulo) rotulo.textContent = "COMECE JÁ";
-      if (status) {
-        status.textContent = "Cadastro liberado.";
-        status.className = "vsl-status is-ok";
-      }
-      // Só "assistiu" vira memória. "erro" não: um tropeço de rede não pode
-      // desligar o portão naquele navegador para sempre. "logado" também não:
-      // quem sair da conta depois volta a ser visitante.
-      if (motivo === "assistiu") { try { localStorage.setItem(CHAVE, "1"); } catch (e) {} }
-      // Sem `pbTrack` aqui: nada navega depois deste evento.
-      if (window.gtag) gtag("event", "vsl_unlock", { motivo: motivo });
-    }
-
-    document.addEventListener("click", function (ev) {
-      if (liberado) return;
-      var a = ev.target && ev.target.closest && ev.target.closest("a");
-      // Pelo href VIVO, não pelo seletor de origem: depois do nav-auth.js o
-      // botão aponta pro /app, e barrar quem já tem conta não faz sentido.
-      if (!a || a.getAttribute("href") !== "/cadastro") return;
-      ev.preventDefault();
-      video.scrollIntoView({ behavior: "smooth", block: "center" });
-      if (status) {
-        status.textContent = "Assista ao vídeo até o fim para liberar o cadastro.";
-        status.className = "vsl-status is-alerta";
-      }
-    });
-
-    var visto = false;
-    try { visto = localStorage.getItem(CHAVE) === "1"; } catch (e) {}
-    if (visto) { liberar("memoria"); } else { travar(); }
-
-    // A porta de saída: depois da tentativa de reprodução, `error` no <video>
-    // cobre os dois jeitos de o vídeo não existir pro usuário — 404 e codec que
-    // o navegador não toca. Com preload="none", não há como detectar antes da
-    // interação sem voltar a transferir mídia na visita inicial.
-    video.addEventListener("error", function () { liberar("erro"); });
-
-    // A outra porta: o nav-auth.js reescreve o href dos CTAs quando o /auth/validate
-    // responde que a sessão está viva. Quem já tem conta não tem o que assistir
-    // pra se cadastrar. É observador de atributo porque o nav-auth é assíncrono
-    // e não anuncia nada — e sem ele o portão só se abriria pelo vídeo.
-    if (window.MutationObserver && alvos.length) {
-      var obs = new MutationObserver(function () {
-        if (alvos.some(function (a) { return a.getAttribute("href") !== "/cadastro"; })) {
-          obs.disconnect();
-          liberar("logado");
-        }
-      });
-      alvos.forEach(function (a) { obs.observe(a, { attributes: true, attributeFilter: ["href"] }); });
-    }
+    var assistido = 0, marcos = {};
 
     video.addEventListener("play", function () {
       if (window.gtag) gtag("event", "vsl_play", {});
@@ -878,17 +758,7 @@ if (!/[?&]site=1(&|$)/.test(location.search) &&
           if (window.gtag) gtag("event", "vsl_progress", { percent: m });
         }
       });
-      // `ended` não vem em todo navegador quando o arquivo termina raspando;
-      // o teto de 0,5s fecha o buraco sem depender do evento.
-      if (assistido >= d - 0.5) liberar("assistiu");
     });
-
-    video.addEventListener("seeking", function () {
-      if (liberado) return;
-      if (video.currentTime > assistido + 0.5) video.currentTime = assistido;
-    });
-
-    video.addEventListener("ended", function () { liberar("assistiu"); });
   })();
   </script>
   <script src="/nav-auth.js?v=7" defer></script>

--- a/tests/frontend/vsl_gate.test.mjs
+++ b/tests/frontend/vsl_gate.test.mjs
@@ -70,26 +70,34 @@ test("todos os CTAs levam ao cadastro sem exigir o vídeo", async () => {
 test("o visitante pode avançar o vídeo sem bloquear o cadastro", async () => {
   const { page, ctx } = await abrirLanding();
   const posicao = await page.evaluate(async () => {
+    window.__eventosVsl = [];
+    window.gtag = (...args) => window.__eventosVsl.push(args);
     const v = document.getElementById("vsl-video");
     v.currentTime = v.duration - 0.01;
     await new Promise(ok => setTimeout(ok, 300));
-    return { atual: v.currentTime, duracao: v.duration };
+    return {
+      atual: v.currentTime,
+      duracao: v.duration,
+      progresso: window.__eventosVsl.filter(e => e[1] === "vsl_progress"),
+    };
   });
   assert.ok(posicao.atual > posicao.duracao / 2,
             `a busca foi impedida: ${posicao.atual}/${posicao.duracao}`);
+  assert.deepEqual(posicao.progresso, [],
+                   "avançar o cursor não pode contar como tempo assistido");
   await ctx.close();
 });
 
 test("play e marcos de progresso continuam sendo medidos", async () => {
   const { page, ctx } = await abrirLanding();
-  const eventos = await page.evaluate(() => {
+  const eventos = await page.evaluate(async () => {
     window.__eventosVsl = [];
     window.gtag = (...args) => window.__eventosVsl.push(args);
     const v = document.getElementById("vsl-video");
-    v.dispatchEvent(new Event("play"));
-    [0.26, 0.51, 0.76].forEach(p => {
-      v.currentTime = v.duration * p;
-      v.dispatchEvent(new Event("timeupdate"));
+    v.muted = true;
+    await new Promise((ok, erro) => {
+      v.addEventListener("ended", ok, { once: true });
+      v.play().catch(erro);
     });
     return window.__eventosVsl;
   });

--- a/tests/frontend/vsl_gate.test.mjs
+++ b/tests/frontend/vsl_gate.test.mjs
@@ -1,45 +1,12 @@
 /**
- * A VSL da landing trava os CTAs de /cadastro até o vídeo acabar.
+ * A VSL da landing é opcional: nenhum caminho para /cadastro depende do vídeo.
  *
- * Pedido explícito do dono: assistir é obrigatório e não dá pra pular. O
- * portão vive no <script> "vsl-gate" do fim do frontend/index.html.
+ * O grupo protege três contratos:
+ *   · os seis CTAs são links acionáveis no HTML, inclusive sem JavaScript;
+ *   · o vídeo continua `preload="none"` e permite busca livre;
+ *   · play e progresso continuam disponíveis para a análise do funil.
  *
- * A mídia é REAL, não simulada: um WAV de 1s gerado aqui. O <video> toca WAV
- * como toca MP4 — o que está sob teste é a máquina de eventos de mídia, e não
- * o decodificador.
- *
- * Ela entra por `data:` URI, e isso não é estilo. Servida pelo `route.fulfill`
- * do Playwright, que não atende Range, o Chromium reporta `seekable.end(0) === 0`
- * e grampeia QUALQUER busca de posição em 0 sozinho. O caso do avanço — o
- * coração do "não pode pular" — passava verde com o `seeking` inteiro apagado,
- * medindo o harness em vez do portão. Medido: com `fulfill`, `duration` 1 e
- * `seekable` 0; com `data:`, `seekable` 1 e o `currentTime` grudando em 0.99
- * antes de o clamp devolver pro 0. A rota continua existindo para o
- * /brand/vsl.mp4 não dar 404 e abrir o portão pelo `error` antes da troca.
- *
- * O grupo tem os dois controles do CLAUDE.md §3:
- *   · conserto — os 6 CTAs nascem travados, e o clique NÃO navega;
- *   · o rótulo do botão da VSL — "Assista ao vídeo para liberar" antes,
- *     "COMECE JÁ" depois;
- *   · SEM JavaScript o botão continua travado. É o caso que prova o `is-locked`
- *     escrito no HTML: com JS ligado o `travar()` põe a classe de qualquer jeito,
- *     então apagá-la do markup não muda nada que os outros casos vejam — e o
- *     visitante sem JS ficaria com um "COMECE JÁ" rosa e pulsante que promete o
- *     que a página não pode cumprir;
- *   · anti-pulo — arrastar pro fim volta pro ponto assistido e o portão
- *     continua fechado (é o caso que morre se o `seeking` sair);
- *   · falha ABERTA — vídeo em 404 libera. Portão que trava por defeito zera
- *     o cadastro do dia em silêncio;
- *   · quem JÁ tem conta — o nav-auth.js real (com /auth/validate mockado em
- *     200) troca o href dos CTAs por /app, e o portão tem de abrir. Sem este
- *     caso, todo visitante logado da landing via botão cinza para sempre:
- *     `liberar()` reconsultava por `a[href="/cadastro"]`, que a essa altura
- *     não casa com nada;
- *   · controle POSITIVO — assistindo até o fim o clique navega pro /cadastro
- *     de verdade. Sem ele o grupo passaria numa página com todos os botões
- *     quebrados, que é pior que o bug.
- *
- * Rodar:  npm run test:frontend
+ * Rodar: npm run test:frontend
  */
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -51,11 +18,9 @@ before(async () => { ({ proc: server, origin: ORIGIN } = await startServer());
                      browser = await chromium.launch(); });
 after(async () => { await browser?.close(); server?.kill(); });
 
-/** WAV PCM 8-bit mono, 8 kHz, `segundos` de silêncio. Chromium toca sem codec
- *  externo, e é o menor arquivo de mídia que dá duração e `ended` reais. */
 function wavSilencioso(segundos) {
   const taxa = 8000, n = taxa * segundos;
-  const buf = Buffer.alloc(44 + n, 0x80);          // 0x80 = silêncio em 8-bit
+  const buf = Buffer.alloc(44 + n, 0x80);
   buf.write("RIFF", 0); buf.writeUInt32LE(36 + n, 4); buf.write("WAVE", 8);
   buf.write("fmt ", 12); buf.writeUInt32LE(16, 16);
   buf.writeUInt16LE(1, 20); buf.writeUInt16LE(1, 22);
@@ -65,95 +30,34 @@ function wavSilencioso(segundos) {
   return buf;
 }
 
-/**
- * Abre a landing. `midia: false` deixa o vídeo dar 404 — é o caso da falha
- * aberta. O contexto é novo a cada chamada: o portão memoriza em
- * localStorage, e um contexto reaproveitado faria o caso seguinte começar
- * já liberado (verde por contaminação, não por conserto).
- */
-async function abrirLanding({ midia = true, logado = false } = {}) {
+async function abrirLanding({ logado = false } = {}) {
   const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
   const page = await ctx.newPage();
   const wav = wavSilencioso(1);
-  // O nav-auth.js que roda é o de verdade — servido pelo mesmo servidor. Só a
-  // resposta do /auth/validate é encenada; a reescrita dos CTAs é dele.
   if (logado) await page.route("**/auth/validate", r =>
     r.fulfill({ status: 200, contentType: "application/json", body: "{}" }));
-  await page.route("**/vsl.mp4*", route => midia
-    ? route.fulfill({ status: 200, contentType: "audio/wav", body: wav })
-    : route.fulfill({ status: 404, contentType: "text/plain", body: "no" }));
+  await page.route("**/vsl.mp4*", route =>
+    route.fulfill({ status: 200, contentType: "audio/wav", body: wav }));
   await page.goto(`${ORIGIN}/index.html`, { waitUntil: "domcontentloaded" });
-  if (midia) {
-    // Troca a fonte por uma buscável (ver o cabeçalho). Os ouvintes do portão
-    // moram no ELEMENTO, não na fonte — trocar o `src` não desfaz nenhum.
-    await page.evaluate(async uri => {
-      const v = document.getElementById("vsl-video");
-      v.src = uri; v.load();
-      await new Promise(ok => v.addEventListener("loadedmetadata", ok, { once: true }));
-    }, "data:audio/wav;base64," + wav.toString("base64"));
-  }
+  await page.evaluate(async uri => {
+    const v = document.getElementById("vsl-video");
+    v.src = uri; v.load();
+    await new Promise(ok => v.addEventListener("loadedmetadata", ok, { once: true }));
+  }, "data:audio/wav;base64," + wav.toString("base64"));
   return { page, ctx };
 }
 
-const travados = page => page.$$eval('a[href="/cadastro"]',
-  as => as.map(a => a.classList.contains("is-locked") && a.getAttribute("aria-disabled") === "true"));
-
-/** Assiste do começo ao fim, de verdade. `muted` porque a política de autoplay
- *  do Chromium recusa `play()` com som sem gesto do usuário. */
-const assistirAteOFim = page => page.evaluate(() => new Promise(ok => {
-  const v = document.getElementById("vsl-video");
-  v.addEventListener("ended", ok, { once: true });
-  v.muted = true;
-  v.play();
-}));
-
-test("os CTAs de /cadastro nascem travados, e o clique não navega", async () => {
+test("todos os CTAs levam ao cadastro sem exigir o vídeo", async () => {
   const { page, ctx } = await abrirLanding();
   assert.equal(await page.$eval("#vsl-video", video => video.preload), "none",
                "a mídia não deve transferir bytes antes da intenção de reprodução");
-  const estados = await travados(page);
-  assert.equal(estados.length, 6, "a landing tem 6 CTAs de /cadastro (5 + o botão da VSL)");
-  assert.match(await page.textContent("#vsl-cta"), /Assista ao vídeo/);
-  assert.ok(estados.every(Boolean), "todo CTA de /cadastro nasce travado");
-
-  // `force` porque o Playwright recusa clicar em [aria-disabled=true] por conta
-  // própria — e é justo o navegador de verdade que NÃO recusa: o atributo diz
-  // ao leitor de tela que o CTA está indisponível, não impede o clique. Sem o
-  // force, o caso mediria a regra do Playwright em vez do portão.
-  await page.click('.hero-cta a[href="/cadastro"]', { force: true });
-  await page.waitForTimeout(300);
-  assert.ok(page.url().endsWith("/index.html"), `clique travado navegou: ${page.url()}`);
-  assert.match(await page.textContent("#vsl-status"), /até o fim/);
-  await ctx.close();
-});
-
-test("arrastar a barra pro fim não vale por assistir", async () => {
-  const { page, ctx } = await abrirLanding();
-  // Guarda do harness: sem isto o caso volta a medir o Playwright. `seekable`
-  // em 0 significa que o navegador recusa a busca sozinho, e aí passar não
-  // prova clamp nenhum.
-  assert.ok(await page.evaluate(() => {
-    const v = document.getElementById("vsl-video");
-    return v.seekable.length > 0 && v.seekable.end(0) > 0.5;
-  }), "a mídia do teste precisa ser buscável, senão o caso não mede nada");
-
-  // Sem o clamp, isto sozinho levaria o `timeupdate` a chamar liberar().
-  const parou = await page.evaluate(async () => {
-    const v = document.getElementById("vsl-video");
-    v.currentTime = v.duration - 0.01;
-    await new Promise(ok => setTimeout(ok, 300));
-    return v.currentTime;
-  });
-  assert.ok(parou < 0.5, `o cursor deveria ter voltado pro início, ficou em ${parou}`);
-  assert.ok((await travados(page)).every(Boolean), "pulou o vídeo e o portão abriu");
-  await ctx.close();
-});
-
-test("assistindo até o fim, o cadastro abre — e o clique navega", async () => {
-  const { page, ctx } = await abrirLanding();
-  await assistirAteOFim(page);
-  assert.ok((await travados(page)).every(e => e === false), "assistiu e continuou travado");
-  assert.match(await page.textContent("#vsl-status"), /liberado/);
+  const estados = await page.$$eval('a[href="/cadastro"]', as => as.map(a => ({
+    travado: a.classList.contains("is-locked"),
+    aria: a.getAttribute("aria-disabled"),
+  })));
+  assert.equal(estados.length, 6, "a landing tem 6 CTAs de /cadastro");
+  assert.ok(estados.every(e => !e.travado && e.aria === null),
+            "nenhum CTA pode nascer bloqueado");
   assert.equal((await page.textContent("#vsl-cta")).trim(), "COMECE JÁ");
 
   await Promise.all([
@@ -163,51 +67,58 @@ test("assistindo até o fim, o cadastro abre — e o clique navega", async () =>
   await ctx.close();
 });
 
-test("quem já assistiu não assiste de novo", async () => {
+test("o visitante pode avançar o vídeo sem bloquear o cadastro", async () => {
   const { page, ctx } = await abrirLanding();
-  await assistirAteOFim(page);
-  await page.reload({ waitUntil: "domcontentloaded" });
-  assert.ok((await travados(page)).every(e => e === false), "recarregou e travou de novo");
+  const posicao = await page.evaluate(async () => {
+    const v = document.getElementById("vsl-video");
+    v.currentTime = v.duration - 0.01;
+    await new Promise(ok => setTimeout(ok, 300));
+    return { atual: v.currentTime, duracao: v.duration };
+  });
+  assert.ok(posicao.atual > posicao.duracao / 2,
+            `a busca foi impedida: ${posicao.atual}/${posicao.duracao}`);
   await ctx.close();
 });
 
-test("vídeo que não carrega LIBERA após a tentativa — o portão falha aberto", async () => {
-  const { page, ctx } = await abrirLanding({ midia: false });
-  await page.$eval("#vsl-video", video => video.play().catch(() => {}));
-  await page.waitForFunction(
-    () => !document.querySelector('.hero-cta a[href="/cadastro"]').classList.contains("is-locked"),
-    null, { timeout: 5000 });
+test("play e marcos de progresso continuam sendo medidos", async () => {
+  const { page, ctx } = await abrirLanding();
+  const eventos = await page.evaluate(() => {
+    window.__eventosVsl = [];
+    window.gtag = (...args) => window.__eventosVsl.push(args);
+    const v = document.getElementById("vsl-video");
+    v.dispatchEvent(new Event("play"));
+    [0.26, 0.51, 0.76].forEach(p => {
+      v.currentTime = v.duration * p;
+      v.dispatchEvent(new Event("timeupdate"));
+    });
+    return window.__eventosVsl;
+  });
+  assert.deepEqual(eventos.map(e => e[1]),
+                   ["vsl_play", "vsl_progress", "vsl_progress", "vsl_progress"]);
+  assert.deepEqual(eventos.slice(1).map(e => e[2].percent), [25, 50, 75]);
   await ctx.close();
 });
 
-test("quem já tem conta não fica com os CTAs travados", async () => {
+test("quem já tem conta continua sendo direcionado ao dashboard", async () => {
   const { page, ctx } = await abrirLanding({ logado: true });
-  // O nav-auth troca href e texto; o portão tem de soltar os mesmos elementos.
   await page.waitForFunction(
-    () => document.querySelectorAll(".is-locked").length === 0,
+    () => document.querySelectorAll('a[href="/cadastro"]').length === 0,
     null, { timeout: 5000 });
-  assert.equal(await page.$$eval('a[href="/cadastro"]', a => a.length), 0,
-               "o nav-auth deveria ter reescrito todos os CTAs");
-  // E não vira memória: quem sair da conta volta a ser visitante e reassiste.
-  assert.equal(await page.evaluate(() => localStorage.getItem("pb_vsl_visto")), null);
-  // Trava o comportamento do NAV-AUTH, não o meu: ele faz `a.textContent = ...`,
-  // que destrói o <span> do rótulo (medido: `parentNode` vira null), então nenhuma
-  // mutação do vsl-gate muda esta linha. Ela fica porque, se o nav-auth um dia
-  // parar de reescrever o texto, o cliente existente passa a ver "COMECE JÁ"
-  // apontando pro /app — e este caso é o que avisa.
   assert.equal(await page.textContent("#vsl-cta"), "Ir para o dashboard");
   await ctx.close();
 });
 
-test("sem JavaScript o botão continua travado", async () => {
+test("sem JavaScript o cadastro também fica disponível", async () => {
   const ctx = await browser.newContext({ javaScriptEnabled: false });
   const page = await ctx.newPage();
   await page.goto(`${ORIGIN}/index.html`, { waitUntil: "domcontentloaded" });
   const b = await page.$eval("#vsl-cta", el => ({
-    classe: el.className, aria: el.getAttribute("aria-disabled"), texto: el.textContent.trim(),
+    href: el.getAttribute("href"), classe: el.className,
+    aria: el.getAttribute("aria-disabled"), texto: el.textContent.trim(),
   }));
-  assert.ok(b.classe.includes("is-locked"), `o botão veio destravado do servidor: ${b.classe}`);
-  assert.equal(b.aria, "true");
-  assert.match(b.texto, /Assista ao vídeo/);
+  assert.equal(b.href, "/cadastro");
+  assert.ok(!b.classe.includes("is-locked"));
+  assert.equal(b.aria, null);
+  assert.equal(b.texto, "COMECE JÁ");
   await ctx.close();
 });

--- a/tests/frontend/vsl_gate.test.mjs
+++ b/tests/frontend/vsl_gate.test.mjs
@@ -107,6 +107,27 @@ test("play e marcos de progresso continuam sendo medidos", async () => {
   await ctx.close();
 });
 
+test("o último intervalo antes da pausa também conta como assistido", async () => {
+  const { page, ctx } = await abrirLanding();
+  const eventos = await page.evaluate(() => {
+    window.__eventosVsl = [];
+    window.gtag = (...args) => window.__eventosVsl.push(args);
+    const v = document.getElementById("vsl-video");
+    Object.defineProperties(v, {
+      currentTime: { configurable: true, writable: true, value: 0 },
+      duration: { configurable: true, value: 1 },
+      paused: { configurable: true, value: true },
+    });
+    v.dispatchEvent(new Event("play"));
+    v.currentTime = 0.26;
+    // O navegador já expõe paused=true quando entrega o timeupdate final.
+    v.dispatchEvent(new Event("timeupdate"));
+    return window.__eventosVsl.filter(e => e[1] === "vsl_progress");
+  });
+  assert.deepEqual(eventos.map(e => e[2].percent), [25]);
+  await ctx.close();
+});
+
 test("quem já tem conta continua sendo direcionado ao dashboard", async () => {
   const { page, ctx } = await abrirLanding({ logado: true });
   await page.waitForFunction(


### PR DESCRIPTION
## O que foi feito

- libera imediatamente todos os CTAs de cadastro da landing
- mantém o vídeo como conteúdo opcional com preload desativado
- preserva os eventos `vsl_play` e `vsl_progress`
- remove o bloqueio de cliques, o antiavanço e a persistência `pb_vsl_visto`
- atualiza os testes e a documentação do contrato da landing

## Validação

- `npm run lint -- --quiet`
- `npm run test:frontend` — 607 testes passaram
- testes Python de páginas estáticas, GA4, Clarity e performance — 47 testes passaram
- conferência visual mobile em 390×844